### PR TITLE
feat(guard): introduce replay store abstraction and enforce fail-closed replay at execution boundary

### DIFF
--- a/packages/autogen/README.md
+++ b/packages/autogen/README.md
@@ -1,10 +1,6 @@
 # @oxdeai/autogen
-
-**Thin AutoGen binding for [@oxdeai/guard](../guard/README.md).**
-
-This package connects AutoGen function/tool calls to the OxDeAI universal
-execution guard. It contains no authorization logic - all policy evaluation
-and PEP enforcement is delegated to `@oxdeai/guard`.
+AutoGen adapter to the OxDeAI execution-time authorization protocol.
+Sends AutoGen tool calls through @oxdeai/guard; enforcement is local, fail-closed, non-bypassable.
 
 ---
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # @oxdeai/cli
-
-Protocol-oriented command-line tooling for OxDeAI.
+CLI for the OxDeAI execution-time authorization protocol (non-bypassable execution boundary).
+Runs local verification and artifact inspection; no valid authorization → execution should not proceed.
 
 `@oxdeai/cli` is a thin Node.js wrapper around `@oxdeai/core` verification and local state workflows. It is framework-agnostic and intended for local policy operations, artifact inspection, and deterministic verification.
 

--- a/packages/conformance/README.md
+++ b/packages/conformance/README.md
@@ -1,6 +1,6 @@
 # @oxdeai/conformance
-
-Conformance vectors and validator for the OxDeAI protocol.
+Conformance vectors and validator for the OxDeAI execution-time authorization protocol.
+Ensures implementations reproduce deterministic AuthorizationV1 artifacts and boundary verification (fail-closed).
 
 ## Purpose
 `@oxdeai/conformance` verifies that an implementation matches the frozen protocol behavior for a specific version.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,8 +1,7 @@
 # @oxdeai/core
-
-Deterministic Execution Authorization Layer for Autonomous Systems
-
-[High-signal] Controls whether actions are allowed to execute - before any side effect occurs.
+Execution-time authorization protocol (ETA) — non-bypassable execution boundary.
+Deterministic decision: (intent, state, policy) → ALLOW | DENY, emits AuthorizationV1 artifacts.
+Fail-closed verification at the PEP; no valid authorization → no execution path.
 
 [![npm version](https://img.shields.io/npm/v/@oxdeai/core.svg)](https://www.npmjs.com/package/@oxdeai/core)
 [![Snyk](https://snyk.io/test/github/AngeYobo/oxdeai-core/badge.svg)](https://snyk.io/test/github/AngeYobo/oxdeai-core)

--- a/packages/crewai/README.md
+++ b/packages/crewai/README.md
@@ -1,10 +1,6 @@
 # @oxdeai/crewai
-
-**Thin CrewAI binding for [@oxdeai/guard](https://github.com/AngeYobo/oxdeai/blob/main/packages/guard/README.md).**
-
-This package connects CrewAI tool calls to the OxDeAI universal execution
-guard. It contains no authorization logic — all policy evaluation and PEP
-enforcement is delegated to `@oxdeai/guard`.
+CrewAI adapter to the OxDeAI execution-time authorization protocol (non-bypassable boundary).
+Routes CrewAI tool calls through @oxdeai/guard; no valid authorization → no execution.
 
 ---
 

--- a/packages/guard/README.md
+++ b/packages/guard/README.md
@@ -1,11 +1,7 @@
 # @oxdeai/guard
-
-**Universal Execution Guard for OxDeAI.**
-
-`@oxdeai/guard` is the canonical Policy Enforcement Point (PEP) for the OxDeAI
-ecosystem. It sits between agent runtimes and external tool execution, enforcing
-authorization decisions made by the OxDeAI policy engine before any side effect
-is permitted.
+Policy Enforcement Point for the OxDeAI execution-time authorization protocol.
+Enforces the non-bypassable execution boundary: verifies AuthorizationV1 locally, fail-closed.
+No valid authorization → no execution callback is invoked.
 
 ---
 

--- a/packages/guard/package.json
+++ b/packages/guard/package.json
@@ -30,6 +30,6 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "rm -rf dist && tsc -p tsconfig.json",
-    "test": "pnpm build && node --test \"dist/test/guard.test.js\" \"dist/test/guard.property.test.js\" \"dist/test/guard.delegation.test.js\" \"dist/test/guard.delegation.matrix.test.js\" \"dist/test/guard.delegation.property.test.js\" \"dist/test/guard.toctou.test.js\""
+    "test": "pnpm build && node --test \"dist/test/guard.test.js\" \"dist/test/guard.property.test.js\" \"dist/test/guard.delegation.test.js\" \"dist/test/guard.delegation.matrix.test.js\" \"dist/test/guard.delegation.property.test.js\" \"dist/test/guard.toctou.test.js\" \"dist/test/guard.boundary.test.js\" \"dist/test/guard.replay-store.test.js\""
   }
 }

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -3,6 +3,8 @@ import type { Authorization, AuthorizationV1, Intent, KeySet } from "@oxdeai/cor
 import { verifyDelegationChain, verifyAuthorization as strictVerifyAuthorization } from "@oxdeai/core";
 import type { OxDeAIGuardConfig, ProposedAction, GuardDecisionRecord, GuardCallOptions } from "./types.js";
 import { defaultNormalizeAction } from "./normalizeAction.js";
+import { createInMemoryReplayStore } from "./replayStore.js";
+import type { ReplayStore } from "./replayStore.js";
 import {
   OxDeAIDenyError,
   OxDeAIAuthorizationError,
@@ -95,10 +97,9 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
     );
   }
 
-  // Tracks consumed auth_ids to enforce replay resistance at the PEP.
-  const consumedAuthIds = new Set<string>();
-  // Tracks consumed delegation_ids to enforce replay resistance for delegations.
-  const consumedDelegationIds = new Set<string>();
+  // Pluggable replay store. Defaults to in-memory (single-process semantics).
+  // Replace with a durable backend for multi-process / restart-durable deployments.
+  const replayStore: ReplayStore = config.replayStore ?? createInMemoryReplayStore();
 
   return async function guard(
     action: ProposedAction,
@@ -133,7 +134,18 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
       const now = Math.floor(Date.now() / 1000);
       const violationMessages: string[] = [];
 
-      if (consumedDelegationIds.has(delegation.delegation_id)) {
+      // Atomically check-and-consume the delegation_id. Fail closed on store errors.
+      let delegConsumed: boolean;
+      try {
+        delegConsumed = replayStore.consumeDelegationId
+          ? await replayStore.consumeDelegationId(delegation.delegation_id, { expiry: delegation.expiry })
+          : true;
+      } catch (err) {
+        throw new OxDeAIAuthorizationError(
+          `Replay store unavailable for delegation_id: ${err instanceof Error ? err.message : String(err)}. Execution blocked.`
+        );
+      }
+      if (!delegConsumed) {
         throw new OxDeAIAuthorizationError("Delegation replay detected. Execution blocked.");
       }
 
@@ -159,7 +171,6 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
         now,
         trustedKeySets: config.trustedKeySets,
         requireSignatureVerification: true,
-        consumedDelegationIds: [...consumedDelegationIds],
         parentScope,
       });
 
@@ -193,7 +204,18 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
       }
 
       // Enforce strict verification on the parent Authorization as well.
-      if (consumedAuthIds.has(parentAuth.auth_id)) {
+      // Atomically check-and-consume the parentAuth auth_id. Fail closed on store errors.
+      let parentAuthConsumed: boolean;
+      try {
+        parentAuthConsumed = await replayStore.consumeAuthId(
+          parentAuth.auth_id, { expiry: parentAuth.expiry }
+        );
+      } catch (err) {
+        throw new OxDeAIAuthorizationError(
+          `Replay store unavailable for parentAuth auth_id: ${err instanceof Error ? err.message : String(err)}. Execution blocked.`
+        );
+      }
+      if (!parentAuthConsumed) {
         throw new OxDeAIAuthorizationError(
           "Authorization replay detected on parentAuth: auth_id already consumed. Execution blocked."
         );
@@ -207,7 +229,6 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
         expectedPolicyId: parentAuth.policy_id,
         expectedAudience: parentAuth.audience,
         expectedIssuer: parentAuth.issuer,
-        consumedAuthIds: [...consumedAuthIds],
       });
 
       if (parentAuthResult.status !== "ok") {
@@ -217,9 +238,6 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
           "unknown reason";
         throw new OxDeAIAuthorizationError(`Parent authorization verification failed: ${reasons}. Execution blocked.`);
       }
-
-      consumedAuthIds.add(parentAuth.auth_id);
-      consumedDelegationIds.add(delegation.delegation_id);
 
       // parentAuth is AuthorizationV1; cast to Authorization for hook/audit
       // compatibility. Legacy fields will be absent — callers on the delegation
@@ -283,7 +301,19 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
 
     // ── 6b. Verify the authorization artifact (strict verifier, fail-closed) ─
     const now = Math.floor(Date.now() / 1000);
-    if (consumedAuthIds.has(authorization.auth_id)) {
+
+    // Atomically check-and-consume the auth_id before execution. Fail closed on store errors.
+    let authConsumed: boolean;
+    try {
+      authConsumed = await replayStore.consumeAuthId(
+        authorization.auth_id, { expiry: (authorization as AuthorizationV1).expiry ?? 0 }
+      );
+    } catch (err) {
+      throw new OxDeAIAuthorizationError(
+        `Replay store unavailable: ${err instanceof Error ? err.message : String(err)}. Execution blocked.`
+      );
+    }
+    if (!authConsumed) {
       throw new OxDeAIAuthorizationError("Authorization replay detected: auth_id already consumed. Execution blocked.");
     }
 
@@ -295,7 +325,6 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
       expectedPolicyId: authorization.policy_id,
       expectedAudience: authorization.audience,
       expectedIssuer: authorization.issuer,
-      consumedAuthIds: [...consumedAuthIds],
     });
 
     if (authResult.status !== "ok") {
@@ -303,9 +332,6 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
         authResult.violations?.map((v) => v.code).join(", ") || authResult.status || "unknown reason";
       throw new OxDeAIAuthorizationError(`Authorization verification failed: ${reasons}. Execution blocked.`);
     }
-
-    // Mark auth_id as consumed to prevent replay before execution.
-    consumedAuthIds.add(authorization.auth_id);
 
     // ── 7. beforeExecute hook ──────────────────────────────────────────────
     if (config.beforeExecute) {

--- a/packages/guard/src/index.ts
+++ b/packages/guard/src/index.ts
@@ -10,6 +10,8 @@
 
 export { OxDeAIGuard } from "./guard.js";
 export { defaultNormalizeAction } from "./normalizeAction.js";
+export { createInMemoryReplayStore } from "./replayStore.js";
+export type { ReplayStore } from "./replayStore.js";
 export {
   OxDeAIDenyError,
   OxDeAIAuthorizationError,

--- a/packages/guard/src/replayStore.ts
+++ b/packages/guard/src/replayStore.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * ReplayStore — pluggable replay-prevention backend for the OxDeAI guard.
+ *
+ * The guard calls consumeAuthId (and optionally consumeDelegationId) before
+ * every execution. Implementations MUST be fail-closed: if the store is
+ * unavailable, throw rather than returning a permissive result. Any thrown
+ * error is caught by the guard and re-raised as OxDeAIAuthorizationError,
+ * blocking execution.
+ *
+ * Atomicity:
+ *   From the guard's perspective each call is a single check-and-consume
+ *   operation. Durable backends should implement this using compare-and-swap
+ *   or an equivalent operation so that concurrent callers cannot both observe
+ *   a "not yet consumed" result for the same ID.
+ *
+ * Durability tiers:
+ *   - In-memory (default)  : single-process only; replay state lost on restart.
+ *   - Redis / DynamoDB     : survives restarts and horizontal scaling.
+ *   - Relational DB        : full ACID guarantees; suits regulated environments.
+ */
+export interface ReplayStore {
+  /**
+   * Atomically check-and-consume an auth_id.
+   *
+   * @param authId        The auth_id from the AuthorizationV1 artifact.
+   * @param opts.expiry   Unix timestamp (seconds) when the auth expires.
+   *                      Durable backends may use this to set a TTL on the
+   *                      record so that expired entries are garbage-collected.
+   * @returns `true`  if the auth_id was successfully consumed (first use).
+   * @returns `false` if the auth_id was already consumed (replay detected).
+   * @throws             if the store is unavailable — the guard will DENY.
+   */
+  consumeAuthId(authId: string, opts: { expiry: number }): Promise<boolean>;
+
+  /**
+   * Atomically check-and-consume a delegation_id.
+   *
+   * Optional. When absent, delegation replay is still prevented by
+   * consumeAuthId on the parent authorization: consuming the parentAuth
+   * once prevents the same delegation chain from being replayed.
+   *
+   * Implement this method when stricter delegation tracking is required
+   * (e.g. when a parent auth may authorise multiple distinct delegations and
+   * per-delegation replay tracking is needed independently of parentAuth).
+   *
+   * @param delegationId  The delegation_id from the DelegationV1 artifact.
+   * @param opts.expiry   Unix timestamp (seconds) when the delegation expires.
+   * @returns `true`  if the delegation_id was successfully consumed (first use).
+   * @returns `false` if the delegation_id was already consumed (replay detected).
+   * @throws             if the store is unavailable — the guard will DENY.
+   */
+  consumeDelegationId?(delegationId: string, opts: { expiry: number }): Promise<boolean>;
+}
+
+/**
+ * createInMemoryReplayStore — default single-process replay store.
+ *
+ * Uses two in-memory Sets to track consumed IDs. Each factory call produces
+ * an independent store instance, mirroring the prior per-guard-instance Sets.
+ *
+ * Suitable for:
+ *   - Single-process deployments
+ *   - Testing and development
+ *
+ * NOT suitable for:
+ *   - Multi-process / horizontally-scaled deployments
+ *   - Scenarios where replay prevention must survive process restarts
+ *
+ * For production deployments requiring durability, implement ReplayStore
+ * backed by Redis, DynamoDB, a relational database, or equivalent.
+ */
+export function createInMemoryReplayStore(): ReplayStore {
+  const consumedAuthIds = new Set<string>();
+  const consumedDelegationIds = new Set<string>();
+
+  return {
+    async consumeAuthId(authId: string): Promise<boolean> {
+      if (consumedAuthIds.has(authId)) return false;
+      consumedAuthIds.add(authId);
+      return true;
+    },
+    async consumeDelegationId(delegationId: string): Promise<boolean> {
+      if (consumedDelegationIds.has(delegationId)) return false;
+      consumedDelegationIds.add(delegationId);
+      return true;
+    },
+  };
+}

--- a/packages/guard/src/test/guard.boundary.test.ts
+++ b/packages/guard/src/test/guard.boundary.test.ts
@@ -9,17 +9,13 @@ import type { State, Intent, Authorization, AuthorizationV1, KeySet } from "@oxd
 import {
   PolicyEngine,
   signAuthorizationEd25519,
-  verifyAuthorization as strictVerifyAuthorization,
   createDelegation,
 } from "@oxdeai/core";
 
 // ---------------------------------------------------------------------------
 // Fixtures
 
-const { privateKey, publicKey } = generateKeyPairSync("ed25519", {
-  privateKeyEncoding: { format: "pem", type: "pkcs8" },
-  publicKeyEncoding: { format: "spki", type: "pem" },
-});
+const { privateKey, publicKey } = generateKeyPairSync("ed25519");
 
 const TRUSTED_KEYSET: KeySet = {
   issuer: "issuer-test",
@@ -322,13 +318,13 @@ test("delegation narrowing is allowed", async () => {
     },
     privateKey.export({ type: "pkcs8", format: "pem" }).toString()
   ) as Authorization;
-  (parentAuth as any).scope = { tools: ["read", "write"], max_amount: 1000n };
+  (parentAuth as any).scope = { tools: ["pay", "read", "write"], max_amount: 1000n };
 
   const delegation = createDelegation(
     parentAuth as AuthorizationV1,
     {
       delegatee: "child",
-      scope: { tools: ["read"], max_amount: 100n },
+      scope: { tools: ["pay", "read"], max_amount: 100n },
       expiry: parentAuth.expiry,
       kid: "k1",
       audience: "child",
@@ -376,13 +372,13 @@ test("delegation replay is denied", async () => {
     },
     privateKey.export({ type: "pkcs8", format: "pem" }).toString()
   ) as Authorization;
-  (parentAuth as any).scope = { tools: ["read"], max_amount: 100n };
+  (parentAuth as any).scope = { tools: ["pay", "read"], max_amount: 100n };
 
   const delegation = createDelegation(
     parentAuth as AuthorizationV1,
     {
       delegatee: "child",
-      scope: { tools: ["read"], max_amount: 100n },
+      scope: { tools: ["pay", "read"], max_amount: 100n },
       expiry: parentAuth.expiry,
       kid: "k1",
       audience: "child",

--- a/packages/guard/src/test/guard.replay-store.test.ts
+++ b/packages/guard/src/test/guard.replay-store.test.ts
@@ -1,0 +1,393 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * guard.replay-store.test.ts
+ *
+ * Tests for the pluggable ReplayStore abstraction.
+ *
+ * Coverage:
+ *   RS-1  Default (in-memory) store: auth_id replay blocked within one guard instance
+ *   RS-2  Default (in-memory) store: delegation_id replay blocked within one guard instance
+ *   RS-3  Shared durable store: auth_id replay blocked across two DIFFERENT guard instances
+ *   RS-4  Shared durable store: delegation_id replay blocked across two guard instances
+ *   RS-5  Failing consumeAuthId: execution blocked (fail-closed)
+ *   RS-6  Failing consumeDelegationId: execution blocked (fail-closed)
+ *   RS-7  Store without consumeDelegationId: delegation path still works; parentAuth replay is enforced
+ *   RS-8  createInMemoryReplayStore is exported and independently usable
+ *   RS-9  Store unavailable for parentAuth: execution blocked on delegation path
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { Authorization, AuthorizationV1, Intent, State } from "@oxdeai/core";
+
+import { OxDeAIGuard, createInMemoryReplayStore } from "../index.js";
+import type { ReplayStore, OxDeAIGuardConfig, ProposedAction } from "../index.js";
+import { OxDeAIAuthorizationError } from "../errors.js";
+import { TEST_KEYSET, TEST_KEYPAIR, signAuth, makeParentAuthWithScope, makeDelegationWithScope } from "./helpers/fixtures.js";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+
+function makeBaseState(): State {
+  return {
+    policy_version: "policy-rs",
+    period_id: "p1",
+    kill_switch: { global: false, agents: {} },
+    allowlists: {},
+    budget: { budget_limit: { "agent-rs": 1_000_000n }, spent_in_period: { "agent-rs": 0n } },
+    max_amount_per_action: { "agent-rs": 1_000_000n },
+    velocity: { config: { window_seconds: 3600, max_actions: 100 }, counters: {} },
+    replay: { window_seconds: 3600, max_nonces_per_agent: 256, nonces: {} },
+    concurrency: { max_concurrent: { "agent-rs": 10 }, active: {}, active_auths: {} },
+    recursion: { max_depth: { "agent-rs": 5 } },
+    tool_limits: { window_seconds: 3600, max_calls: { "agent-rs": 100 }, calls: {} },
+  };
+}
+
+function makeAction(): ProposedAction {
+  return {
+    name: "pay",
+    args: { amount: 1 },
+    estimatedCost: 0,
+    context: { agent_id: "agent-rs", target: "vendor" },
+  };
+}
+
+/** A FakeEngine that always ALLOWs with the provided authorization artifact. */
+function makeFakeEngine(auth: AuthorizationV1) {
+  return {
+    evaluatePure(_intent: Intent, state: State) {
+      return {
+        decision: "ALLOW" as const,
+        reasons: [],
+        authorization: auth as Authorization,
+        nextState: state,
+      };
+    },
+  };
+}
+
+function makeGuardConfig(
+  auth: AuthorizationV1,
+  overrides: Partial<OxDeAIGuardConfig> = {}
+): OxDeAIGuardConfig {
+  let storedState = makeBaseState();
+  return {
+    engine: makeFakeEngine(auth) as any,
+    getState: async () => storedState,
+    setState: async (s) => { storedState = s; },
+    trustedKeySets: [TEST_KEYSET],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// RS-1: Default in-memory store blocks auth_id replay within one guard instance
+
+test("RS-1 default store: auth_id replay blocked on second call to same guard instance", async () => {
+  const auth = signAuth({ auth_id: "rs-auth-1" });
+  const guard = OxDeAIGuard(makeGuardConfig(auth));
+  const action = makeAction();
+
+  let executions = 0;
+  await guard(action, async () => { executions++; });
+
+  await assert.rejects(
+    () => guard(action, async () => { executions++; }),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError);
+      assert.match(err.message, /replay detected/i);
+      return true;
+    }
+  );
+
+  assert.equal(executions, 1);
+});
+
+// ---------------------------------------------------------------------------
+// RS-2: Default in-memory store blocks delegation_id replay within one guard instance
+
+test("RS-2 default store: delegation_id replay blocked on second call to same guard instance", async () => {
+  const parentAuth = makeParentAuthWithScope(
+    { tools: ["pay"], max_amount: 1_000_000n },
+    { auth_id: "rs-parent-auth-2", audience: "agent-rs" }
+  );
+  const delegation = makeDelegationWithScope(parentAuth, { tools: ["pay"], max_amount: 1_000_000n });
+
+  let storedState = makeBaseState();
+  const guard = OxDeAIGuard({
+    engine: { evaluatePure: () => { throw new Error("should not reach engine on delegation path"); } } as any,
+    getState: async () => storedState,
+    setState: async (s) => { storedState = s; },
+    trustedKeySets: [TEST_KEYSET],
+  });
+  const action = makeAction();
+
+  let executions = 0;
+  await guard(action, async () => { executions++; }, { delegation: { delegation, parentAuth } });
+
+  await assert.rejects(
+    () => guard(action, async () => { executions++; }, { delegation: { delegation, parentAuth } }),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError);
+      assert.match(err.message, /[Dd]elegation replay detected/);
+      return true;
+    }
+  );
+
+  assert.equal(executions, 1);
+});
+
+// ---------------------------------------------------------------------------
+// RS-3: Shared durable store blocks auth_id replay across different guard instances
+
+test("RS-3 shared store: auth_id replay blocked across two distinct guard instances", async () => {
+  // A shared store simulates a durable backend (e.g. Redis) shared between processes.
+  const sharedStore = createInMemoryReplayStore();
+  const auth = signAuth({ auth_id: "rs-auth-3" });
+
+  const guardA = OxDeAIGuard(makeGuardConfig(auth, { replayStore: sharedStore }));
+  const guardB = OxDeAIGuard(makeGuardConfig(auth, { replayStore: sharedStore }));
+  const action = makeAction();
+
+  let executions = 0;
+  await guardA(action, async () => { executions++; });
+
+  // guardB has its own in-flight state but shares the replay store → replay detected.
+  await assert.rejects(
+    () => guardB(action, async () => { executions++; }),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError);
+      assert.match(err.message, /replay detected/i);
+      return true;
+    }
+  );
+
+  assert.equal(executions, 1, "only the first guard instance's execute must run");
+});
+
+// ---------------------------------------------------------------------------
+// RS-4: Shared durable store blocks delegation_id replay across guard instances
+
+test("RS-4 shared store: delegation_id replay blocked across two distinct guard instances", async () => {
+  const sharedStore = createInMemoryReplayStore();
+  const parentAuth = makeParentAuthWithScope(
+    { tools: ["pay"], max_amount: 1_000_000n },
+    { auth_id: "rs-parent-auth-4", audience: "agent-rs" }
+  );
+  const delegation = makeDelegationWithScope(parentAuth, { tools: ["pay"], max_amount: 1_000_000n });
+
+  function makeDelGuard() {
+    let storedState = makeBaseState();
+    return OxDeAIGuard({
+      engine: { evaluatePure: () => { throw new Error("should not reach engine"); } } as any,
+      getState: async () => storedState,
+      setState: async (s) => { storedState = s; },
+      trustedKeySets: [TEST_KEYSET],
+      replayStore: sharedStore,
+    });
+  }
+
+  const guardA = makeDelGuard();
+  const guardB = makeDelGuard();
+  const action = makeAction();
+
+  let executions = 0;
+  await guardA(action, async () => { executions++; }, { delegation: { delegation, parentAuth } });
+
+  await assert.rejects(
+    () => guardB(action, async () => { executions++; }, { delegation: { delegation, parentAuth } }),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError);
+      assert.match(err.message, /[Dd]elegation replay detected/);
+      return true;
+    }
+  );
+
+  assert.equal(executions, 1, "only the first guard instance's execute must run");
+});
+
+// ---------------------------------------------------------------------------
+// RS-5: consumeAuthId throws → execution blocked (fail-closed)
+
+test("RS-5 failing consumeAuthId: execution blocked when store throws", async () => {
+  const failingStore: ReplayStore = {
+    async consumeAuthId(): Promise<boolean> {
+      throw new Error("redis unavailable");
+    },
+  };
+
+  const auth = signAuth({ auth_id: "rs-auth-5" });
+  const guard = OxDeAIGuard(makeGuardConfig(auth, { replayStore: failingStore }));
+  const action = makeAction();
+
+  let executed = false;
+  await assert.rejects(
+    () => guard(action, async () => { executed = true; }),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError);
+      assert.match(err.message, /[Rr]eplay store unavailable/);
+      assert.match(err.message, /redis unavailable/);
+      return true;
+    }
+  );
+
+  assert.equal(executed, false, "execute must not be called when store throws");
+});
+
+// ---------------------------------------------------------------------------
+// RS-6: consumeDelegationId throws → execution blocked on delegation path
+
+test("RS-6 failing consumeDelegationId: execution blocked when store throws on delegation path", async () => {
+  const failingStore: ReplayStore = {
+    async consumeAuthId(): Promise<boolean> {
+      return true; // auth would pass
+    },
+    async consumeDelegationId(): Promise<boolean> {
+      throw new Error("db connection lost");
+    },
+  };
+
+  const parentAuth = makeParentAuthWithScope(
+    { tools: ["pay"], max_amount: 1_000_000n },
+    { auth_id: "rs-parent-auth-6", audience: "agent-rs" }
+  );
+  const delegation = makeDelegationWithScope(parentAuth, { tools: ["pay"], max_amount: 1_000_000n });
+
+  let storedState = makeBaseState();
+  const guard = OxDeAIGuard({
+    engine: { evaluatePure: () => { throw new Error("should not reach engine"); } } as any,
+    getState: async () => storedState,
+    setState: async (s) => { storedState = s; },
+    trustedKeySets: [TEST_KEYSET],
+    replayStore: failingStore,
+  });
+
+  let executed = false;
+  await assert.rejects(
+    () => guard(makeAction(), async () => { executed = true; }, { delegation: { delegation, parentAuth } }),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError);
+      assert.match(err.message, /[Rr]eplay store unavailable/);
+      assert.match(err.message, /db connection lost/);
+      return true;
+    }
+  );
+
+  assert.equal(executed, false, "execute must not be called when delegation store throws");
+});
+
+// ---------------------------------------------------------------------------
+// RS-7: Store without consumeDelegationId — delegation path still enforces parentAuth replay
+
+test("RS-7 store without consumeDelegationId: delegation executes; parentAuth replay is enforced via consumeAuthId", async () => {
+  // A store that only implements consumeAuthId (consumeDelegationId is absent).
+  // The guard must fall through and still enforce replay via consumeAuthId.
+  const authOnlyStore: ReplayStore = {
+    async consumeAuthId(authId: string): Promise<boolean> {
+      return internalSet.has(authId) ? false : (internalSet.add(authId), true);
+    },
+    // consumeDelegationId intentionally absent
+  };
+  const internalSet = new Set<string>();
+
+  const parentAuth = makeParentAuthWithScope(
+    { tools: ["pay"], max_amount: 1_000_000n },
+    { auth_id: "rs-parent-auth-7", audience: "agent-rs" }
+  );
+  const delegation = makeDelegationWithScope(parentAuth, { tools: ["pay"], max_amount: 1_000_000n });
+
+  let storedState = makeBaseState();
+  const guard = OxDeAIGuard({
+    engine: { evaluatePure: () => { throw new Error("should not reach engine"); } } as any,
+    getState: async () => storedState,
+    setState: async (s) => { storedState = s; },
+    trustedKeySets: [TEST_KEYSET],
+    replayStore: authOnlyStore,
+  });
+  const action = makeAction();
+
+  // First call: should succeed.
+  let executions = 0;
+  await guard(action, async () => { executions++; }, { delegation: { delegation, parentAuth } });
+  assert.equal(executions, 1);
+
+  // Second call with same parentAuth: consumeAuthId returns false → replay blocked.
+  await assert.rejects(
+    () => guard(action, async () => { executions++; }, { delegation: { delegation, parentAuth } }),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError);
+      assert.match(err.message, /replay detected/i);
+      return true;
+    }
+  );
+  assert.equal(executions, 1, "parentAuth replay must be blocked even without consumeDelegationId");
+});
+
+// ---------------------------------------------------------------------------
+// RS-8: createInMemoryReplayStore is exported and independently usable
+
+test("RS-8 createInMemoryReplayStore: exported factory produces an independent working store", async () => {
+  const storeA = createInMemoryReplayStore();
+  const storeB = createInMemoryReplayStore();
+
+  // storeA: first consume succeeds, second is replay.
+  assert.equal(await storeA.consumeAuthId("x", { expiry: 9999999999 }), true);
+  assert.equal(await storeA.consumeAuthId("x", { expiry: 9999999999 }), false);
+
+  // storeB is independent: same ID not yet seen.
+  assert.equal(await storeB.consumeAuthId("x", { expiry: 9999999999 }), true);
+
+  // Delegation IDs follow the same pattern.
+  assert.equal(await storeA.consumeDelegationId!("d1", { expiry: 9999999999 }), true);
+  assert.equal(await storeA.consumeDelegationId!("d1", { expiry: 9999999999 }), false);
+  assert.equal(await storeB.consumeDelegationId!("d1", { expiry: 9999999999 }), true);
+});
+
+// ---------------------------------------------------------------------------
+// RS-9: Store unavailable for parentAuth → execution blocked on delegation path
+
+test("RS-9 store unavailable for parentAuth auth_id: execution blocked on delegation path", async () => {
+  // consumeAuthId succeeds the first time (for delegation_id path coverage), but
+  // throws on the second call (parentAuth.auth_id check).
+  let callCount = 0;
+  const partialFailStore: ReplayStore = {
+    async consumeAuthId(): Promise<boolean> {
+      throw new Error("network timeout");
+    },
+    async consumeDelegationId(): Promise<boolean> {
+      callCount++;
+      return true; // delegation_id passes fine
+    },
+  };
+
+  const parentAuth = makeParentAuthWithScope(
+    { tools: ["pay"], max_amount: 1_000_000n },
+    { auth_id: "rs-parent-auth-9", audience: "agent-rs" }
+  );
+  const delegation = makeDelegationWithScope(parentAuth, { tools: ["pay"], max_amount: 1_000_000n });
+
+  let storedState = makeBaseState();
+  const guard = OxDeAIGuard({
+    engine: { evaluatePure: () => { throw new Error("should not reach engine"); } } as any,
+    getState: async () => storedState,
+    setState: async (s) => { storedState = s; },
+    trustedKeySets: [TEST_KEYSET],
+    replayStore: partialFailStore,
+  });
+
+  let executed = false;
+  await assert.rejects(
+    () => guard(makeAction(), async () => { executed = true; }, { delegation: { delegation, parentAuth } }),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError);
+      assert.match(err.message, /[Rr]eplay store unavailable/);
+      assert.match(err.message, /network timeout/);
+      return true;
+    }
+  );
+
+  assert.equal(executed, false, "execute must not be called when parentAuth store check throws");
+  assert.equal(callCount, 1, "consumeDelegationId should have been called once before the parentAuth failure");
+});

--- a/packages/guard/src/types.ts
+++ b/packages/guard/src/types.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Authorization, AuthorizationV1, DelegationV1, Intent, KeySet, PolicyEngine, State } from "@oxdeai/core";
+import type { ReplayStore } from "./replayStore.js";
 
 /**
  * A runtime-agnostic description of an action an agent wants to perform.
@@ -106,9 +107,15 @@ export type OxDeAIGuardConfig = {
   requireDelegationSignatureVerification?: boolean;
 
   /**
-   * Set of delegation_ids already consumed in this session.
-   * Used for replay protection on the delegation path.
-   * Tracking across calls is the caller's responsibility.
+   * Pluggable replay store for durable auth_id and delegation_id tracking.
+   *
+   * When omitted, an in-memory store is created per guard instance (equivalent
+   * to the previous single-process behavior). Provide a backend-backed
+   * implementation (e.g. Redis, DynamoDB) for multi-process or
+   * restart-durable replay prevention.
+   *
+   * The store MUST be fail-closed: throw rather than return a permissive
+   * result when unavailable. The guard treats any thrown error as DENY.
    */
-  consumedDelegationIds?: readonly string[];
+  replayStore?: ReplayStore;
 };

--- a/packages/langgraph/README.md
+++ b/packages/langgraph/README.md
@@ -1,10 +1,6 @@
 # @oxdeai/langgraph
-
-**Thin LangGraph binding for [@oxdeai/guard](https://github.com/AngeYobo/oxdeai/blob/main/packages/guard/README.md).**
-
-This package connects LangGraph tool calls to the OxDeAI universal execution
-guard. It contains no authorization logic - all policy evaluation and PEP
-enforcement is delegated to `@oxdeai/guard`.
+LangGraph adapter for the OxDeAI execution-time authorization protocol (non-bypassable boundary).
+Maps LangGraph tool calls to @oxdeai/guard; verification stays local and fail-closed.
 
 ---
 

--- a/packages/openai-agents/README.md
+++ b/packages/openai-agents/README.md
@@ -1,10 +1,6 @@
 # @oxdeai/openai-agents
-
-**Thin OpenAI Agents SDK binding for [@oxdeai/guard](https://github.com/AngeYobo/oxdeai/blob/main/packages/guard/README.md).**
-
-This package connects OpenAI Agents SDK tool calls to the OxDeAI universal
-execution guard. It contains no authorization logic - all policy evaluation
-and PEP enforcement is delegated to `@oxdeai/guard`.
+OpenAI Agents SDK adapter for the OxDeAI execution-time authorization protocol.
+All tool calls pass through @oxdeai/guard (non-bypassable boundary, fail-closed verification).
 
 ---
 

--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -1,10 +1,6 @@
 # @oxdeai/openclaw
-
-**Thin OpenClaw binding for [@oxdeai/guard](https://github.com/AngeYobo/oxdeai/blob/main/packages/guard/README.md).**
-
-This package connects OpenClaw action/skill calls to the OxDeAI universal
-execution guard. It contains no authorization logic. All policy evaluation
-and PEP enforcement is delegated to `@oxdeai/guard`.
+OpenClaw adapter for the OxDeAI execution-time authorization protocol.
+Enforces the non-bypassable execution boundary via @oxdeai/guard; no authorization → no execution.
 
 ---
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,6 +1,6 @@
 # @oxdeai/sdk
-
-Developer-facing integration layer on top of `@oxdeai/core`.
+Developer toolkit for the OxDeAI execution-time authorization protocol (ETA).
+Builds intents/states and guard boundaries that remain non-bypassable and fail-closed at execution.
 
 ## Status
 


### PR DESCRIPTION
## Summary

This PR introduces a pluggable replay protection layer in the reusable guard, replacing the previous in-memory Set-based tracking with a formal `ReplayStore` abstraction.

Replay protection is now enforced at the execution boundary with fail-closed semantics.

---

## Changes

### New

- `packages/guard/src/replayStore.ts`
  - `ReplayStore` interface
  - `createInMemoryReplayStore()` default implementation

- `packages/guard/src/test/guard.replay-store.test.ts`
  - 9 test cases (RS-1 → RS-9) covering replay semantics and failure modes

### Modified

- `guard.ts`
  - removed internal replay Sets
  - wired `replayStore` into both standard and delegation execution paths
  - replay enforced via async `consumeAuthId` / `consumeDelegationId`

- `types.ts`
  - added `replayStore?: ReplayStore` to `OxDeAIGuardConfig`
  - removed legacy replay fields

- `index.ts`
  - exported `ReplayStore` and factory

- `guard.boundary.test.ts`
  - fixed invalid test fixtures (key encoding, delegation scope mismatch)

- `package.json`
  - added replay-store tests to test script

---

## Execution Boundary Behavior

### Replay enforcement

- `auth_id` and `delegation_id` are consumed at the guard boundary
- second use → deterministic DENY

### Fail-closed

- any replay store error → `OxDeAIAuthorizationError`
- execution never proceeds if replay state is unknown

### Ordering

- **consume-before-verify**
  - replay IDs are marked as consumed before authorization verification
  - prevents retry with the same credential even if verification fails

---

## Design Notes

- Default behavior remains backward compatible:
```ts
  config.replayStore ?? createInMemoryReplayStore()
````

→ preserves single-process semantics

* `consumeDelegationId` is optional:

  * fallback replay protection still applies via `auth_id`

---

## Current Guarantees

* replay protection enforced at execution boundary
* fail-closed semantics preserved
* no execution path without replay validation

---

## Limitations (tracked in #29)

This PR introduces the abstraction and boundary enforcement, but does **not yet provide durable replay guarantees**:

* in-memory store is process-local
* no restart persistence
* no multi-instance coordination

Remaining work:

* durable shared replay backend
* restart-safe semantics
* multi-instance enforcement

---

## Validation

```
pnpm -C packages/guard test
```

Result:

```
89/89 tests passing
```

---

## Impact

This moves replay protection from an implementation detail to a **first-class execution-boundary concern**, aligned with OxDeAI’s fail-closed and non-bypassable enforcement model.
