### PR TITLE
Fix adapter diagrams links

### DIFF
--- a/docs/adapters/adapter-reference-architecture.md
+++ b/docs/adapters/adapter-reference-architecture.md
@@ -21,10 +21,10 @@ Shared adapter contract:
 
 ## Adapter Sidecar Architecture
 
-![Adapter sidecar architecture](./diagrams/adapter-sidecar-architecture.svg)
+![Adapter sidecar architecture](../diagrams/adapter-sidecar-architecture.svg)
 
 Related boundary view:
-- [`Agent authorization boundary`](./diagrams/agent-authorization-boundary.svg)
+- [`Agent authorization boundary`](../diagrams/agent-authorization-boundary.svg)
 
 Diagram source/editing policy:
 - [`docs/diagrams/README.md`](../diagrams/README.md)

--- a/docs/archive/integrations/adapter-stack.md
+++ b/docs/archive/integrations/adapter-stack.md
@@ -13,7 +13,7 @@ This document describes the full adapter layer model and the complete set of run
 
 ## Layer Model
 
-![Adapter stack layer model](../diagrams/adapter-layer-model.svg)
+![Adapter stack layer model](../../diagrams/adapter-layer-model.svg)
 
 ## Package Roles
 

--- a/docs/spec/artifacts/delegation-v1.md
+++ b/docs/spec/artifacts/delegation-v1.md
@@ -354,8 +354,8 @@ Both events MUST be included in the hash-chained audit log.
 
 ## 10. References
 
-- [OxDeAI Specification](../../SPEC.md)
-- [AuthorizationV1 schema](../../SPEC.md#4-authorizationv1)
-- [KeySet Distribution](../../SPEC.md#11-keyset-distribution-v1-baseline)
-- [Cross-Organization Verification Model](../../SPEC.md#12-cross-organization-verification-model)
-- [Roadmap: v2.x Delegated Agent Authorization (shipped)](../../ROADMAP.md)
+- [OxDeAI Specification](../../../SPEC.md)
+- [AuthorizationV1 schema](../../../SPEC.md#4-authorizationv1)
+- [KeySet Distribution](../../../SPEC.md#11-keyset-distribution-v1-baseline)
+- [Cross-Organization Verification Model](../../../SPEC.md#12-cross-organization-verification-model)
+- [Roadmap: v2.x Delegated Agent Authorization (shipped)](../../../ROADMAP.md)


### PR DESCRIPTION
- Point adapter reference architecture images to shared `docs/diagrams/` assets.
- Fix archived adapter stack doc link to adapter-layer-model diagram.
- Repair delegation-v1 spec references to root `SPEC.md` and `ROADMAP.md`.
- No code changes; doc link hygiene only.

**Tests**
- Not run (docs-only).