### PR TITLE
fix(guard): enforce strict fail-closed execution boundary

### DIFF
--- a/examples/autogen/src/crypto.ts
+++ b/examples/autogen/src/crypto.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+import { generateKeyPairSync } from "node:crypto";
+import type { KeySet } from "@oxdeai/core";
+
+const KEYPAIR = generateKeyPairSync("ed25519", {
+  privateKeyEncoding: { format: "pem", type: "pkcs8" },
+  publicKeyEncoding: { format: "pem", type: "spki" },
+});
+
+export const DEMO_PRIVATE_KEY_PEM = KEYPAIR.privateKey.toString();
+
+export const DEMO_KEYSET: KeySet = {
+  issuer: "oxdeai.policy-engine.demo",
+  version: "v1",
+  keys: [{ kid: "k1", alg: "Ed25519", public_key: KEYPAIR.publicKey.toString() }],
+};

--- a/examples/autogen/src/pep.ts
+++ b/examples/autogen/src/pep.ts
@@ -10,6 +10,7 @@ import type { Authorization, State } from "@oxdeai/core";
 import { createAutoGenGuard, OxDeAIDenyError } from "@oxdeai/autogen";
 import type { AutoGenToolCall } from "@oxdeai/autogen";
 import { buildProvisionIntent, engine, gpuCost, AGENT_ID } from "./policy.js";
+import { DEMO_KEYSET } from "./crypto.js";
 
 const C = {
   reset:      "\x1b[0m",
@@ -74,6 +75,7 @@ export async function guardedProvision(
     agentId: AGENT_ID,
     getState: () => state,
     setState: (s: State) => { nextState = s; },
+    trustedKeySets: [DEMO_KEYSET],
     // Return the pre-built intent so nonce/intent_id are stable.
     mapActionToIntent: () => intent,
     beforeExecute(_action: unknown, authorization: Authorization) {

--- a/examples/autogen/src/policy.ts
+++ b/examples/autogen/src/policy.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { PolicyEngine } from "@oxdeai/core";
 import type { Intent, State } from "@oxdeai/core";
+import { DEMO_KEYSET, DEMO_PRIVATE_KEY_PEM } from "./crypto.js";
 
 export const GPU_COST: Record<string, Record<string, bigint>> = {
   a100: { "us-east-1": 500n },
@@ -29,7 +30,11 @@ if (!process.env.OXDEAI_ENGINE_SECRET) {
 export const engine = new PolicyEngine({
   policy_version: "v1.0.0",
   engine_secret: _engineSecret,
-  authorization_ttl_seconds: 60,
+  authorization_signing_alg: "Ed25519",
+  authorization_signing_kid: "k1",
+  authorization_issuer: DEMO_KEYSET.issuer,
+  authorization_private_key_pem: DEMO_PRIVATE_KEY_PEM,
+  authorization_ttl_seconds: 600,
   policyId: POLICY_ID,
 });
 

--- a/examples/autogen/src/run.ts
+++ b/examples/autogen/src/run.ts
@@ -6,10 +6,11 @@ import {
   verifyEnvelope,
   verifySnapshot,
 } from "@oxdeai/core";
-import type { KeySet, State } from "@oxdeai/core";
+import type { State } from "@oxdeai/core";
 import { AGENT_ID, engine, makeState, POLICY_ID } from "./policy.js";
 import { guardedProvision } from "./pep.js";
 import { proposeCallsViaAutoGen } from "./autogen.js";
+import { DEMO_KEYSET } from "./crypto.js";
 
 const C = {
   reset:      "\x1b[0m",
@@ -31,20 +32,6 @@ const C = {
 };
 
 const c = (color: string, text: string) => `${color}${text}${C.reset}`;
-
-const DEMO_TRUSTED_KEYSET: KeySet = {
-  issuer: "oxdeai.policy-engine",
-  version: "1",
-  keys: [
-    {
-      kid: "2026-01",
-      alg: "Ed25519",
-      public_key: `-----BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEAWiMMGTYK7zzHwZXLzDpCshxAH6Lgx8gVsJaixePuY7g=
------END PUBLIC KEY-----`,
-    },
-  ],
-};
 
 export async function runDemo(log: (msg: string) => void = (msg) => console.log(msg)): Promise<void> {
   const decisions: string[] = [];
@@ -138,7 +125,7 @@ export async function runDemo(log: (msg: string) => void = (msg) => console.log(
   const vr = verifyEnvelope(envelopeBytes, {
     expectedPolicyId: POLICY_ID,
     mode: "strict",
-    trustedKeySets: DEMO_TRUSTED_KEYSET,
+    trustedKeySets: DEMO_KEYSET,
   });
 
   log(`   ${c(C.dim, "status:")}        ${vr.status === "ok" ? c(C.bGreen, "ok") : c(C.bRed, vr.status)}`);

--- a/examples/crewai/src/crypto.ts
+++ b/examples/crewai/src/crypto.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+import { generateKeyPairSync } from "node:crypto";
+import type { KeySet } from "@oxdeai/core";
+
+const KEYPAIR = generateKeyPairSync("ed25519", {
+  privateKeyEncoding: { format: "pem", type: "pkcs8" },
+  publicKeyEncoding: { format: "pem", type: "spki" },
+});
+
+export const DEMO_PRIVATE_KEY_PEM = KEYPAIR.privateKey.toString();
+
+export const DEMO_KEYSET: KeySet = {
+  issuer: "oxdeai.policy-engine.demo",
+  version: "v1",
+  keys: [{ kid: "k1", alg: "Ed25519", public_key: KEYPAIR.publicKey.toString() }],
+};

--- a/examples/crewai/src/pep.ts
+++ b/examples/crewai/src/pep.ts
@@ -10,6 +10,7 @@ import type { Authorization, State } from "@oxdeai/core";
 import { createCrewAIGuard, OxDeAIDenyError } from "@oxdeai/crewai";
 import type { CrewAIToolCall } from "@oxdeai/crewai";
 import { buildProvisionIntent, engine, gpuCost, AGENT_ID } from "./policy.js";
+import { DEMO_KEYSET } from "./crypto.js";
 
 const C = {
   reset:      "\x1b[0m",
@@ -74,6 +75,7 @@ export async function guardedProvision(
     agentId: AGENT_ID,
     getState: () => state,
     setState: (s: State) => { nextState = s; },
+    trustedKeySets: [DEMO_KEYSET],
     // Return the pre-built intent so nonce/intent_id are stable.
     mapActionToIntent: () => intent,
     beforeExecute(_action: unknown, authorization: Authorization) {

--- a/examples/crewai/src/policy.ts
+++ b/examples/crewai/src/policy.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { PolicyEngine } from "@oxdeai/core";
 import type { Intent, State } from "@oxdeai/core";
+import { DEMO_KEYSET, DEMO_PRIVATE_KEY_PEM } from "./crypto.js";
 
 export const GPU_COST: Record<string, Record<string, bigint>> = {
   a100: { "us-east-1": 500n },
@@ -29,7 +30,11 @@ if (!process.env.OXDEAI_ENGINE_SECRET) {
 export const engine = new PolicyEngine({
   policy_version: "v1.0.0",
   engine_secret: _engineSecret,
-  authorization_ttl_seconds: 60,
+  authorization_signing_alg: "Ed25519",
+  authorization_signing_kid: "k1",
+  authorization_issuer: DEMO_KEYSET.issuer,
+  authorization_private_key_pem: DEMO_PRIVATE_KEY_PEM,
+  authorization_ttl_seconds: 600,
   policyId: POLICY_ID,
 });
 

--- a/examples/crewai/src/run.ts
+++ b/examples/crewai/src/run.ts
@@ -6,10 +6,11 @@ import {
   verifyEnvelope,
   verifySnapshot,
 } from "@oxdeai/core";
-import type { KeySet, State } from "@oxdeai/core";
+import type { State } from "@oxdeai/core";
 import { AGENT_ID, engine, makeState, POLICY_ID } from "./policy.js";
 import { guardedProvision } from "./pep.js";
 import { proposeCallsViaCrewAI } from "./crewai.js";
+import { DEMO_KEYSET } from "./crypto.js";
 
 const C = {
   reset:      "\x1b[0m",
@@ -31,20 +32,6 @@ const C = {
 };
 
 const c = (color: string, text: string) => `${color}${text}${C.reset}`;
-
-const DEMO_TRUSTED_KEYSET: KeySet = {
-  issuer: "oxdeai.policy-engine",
-  version: "1",
-  keys: [
-    {
-      kid: "2026-01",
-      alg: "Ed25519",
-      public_key: `-----BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEAWiMMGTYK7zzHwZXLzDpCshxAH6Lgx8gVsJaixePuY7g=
------END PUBLIC KEY-----`,
-    },
-  ],
-};
 
 export async function runDemo(log: (msg: string) => void = (msg) => console.log(msg)): Promise<void> {
   const decisions: string[] = [];
@@ -138,7 +125,7 @@ export async function runDemo(log: (msg: string) => void = (msg) => console.log(
   const vr = verifyEnvelope(envelopeBytes, {
     expectedPolicyId: POLICY_ID,
     mode: "strict",
-    trustedKeySets: DEMO_TRUSTED_KEYSET,
+    trustedKeySets: DEMO_KEYSET,
   });
 
   log(`   ${c(C.dim, "status:")}        ${vr.status === "ok" ? c(C.bGreen, "ok") : c(C.bRed, vr.status)}`);

--- a/examples/langgraph/src/crypto.ts
+++ b/examples/langgraph/src/crypto.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+import { generateKeyPairSync } from "node:crypto";
+import type { KeySet } from "@oxdeai/core";
+
+const KEYPAIR = generateKeyPairSync("ed25519", {
+  privateKeyEncoding: { format: "pem", type: "pkcs8" },
+  publicKeyEncoding: { format: "pem", type: "spki" },
+});
+
+export const DEMO_PRIVATE_KEY_PEM = KEYPAIR.privateKey.toString();
+
+export const DEMO_KEYSET: KeySet = {
+  issuer: "oxdeai.policy-engine.demo",
+  version: "v1",
+  keys: [{ kid: "k1", alg: "Ed25519", public_key: KEYPAIR.publicKey.toString() }],
+};

--- a/examples/langgraph/src/pep.ts
+++ b/examples/langgraph/src/pep.ts
@@ -10,6 +10,7 @@ import type { Authorization, State } from "@oxdeai/core";
 import { createLangGraphGuard, OxDeAIDenyError } from "@oxdeai/langgraph";
 import type { LangGraphToolCall } from "@oxdeai/langgraph";
 import { buildProvisionIntent, engine, gpuCost, AGENT_ID } from "./policy.js";
+import { DEMO_KEYSET } from "./crypto.js";
 
 const C = {
   reset:      "\x1b[0m",
@@ -74,6 +75,7 @@ export async function guardedProvision(
     agentId: AGENT_ID,
     getState: () => state,
     setState: (s: State) => { nextState = s; },
+    trustedKeySets: [DEMO_KEYSET],
     // Return the pre-built intent so nonce/intent_id are stable.
     mapActionToIntent: () => intent,
     beforeExecute(_action: unknown, authorization: Authorization) {

--- a/examples/langgraph/src/policy.ts
+++ b/examples/langgraph/src/policy.ts
@@ -8,6 +8,7 @@
 
 import { PolicyEngine } from "@oxdeai/core";
 import type { Intent, State } from "@oxdeai/core";
+import { DEMO_KEYSET, DEMO_PRIVATE_KEY_PEM } from "./crypto.js";
 
 export const GPU_COST: Record<string, Record<string, bigint>> = {
   a100: { "us-east-1": 500n },
@@ -36,7 +37,11 @@ if (!process.env.OXDEAI_ENGINE_SECRET) {
 export const engine = new PolicyEngine({
   policy_version: "v1.0.0",
   engine_secret: _engineSecret,
-  authorization_ttl_seconds: 60,
+  authorization_signing_alg: "Ed25519",
+  authorization_signing_kid: "k1",
+  authorization_issuer: DEMO_KEYSET.issuer,
+  authorization_private_key_pem: DEMO_PRIVATE_KEY_PEM,
+  authorization_ttl_seconds: 600,
   policyId: POLICY_ID,
 });
 

--- a/examples/langgraph/src/run.ts
+++ b/examples/langgraph/src/run.ts
@@ -18,10 +18,11 @@ import {
   verifyEnvelope,
   verifySnapshot,
 } from "@oxdeai/core";
-import type { KeySet, State } from "@oxdeai/core";
+import type { State } from "@oxdeai/core";
 import { AGENT_ID, engine, makeState, POLICY_ID } from "./policy.js";
 import { guardedProvision } from "./pep.js";
 import { proposeCallsViaLangGraph } from "./graph.js";
+import { DEMO_KEYSET } from "./crypto.js";
 
 const C = {
   reset:      "\x1b[0m",
@@ -43,20 +44,6 @@ const C = {
 };
 
 const c = (color: string, text: string) => `${color}${text}${C.reset}`;
-
-const DEMO_TRUSTED_KEYSET: KeySet = {
-  issuer: "oxdeai.policy-engine",
-  version: "1",
-  keys: [
-    {
-      kid: "2026-01",
-      alg: "Ed25519",
-      public_key: `-----BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEAWiMMGTYK7zzHwZXLzDpCshxAH6Lgx8gVsJaixePuY7g=
------END PUBLIC KEY-----`,
-    },
-  ],
-};
 
 export async function runDemo(log: (msg: string) => void = (msg) => console.log(msg)): Promise<void> {
   const decisions: string[] = [];
@@ -150,7 +137,7 @@ export async function runDemo(log: (msg: string) => void = (msg) => console.log(
   const vr = verifyEnvelope(envelopeBytes, {
     expectedPolicyId: POLICY_ID,
     mode: "strict",
-    trustedKeySets: DEMO_TRUSTED_KEYSET,
+    trustedKeySets: DEMO_KEYSET,
   });
 
   log(`   ${c(C.dim, "status:")}        ${vr.status === "ok" ? c(C.bGreen, "ok") : c(C.bRed, vr.status)}`);

--- a/examples/openai-agents-sdk/src/crypto.ts
+++ b/examples/openai-agents-sdk/src/crypto.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+import { generateKeyPairSync } from "node:crypto";
+import type { KeySet } from "@oxdeai/core";
+
+const KEYPAIR = generateKeyPairSync("ed25519", {
+  privateKeyEncoding: { format: "pem", type: "pkcs8" },
+  publicKeyEncoding: { format: "pem", type: "spki" },
+});
+
+export const DEMO_PRIVATE_KEY_PEM = KEYPAIR.privateKey.toString();
+
+export const DEMO_KEYSET: KeySet = {
+  issuer: "oxdeai.policy-engine.demo",
+  version: "v1",
+  keys: [{ kid: "k1", alg: "Ed25519", public_key: KEYPAIR.publicKey.toString() }],
+};

--- a/examples/openai-agents-sdk/src/pep.ts
+++ b/examples/openai-agents-sdk/src/pep.ts
@@ -10,6 +10,7 @@ import type { Authorization, State } from "@oxdeai/core";
 import { createOpenAIAgentsGuard, OxDeAIDenyError } from "@oxdeai/openai-agents";
 import type { OpenAIAgentsToolCall } from "@oxdeai/openai-agents";
 import { buildProvisionIntent, engine, gpuCost, AGENT_ID } from "./policy.js";
+import { DEMO_KEYSET } from "./crypto.js";
 
 const C = {
   reset:      "\x1b[0m",
@@ -74,6 +75,7 @@ export async function guardedProvision(
     agentId: AGENT_ID,
     getState: () => state,
     setState: (s: State) => { nextState = s; },
+    trustedKeySets: [DEMO_KEYSET],
     // Return the pre-built intent so nonce/intent_id are stable.
     mapActionToIntent: () => intent,
     beforeExecute(_action: unknown, authorization: Authorization) {

--- a/examples/openai-agents-sdk/src/policy.ts
+++ b/examples/openai-agents-sdk/src/policy.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { PolicyEngine } from "@oxdeai/core";
 import type { Intent, State } from "@oxdeai/core";
+import { DEMO_KEYSET, DEMO_PRIVATE_KEY_PEM } from "./crypto.js";
 
 export const GPU_COST: Record<string, Record<string, bigint>> = {
   a100: { "us-east-1": 500n },
@@ -29,7 +30,11 @@ if (!process.env.OXDEAI_ENGINE_SECRET) {
 export const engine = new PolicyEngine({
   policy_version: "v1.0.0",
   engine_secret: _engineSecret,
-  authorization_ttl_seconds: 60,
+  authorization_signing_alg: "Ed25519",
+  authorization_signing_kid: "k1",
+  authorization_issuer: DEMO_KEYSET.issuer,
+  authorization_private_key_pem: DEMO_PRIVATE_KEY_PEM,
+  authorization_ttl_seconds: 600,
   policyId: POLICY_ID,
 });
 

--- a/examples/openai-agents-sdk/src/run.ts
+++ b/examples/openai-agents-sdk/src/run.ts
@@ -6,10 +6,11 @@ import {
   verifyEnvelope,
   verifySnapshot,
 } from "@oxdeai/core";
-import type { KeySet, State } from "@oxdeai/core";
+import type { State } from "@oxdeai/core";
 import { AGENT_ID, engine, makeState, POLICY_ID } from "./policy.js";
 import { guardedProvision } from "./pep.js";
 import { proposeCallsViaOpenAIAgents } from "./agents.js";
+import { DEMO_KEYSET } from "./crypto.js";
 
 const C = {
   reset:      "\x1b[0m",
@@ -31,20 +32,6 @@ const C = {
 };
 
 const c = (color: string, text: string) => `${color}${text}${C.reset}`;
-
-const DEMO_TRUSTED_KEYSET: KeySet = {
-  issuer: "oxdeai.policy-engine",
-  version: "1",
-  keys: [
-    {
-      kid: "2026-01",
-      alg: "Ed25519",
-      public_key: `-----BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEAWiMMGTYK7zzHwZXLzDpCshxAH6Lgx8gVsJaixePuY7g=
------END PUBLIC KEY-----`,
-    },
-  ],
-};
 
 export async function runDemo(log: (msg: string) => void = (msg) => console.log(msg)): Promise<void> {
   const decisions: string[] = [];
@@ -138,7 +125,7 @@ export async function runDemo(log: (msg: string) => void = (msg) => console.log(
   const vr = verifyEnvelope(envelopeBytes, {
     expectedPolicyId: POLICY_ID,
     mode: "strict",
-    trustedKeySets: DEMO_TRUSTED_KEYSET,
+    trustedKeySets: DEMO_KEYSET,
   });
 
   log(`   ${c(C.dim, "status:")}        ${vr.status === "ok" ? c(C.bGreen, "ok") : c(C.bRed, vr.status)}`);

--- a/examples/openclaw/src/crypto.ts
+++ b/examples/openclaw/src/crypto.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+import { generateKeyPairSync } from "node:crypto";
+import type { KeySet } from "@oxdeai/core";
+
+const KEYPAIR = generateKeyPairSync("ed25519", {
+  privateKeyEncoding: { format: "pem", type: "pkcs8" },
+  publicKeyEncoding: { format: "pem", type: "spki" },
+});
+
+export const DEMO_PRIVATE_KEY_PEM = KEYPAIR.privateKey.toString();
+
+export const DEMO_KEYSET: KeySet = {
+  issuer: "oxdeai.policy-engine.demo",
+  version: "v1",
+  keys: [{ kid: "k1", alg: "Ed25519", public_key: KEYPAIR.publicKey.toString() }],
+};

--- a/examples/openclaw/src/pep.ts
+++ b/examples/openclaw/src/pep.ts
@@ -10,6 +10,7 @@ import type { Authorization, State } from "@oxdeai/core";
 import { createOpenClawGuard, OxDeAIDenyError } from "@oxdeai/openclaw";
 import type { OpenClawAction } from "@oxdeai/openclaw";
 import { buildProvisionIntent, engine, gpuCost, AGENT_ID } from "./policy.js";
+import { DEMO_KEYSET } from "./crypto.js";
 
 // ── ANSI color helpers ────────────────────────────────────────────────────────
 const C = {
@@ -72,6 +73,7 @@ export async function guardedProvision(
     agentId: AGENT_ID,
     getState: () => state,
     setState: (s: State) => { nextState = s; },
+    trustedKeySets: [DEMO_KEYSET],
     // Return the pre-built intent so nonce/intent_id are stable.
     mapActionToIntent: () => intent,
     beforeExecute(_action: unknown, authorization: Authorization) {

--- a/examples/openclaw/src/policy.ts
+++ b/examples/openclaw/src/policy.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { PolicyEngine } from "@oxdeai/core";
 import type { Intent, State } from "@oxdeai/core";
+import { DEMO_KEYSET, DEMO_PRIVATE_KEY_PEM } from "./crypto.js";
 
 export const GPU_COST: Record<string, Record<string, bigint>> = {
   a100: { "us-east-1": 500n },
@@ -29,7 +30,11 @@ if (!process.env.OXDEAI_ENGINE_SECRET) {
 export const engine = new PolicyEngine({
   policy_version: "v1.0.0",
   engine_secret: _engineSecret,
-  authorization_ttl_seconds: 60,
+  authorization_signing_alg: "Ed25519",
+  authorization_signing_kid: "k1",
+  authorization_issuer: DEMO_KEYSET.issuer,
+  authorization_private_key_pem: DEMO_PRIVATE_KEY_PEM,
+  authorization_ttl_seconds: 600,
   policyId: POLICY_ID,
 });
 

--- a/examples/openclaw/src/run.ts
+++ b/examples/openclaw/src/run.ts
@@ -21,9 +21,10 @@ import {
   verifySnapshot,
   verifyEnvelope,
 } from "@oxdeai/core";
-import type { KeySet, State } from "@oxdeai/core";
+import type { State } from "@oxdeai/core";
 import { engine, POLICY_ID, AGENT_ID, makeState } from "./policy.js";
 import { guardedProvision } from "./pep.js";
+import { DEMO_KEYSET } from "./crypto.js";
 
 // ── ANSI color helpers ────────────────────────────────────────────────────────
 const C = {
@@ -48,20 +49,6 @@ const C = {
 };
 
 const c = (color: string, text: string) => `${color}${text}${C.reset}`;
-
-const DEMO_TRUSTED_KEYSET: KeySet = {
-  issuer: "oxdeai.policy-engine",
-  version: "1",
-  keys: [
-    {
-      kid: "2026-01",
-      alg: "Ed25519",
-      public_key: `-----BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEAWiMMGTYK7zzHwZXLzDpCshxAH6Lgx8gVsJaixePuY7g=
------END PUBLIC KEY-----`,
-    },
-  ],
-};
 
 // ── Planned calls (simulates OpenAI tool-call proposals) ──────────────────────
 
@@ -188,7 +175,7 @@ export async function runDemo(log: (msg: string) => void = (msg) => console.log(
   const vr = verifyEnvelope(envelopeBytes, {
     expectedPolicyId: POLICY_ID,
     mode: "strict",
-    trustedKeySets: DEMO_TRUSTED_KEYSET,
+    trustedKeySets: DEMO_KEYSET,
   });
 
   const statusColor = vr.status === "ok" ? c(C.bGreen, vr.status) : c(C.bRed, vr.status);

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "pnpm": {
     "overrides": {
-      "langsmith": "^0.5.18",
+      "langsmith": "0.5.18",
       "minimatch": ">=10.2.3",
       "lodash": ">=4.18.0",
       "brace-expansion": ">=5.0.5"

--- a/packages/autogen/src/adapter.ts
+++ b/packages/autogen/src/adapter.ts
@@ -53,6 +53,7 @@ export function createAutoGenGuard(config: AutoGenGuardConfig): AutoGenGuardFn {
     beforeExecute: config.beforeExecute,
     onDecision: config.onDecision,
     strict: config.strict,
+    trustedKeySets: config.trustedKeySets,
   });
 
   return async function autoGenGuard<T>(

--- a/packages/autogen/src/test/adapter.test.ts
+++ b/packages/autogen/src/test/adapter.test.ts
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import test from "node:test";
 import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
 import { PolicyEngine } from "@oxdeai/core";
-import type { Authorization, State } from "@oxdeai/core";
+import type { Authorization, KeySet, State } from "@oxdeai/core";
 import { buildState } from "@oxdeai/sdk";
 import { OxDeAIDenyError, OxDeAIAuthorizationError, OxDeAINormalizationError } from "@oxdeai/guard";
 
@@ -14,8 +15,28 @@ import type { AutoGenToolCall, AutoGenGuardConfig } from "../types.js";
 const AGENT_ID = "autogen-agent-001";
 const ENGINE_SECRET = "test-secret-must-be-at-least-32-chars!!";
 
+const TEST_KEYPAIR = generateKeyPairSync("ed25519", {
+  privateKeyEncoding: { format: "pem", type: "pkcs8" },
+  publicKeyEncoding:  { format: "pem", type: "spki" },
+});
+
+const TEST_KEYSET: KeySet = {
+  issuer: "test-issuer",
+  version: "v1",
+  keys: [{ kid: "k1", alg: "Ed25519", public_key: TEST_KEYPAIR.publicKey.toString() }],
+};
+
 function makeEngine(): PolicyEngine {
-  return new PolicyEngine({ policy_version: "v1", engine_secret: ENGINE_SECRET });
+  return new PolicyEngine({
+    policy_version: "v1",
+    engine_secret: ENGINE_SECRET,
+    authorization_signing_alg: "Ed25519",
+    authorization_signing_kid: "k1",
+    authorization_issuer: TEST_KEYSET.issuer,
+    authorization_audience: AGENT_ID,
+    authorization_ttl_seconds: 600,
+    authorization_private_key_pem: TEST_KEYPAIR.privateKey.toString(),
+  });
 }
 
 function makeState(agentId = AGENT_ID): State {
@@ -35,7 +56,7 @@ const baseToolCall: AutoGenToolCall = {
   id: "call-abc-123",
   estimatedCost: 0.5,
   resourceType: "gpu",
-  timestampSeconds: 1_700_000_000,
+  timestampSeconds: Math.floor(Date.now() / 1000),
 };
 
 function makeGuardConfig(overrides: Partial<AutoGenGuardConfig> = {}): AutoGenGuardConfig {
@@ -45,6 +66,7 @@ function makeGuardConfig(overrides: Partial<AutoGenGuardConfig> = {}): AutoGenGu
     agentId: AGENT_ID,
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
     ...overrides,
   };
 }
@@ -89,6 +111,7 @@ test("adapter: DENY throws OxDeAIDenyError and does not call execute", async () 
     agentId: AGENT_ID,
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(
@@ -254,6 +277,7 @@ test("adapter: ALLOW without authorization artifact throws OxDeAIAuthorizationEr
     agentId: AGENT_ID,
     getState: () => state,
     setState: () => {},
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(
@@ -277,6 +301,7 @@ test("adapter: setState is called after successful execution", async () => {
     agentId: AGENT_ID,
     getState: () => makeState(),
     setState: (s) => { storedState = s; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await guard(baseToolCall, async () => "ok");
@@ -294,6 +319,7 @@ test("adapter: setState is NOT called on DENY", async () => {
     agentId: AGENT_ID,
     getState: () => makeState(),
     setState: () => { setStateCalled = true; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(() => guard(baseToolCall, async () => {}), OxDeAIDenyError);
@@ -323,6 +349,7 @@ test("adapter: onDecision receives DENY when blocked", async () => {
     getState: () => currentState,
     setState: (s) => { currentState = s; },
     onDecision({ decision: d }) { decision = d; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(() => guard(baseToolCall, async () => {}));
@@ -338,6 +365,7 @@ test("adapter: guard is reusable — multiple sequential calls work", async () =
     agentId: AGENT_ID,
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   const r1 = await guard(baseToolCall, async () => "first");

--- a/packages/autogen/src/types.ts
+++ b/packages/autogen/src/types.ts
@@ -72,6 +72,9 @@ export type AutoGenGuardConfig = {
 
   /** When true, missing optional normalizer fields cause hard failures. */
   strict?: boolean;
+
+  /** Trusted keysets required for strict authorization verification. */
+  trustedKeySets?: OxDeAIGuardConfig["trustedKeySets"];
 };
 
 /**

--- a/packages/compat/src/test/cross-adapter.test.ts
+++ b/packages/compat/src/test/cross-adapter.test.ts
@@ -56,9 +56,10 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
 
 import { PolicyEngine } from "@oxdeai/core";
-import type { Intent, State } from "@oxdeai/core";
+import type { Intent, KeySet, State } from "@oxdeai/core";
 import {
   defaultNormalizeAction,
   OxDeAIDenyError,
@@ -106,13 +107,27 @@ function seeds(): number[] {
   return out;
 }
 
+// ── Ed25519 test fixture ──────────────────────────────────────────────────────
+
+const TEST_KEYPAIR = generateKeyPairSync("ed25519", {
+  privateKeyEncoding: { format: "pem", type: "pkcs8" },
+  publicKeyEncoding:  { format: "pem", type: "spki" },
+});
+
+const TEST_KEYSET: KeySet = {
+  issuer: "test-issuer",
+  version: "v1",
+  keys: [{ kid: "k1", alg: "Ed25519", public_key: TEST_KEYPAIR.publicKey.toString() }],
+};
+
 // ── Shared policy infrastructure ──────────────────────────────────────────────
 
 const AGENT_ID = "cross-adapter-agent";
 
-// Fixed unix timestamp injected into every tool call so the timestamp field
-// in the normalized intent is deterministic and comparable.
-const T_FIXED = 1_700_000_000;
+// Current unix timestamp injected into every tool call so the timestamp field
+// in the normalized intent is deterministic and comparable, and auth tokens
+// are not expired.
+const T_FIXED = Math.floor(Date.now() / 1000);
 
 // One engine instance shared across all adapters in every test. Using the same
 // engine ensures policy_version, engine_secret, and all policy module configs
@@ -120,6 +135,12 @@ const T_FIXED = 1_700_000_000;
 const ENGINE = new PolicyEngine({
   policy_version: "v1-cross-adapter",
   engine_secret: "cross-adapter-test-secret-32-chars!",
+  authorization_signing_alg: "Ed25519",
+  authorization_signing_kid: "k1",
+  authorization_issuer: TEST_KEYSET.issuer,
+  authorization_audience: AGENT_ID,
+  authorization_ttl_seconds: 600,
+  authorization_private_key_pem: TEST_KEYPAIR.privateKey.toString(),
 });
 
 // Policy state: only PROVISION-type actions are allowed, budget is generous so
@@ -145,6 +166,12 @@ const POLICY_STATE = buildState({
 const CAP_ENGINE = new PolicyEngine({
   policy_version: "v1-cross-adapter-cap",
   engine_secret: "cross-adapter-cap-secret-32-chars!!",
+  authorization_signing_alg: "Ed25519",
+  authorization_signing_kid: "k1",
+  authorization_issuer: TEST_KEYSET.issuer,
+  authorization_audience: AGENT_ID,
+  authorization_ttl_seconds: 600,
+  authorization_private_key_pem: TEST_KEYPAIR.privateKey.toString(),
 });
 
 // 500 units in fixed-point micro-units (1 unit = 1_000_000 micro-units).
@@ -208,6 +235,12 @@ const REPLAY_STATE: State = {
 const CONCURRENCY_ENGINE = new PolicyEngine({
   policy_version: "v1-cross-adapter-concurrency",
   engine_secret: "cross-adapter-concurrency-32chars!",
+  authorization_signing_alg: "Ed25519",
+  authorization_signing_kid: "k1",
+  authorization_issuer: TEST_KEYSET.issuer,
+  authorization_audience: AGENT_ID,
+  authorization_ttl_seconds: 600,
+  authorization_private_key_pem: TEST_KEYPAIR.privateKey.toString(),
 });
 
 const ISOLATED_BUDGET = 100_000_000n; // 100 units
@@ -335,6 +368,7 @@ async function runLangGraph(ca: ConceptualAction, opts: RunnerOptions = {}): Pro
     agentId: AGENT_ID,
     mapActionToIntent: norm.mapActionToIntent,
     onDecision: r => { record = r; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   // LangGraph field mapping: toolCall.args → ProposedAction.args
@@ -374,6 +408,7 @@ async function runOpenAIAgents(ca: ConceptualAction, opts: RunnerOptions = {}): 
     agentId: AGENT_ID,
     mapActionToIntent: norm.mapActionToIntent,
     onDecision: r => { record = r; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   // OpenAI Agents SDK field mapping: toolCall.input    → ProposedAction.args
@@ -414,6 +449,7 @@ async function runCrewAI(ca: ConceptualAction, opts: RunnerOptions = {}): Promis
     agentId: AGENT_ID,
     mapActionToIntent: norm.mapActionToIntent,
     onDecision: r => { record = r; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   // CrewAI field mapping: toolCall.args → ProposedAction.args

--- a/packages/crewai/src/adapter.ts
+++ b/packages/crewai/src/adapter.ts
@@ -53,6 +53,7 @@ export function createCrewAIGuard(config: CrewAIGuardConfig): CrewAIGuardFn {
     beforeExecute: config.beforeExecute,
     onDecision: config.onDecision,
     strict: config.strict,
+    trustedKeySets: config.trustedKeySets,
   });
 
   return async function crewAIGuard<T>(

--- a/packages/crewai/src/test/adapter.test.ts
+++ b/packages/crewai/src/test/adapter.test.ts
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import test from "node:test";
 import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
 import { PolicyEngine } from "@oxdeai/core";
-import type { Authorization, State } from "@oxdeai/core";
+import type { Authorization, KeySet, State } from "@oxdeai/core";
 import { buildState } from "@oxdeai/sdk";
 import { OxDeAIDenyError, OxDeAIAuthorizationError, OxDeAINormalizationError } from "@oxdeai/guard";
 
@@ -14,8 +15,28 @@ import type { CrewAIToolCall, CrewAIGuardConfig } from "../types.js";
 const AGENT_ID = "crewai-agent-001";
 const ENGINE_SECRET = "test-secret-must-be-at-least-32-chars!!";
 
+const TEST_KEYPAIR = generateKeyPairSync("ed25519", {
+  privateKeyEncoding: { format: "pem", type: "pkcs8" },
+  publicKeyEncoding:  { format: "pem", type: "spki" },
+});
+
+const TEST_KEYSET: KeySet = {
+  issuer: "test-issuer",
+  version: "v1",
+  keys: [{ kid: "k1", alg: "Ed25519", public_key: TEST_KEYPAIR.publicKey.toString() }],
+};
+
 function makeEngine(): PolicyEngine {
-  return new PolicyEngine({ policy_version: "v1", engine_secret: ENGINE_SECRET });
+  return new PolicyEngine({
+    policy_version: "v1",
+    engine_secret: ENGINE_SECRET,
+    authorization_signing_alg: "Ed25519",
+    authorization_signing_kid: "k1",
+    authorization_issuer: TEST_KEYSET.issuer,
+    authorization_audience: AGENT_ID,
+    authorization_ttl_seconds: 600,
+    authorization_private_key_pem: TEST_KEYPAIR.privateKey.toString(),
+  });
 }
 
 function makeState(agentId = AGENT_ID): State {
@@ -35,7 +56,7 @@ const baseToolCall: CrewAIToolCall = {
   id: "call-abc-123",
   estimatedCost: 0.5,
   resourceType: "gpu",
-  timestampSeconds: 1_700_000_000,
+  timestampSeconds: Math.floor(Date.now() / 1000),
 };
 
 function makeGuardConfig(overrides: Partial<CrewAIGuardConfig> = {}): CrewAIGuardConfig {
@@ -45,6 +66,7 @@ function makeGuardConfig(overrides: Partial<CrewAIGuardConfig> = {}): CrewAIGuar
     agentId: AGENT_ID,
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
     ...overrides,
   };
 }
@@ -89,6 +111,7 @@ test("adapter: DENY throws OxDeAIDenyError and does not call execute", async () 
     agentId: AGENT_ID,
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(
@@ -254,6 +277,7 @@ test("adapter: ALLOW without authorization artifact throws OxDeAIAuthorizationEr
     agentId: AGENT_ID,
     getState: () => state,
     setState: () => {},
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(
@@ -277,6 +301,7 @@ test("adapter: setState is called after successful execution", async () => {
     agentId: AGENT_ID,
     getState: () => makeState(),
     setState: (s) => { storedState = s; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await guard(baseToolCall, async () => "ok");
@@ -294,6 +319,7 @@ test("adapter: setState is NOT called on DENY", async () => {
     agentId: AGENT_ID,
     getState: () => makeState(),
     setState: () => { setStateCalled = true; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(() => guard(baseToolCall, async () => {}), OxDeAIDenyError);
@@ -323,6 +349,7 @@ test("adapter: onDecision receives DENY when blocked", async () => {
     getState: () => currentState,
     setState: (s) => { currentState = s; },
     onDecision({ decision: d }) { decision = d; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(() => guard(baseToolCall, async () => {}));
@@ -338,6 +365,7 @@ test("adapter: guard is reusable — multiple sequential calls work", async () =
     agentId: AGENT_ID,
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   const r1 = await guard(baseToolCall, async () => "first");

--- a/packages/crewai/src/types.ts
+++ b/packages/crewai/src/types.ts
@@ -72,6 +72,9 @@ export type CrewAIGuardConfig = {
 
   /** When true, missing optional normalizer fields cause hard failures. */
   strict?: boolean;
+
+  /** Trusted keysets required for strict authorization verification. */
+  trustedKeySets?: OxDeAIGuardConfig["trustedKeySets"];
 };
 
 /**

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-import type { Authorization, Intent } from "@oxdeai/core";
-import { verifyDelegationChain } from "@oxdeai/core";
+import type { Authorization, AuthorizationV1, Intent, KeySet } from "@oxdeai/core";
+import { verifyDelegationChain, verifyAuthorization as strictVerifyAuthorization } from "@oxdeai/core";
 import type { OxDeAIGuardConfig, ProposedAction, GuardDecisionRecord, GuardCallOptions } from "./types.js";
 import { defaultNormalizeAction } from "./normalizeAction.js";
 import {
@@ -83,6 +83,22 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
 
   const normalize: (action: ProposedAction) => Intent =
     config.mapActionToIntent ?? defaultNormalizeAction;
+  const trustedKeySets: readonly KeySet[] | undefined = config.trustedKeySets
+    ? Array.isArray(config.trustedKeySets)
+      ? config.trustedKeySets
+      : [config.trustedKeySets]
+    : undefined;
+
+  if (!trustedKeySets || trustedKeySets.length === 0) {
+    throw new OxDeAIGuardConfigurationError(
+      "trustedKeySets are required for authorization verification and must not be empty."
+    );
+  }
+
+  // Tracks consumed auth_ids to enforce replay resistance at the PEP.
+  const consumedAuthIds = new Set<string>();
+  // Tracks consumed delegation_ids to enforce replay resistance for delegations.
+  const consumedDelegationIds = new Set<string>();
 
   return async function guard(
     action: ProposedAction,
@@ -114,8 +130,12 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
         );
       }
 
-      const now = intent.timestamp;
+      const now = Math.floor(Date.now() / 1000);
       const violationMessages: string[] = [];
+
+      if (consumedDelegationIds.has(delegation.delegation_id)) {
+        throw new OxDeAIAuthorizationError("Delegation replay detected. Execution blocked.");
+      }
 
       // Verify delegation chain:
       //   - parent hash binding
@@ -125,13 +145,22 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
       //   - delegation expiry <= parent expiry
       //   - delegation expiry
       //   - delegation signature (if trustedKeySets provided)
-      //   - scope narrowing against parent is NOT checked here (parentScope
-      //     is the deployer's responsibility when constructing the delegation)
+      //   - scope narrowing against parent (enforced via parentScope)
+      //
+      // Derive parentScope from parentAuth; if not present, fail closed.
+      const parentScope = (parentAuth as any).scope;
+      if (!parentScope) {
+        throw new OxDeAIAuthorizationError(
+          "Parent authorization scope is required for delegation narrowing but was not provided. Execution blocked."
+        );
+      }
+
       const chainResult = verifyDelegationChain(delegation, parentAuth, {
         now,
         trustedKeySets: config.trustedKeySets,
-        requireSignatureVerification: config.requireDelegationSignatureVerification ?? false,
-        consumedDelegationIds: config.consumedDelegationIds,
+        requireSignatureVerification: true,
+        consumedDelegationIds: [...consumedDelegationIds],
+        parentScope,
       });
 
       if (!chainResult.ok) {
@@ -154,9 +183,43 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
         );
       }
 
+      // Require scope presence for narrowing; fail closed if absent.
+      if (!delegation.scope) {
+        violationMessages.push("delegation.scope is required for narrowing; execution blocked.");
+      }
+
       if (violationMessages.length > 0) {
         throw new OxDeAIDelegationError(violationMessages);
       }
+
+      // Enforce strict verification on the parent Authorization as well.
+      if (consumedAuthIds.has(parentAuth.auth_id)) {
+        throw new OxDeAIAuthorizationError(
+          "Authorization replay detected on parentAuth: auth_id already consumed. Execution blocked."
+        );
+      }
+
+      const parentAuthResult = strictVerifyAuthorization(parentAuth as AuthorizationV1, {
+        now,
+        mode: "strict",
+        trustedKeySets,
+        requireSignatureVerification: true,
+        expectedPolicyId: parentAuth.policy_id,
+        expectedAudience: parentAuth.audience,
+        expectedIssuer: parentAuth.issuer,
+        consumedAuthIds: [...consumedAuthIds],
+      });
+
+      if (parentAuthResult.status !== "ok") {
+        const reasons =
+          parentAuthResult.violations?.map((v) => v.code).join(", ") ||
+          parentAuthResult.status ||
+          "unknown reason";
+        throw new OxDeAIAuthorizationError(`Parent authorization verification failed: ${reasons}. Execution blocked.`);
+      }
+
+      consumedAuthIds.add(parentAuth.auth_id);
+      consumedDelegationIds.add(delegation.delegation_id);
 
       // parentAuth is AuthorizationV1; cast to Authorization for hook/audit
       // compatibility. Legacy fields will be absent — callers on the delegation
@@ -218,14 +281,31 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
 
     const { authorization, nextState } = evalResult;
 
-    // ── 6b. Verify the authorization artifact ──────────────────────────────
-    const now = intent.timestamp;
-    const authCheck = config.engine.verifyAuthorization(intent, authorization, nextState, now);
-    if (!authCheck.valid) {
-      throw new OxDeAIAuthorizationError(
-        `Authorization verification failed: ${authCheck.reason ?? "unknown reason"}. Execution blocked.`
-      );
+    // ── 6b. Verify the authorization artifact (strict verifier, fail-closed) ─
+    const now = Math.floor(Date.now() / 1000);
+    if (consumedAuthIds.has(authorization.auth_id)) {
+      throw new OxDeAIAuthorizationError("Authorization replay detected: auth_id already consumed. Execution blocked.");
     }
+
+    const authResult = strictVerifyAuthorization(authorization as AuthorizationV1, {
+      now,
+      mode: "strict",
+      trustedKeySets,
+      requireSignatureVerification: true,
+      expectedPolicyId: authorization.policy_id,
+      expectedAudience: authorization.audience,
+      expectedIssuer: authorization.issuer,
+      consumedAuthIds: [...consumedAuthIds],
+    });
+
+    if (authResult.status !== "ok") {
+      const reasons =
+        authResult.violations?.map((v) => v.code).join(", ") || authResult.status || "unknown reason";
+      throw new OxDeAIAuthorizationError(`Authorization verification failed: ${reasons}. Execution blocked.`);
+    }
+
+    // Mark auth_id as consumed to prevent replay before execution.
+    consumedAuthIds.add(authorization.auth_id);
 
     // ── 7. beforeExecute hook ──────────────────────────────────────────────
     if (config.beforeExecute) {

--- a/packages/guard/src/test/guard.boundary.test.ts
+++ b/packages/guard/src/test/guard.boundary.test.ts
@@ -1,0 +1,615 @@
+// SPDX-License-Identifier: Apache-2.0
+import test from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+
+import { OxDeAIGuard } from "../index.js";
+import type { ProposedAction } from "../types.js";
+import type { State, Intent, Authorization, AuthorizationV1, KeySet } from "@oxdeai/core";
+import {
+  PolicyEngine,
+  signAuthorizationEd25519,
+  verifyAuthorization as strictVerifyAuthorization,
+  createDelegation,
+} from "@oxdeai/core";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+
+const { privateKey, publicKey } = generateKeyPairSync("ed25519", {
+  privateKeyEncoding: { format: "pem", type: "pkcs8" },
+  publicKeyEncoding: { format: "spki", type: "pem" },
+});
+
+const TRUSTED_KEYSET: KeySet = {
+  issuer: "issuer-test",
+  version: "v1",
+  keys: [
+    {
+      kid: "k1",
+      alg: "Ed25519",
+      public_key: publicKey.export({ type: "spki", format: "pem" }).toString(),
+    },
+  ],
+};
+
+function makeState(policyVersion = "policy-test"): State {
+  return {
+    policy_version: policyVersion,
+    period_id: "p1",
+    kill_switch: { global: false, agents: {} },
+    allowlists: {},
+    budget: { budget_limit: { "agent-1": 1_000_000n }, spent_in_period: { "agent-1": 0n } },
+    max_amount_per_action: { "agent-1": 1_000_000n },
+    velocity: { config: { window_seconds: 3600, max_actions: 100 }, counters: {} },
+    replay: { window_seconds: 3600, max_nonces_per_agent: 256, nonces: {} },
+    concurrency: { max_concurrent: { "agent-1": 3 }, active: {}, active_auths: {} },
+    recursion: { max_depth: { "agent-1": 5 } },
+    tool_limits: { window_seconds: 3600, max_calls: { "agent-1": 100 }, calls: {} },
+  };
+}
+
+function makeAction(overrides: Partial<ProposedAction["context"]> = {}, extra?: Partial<ProposedAction>): ProposedAction {
+  return {
+    name: "pay",
+    args: { amount: 1 },
+    estimatedCost: 0,
+    ...extra,
+    context: {
+      agent_id: "agent-1",
+      target: "vendor",
+      ...overrides,
+    },
+  } satisfies ProposedAction;
+}
+
+function makeEngine(policyVersion = "policy-test") {
+  return new PolicyEngine({
+    policy_version: policyVersion,
+    engine_secret: "a".repeat(32),
+    authorization_ttl_seconds: 60,
+    authorization_signing_alg: "Ed25519",
+    authorization_signing_kid: "k1",
+    authorization_issuer: TRUSTED_KEYSET.issuer,
+    authorization_audience: "aud-test",
+    authorization_private_key_pem: privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+
+test("expired authorization is denied (execute not called)", async () => {
+  const engine = makeEngine();
+  const state = makeState();
+  let storedState = state;
+  const guard = OxDeAIGuard({
+    engine,
+    getState: async () => storedState,
+    setState: async (s) => {
+      storedState = s;
+    },
+    trustedKeySets: [TRUSTED_KEYSET],
+  });
+
+  const pastTs = 1;
+  const action = makeAction({ timestampSeconds: pastTs } as any, { timestampSeconds: pastTs });
+
+  let executed = false;
+  await assert.rejects(
+    guard(action, async () => {
+      executed = true;
+    }),
+    /AUTH_EXPIRED|Authorization verification failed/i
+  );
+  assert.equal(executed, false);
+});
+
+test("audience tampering is denied by strict verifier", async () => {
+  const engine = makeEngine();
+  const state = makeState();
+  let storedState = state;
+
+  const originalEval = engine.evaluatePure.bind(engine);
+  engine.evaluatePure = ((intent: Intent, st: State) => {
+    const out = originalEval(intent, st);
+    if (out.decision === "ALLOW") {
+      const tampered: Authorization = { ...out.authorization, audience: "attacker" };
+      return { ...out, authorization: tampered };
+    }
+    return out;
+  }) as any;
+
+  const guard = OxDeAIGuard({
+    engine,
+    getState: async () => storedState,
+    setState: async (s) => {
+      storedState = s;
+    },
+    trustedKeySets: [TRUSTED_KEYSET],
+  });
+
+  const action = makeAction();
+  let executed = false;
+  await assert.rejects(
+    guard(action, async () => {
+      executed = true;
+    }),
+    /AUTH_AUDIENCE_MISMATCH|Authorization verification failed/i
+  );
+  assert.equal(executed, false);
+});
+
+test("auth_id replay is denied on second use", async () => {
+  const issued_at = Math.floor(Date.now() / 1000);
+  const auth: AuthorizationV1 = signAuthorizationEd25519(
+    {
+      auth_id: "auth-replay-test",
+      issuer: TRUSTED_KEYSET.issuer,
+      audience: "aud-test",
+      intent_hash: "i".repeat(64),
+      state_hash: "s".repeat(64),
+      policy_id: "p".repeat(64),
+      decision: "ALLOW",
+      issued_at,
+      expiry: issued_at + 300,
+      kid: "k1",
+      nonce: "1",
+      capability: "exec",
+    },
+    privateKey.export({ type: "pkcs8", format: "pem" }).toString()
+  );
+
+  class FakeEngine {
+    evaluatePure(_intent: Intent, state: State) {
+      return { decision: "ALLOW" as const, reasons: [], authorization: auth as Authorization, nextState: state };
+    }
+    verifyAuthorization() {
+      return { valid: true };
+    }
+  }
+
+  const state = makeState();
+  let storedState = state;
+  const guard = OxDeAIGuard({
+    engine: new FakeEngine() as any,
+    getState: async () => storedState,
+    setState: async (s) => {
+      storedState = s;
+    },
+    trustedKeySets: [TRUSTED_KEYSET],
+  });
+
+  const action = makeAction();
+  let executions = 0;
+  await guard(action, async () => {
+    executions += 1;
+  });
+  await assert.rejects(
+    guard(action, async () => {
+      executions += 1;
+    }),
+    /Authorization replay detected|AUTH_REPLAY/i
+  );
+  assert.equal(executions, 1);
+});
+
+test("delegation tool widening is denied", async () => {
+  const parentAuth = signAuthorizationEd25519(
+    {
+      auth_id: "auth-parent-tool",
+      issuer: TRUSTED_KEYSET.issuer,
+      audience: "child",
+      intent_hash: "i".repeat(64),
+      state_hash: "s".repeat(64),
+      policy_id: "p".repeat(64),
+      decision: "ALLOW",
+      issued_at: Math.floor(Date.now() / 1000),
+      expiry: Math.floor(Date.now() / 1000) + 300,
+      kid: "k1",
+      capability: "exec",
+      nonce: "1",
+    },
+    privateKey.export({ type: "pkcs8", format: "pem" }).toString()
+  ) as Authorization;
+  (parentAuth as any).scope = { tools: ["read"], max_amount: 100n };
+
+  const delegation = createDelegation(
+    parentAuth as AuthorizationV1,
+    {
+      delegatee: "child",
+      scope: { tools: ["read", "write"], max_amount: 100n },
+      expiry: parentAuth.expiry,
+      kid: "k1",
+      audience: "child",
+      issuer: TRUSTED_KEYSET.issuer,
+    },
+    privateKey.export({ type: "pkcs8", format: "pem" }).toString()
+  );
+
+  const state = makeState();
+  let storedState = state;
+  const guard = OxDeAIGuard({
+    engine: makeEngine(),
+    getState: async () => storedState,
+    setState: async (s) => {
+      storedState = s;
+    },
+    trustedKeySets: [TRUSTED_KEYSET],
+  });
+
+  const action = makeAction();
+  let executed = false;
+  await assert.rejects(
+    guard(action, async () => {
+      executed = true;
+    }, { delegation: { delegation, parentAuth: parentAuth as AuthorizationV1 } }),
+    /DELEGATION_SCOPE_VIOLATION|execution blocked/i
+  );
+  assert.equal(executed, false);
+});
+
+test("delegation amount widening is denied", async () => {
+  const parentAuth = signAuthorizationEd25519(
+    {
+      auth_id: "auth-parent-amount",
+      issuer: TRUSTED_KEYSET.issuer,
+      audience: "child",
+      intent_hash: "i".repeat(64),
+      state_hash: "s".repeat(64),
+      policy_id: "p".repeat(64),
+      decision: "ALLOW",
+      issued_at: Math.floor(Date.now() / 1000),
+      expiry: Math.floor(Date.now() / 1000) + 300,
+      kid: "k1",
+      capability: "exec",
+      nonce: "2",
+    },
+    privateKey.export({ type: "pkcs8", format: "pem" }).toString()
+  ) as Authorization;
+  (parentAuth as any).scope = { tools: ["read"], max_amount: 100n };
+
+  const delegation = createDelegation(
+    parentAuth as AuthorizationV1,
+    {
+      delegatee: "child",
+      scope: { tools: ["read"], max_amount: 1000n },
+      expiry: parentAuth.expiry,
+      kid: "k1",
+      audience: "child",
+      issuer: TRUSTED_KEYSET.issuer,
+    },
+    privateKey.export({ type: "pkcs8", format: "pem" }).toString()
+  );
+
+  const state = makeState();
+  let storedState = state;
+  const guard = OxDeAIGuard({
+    engine: makeEngine(),
+    getState: async () => storedState,
+    setState: async (s) => {
+      storedState = s;
+    },
+    trustedKeySets: [TRUSTED_KEYSET],
+  });
+
+  const action = makeAction();
+  let executed = false;
+  await assert.rejects(
+    guard(action, async () => {
+      executed = true;
+    }, { delegation: { delegation, parentAuth: parentAuth as AuthorizationV1 } }),
+    /DELEGATION_SCOPE_VIOLATION|execution blocked/i
+  );
+  assert.equal(executed, false);
+});
+
+test("delegation narrowing is allowed", async () => {
+  const parentAuth = signAuthorizationEd25519(
+    {
+      auth_id: "auth-parent-narrow",
+      issuer: TRUSTED_KEYSET.issuer,
+      audience: "child",
+      intent_hash: "i".repeat(64),
+      state_hash: "s".repeat(64),
+      policy_id: "p".repeat(64),
+      decision: "ALLOW",
+      issued_at: Math.floor(Date.now() / 1000),
+      expiry: Math.floor(Date.now() / 1000) + 300,
+      kid: "k1",
+      capability: "exec",
+      nonce: "3",
+    },
+    privateKey.export({ type: "pkcs8", format: "pem" }).toString()
+  ) as Authorization;
+  (parentAuth as any).scope = { tools: ["read", "write"], max_amount: 1000n };
+
+  const delegation = createDelegation(
+    parentAuth as AuthorizationV1,
+    {
+      delegatee: "child",
+      scope: { tools: ["read"], max_amount: 100n },
+      expiry: parentAuth.expiry,
+      kid: "k1",
+      audience: "child",
+      issuer: TRUSTED_KEYSET.issuer,
+    },
+    privateKey.export({ type: "pkcs8", format: "pem" }).toString()
+  );
+
+  const state = makeState();
+  let storedState = state;
+  const guard = OxDeAIGuard({
+    engine: makeEngine(),
+    getState: async () => storedState,
+    setState: async (s) => {
+      storedState = s;
+    },
+    trustedKeySets: [TRUSTED_KEYSET],
+  });
+
+  const action = makeAction();
+  let executed = false;
+  await guard(action, async () => {
+    executed = true;
+  }, { delegation: { delegation, parentAuth: parentAuth as AuthorizationV1 } });
+
+  assert.equal(executed, true);
+});
+
+test("delegation replay is denied", async () => {
+  const issued_at = Math.floor(Date.now() / 1000);
+  const parentAuth = signAuthorizationEd25519(
+    {
+      auth_id: "auth-parent-replay",
+      issuer: TRUSTED_KEYSET.issuer,
+      audience: "child",
+      intent_hash: "i".repeat(64),
+      state_hash: "s".repeat(64),
+      policy_id: "p".repeat(64),
+      decision: "ALLOW",
+      issued_at,
+      expiry: issued_at + 300,
+      kid: "k1",
+      capability: "exec",
+      nonce: "4",
+    },
+    privateKey.export({ type: "pkcs8", format: "pem" }).toString()
+  ) as Authorization;
+  (parentAuth as any).scope = { tools: ["read"], max_amount: 100n };
+
+  const delegation = createDelegation(
+    parentAuth as AuthorizationV1,
+    {
+      delegatee: "child",
+      scope: { tools: ["read"], max_amount: 100n },
+      expiry: parentAuth.expiry,
+      kid: "k1",
+      audience: "child",
+      issuer: TRUSTED_KEYSET.issuer,
+    },
+    privateKey.export({ type: "pkcs8", format: "pem" }).toString()
+  );
+
+  const state = makeState();
+  let storedState = state;
+  const guard = OxDeAIGuard({
+    engine: makeEngine(),
+    getState: async () => storedState,
+    setState: async (s) => {
+      storedState = s;
+    },
+    trustedKeySets: [TRUSTED_KEYSET],
+  });
+
+  const action = makeAction();
+  let executions = 0;
+
+  await guard(action, async () => {
+    executions += 1;
+  }, { delegation: { delegation, parentAuth: parentAuth as AuthorizationV1 } });
+
+  await assert.rejects(
+    guard(action, async () => {
+      executions += 1;
+    }, { delegation: { delegation, parentAuth: parentAuth as AuthorizationV1 } }),
+    /Delegation replay detected|DELEGATION_REPLAY/i
+  );
+
+  assert.equal(executions, 1);
+});
+
+test("unsigned delegation is denied", async () => {
+  const issued_at = Math.floor(Date.now() / 1000);
+  const parentAuth = signAuthorizationEd25519(
+    {
+      auth_id: "auth-parent-unsigned",
+      issuer: TRUSTED_KEYSET.issuer,
+      audience: "child",
+      intent_hash: "i".repeat(64),
+      state_hash: "s".repeat(64),
+      policy_id: "p".repeat(64),
+      decision: "ALLOW",
+      issued_at,
+      expiry: issued_at + 300,
+      kid: "k1",
+      capability: "exec",
+      nonce: "5",
+    },
+    privateKey.export({ type: "pkcs8", format: "pem" }).toString()
+  ) as Authorization;
+  (parentAuth as any).scope = { tools: ["read"], max_amount: 100n };
+
+  const unsignedDelegation = createDelegation(
+    parentAuth as AuthorizationV1,
+    {
+      delegatee: "child",
+      scope: { tools: ["read"], max_amount: 100n },
+      expiry: parentAuth.expiry,
+      kid: "k1",
+      audience: "child",
+      issuer: TRUSTED_KEYSET.issuer,
+    },
+    privateKey.export({ type: "pkcs8", format: "pem" }).toString()
+  );
+  (unsignedDelegation as any).signature = "";
+
+  const state = makeState();
+  let storedState = state;
+  const guard = OxDeAIGuard({
+    engine: makeEngine(),
+    getState: async () => storedState,
+    setState: async (s) => {
+      storedState = s;
+    },
+    trustedKeySets: [TRUSTED_KEYSET],
+  });
+
+  const action = makeAction();
+  await assert.rejects(
+    guard(action, async () => {
+      /* no-op */
+    }, { delegation: { delegation: unsignedDelegation, parentAuth: parentAuth as AuthorizationV1 } }),
+    /DELEGATION_SIGNATURE_INVALID|signature verification failed|execution blocked/i
+  );
+});
+
+test("tampered delegation signature is denied", async () => {
+  const issued_at = Math.floor(Date.now() / 1000);
+  const parentAuth = signAuthorizationEd25519(
+    {
+      auth_id: "auth-parent-tamper",
+      issuer: TRUSTED_KEYSET.issuer,
+      audience: "child",
+      intent_hash: "i".repeat(64),
+      state_hash: "s".repeat(64),
+      policy_id: "p".repeat(64),
+      decision: "ALLOW",
+      issued_at,
+      expiry: issued_at + 300,
+      kid: "k1",
+      capability: "exec",
+      nonce: "6",
+    },
+    privateKey.export({ type: "pkcs8", format: "pem" }).toString()
+  ) as Authorization;
+  (parentAuth as any).scope = { tools: ["read"], max_amount: 100n };
+
+  const delegation = createDelegation(
+    parentAuth as AuthorizationV1,
+    {
+      delegatee: "child",
+      scope: { tools: ["read"], max_amount: 100n },
+      expiry: parentAuth.expiry,
+      kid: "k1",
+      audience: "child",
+      issuer: TRUSTED_KEYSET.issuer,
+    },
+    privateKey.export({ type: "pkcs8", format: "pem" }).toString()
+  );
+  (delegation as any).signature = "invalid-signature";
+
+  const state = makeState();
+  let storedState = state;
+  const guard = OxDeAIGuard({
+    engine: makeEngine(),
+    getState: async () => storedState,
+    setState: async (s) => {
+      storedState = s;
+    },
+    trustedKeySets: [TRUSTED_KEYSET],
+  });
+
+  const action = makeAction();
+  await assert.rejects(
+    guard(action, async () => {
+      /* no-op */
+    }, { delegation: { delegation, parentAuth: parentAuth as AuthorizationV1 } }),
+    /DELEGATION_SIGNATURE_INVALID|signature verification failed|execution blocked/i
+  );
+});
+
+test("verifier failure (throws) blocks execution", async () => {
+  // Create an evil keyset that throws when accessed to simulate verifier throw.
+  const evilKeyset = new Proxy(
+    {
+      issuer: "issuer-evil",
+      version: "v1",
+      keys: [],
+    },
+    {
+      get() {
+        throw new Error("boom");
+      },
+    }
+  ) as unknown as KeySet;
+
+  const engine = makeEngine();
+  const state = makeState();
+  let storedState = state;
+  const guard = OxDeAIGuard({
+    engine,
+    getState: async () => storedState,
+    setState: async (s) => {
+      storedState = s;
+    },
+    trustedKeySets: [evilKeyset],
+  });
+
+  const action = makeAction();
+  let executed = false;
+  await assert.rejects(
+    guard(action, async () => {
+      executed = true;
+    }),
+    /boom|Authorization verification failed/i
+  );
+  assert.equal(executed, false);
+});
+
+test("missing required auth fields is denied before execution", async () => {
+  const badAuth: AuthorizationV1 = {
+    auth_id: "",
+    issuer: "",
+    audience: "",
+    intent_hash: "",
+    state_hash: "",
+    policy_id: "",
+    decision: "ALLOW",
+    issued_at: 0,
+    expiry: 0,
+    alg: "Ed25519",
+    kid: "k1",
+    signature: "",
+  };
+
+  class FakeEngineBadAuth {
+    evaluatePure(_intent: Intent, state: State) {
+      return { decision: "ALLOW" as const, reasons: [], authorization: badAuth as Authorization, nextState: state };
+    }
+    verifyAuthorization() {
+      return { valid: true };
+    }
+  }
+
+  const state = makeState();
+  let storedState = state;
+  const guard = OxDeAIGuard({
+    engine: new FakeEngineBadAuth() as any,
+    getState: async () => storedState,
+    setState: async (s) => {
+      storedState = s;
+    },
+    trustedKeySets: [TRUSTED_KEYSET],
+  });
+
+  const action = makeAction();
+  let executed = false;
+  await assert.rejects(
+    guard(action, async () => {
+      executed = true;
+    }),
+    /AUTH_MISSING_FIELD|Authorization verification failed/i
+  );
+  assert.equal(executed, false);
+});

--- a/packages/guard/src/test/guard.delegation.matrix.test.ts
+++ b/packages/guard/src/test/guard.delegation.matrix.test.ts
@@ -37,22 +37,21 @@ const KEYS = generateKeyPairSync("ed25519", {
 });
 
 const KEYSET: KeySet = {
-  issuer: "agent-A",
+  issuer: "pdp-issuer",
   version: "1",
-  keys: [{ kid: "k1", alg: "Ed25519", public_key: KEYS.publicKey }],
+  keys: [{ kid: "k1", alg: "Ed25519", public_key: KEYS.publicKey.toString() }],
 };
 
-// ── Fixed timestamps ──────────────────────────────────────────────────────────
-
-const T_ISSUED  = 1_000_000;
-const T_NOW     = 1_001_000; // action.timestampSeconds — used as `now` by guard
-const T_DEL_EXP = 1_002_000;
-const T_PAR_EXP = 1_003_000;
+// ── Trusted timestamps (relative to wall clock) ──────────────────────────────
+const T_NOW     = Math.floor(Date.now() / 1000);
+const T_ISSUED  = T_NOW - 60;
+const T_DEL_EXP = T_NOW + 600;
+const T_PAR_EXP = T_NOW + 900;
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
 function makeParent(overrides?: { expiry?: number; audience?: string }): AuthorizationV1 {
-  return signAuthorizationEd25519(
+  const auth = signAuthorizationEd25519(
     {
       auth_id:     "f".repeat(64),
       issuer:      "pdp-issuer",
@@ -67,6 +66,8 @@ function makeParent(overrides?: { expiry?: number; audience?: string }): Authori
     },
     KEYS.privateKey
   );
+  (auth as any).scope = { tools: ["provision_gpu"], max_amount: 1_000_000n };
+  return auth;
 }
 
 function makeGuard(overrides?: Partial<OxDeAIGuardConfig>) {
@@ -82,6 +83,8 @@ function makeGuard(overrides?: Partial<OxDeAIGuardConfig>) {
     engine: new PolicyEngine({ policy_version: "v1", engine_secret: "test-secret-must-be-at-least-32-chars!!" }),
     getState: () => state,
     setState: () => {},
+    trustedKeySets: [KEYSET],
+    requireDelegationSignatureVerification: true,
     ...overrides,
   });
 }
@@ -102,11 +105,11 @@ test("CASE-7a: valid chain with signature verification → execute runs", async 
   const parent = makeParent();
   const delegation = createDelegation(
     parent,
-    { delegatee: "agent-B", scope: { tools: ["provision_gpu"] }, expiry: T_DEL_EXP, kid: "k1" },
+    { delegatee: "agent-B", issuer: KEYSET.issuer, scope: { tools: ["provision_gpu"] }, expiry: T_DEL_EXP, kid: "k1" },
     KEYS.privateKey
   );
 
-  const guard = makeGuard({ trustedKeySets: KEYSET, requireDelegationSignatureVerification: true });
+  const guard = makeGuard();
   let executed = false;
 
   const result = await guard(
@@ -119,32 +122,27 @@ test("CASE-7a: valid chain with signature verification → execute runs", async 
   assert.equal(result, "executed");
 });
 
-test("CASE-7b: valid chain without signature verification → execute runs", async () => {
+test("CASE-7b: unsigned delegation is rejected (fail-closed)", async () => {
   const parent = makeParent();
   const delegation = createDelegation(
     parent,
-    { delegatee: "agent-B", scope: {}, expiry: T_DEL_EXP, kid: "k1" },
+    { delegatee: "agent-B", issuer: KEYSET.issuer, scope: { tools: ["provision_gpu"] }, expiry: T_DEL_EXP, kid: "k1" },
     KEYS.privateKey
   );
+  (delegation as any).signature = "";
 
-  // No trustedKeySets — signature not verified; chain integrity still checked
   const guard = makeGuard();
-  let executed = false;
-
-  await guard(
-    action,
-    async () => { executed = true; },
-    { delegation: { delegation, parentAuth: parent } }
+  await assert.rejects(
+    () => guard(action, async () => {}, { delegation: { delegation, parentAuth: parent } }),
+    /signature is required|DELEGATION_SIGNATURE_INVALID|Authorization verification failed/i
   );
-
-  assert.ok(executed);
 });
 
 test("CASE-7c: delegation path does not call setState", async () => {
   const parent = makeParent();
   const delegation = createDelegation(
     parent,
-    { delegatee: "agent-B", scope: {}, expiry: T_DEL_EXP, kid: "k1" },
+    { delegatee: "agent-B", issuer: KEYSET.issuer, scope: { tools: ["provision_gpu"] }, expiry: T_DEL_EXP, kid: "k1" },
     KEYS.privateKey
   );
 
@@ -160,7 +158,7 @@ test("CASE-7d: onDecision fires ALLOW with delegation artifact present", async (
   const parent = makeParent();
   const delegation = createDelegation(
     parent,
-    { delegatee: "agent-B", scope: {}, expiry: T_DEL_EXP, kid: "k1", delegationId: "d-audit-test" },
+    { delegatee: "agent-B", issuer: KEYSET.issuer, scope: { tools: ["provision_gpu"] }, expiry: T_DEL_EXP, kid: "k1", delegationId: "d-audit-test" },
     KEYS.privateKey
   );
 
@@ -184,7 +182,7 @@ test("CASE-7e: beforeExecute is called before execute on delegation path", async
   const parent = makeParent();
   const delegation = createDelegation(
     parent,
-    { delegatee: "agent-B", scope: {}, expiry: T_DEL_EXP, kid: "k1" },
+    { delegatee: "agent-B", issuer: KEYSET.issuer, scope: { tools: ["provision_gpu"] }, expiry: T_DEL_EXP, kid: "k1" },
     KEYS.privateKey
   );
 
@@ -204,7 +202,7 @@ test("CASE-8a: expired delegation → OxDeAIDelegationError, execute blocked", a
   const parent = makeParent();
   const delegation = createDelegation(
     parent,
-    { delegatee: "agent-B", scope: {}, expiry: T_NOW - 1, kid: "k1" }, // expired
+    { delegatee: "agent-B", issuer: KEYSET.issuer, scope: { tools: ["provision_gpu"] }, expiry: T_NOW - 1, kid: "k1" }, // expired
     KEYS.privateKey
   );
 
@@ -226,15 +224,12 @@ test("CASE-8b: tampered delegation signature → OxDeAIDelegationError, execute 
   const parent = makeParent();
   const delegation = createDelegation(
     parent,
-    { delegatee: "agent-B", scope: { tools: ["provision_gpu"] }, expiry: T_DEL_EXP, kid: "k1" },
+    { delegatee: "agent-B", issuer: KEYSET.issuer, scope: { tools: ["provision_gpu"] }, expiry: T_DEL_EXP, kid: "k1" },
     KEYS.privateKey
   );
   const tampered: DelegationV1 = { ...delegation, delegatee: "agent-EVIL" };
 
-  const guard = makeGuard({
-    trustedKeySets: KEYSET,
-    requireDelegationSignatureVerification: true,
-  });
+  const guard = makeGuard();
   let executed = false;
 
   await assert.rejects(
@@ -251,7 +246,7 @@ test("CASE-8c: action not in scope.tools → OxDeAIDelegationError, execute bloc
   const parent = makeParent();
   const delegation = createDelegation(
     parent,
-    { delegatee: "agent-B", scope: { tools: ["query_db"] }, expiry: T_DEL_EXP, kid: "k1" },
+    { delegatee: "agent-B", issuer: KEYSET.issuer, scope: { tools: ["query_db"] }, expiry: T_DEL_EXP, kid: "k1" },
     KEYS.privateKey
   );
 
@@ -274,7 +269,7 @@ test("CASE-8d: parent hash mismatch → OxDeAIDelegationError, execute blocked",
   const otherParent = makeParent({ audience: "agent-OTHER" });
   const delegation = createDelegation(
     parent,
-    { delegatee: "agent-B", scope: {}, expiry: T_DEL_EXP, kid: "k1" },
+    { delegatee: "agent-B", issuer: KEYSET.issuer, scope: { tools: ["provision_gpu"] }, expiry: T_DEL_EXP, kid: "k1" },
     KEYS.privateKey
   );
 
@@ -296,7 +291,7 @@ test("CASE-8e: OxDeAIDelegationError is catchable as OxDeAIAuthorizationError", 
   const parent = makeParent();
   const delegation = createDelegation(
     parent,
-    { delegatee: "agent-B", scope: {}, expiry: T_NOW - 1, kid: "k1" },
+    { delegatee: "agent-B", issuer: KEYSET.issuer, scope: { tools: ["provision_gpu"] }, expiry: T_NOW - 1, kid: "k1" },
     KEYS.privateKey
   );
 
@@ -317,7 +312,7 @@ test("CASE-8f: setState is NOT called when delegation verification fails", async
   const parent = makeParent();
   const delegation = createDelegation(
     parent,
-    { delegatee: "agent-B", scope: {}, expiry: T_NOW - 1, kid: "k1" },
+    { delegatee: "agent-B", issuer: KEYSET.issuer, scope: { tools: ["provision_gpu"] }, expiry: T_NOW - 1, kid: "k1" },
     KEYS.privateKey
   );
 

--- a/packages/guard/src/test/guard.delegation.property.test.ts
+++ b/packages/guard/src/test/guard.delegation.property.test.ts
@@ -65,10 +65,10 @@ function seeds(): number[] {
 
 // ── Fixed timestamps ───────────────────────────────────────────────────────────
 
-const T_ISSUED  = 1_000_000;  // parent issued_at
-const T_NOW     = 1_001_000;  // action.timestampSeconds (= now used by guard)
-const T_DEL_EXP = 1_002_000;  // valid delegation expiry
-const T_PAR_EXP = 1_003_000;  // parent expiry
+const T_NOW     = Math.floor(Date.now() / 1000);
+const T_ISSUED  = T_NOW - 60;    // parent issued_at
+const T_DEL_EXP = T_NOW + 600;   // valid delegation expiry
+const T_PAR_EXP = T_NOW + 900;   // parent expiry
 
 // ── Fixed key material ────────────────────────────────────────────────────────
 
@@ -80,7 +80,7 @@ const KEYS = generateKeyPairSync("ed25519", {
 const KEYSET: KeySet = {
   issuer: "parent-agent",
   version: "1",
-  keys: [{ kid: "k1", alg: "Ed25519", public_key: KEYS.publicKey }],
+  keys: [{ kid: "k1", alg: "Ed25519", public_key: KEYS.publicKey.toString() }],
 };
 
 const TOOL_POOL = [
@@ -96,10 +96,10 @@ const TOOL_POOL = [
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function makeParentAuth(expiry = T_PAR_EXP): AuthorizationV1 {
-  return signAuthorizationEd25519(
+  const auth = signAuthorizationEd25519(
     {
       auth_id: "f".repeat(64),
-      issuer: "pdp-issuer",
+      issuer: KEYSET.issuer,
       audience: "parent-agent",
       intent_hash: "a".repeat(64),
       state_hash: "b".repeat(64),
@@ -111,6 +111,8 @@ function makeParentAuth(expiry = T_PAR_EXP): AuthorizationV1 {
     },
     KEYS.privateKey
   );
+  (auth as any).scope = { tools: [...TOOL_POOL], max_amount: 1_000_000n };
+  return auth;
 }
 
 function makeDelegation(
@@ -126,6 +128,8 @@ function makeDelegation(
       expiry,
       kid: "k1",
       issuedAt: T_ISSUED,
+      audience: "child-agent",
+      issuer: KEYSET.issuer,
     },
     KEYS.privateKey
   );
@@ -326,10 +330,11 @@ test("G-D3: delegation presented with wrong parent authorization is rejected (DE
     // Parent B: structurally valid, non-expired, same audience/policy_id/expiry
     // as A — only auth_id differs. This isolates the parent_auth_hash check and
     // prevents other chain violations (delegator, policy, expiry) from firing first.
-    const parentB = signAuthorizationEd25519(
+    // Must carry .scope so the guard does not short-circuit before verifyDelegationChain.
+    const parentBAuth = signAuthorizationEd25519(
       {
         auth_id: wrongChar.repeat(64),
-        issuer: "pdp-issuer",
+        issuer: KEYSET.issuer,
         audience: "parent-agent",
         intent_hash: "a".repeat(64),
         state_hash: "b".repeat(64),
@@ -341,6 +346,8 @@ test("G-D3: delegation presented with wrong parent authorization is rejected (DE
       },
       KEYS.privateKey
     );
+    const parentB = parentBAuth;
+    (parentB as any).scope = { tools: [scopeTool], max_amount: 1_000_000n };
 
     // Delegation is cryptographically bound to parentA via parent_auth_hash.
     const delegation = makeDelegation(parentA, [scopeTool], T_DEL_EXP);

--- a/packages/guard/src/test/guard.delegation.test.ts
+++ b/packages/guard/src/test/guard.delegation.test.ts
@@ -8,13 +8,12 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { generateKeyPairSync } from "node:crypto";
 import {
   PolicyEngine,
   signAuthorizationEd25519,
   createDelegation,
 } from "@oxdeai/core";
-import type { AuthorizationV1, DelegationV1, KeySet } from "@oxdeai/core";
+import type { AuthorizationV1, DelegationV1 } from "@oxdeai/core";
 import { buildState } from "@oxdeai/sdk";
 
 import { OxDeAIGuard } from "../guard.js";
@@ -22,42 +21,31 @@ import {
   OxDeAIAuthorizationError,
   OxDeAIDelegationError,
 } from "../errors.js";
-import type { ProposedAction, OxDeAIGuardConfig, GuardDelegationInput } from "../types.js";
-
-// ── Test key material ─────────────────────────────────────────────────────────
-
-const KEYS = generateKeyPairSync("ed25519", {
-  privateKeyEncoding: { format: "pem", type: "pkcs8" },
-  publicKeyEncoding: { format: "pem", type: "spki" },
-});
-
-// Delegation is signed by the delegating principal (parentAuth.audience = "agent-A")
-const KEYSET: KeySet = {
-  issuer: "agent-A",
-  version: "1",
-  keys: [{ kid: "k1", alg: "Ed25519", public_key: KEYS.publicKey }],
-};
+import type { ProposedAction, OxDeAIGuardConfig } from "../types.js";
+import { TEST_KEYSET, TEST_KEYPAIR } from "./helpers/fixtures.js";
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
-const NOW_S = 1_700_000_000;
+const T_NOW = Math.floor(Date.now() / 1000);
 
 function makeParentAuth(overrides?: { expiry?: number; audience?: string }): AuthorizationV1 {
-  return signAuthorizationEd25519(
+  const auth = signAuthorizationEd25519(
     {
       auth_id: "f".repeat(64),
-      issuer: "pdp-A",
+      issuer: TEST_KEYSET.issuer,
       audience: overrides?.audience ?? "agent-A",
       intent_hash: "a".repeat(64),
       state_hash: "b".repeat(64),
       policy_id: "policy-1",
       decision: "ALLOW",
-      issued_at: NOW_S - 60,
-      expiry: overrides?.expiry ?? NOW_S + 3600,
+      issued_at: T_NOW - 60,
+      expiry: overrides?.expiry ?? T_NOW + 900,
       kid: "k1",
     },
-    KEYS.privateKey
+    TEST_KEYPAIR.privateKey.toString()
   );
+  (auth as any).scope = { tools: ["provision_gpu"], max_amount: 1_000_000n };
+  return auth;
 }
 
 function makeDelegation(
@@ -68,14 +56,15 @@ function makeDelegation(
     parentAuth,
     {
       delegatee: overrides?.delegatee ?? "agent-B",
+      issuer: TEST_KEYSET.issuer,
       scope: {
         tools: overrides?.tools,
         max_amount: overrides?.max_amount,
       },
-      expiry: overrides?.expiry ?? NOW_S + 1800,
+      expiry: overrides?.expiry ?? T_NOW + 300,
       kid: "k1",
     },
-    KEYS.privateKey
+    TEST_KEYPAIR.privateKey.toString()
   );
 }
 
@@ -89,9 +78,19 @@ function makeGuardConfig(overrides?: Partial<OxDeAIGuardConfig>): OxDeAIGuardCon
     max_concurrent: 16,
   });
   return {
-    engine: new PolicyEngine({ policy_version: "v1", engine_secret: "test-secret-must-be-at-least-32-chars!!" }),
+    engine: new PolicyEngine({
+      policy_version: "v1",
+      engine_secret: "test-secret-must-be-at-least-32-chars!!",
+      authorization_signing_alg: "Ed25519",
+      authorization_signing_kid: "k1",
+      authorization_issuer: TEST_KEYSET.issuer,
+      authorization_audience: "aud-test",
+      authorization_ttl_seconds: 600,
+      authorization_private_key_pem: TEST_KEYPAIR.privateKey.toString(),
+    }),
     getState: () => state,
     setState: () => {},
+    trustedKeySets: [TEST_KEYSET],
     ...overrides,
   };
 }
@@ -104,7 +103,7 @@ const baseAction: ProposedAction = {
     agent_id: "agent-B",
     target: "gpu-pool",
   },
-  timestampSeconds: NOW_S,
+  timestampSeconds: T_NOW,
 };
 
 // ── Happy path ────────────────────────────────────────────────────────────────
@@ -112,7 +111,7 @@ const baseAction: ProposedAction = {
 test("delegation: valid delegation allows execution", async () => {
   const parentAuth = makeParentAuth();
   const delegation = makeDelegation(parentAuth);
-  const config = makeGuardConfig({ trustedKeySets: KEYSET, requireDelegationSignatureVerification: true });
+  const config = makeGuardConfig({ trustedKeySets: TEST_KEYSET, requireDelegationSignatureVerification: true });
   const guard = OxDeAIGuard(config);
 
   let executed = false;
@@ -203,7 +202,7 @@ test("delegation: blocks action not in scope.tools", async () => {
 
 test("delegation: allows action in scope.tools", async () => {
   const parentAuth = makeParentAuth();
-  const delegation = makeDelegation(parentAuth, { tools: ["provision_gpu", "query_db"] });
+  const delegation = makeDelegation(parentAuth, { tools: ["provision_gpu"] });
 
   const config = makeGuardConfig();
   const guard = OxDeAIGuard(config);
@@ -239,7 +238,7 @@ test("delegation: blocks intent amount exceeding scope.max_amount", async () => 
 
 test("delegation: blocks expired delegation", async () => {
   const parentAuth = makeParentAuth();
-  const delegation = makeDelegation(parentAuth, { expiry: NOW_S - 1 }); // already expired
+  const delegation = makeDelegation(parentAuth, { expiry: T_NOW - 1 }); // already expired
 
   const config = makeGuardConfig();
   const guard = OxDeAIGuard(config);
@@ -282,7 +281,7 @@ test("delegation: blocks invalid signature when requireDelegationSignatureVerifi
   const tampered = { ...delegation, delegatee: "agent-EVIL" }; // breaks signature
 
   const config = makeGuardConfig({
-    trustedKeySets: KEYSET,
+    trustedKeySets: TEST_KEYSET,
     requireDelegationSignatureVerification: true,
   });
   const guard = OxDeAIGuard(config);
@@ -317,7 +316,7 @@ test("delegation: blocks when delegation and parentAuth are missing from input",
 
 test("OxDeAIDelegationError is instanceof OxDeAIAuthorizationError", async () => {
   const parentAuth = makeParentAuth();
-  const delegation = makeDelegation(parentAuth, { expiry: NOW_S - 1 });
+  const delegation = makeDelegation(parentAuth, { expiry: T_NOW - 1 });
 
   const config = makeGuardConfig();
   const guard = OxDeAIGuard(config);

--- a/packages/guard/src/test/guard.property.test.ts
+++ b/packages/guard/src/test/guard.property.test.ts
@@ -17,6 +17,8 @@ import assert from "node:assert/strict";
 import type { Authorization, PolicyEngine, State } from "@oxdeai/core";
 import { buildState } from "@oxdeai/sdk";
 
+import { TEST_KEYSET, signAuth } from "./helpers/fixtures.js";
+
 import { defaultNormalizeAction } from "../normalizeAction.js";
 import { OxDeAIGuard } from "../guard.js";
 import {
@@ -75,6 +77,8 @@ const ACTION_KEYWORDS = [
   "blockchain", "subscribe", "order",
 ];
 const VALID_ACTION_TYPES = ["PAYMENT", "PURCHASE", "PROVISION", "ONCHAIN_TX"] as const;
+
+const BASE_TRUST = { trustedKeySets: [TEST_KEYSET] };
 
 function genAlphaStr(rng: () => number, minLen: number, maxLen: number): string {
   const len = randInt(rng, minLen, maxLen);
@@ -164,25 +168,10 @@ function genInvalidCost(rng: () => number): number {
 
 // ── mock engine factories ─────────────────────────────────────────────────────
 
-const STUB_AUTH: Authorization = {
-  authorization_id: "stub-legacy",
-  intent_hash: "a".repeat(64),
-  policy_version: "v1",
-  state_snapshot_hash: "b".repeat(64),
-  decision: "ALLOW",
-  expires_at: 9_999_999_999,
-  engine_signature: "stub-sig",
-  auth_id: "stub-v1",
-  issuer: "test-issuer",
-  audience: "test-audience",
-  state_hash: "b".repeat(64),
-  policy_id: "test-policy",
-  issued_at: 1_000,
-  expiry: 9_999_999_999,
-  alg: "HMAC-SHA256",
-  kid: "test-kid",
-  signature: "stub-v1-sig",
-};
+// Signed with TEST_KEYPAIR; valid for 10 minutes from module-load time.
+const VALID_STUB_AUTH = signAuth({ auth_id: "stub-valid" }) as unknown as Authorization;
+// Signed but long-expired — strict verifier will reject with AUTH_EXPIRED.
+const EXPIRED_STUB_AUTH = signAuth({ auth_id: "stub-expired", issued_at: 1_000, expiry: 2_000 }) as unknown as Authorization;
 
 function makeDenyEngine(): PolicyEngine {
   return {
@@ -196,7 +185,7 @@ function makeAllowEngine(nextState: State): PolicyEngine {
     evaluatePure: () => ({
       decision: "ALLOW" as const,
       reasons: [] as [],
-      authorization: STUB_AUTH,
+      authorization: VALID_STUB_AUTH,
       nextState,
     }),
     verifyAuthorization: () => ({ valid: true }),
@@ -220,10 +209,9 @@ function makeAuthFailEngine(nextState: State): PolicyEngine {
     evaluatePure: () => ({
       decision: "ALLOW" as const,
       reasons: [] as [],
-      authorization: STUB_AUTH,
+      authorization: EXPIRED_STUB_AUTH,
       nextState,
     }),
-    verifyAuthorization: () => ({ valid: false, reason: "AUTH_EXPIRED" as const }),
   } as unknown as PolicyEngine;
 }
 
@@ -455,6 +443,7 @@ test("G1 engine DENY always prevents execute() and setState() for any ProposedAc
       engine: makeDenyEngine(),
       getState: () => currentState,
       setState: (s) => { setStateCalled = true; currentState = s; },
+      ...BASE_TRUST,
     };
 
     const guard = OxDeAIGuard(config);
@@ -487,6 +476,7 @@ test("G2 missing agent_id always prevents execute() for any ProposedAction", asy
       engine: makeAllowEngine(currentState),
       getState: () => currentState,
       setState: (s) => { currentState = s; },
+      ...BASE_TRUST,
     };
 
     const guard = OxDeAIGuard(config);
@@ -522,6 +512,7 @@ test("G3 ALLOW without authorization artifact always prevents execute() for any 
       engine: makeAllowEngineNoAuth(currentState),
       getState: () => currentState,
       setState: (s) => { currentState = s; },
+      ...BASE_TRUST,
     };
 
     const guard = OxDeAIGuard(config);
@@ -557,6 +548,7 @@ test("G4 failed verifyAuthorization always prevents execute() for any ProposedAc
       engine: makeAuthFailEngine(currentState),
       getState: () => currentState,
       setState: (s) => { currentState = s; },
+      ...BASE_TRUST,
     };
 
     const guard = OxDeAIGuard(config);
@@ -605,6 +597,7 @@ test("G5 successful ALLOW always calls execute() then setState() and returns res
         setStateCalled = true;
         currentState = s;
       },
+      ...BASE_TRUST,
     };
 
     const guard = OxDeAIGuard(config);
@@ -642,6 +635,7 @@ test("G6 onDecision always receives correct decision value for any outcome", asy
         getState: () => currentState,
         setState: (s) => { currentState = s; },
         onDecision: ({ decision }) => { denyDecision = decision; },
+        ...BASE_TRUST,
       })(action, async () => {}),
       OxDeAIDenyError
     );
@@ -654,6 +648,7 @@ test("G6 onDecision always receives correct decision value for any outcome", asy
       getState: () => currentState,
       setState: (s) => { currentState = s; },
       onDecision: ({ decision }) => { allowDecision = decision; },
+      ...BASE_TRUST,
     })(action, async () => {});
     assert.equal(allowDecision, "ALLOW", `seed=${seed} onDecision must receive ALLOW`);
   }
@@ -674,6 +669,7 @@ test("G7 onDecision hook errors never surface to the caller for any ProposedActi
       getState: () => currentState,
       setState: (s) => { currentState = s; },
       onDecision: () => { throw new Error(`seed=${seed} hook explosion`); },
+      ...BASE_TRUST,
     });
 
     // Must not throw despite the hook error

--- a/packages/guard/src/test/guard.test.ts
+++ b/packages/guard/src/test/guard.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import { PolicyEngine } from "@oxdeai/core";
 import type { Authorization, State } from "@oxdeai/core";
 import { buildState } from "@oxdeai/sdk";
+import { TEST_KEYSET, TEST_KEYPAIR, signAuth } from "./helpers/fixtures.js";
 
 import { OxDeAIGuard } from "../guard.js";
 import { defaultNormalizeAction } from "../normalizeAction.js";
@@ -24,6 +25,12 @@ function makeEngine(): PolicyEngine {
   return new PolicyEngine({
     policy_version: "v1",
     engine_secret: ENGINE_SECRET,
+    authorization_signing_alg: "Ed25519",
+    authorization_signing_kid: "k1",
+    authorization_issuer: TEST_KEYSET.issuer,
+    authorization_audience: "aud-test",
+    authorization_ttl_seconds: 600,
+    authorization_private_key_pem: TEST_KEYPAIR.privateKey.toString(),
   });
 }
 
@@ -78,6 +85,7 @@ function makeGuardConfig(overrides: Partial<OxDeAIGuardConfig> = {}): OxDeAIGuar
     engine: makeEngine(),
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
     ...overrides,
   };
 }
@@ -202,6 +210,7 @@ test("guard: uses custom mapActionToIntent when provided", async () => {
     engine: makeEngine(),
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
     mapActionToIntent(action) {
       mapperCalled = true;
       // Return a well-formed intent via the default normalizer so the
@@ -235,6 +244,7 @@ test("guard: DENY throws OxDeAIDenyError and does not call execute", async () =>
     engine: makeEngine(),
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
   };
 
   const guard = OxDeAIGuard(config);
@@ -266,6 +276,7 @@ test("guard: DENY fires onDecision hook with DENY decision", async () => {
     engine: makeEngine(),
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
     onDecision({ decision }) {
       decisionFired = true;
       capturedDecision = decision;
@@ -340,6 +351,7 @@ test("guard: ALLOW without authorization artifact throws OxDeAIAuthorizationErro
     engine: mockEngine,
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
   };
 
   const guard = OxDeAIGuard(config);
@@ -374,6 +386,7 @@ test("guard: ALLOW without nextState throws OxDeAIAuthorizationError", async () 
     engine: mockEngine,
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
   };
 
   const guard = OxDeAIGuard(config);
@@ -395,21 +408,23 @@ test("guard: ALLOW without nextState throws OxDeAIAuthorizationError", async () 
 
 test("guard: failed verifyAuthorization throws OxDeAIAuthorizationError", async () => {
   let currentState = makeState();
+  // A properly-signed but expired artifact — the strict verifier will reject it with AUTH_EXPIRED.
+  const expiredAuth = signAuth({ auth_id: "stub-expired", issued_at: 1_000, expiry: 2_000 });
 
   const mockEngine = {
     evaluatePure: () => ({
       decision: "ALLOW" as const,
       reasons: [] as [],
-      authorization: stubAuth,
+      authorization: expiredAuth,
       nextState: currentState,
     }),
-    verifyAuthorization: () => ({ valid: false, reason: "EXPIRED" }),
   } as unknown as PolicyEngine;
 
   const config: OxDeAIGuardConfig = {
     engine: mockEngine,
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
   };
 
   const guard = OxDeAIGuard(config);
@@ -419,7 +434,7 @@ test("guard: failed verifyAuthorization throws OxDeAIAuthorizationError", async 
     () => guard(baseAction, async () => { executed = true; }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIAuthorizationError, `expected OxDeAIAuthorizationError, got ${err}`);
-      assert.ok(err.message.includes("EXPIRED"));
+      assert.ok(err.message.includes("AUTH_EXPIRED"));
       return true;
     }
   );
@@ -437,6 +452,7 @@ test("guard: setState is called with nextState after successful execution", asyn
     engine: makeEngine(),
     getState: () => initialState,
     setState: (s) => { storedState = s; },
+    trustedKeySets: [TEST_KEYSET],
   };
 
   const guard = OxDeAIGuard(config);
@@ -461,6 +477,7 @@ test("guard: setState is NOT called when execution is denied", async () => {
     engine: makeEngine(),
     getState: () => currentState,
     setState: (s) => { setStateCalled = true; currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
   };
 
   const guard = OxDeAIGuard(config);

--- a/packages/guard/src/test/guard.toctou.test.ts
+++ b/packages/guard/src/test/guard.toctou.test.ts
@@ -17,18 +17,25 @@ import type { State } from "@oxdeai/core";
 import { buildState } from "@oxdeai/sdk";
 
 import { OxDeAIGuard } from "../guard.js";
+import { TEST_KEYSET, TEST_KEYPAIR } from "./helpers/fixtures.js";
 import { OxDeAIDenyError } from "../errors.js";
 import type { ProposedAction, OxDeAIGuardConfig } from "../types.js";
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
 const AGENT_ID = "agent-guard-toctou";
-const T0 = 1_700_000_000;
+const T0 = Math.floor(Date.now() / 1000);
 
 function makeEngine(): PolicyEngine {
   return new PolicyEngine({
     policy_version: "v1",
     engine_secret:  "guard-toctou-secret-32-bytes-ok!",
+    authorization_signing_alg: "Ed25519",
+    authorization_signing_kid: "k1",
+    authorization_issuer: TEST_KEYSET.issuer,
+    authorization_audience: "aud-test",
+    authorization_ttl_seconds: 600,
+    authorization_private_key_pem: TEST_KEYPAIR.privateKey.toString(),
   });
 }
 
@@ -44,6 +51,7 @@ function makeStatefulConfig(
     engine,
     getState: () => current,
     setState: (s) => { current = s; },
+    trustedKeySets: [TEST_KEYSET],
     ...overrides,
   };
 }
@@ -177,6 +185,7 @@ test("G-3 reverification: state mutated between calls → policy re-evaluated ea
     engine,
     getState: () => current,
     setState: (s) => { current = s; },
+    trustedKeySets: [TEST_KEYSET],
   };
 
   const guard = OxDeAIGuard(config);

--- a/packages/guard/src/test/helpers/fixtures.ts
+++ b/packages/guard/src/test/helpers/fixtures.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+import { generateKeyPairSync } from "node:crypto";
+import {
+  signAuthorizationEd25519,
+  createDelegation,
+} from "@oxdeai/core";
+import type { KeySet, AuthorizationV1, DelegationV1 } from "@oxdeai/core";
+
+export const TEST_KEYPAIR = generateKeyPairSync("ed25519", {
+  privateKeyEncoding: { format: "pem", type: "pkcs8" },
+  publicKeyEncoding: { format: "pem", type: "spki" },
+});
+
+export const TEST_KEYSET: KeySet = {
+  issuer: "test-issuer",
+  version: "v1",
+  keys: [{ kid: "k1", alg: "Ed25519", public_key: TEST_KEYPAIR.publicKey.toString() }],
+};
+
+export const nowSeconds = () => Math.floor(Date.now() / 1000);
+
+export function signAuth(overrides: Partial<AuthorizationV1 & { scope?: { tools?: string[]; max_amount?: bigint } }> = {}): AuthorizationV1 {
+  const issued_at = overrides.issued_at ?? nowSeconds();
+  const auth = signAuthorizationEd25519(
+    {
+      auth_id: overrides.auth_id ?? `auth-${issued_at}`,
+      issuer: overrides.issuer ?? TEST_KEYSET.issuer,
+      audience: overrides.audience ?? "aud-test",
+      intent_hash: overrides.intent_hash ?? "i".repeat(64),
+      state_hash: overrides.state_hash ?? "s".repeat(64),
+      policy_id: overrides.policy_id ?? "p".repeat(64),
+      decision: "ALLOW",
+      issued_at,
+      expiry: overrides.expiry ?? issued_at + 600,
+      kid: overrides.kid ?? "k1",
+      nonce: overrides.nonce ?? "1",
+      capability: overrides.capability ?? "exec",
+    },
+    TEST_KEYPAIR.privateKey.toString()
+  );
+  if ((overrides as any).scope) (auth as any).scope = (overrides as any).scope;
+  return auth;
+}
+
+export function makeParentAuthWithScope(
+  scope: { tools?: string[]; max_amount?: bigint },
+  overrides: Partial<AuthorizationV1> = {}
+): AuthorizationV1 {
+  const auth = signAuth(overrides);
+  (auth as any).scope = scope;
+  return auth;
+}
+
+export function makeDelegationWithScope(parent: AuthorizationV1, scope: DelegationV1["scope"]): DelegationV1 {
+  return createDelegation(
+    parent,
+    {
+      delegatee: parent.audience,
+      scope,
+      expiry: parent.expiry,
+      kid: "k1",
+      audience: parent.audience,
+      issuer: TEST_KEYSET.issuer,
+    },
+    TEST_KEYPAIR.privateKey.toString()
+  );
+}

--- a/packages/langgraph/src/adapter.ts
+++ b/packages/langgraph/src/adapter.ts
@@ -53,6 +53,7 @@ export function createLangGraphGuard(config: LangGraphGuardConfig): LangGraphGua
     beforeExecute: config.beforeExecute,
     onDecision: config.onDecision,
     strict: config.strict,
+    trustedKeySets: config.trustedKeySets,
   });
 
   return async function langGraphGuard<T>(

--- a/packages/langgraph/src/test/adapter.test.ts
+++ b/packages/langgraph/src/test/adapter.test.ts
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import test from "node:test";
 import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
 import { PolicyEngine } from "@oxdeai/core";
-import type { Authorization, State } from "@oxdeai/core";
+import type { Authorization, KeySet, State } from "@oxdeai/core";
 import { buildState } from "@oxdeai/sdk";
 import { OxDeAIDenyError, OxDeAIAuthorizationError, OxDeAINormalizationError } from "@oxdeai/guard";
 
@@ -14,8 +15,28 @@ import type { LangGraphToolCall, LangGraphGuardConfig } from "../types.js";
 const AGENT_ID = "lg-agent-001";
 const ENGINE_SECRET = "test-secret-must-be-at-least-32-chars!!";
 
+const TEST_KEYPAIR = generateKeyPairSync("ed25519", {
+  privateKeyEncoding: { format: "pem", type: "pkcs8" },
+  publicKeyEncoding:  { format: "pem", type: "spki" },
+});
+
+const TEST_KEYSET: KeySet = {
+  issuer: "test-issuer",
+  version: "v1",
+  keys: [{ kid: "k1", alg: "Ed25519", public_key: TEST_KEYPAIR.publicKey.toString() }],
+};
+
 function makeEngine(): PolicyEngine {
-  return new PolicyEngine({ policy_version: "v1", engine_secret: ENGINE_SECRET });
+  return new PolicyEngine({
+    policy_version: "v1",
+    engine_secret: ENGINE_SECRET,
+    authorization_signing_alg: "Ed25519",
+    authorization_signing_kid: "k1",
+    authorization_issuer: TEST_KEYSET.issuer,
+    authorization_audience: AGENT_ID,
+    authorization_ttl_seconds: 600,
+    authorization_private_key_pem: TEST_KEYPAIR.privateKey.toString(),
+  });
 }
 
 function makeState(agentId = AGENT_ID): State {
@@ -36,7 +57,7 @@ const baseToolCall: LangGraphToolCall = {
   type: "tool_call",
   estimatedCost: 0.5,
   resourceType: "gpu",
-  timestampSeconds: 1_700_000_000,
+  timestampSeconds: Math.floor(Date.now() / 1000),
 };
 
 function makeGuardConfig(overrides: Partial<LangGraphGuardConfig> = {}): LangGraphGuardConfig {
@@ -46,6 +67,7 @@ function makeGuardConfig(overrides: Partial<LangGraphGuardConfig> = {}): LangGra
     agentId: AGENT_ID,
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
     ...overrides,
   };
 }
@@ -90,6 +112,7 @@ test("adapter: DENY throws OxDeAIDenyError and does not call execute", async () 
     agentId: AGENT_ID,
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(
@@ -255,6 +278,7 @@ test("adapter: ALLOW without authorization artifact throws OxDeAIAuthorizationEr
     agentId: AGENT_ID,
     getState: () => state,
     setState: () => {},
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(
@@ -278,6 +302,7 @@ test("adapter: setState is called after successful execution", async () => {
     agentId: AGENT_ID,
     getState: () => makeState(),
     setState: (s) => { storedState = s; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await guard(baseToolCall, async () => "ok");
@@ -295,6 +320,7 @@ test("adapter: setState is NOT called on DENY", async () => {
     agentId: AGENT_ID,
     getState: () => makeState(),
     setState: () => { setStateCalled = true; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(() => guard(baseToolCall, async () => {}), OxDeAIDenyError);
@@ -324,6 +350,7 @@ test("adapter: onDecision receives DENY when blocked", async () => {
     getState: () => currentState,
     setState: (s) => { currentState = s; },
     onDecision({ decision: d }) { decision = d; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(() => guard(baseToolCall, async () => {}));
@@ -339,6 +366,7 @@ test("adapter: guard is reusable — multiple sequential calls work", async () =
     agentId: AGENT_ID,
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   const r1 = await guard(baseToolCall, async () => "first");

--- a/packages/langgraph/src/types.ts
+++ b/packages/langgraph/src/types.ts
@@ -74,6 +74,9 @@ export type LangGraphGuardConfig = {
 
   /** When true, missing optional normalizer fields cause hard failures. */
   strict?: boolean;
+
+  /** Trusted keysets required for strict authorization verification. */
+  trustedKeySets?: OxDeAIGuardConfig["trustedKeySets"];
 };
 
 /**

--- a/packages/openai-agents/src/adapter.ts
+++ b/packages/openai-agents/src/adapter.ts
@@ -53,6 +53,7 @@ export function createOpenAIAgentsGuard(config: OpenAIAgentsGuardConfig): OpenAI
     beforeExecute: config.beforeExecute,
     onDecision: config.onDecision,
     strict: config.strict,
+    trustedKeySets: config.trustedKeySets,
   });
 
   return async function openAIAgentsGuard<T>(

--- a/packages/openai-agents/src/test/adapter.test.ts
+++ b/packages/openai-agents/src/test/adapter.test.ts
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import test from "node:test";
 import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
 import { PolicyEngine } from "@oxdeai/core";
-import type { Authorization, State } from "@oxdeai/core";
+import type { Authorization, KeySet, State } from "@oxdeai/core";
 import { buildState } from "@oxdeai/sdk";
 import { OxDeAIDenyError, OxDeAIAuthorizationError, OxDeAINormalizationError } from "@oxdeai/guard";
 
@@ -14,8 +15,28 @@ import type { OpenAIAgentsToolCall, OpenAIAgentsGuardConfig } from "../types.js"
 const AGENT_ID = "oa-agent-001";
 const ENGINE_SECRET = "test-secret-must-be-at-least-32-chars!!";
 
+const TEST_KEYPAIR = generateKeyPairSync("ed25519", {
+  privateKeyEncoding: { format: "pem", type: "pkcs8" },
+  publicKeyEncoding:  { format: "pem", type: "spki" },
+});
+
+const TEST_KEYSET: KeySet = {
+  issuer: "test-issuer",
+  version: "v1",
+  keys: [{ kid: "k1", alg: "Ed25519", public_key: TEST_KEYPAIR.publicKey.toString() }],
+};
+
 function makeEngine(): PolicyEngine {
-  return new PolicyEngine({ policy_version: "v1", engine_secret: ENGINE_SECRET });
+  return new PolicyEngine({
+    policy_version: "v1",
+    engine_secret: ENGINE_SECRET,
+    authorization_signing_alg: "Ed25519",
+    authorization_signing_kid: "k1",
+    authorization_issuer: TEST_KEYSET.issuer,
+    authorization_audience: AGENT_ID,
+    authorization_ttl_seconds: 600,
+    authorization_private_key_pem: TEST_KEYPAIR.privateKey.toString(),
+  });
 }
 
 function makeState(agentId = AGENT_ID): State {
@@ -35,7 +56,7 @@ const baseToolCall: OpenAIAgentsToolCall = {
   call_id: "call-abc-123",
   estimatedCost: 0.5,
   resourceType: "gpu",
-  timestampSeconds: 1_700_000_000,
+  timestampSeconds: Math.floor(Date.now() / 1000),
 };
 
 function makeGuardConfig(overrides: Partial<OpenAIAgentsGuardConfig> = {}): OpenAIAgentsGuardConfig {
@@ -45,6 +66,7 @@ function makeGuardConfig(overrides: Partial<OpenAIAgentsGuardConfig> = {}): Open
     agentId: AGENT_ID,
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
     ...overrides,
   };
 }
@@ -89,6 +111,7 @@ test("adapter: DENY throws OxDeAIDenyError and does not call execute", async () 
     agentId: AGENT_ID,
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(
@@ -254,6 +277,7 @@ test("adapter: ALLOW without authorization artifact throws OxDeAIAuthorizationEr
     agentId: AGENT_ID,
     getState: () => state,
     setState: () => {},
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(
@@ -277,6 +301,7 @@ test("adapter: setState is called after successful execution", async () => {
     agentId: AGENT_ID,
     getState: () => makeState(),
     setState: (s) => { storedState = s; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await guard(baseToolCall, async () => "ok");
@@ -294,6 +319,7 @@ test("adapter: setState is NOT called on DENY", async () => {
     agentId: AGENT_ID,
     getState: () => makeState(),
     setState: () => { setStateCalled = true; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(() => guard(baseToolCall, async () => {}), OxDeAIDenyError);
@@ -323,6 +349,7 @@ test("adapter: onDecision receives DENY when blocked", async () => {
     getState: () => currentState,
     setState: (s) => { currentState = s; },
     onDecision({ decision: d }) { decision = d; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(() => guard(baseToolCall, async () => {}));
@@ -338,6 +365,7 @@ test("adapter: guard is reusable - multiple sequential calls work", async () => 
     agentId: AGENT_ID,
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   const r1 = await guard(baseToolCall, async () => "first");

--- a/packages/openai-agents/src/types.ts
+++ b/packages/openai-agents/src/types.ts
@@ -74,6 +74,9 @@ export type OpenAIAgentsGuardConfig = {
 
   /** When true, missing optional normalizer fields cause hard failures. */
   strict?: boolean;
+
+  /** Trusted keysets required for strict authorization verification. */
+  trustedKeySets?: OxDeAIGuardConfig["trustedKeySets"];
 };
 
 /**

--- a/packages/openclaw/src/adapter.ts
+++ b/packages/openclaw/src/adapter.ts
@@ -55,6 +55,7 @@ export function createOpenClawGuard(config: OpenClawGuardConfig): OpenClawGuardF
     beforeExecute: config.beforeExecute,
     onDecision: config.onDecision,
     strict: config.strict,
+    trustedKeySets: config.trustedKeySets,
   });
 
   return async function openClawGuard<T>(

--- a/packages/openclaw/src/test/adapter.test.ts
+++ b/packages/openclaw/src/test/adapter.test.ts
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import test from "node:test";
 import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
 import { PolicyEngine } from "@oxdeai/core";
-import type { Authorization, State } from "@oxdeai/core";
+import type { Authorization, KeySet, State } from "@oxdeai/core";
 import { buildState } from "@oxdeai/sdk";
 import { OxDeAIDenyError, OxDeAIAuthorizationError, OxDeAINormalizationError } from "@oxdeai/guard";
 
@@ -14,8 +15,28 @@ import type { OpenClawAction, OpenClawGuardConfig } from "../types.js";
 const AGENT_ID = "openclaw-agent-001";
 const ENGINE_SECRET = "test-secret-must-be-at-least-32-chars!!";
 
+const TEST_KEYPAIR = generateKeyPairSync("ed25519", {
+  privateKeyEncoding: { format: "pem", type: "pkcs8" },
+  publicKeyEncoding:  { format: "pem", type: "spki" },
+});
+
+const TEST_KEYSET: KeySet = {
+  issuer: "test-issuer",
+  version: "v1",
+  keys: [{ kid: "k1", alg: "Ed25519", public_key: TEST_KEYPAIR.publicKey.toString() }],
+};
+
 function makeEngine(): PolicyEngine {
-  return new PolicyEngine({ policy_version: "v1", engine_secret: ENGINE_SECRET });
+  return new PolicyEngine({
+    policy_version: "v1",
+    engine_secret: ENGINE_SECRET,
+    authorization_signing_alg: "Ed25519",
+    authorization_signing_kid: "k1",
+    authorization_issuer: TEST_KEYSET.issuer,
+    authorization_audience: AGENT_ID,
+    authorization_ttl_seconds: 600,
+    authorization_private_key_pem: TEST_KEYPAIR.privateKey.toString(),
+  });
 }
 
 function makeState(agentId = AGENT_ID): State {
@@ -36,7 +57,7 @@ const baseAction: OpenClawAction = {
   workflow_id: "openclaw-gpu-demo",
   estimatedCost: 0.5,
   resourceType: "gpu",
-  timestampSeconds: 1_700_000_000,
+  timestampSeconds: Math.floor(Date.now() / 1000),
 };
 
 function makeGuardConfig(overrides: Partial<OpenClawGuardConfig> = {}): OpenClawGuardConfig {
@@ -46,6 +67,7 @@ function makeGuardConfig(overrides: Partial<OpenClawGuardConfig> = {}): OpenClaw
     agentId: AGENT_ID,
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
     ...overrides,
   };
 }
@@ -90,6 +112,7 @@ test("adapter: DENY throws OxDeAIDenyError and does not call execute", async () 
     agentId: AGENT_ID,
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(
@@ -272,6 +295,7 @@ test("adapter: ALLOW without authorization artifact throws OxDeAIAuthorizationEr
     agentId: AGENT_ID,
     getState: () => state,
     setState: () => {},
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(
@@ -295,6 +319,7 @@ test("adapter: setState is called after successful execution", async () => {
     agentId: AGENT_ID,
     getState: () => makeState(),
     setState: (s) => { storedState = s; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await guard(baseAction, async () => "ok");
@@ -312,6 +337,7 @@ test("adapter: setState is NOT called on DENY", async () => {
     agentId: AGENT_ID,
     getState: () => makeState(),
     setState: () => { setStateCalled = true; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(() => guard(baseAction, async () => {}), OxDeAIDenyError);
@@ -341,6 +367,7 @@ test("adapter: onDecision receives DENY when blocked", async () => {
     getState: () => currentState,
     setState: (s) => { currentState = s; },
     onDecision({ decision: d }) { decision = d; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   await assert.rejects(() => guard(baseAction, async () => {}));
@@ -356,6 +383,7 @@ test("adapter: guard is reusable — multiple sequential calls work", async () =
     agentId: AGENT_ID,
     getState: () => currentState,
     setState: (s) => { currentState = s; },
+    trustedKeySets: [TEST_KEYSET],
   });
 
   const r1 = await guard(baseAction, async () => "first");

--- a/packages/openclaw/src/types.ts
+++ b/packages/openclaw/src/types.ts
@@ -78,6 +78,9 @@ export type OpenClawGuardConfig = {
 
   /** When true, missing optional normalizer fields cause hard failures. */
   strict?: boolean;
+
+  /** Trusted keysets required for strict authorization verification. */
+  trustedKeySets?: OxDeAIGuardConfig["trustedKeySets"];
 };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  langsmith: ^0.5.18
+  langsmith: 0.5.18
   minimatch: '>=10.2.3'
   lodash: '>=4.18.0'
   brace-expansion: '>=5.0.5'


### PR DESCRIPTION
## Summary

This PR aligns the reusable `@oxdeai/guard` with the OxDeAI execution-boundary model.

It removes weak verification paths and enforces strict, fail-closed authorization at execution time.

Core invariant enforced:

> No valid authorization → no execution path

---

## What changed

### Guard boundary hardening

- replaced weak boundary checks with strict AuthorizationV1 verification
- required `trustedKeySets` at guard construction (no implicit trust)
- switched expiry validation to trusted wall-clock time
- enforced `auth_id` replay protection before execution
- removed fallback paths that allowed execution under partial verification

### Delegation hardening

- required signed delegation artifacts
- enforced strict parent authorization verification
- enforced parent-bound scope narrowing (no widening)
- enforced delegation replay protection
- fail-closed on:
  - missing trust configuration
  - invalid signature
  - parent mismatch
  - scope violations

### Test suite migration

- migrated all guard tests to real Ed25519 AuthorizationV1 artifacts
- removed stub / weak verification assumptions
- re-based valid fixtures on wall-clock timestamps (no stale constants)
- aligned delegation/property tests with strict narrowing rules
- added boundary and non-bypassability coverage

---

## Security impact

The reusable guard now enforces:

- deterministic authorization verification
- trusted-time expiry checks
- replay resistance at the execution boundary
- non-bypassable delegation verification
- fail-closed semantics across all paths

This closes the gap between:
- protocol-level guarantees
- reusable guard implementation

---

## Validation

```bash
pnpm -C packages/guard test
````

Result:

```
69 / 69 tests passing
```

Coverage includes:

* ALLOW execution path under strict verification
* expired authorization denial
* replay denial
* delegation scope violations
* delegation signature failures
* parent hash mismatch
* TOCTOU / re-verification scenarios
* non-bypassability guarantees

---

## Notes / Follow-ups

Replay protection is currently enforced in-memory at the guard boundary.

A follow-up issue will introduce a durable replay store for:

* multi-instance deployments
* restart persistence
* distributed enforcement guarantees

---

## Positioning

This PR makes the reusable guard consistent with OxDeAI’s core model:

* authorization is verified **at execution time**
* enforcement is **outside the agent**
* verification is **deterministic and fail-closed**

This is not monitoring or advisory control, it is an execution boundary.

```
