### PR TITLE
feat(guard): add Redis-backed replay store for execution-boundary enf…

### DIFF
--- a/packages/guard/README.md
+++ b/packages/guard/README.md
@@ -136,6 +136,97 @@ OxDeAIGuard({
 
 ---
 
+## Replay store — production requirements
+
+The guard prevents replay via a pluggable `ReplayStore`. Every `auth_id` and
+`delegation_id` is atomically check-and-consumed before execution.
+
+### Default: in-memory (development only)
+
+```typescript
+import { OxDeAIGuard } from "@oxdeai/guard";
+// No replayStore config → createInMemoryReplayStore() used automatically.
+```
+
+**NOT suitable for production.** Replay state is:
+- lost on process restart
+- not shared across instances (horizontal scaling allows cross-instance replay)
+
+### Production: Redis backend
+
+```typescript
+import { OxDeAIGuard, createRedisReplayStore } from "@oxdeai/guard";
+import Redis from "ioredis"; // or node-redis v4
+
+const redis = new Redis({ host: "redis.internal", port: 6379 });
+
+const guard = OxDeAIGuard({
+  engine,
+  getState,
+  setState,
+  trustedKeySets: [myKeySet],
+  replayStore: createRedisReplayStore({ client: redis }),
+});
+```
+
+Atomicity is guaranteed by `SET key value NX EX ttl`. Exactly one caller
+wins across any number of instances; all others see `null` and receive
+`OxDeAIAuthorizationError: replay detected`.
+
+**Key schema:**
+
+| Artifact | Redis key |
+|---|---|
+| `AuthorizationV1` | `replay:auth:<auth_id>` |
+| `DelegationV1` | `replay:delegation:<delegation_id>` |
+
+**TTL:** derived from artifact `expiry` — `max(1, expiry - now)`. Keys
+auto-evict after the artifact expires. No manual cleanup required.
+
+**Fail-closed:** if Redis is unavailable (network failure, timeout, restart),
+`consumeAuthId` throws. The guard catches this and raises
+`OxDeAIAuthorizationError: Replay store unavailable`, blocking execution.
+There is no fallback to memory and no best-effort path.
+
+### node-redis v4 adapter
+
+```typescript
+import { createClient } from "redis";
+import type { RedisClient } from "@oxdeai/guard";
+
+const nodeRedis = createClient({ url: "redis://redis.internal:6379" });
+await nodeRedis.connect();
+
+// Adapt the node-redis v4 API to the RedisClient interface.
+const client: RedisClient = {
+  set: (key, value, _nx, _ex, ttl) =>
+    nodeRedis.set(key, value, { NX: true, EX: ttl }),
+};
+
+const guard = OxDeAIGuard({
+  // ...
+  replayStore: createRedisReplayStore({ client }),
+});
+```
+
+### Custom backends
+
+Implement `ReplayStore` directly for DynamoDB, Postgres, or any store that
+provides compare-and-set semantics:
+
+```typescript
+import type { ReplayStore } from "@oxdeai/guard";
+
+const myStore: ReplayStore = {
+  async consumeAuthId(authId, { expiry }) {
+    // Must be atomic. Return true = first use, false = replay, throw = fail-closed.
+    return await db.setIfAbsent(`auth:${authId}`, expiry);
+  },
+};
+```
+
+---
+
 ## Error classes
 
 | Class | When thrown |

--- a/packages/guard/package.json
+++ b/packages/guard/package.json
@@ -30,6 +30,6 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "rm -rf dist && tsc -p tsconfig.json",
-    "test": "pnpm build && node --test \"dist/test/guard.test.js\" \"dist/test/guard.property.test.js\" \"dist/test/guard.delegation.test.js\" \"dist/test/guard.delegation.matrix.test.js\" \"dist/test/guard.delegation.property.test.js\" \"dist/test/guard.toctou.test.js\" \"dist/test/guard.boundary.test.js\" \"dist/test/guard.replay-store.test.js\""
+    "test": "pnpm build && node --test \"dist/test/guard.test.js\" \"dist/test/guard.property.test.js\" \"dist/test/guard.delegation.test.js\" \"dist/test/guard.delegation.matrix.test.js\" \"dist/test/guard.delegation.property.test.js\" \"dist/test/guard.toctou.test.js\" \"dist/test/guard.boundary.test.js\" \"dist/test/guard.replay-store.test.js\" \"dist/test/guard.replay-store.redis.test.js\""
   }
 }

--- a/packages/guard/src/index.ts
+++ b/packages/guard/src/index.ts
@@ -12,6 +12,8 @@ export { OxDeAIGuard } from "./guard.js";
 export { defaultNormalizeAction } from "./normalizeAction.js";
 export { createInMemoryReplayStore } from "./replayStore.js";
 export type { ReplayStore } from "./replayStore.js";
+export { createRedisReplayStore } from "./replayStore.redis.js";
+export type { RedisClient, RedisReplayStoreConfig } from "./replayStore.redis.js";
 export {
   OxDeAIDenyError,
   OxDeAIAuthorizationError,

--- a/packages/guard/src/replayStore.redis.ts
+++ b/packages/guard/src/replayStore.redis.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * replayStore.redis.ts
+ *
+ * Production-grade ReplayStore backed by Redis.
+ *
+ * Atomicity guarantee:
+ *   SET key value NX EX ttl is a single atomic Redis command.
+ *   Across any number of guard instances sharing the same Redis cluster,
+ *   exactly one caller will receive "OK" for a given key; all others receive
+ *   null. This eliminates the TOCTOU window present in read-then-write patterns.
+ *
+ * Key schema:
+ *   replay:auth:<auth_id>           — AuthorizationV1 single-use tokens
+ *   replay:delegation:<delegation_id> — DelegationV1 single-use tokens
+ *
+ * TTL policy:
+ *   ttl = max(1, expiry - now)
+ *   Keys are automatically evicted by Redis once the artifact expires.
+ *   A minimum of 1 second is enforced so that already-expired artifacts
+ *   never create zero-TTL or infinite-TTL keys.
+ *
+ * Fail-closed:
+ *   Any Redis error (network failure, timeout, cluster failover) is re-thrown.
+ *   The guard catches this and raises OxDeAIAuthorizationError, blocking execution.
+ *   There is no fallback, no best-effort path, no silent memory store.
+ *
+ * Client compatibility:
+ *   The RedisClient interface matches the ioredis positional argument style:
+ *     client.set(key, value, "NX", "EX", ttlSeconds) → Promise<"OK" | null>
+ *
+ *   node-redis v4 adapter:
+ *     const client: RedisClient = {
+ *       set: (k, v, _nx, _ex, ttl) =>
+ *         nodeRedisClient.set(k, v, { NX: true, EX: ttl }),
+ *     };
+ *
+ * Clock skew:
+ *   TTL is derived from artifact expiry (absolute Unix timestamp). If the
+ *   guard host clock is skewed relative to the issuer, the TTL may be shorter
+ *   or longer than intended. A skew of ±30 seconds is typical and acceptable
+ *   given that authorization artifacts already carry explicit expiry checks in
+ *   strictVerifyAuthorization. The Redis TTL only governs key eviction, not
+ *   authorization validity.
+ */
+
+import type { ReplayStore } from "./replayStore.js";
+
+// ---------------------------------------------------------------------------
+// Minimal Redis client interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal Redis client interface required by createRedisReplayStore.
+ *
+ * Intentionally narrow — only the SET NX EX command is required.
+ * Compatible natively with ioredis and @redis/client (node-redis v4 wrapper).
+ *
+ * The caller owns the client lifecycle (connection, reconnection, shutdown).
+ * The store does NOT create, pool, or close connections.
+ */
+export interface RedisClient {
+  /**
+   * SET key value NX EX seconds
+   *
+   * @returns "OK"  if the key was set (first use — consume allowed)
+   * @returns null  if the key already existed (replay — consume denied)
+   * @throws        on any Redis or network error
+   */
+  set(
+    key: string,
+    value: string,
+    nx: "NX",
+    ex: "EX",
+    seconds: number
+  ): Promise<"OK" | null>;
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface RedisReplayStoreConfig {
+  /** Pre-connected Redis client. The store does not manage its lifecycle. */
+  client: RedisClient;
+}
+
+// ---------------------------------------------------------------------------
+// Key helpers
+// ---------------------------------------------------------------------------
+
+/** Returns the Redis key for an auth_id. Not user-overridable. */
+function authKey(authId: string): string {
+  return `replay:auth:${authId}`;
+}
+
+/** Returns the Redis key for a delegation_id. Not user-overridable. */
+function delegationKey(delegationId: string): string {
+  return `replay:delegation:${delegationId}`;
+}
+
+/**
+ * Compute the TTL (seconds) to assign to a Redis key.
+ *
+ * Always at least 1 second — zero or negative TTLs would cause Redis to either
+ * reject the command or create a key that expires immediately, which could allow
+ * replay of already-expired artifacts on a subsequent request within the same
+ * second.
+ */
+function computeTtl(expiry: number): number {
+  const now = Math.floor(Date.now() / 1000);
+  return Math.max(1, expiry - now);
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * createRedisReplayStore — production-grade, multi-instance-safe ReplayStore.
+ *
+ * Usage:
+ *
+ *   import { createClient } from "ioredis"; // or node-redis v4
+ *   import { createRedisReplayStore } from "@oxdeai/guard/replayStore.redis";
+ *
+ *   const redis = new Redis({ host: "redis.internal", port: 6379 });
+ *
+ *   const guard = OxDeAIGuard({
+ *     // ...
+ *     replayStore: createRedisReplayStore({ client: redis }),
+ *   });
+ *
+ * @param config.client  Pre-connected Redis client. Must remain connected for
+ *                       the lifetime of the guard. The caller is responsible
+ *                       for reconnection and graceful shutdown.
+ */
+export function createRedisReplayStore(config: RedisReplayStoreConfig): ReplayStore {
+  const { client } = config;
+
+  if (!client || typeof client.set !== "function") {
+    throw new TypeError(
+      "createRedisReplayStore: config.client must implement RedisClient (set method required)."
+    );
+  }
+
+  return {
+    async consumeAuthId(authId: string, opts: { expiry: number }): Promise<boolean> {
+      const ttl = computeTtl(opts.expiry);
+      const result = await client.set(authKey(authId), "1", "NX", "EX", ttl);
+      return result === "OK";
+    },
+
+    async consumeDelegationId(delegationId: string, opts: { expiry: number }): Promise<boolean> {
+      const ttl = computeTtl(opts.expiry);
+      const result = await client.set(delegationKey(delegationId), "1", "NX", "EX", ttl);
+      return result === "OK";
+    },
+  };
+}

--- a/packages/guard/src/test/guard.replay-store.redis.test.ts
+++ b/packages/guard/src/test/guard.replay-store.redis.test.ts
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * guard.replay-store.redis.test.ts
+ *
+ * Tests for createRedisReplayStore.
+ *
+ * No real Redis instance is required. A FakeRedisClient mirrors the exact
+ * atomic semantics of SET NX EX: a Map<key, expiry> is the backing store,
+ * and SET NX is implemented as a single check-and-insert with no window
+ * between the check and the write. This faithfully models what Redis does.
+ *
+ * Coverage:
+ *   RS-R1  First consumeAuthId → true
+ *   RS-R2  Second consumeAuthId (same id) → false (replay)
+ *   RS-R3  After TTL elapses, key is reusable (first-use returns true again)
+ *   RS-R4  Concurrent calls: exactly one returns true (atomic NX semantics)
+ *   RS-R5  consumeDelegationId: first use → true; replay → false
+ *   RS-R6  Redis error in consumeAuthId → throws (fail-closed)
+ *   RS-R7  Redis error in consumeDelegationId → throws (fail-closed)
+ *   RS-R8  Multiple guard instances sharing one client: cross-instance replay blocked
+ *   RS-R9  createRedisReplayStore rejects invalid client at construction time
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createRedisReplayStore } from "../replayStore.redis.js";
+import type { RedisClient } from "../replayStore.redis.js";
+import { OxDeAIGuard } from "../index.js";
+import type { OxDeAIGuardConfig, ProposedAction } from "../index.js";
+import { OxDeAIAuthorizationError } from "../errors.js";
+import type { Authorization, AuthorizationV1, Intent, State } from "@oxdeai/core";
+import { TEST_KEYSET, signAuth } from "./helpers/fixtures.js";
+
+// ---------------------------------------------------------------------------
+// FakeRedisClient
+//
+// Implements RedisClient with in-memory Map that mirrors exact Redis NX EX
+// semantics. The SET NX operation is synchronous within a single JS turn,
+// so it is race-free (JS event loop is single-threaded). This matches the
+// atomicity guarantee Redis provides via its single-threaded command processor.
+// ---------------------------------------------------------------------------
+
+class FakeRedisClient implements RedisClient {
+  /** key → absolute expiry timestamp (seconds). 0 = no expiry. */
+  private readonly store = new Map<string, number>();
+  /** Simulated clock offset in seconds (for TTL expiry tests). */
+  private clockOffset = 0;
+
+  private now(): number {
+    return Math.floor(Date.now() / 1000) + this.clockOffset;
+  }
+
+  /** Advance the simulated clock by `seconds`. Causes expired keys to be evicted. */
+  advanceClock(seconds: number): void {
+    this.clockOffset += seconds;
+    // Evict expired keys eagerly so subsequent SET NX can succeed.
+    const now = this.now();
+    for (const [key, expiry] of this.store) {
+      if (expiry > 0 && now >= expiry) {
+        this.store.delete(key);
+      }
+    }
+  }
+
+  async set(
+    key: string,
+    value: string,
+    nx: "NX",
+    ex: "EX",
+    seconds: number
+  ): Promise<"OK" | null> {
+    const now = this.now();
+
+    // Evict the key if it has expired (lazy eviction path for non-advancing tests).
+    const existing = this.store.get(key);
+    if (existing !== undefined && existing > 0 && now >= existing) {
+      this.store.delete(key);
+    }
+
+    if (this.store.has(key)) {
+      return null; // NX: key already exists
+    }
+
+    const expiry = seconds > 0 ? now + seconds : 0;
+    this.store.set(key, expiry);
+    return "OK";
+  }
+
+  /** Expose internal store size for assertions. */
+  size(): number { return this.store.size; }
+}
+
+/** A FakeRedisClient that throws on every SET call. */
+class ErrorRedisClient implements RedisClient {
+  constructor(private readonly message: string) {}
+  async set(): Promise<"OK" | null> {
+    throw new Error(this.message);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Guard integration helpers (mirrors guard.replay-store.test.ts pattern)
+// ---------------------------------------------------------------------------
+
+function makeBaseState(): State {
+  return {
+    policy_version: "policy-redis",
+    period_id: "p1",
+    kill_switch: { global: false, agents: {} },
+    allowlists: {},
+    budget: { budget_limit: { "agent-redis": 1_000_000n }, spent_in_period: { "agent-redis": 0n } },
+    max_amount_per_action: { "agent-redis": 1_000_000n },
+    velocity: { config: { window_seconds: 3600, max_actions: 100 }, counters: {} },
+    replay: { window_seconds: 3600, max_nonces_per_agent: 256, nonces: {} },
+    concurrency: { max_concurrent: { "agent-redis": 10 }, active: {}, active_auths: {} },
+    recursion: { max_depth: { "agent-redis": 5 } },
+    tool_limits: { window_seconds: 3600, max_calls: { "agent-redis": 100 }, calls: {} },
+  };
+}
+
+function makeAction(): ProposedAction {
+  return {
+    name: "pay",
+    args: { amount: 1 },
+    estimatedCost: 0,
+    context: { agent_id: "agent-redis", target: "vendor" },
+  };
+}
+
+function makeFakeEngine(auth: AuthorizationV1) {
+  return {
+    evaluatePure(_intent: Intent, state: State) {
+      return {
+        decision: "ALLOW" as const,
+        reasons: [],
+        authorization: auth as Authorization,
+        nextState: state,
+      };
+    },
+  };
+}
+
+function makeGuardConfig(
+  auth: AuthorizationV1,
+  redisClient: RedisClient,
+  stateOverride?: { get: () => State; set: (s: State) => void }
+): OxDeAIGuardConfig {
+  let storedState = makeBaseState();
+  const get = stateOverride?.get ?? (() => storedState);
+  const set = stateOverride?.set ?? ((s: State) => { storedState = s; });
+  return {
+    engine: makeFakeEngine(auth) as any,
+    getState: async () => get(),
+    setState: async (s) => set(s),
+    trustedKeySets: [TEST_KEYSET],
+    replayStore: createRedisReplayStore({ client: redisClient }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// RS-R1: First consumeAuthId → true
+// ---------------------------------------------------------------------------
+
+test("RS-R1 first consumeAuthId via guard: execution succeeds", async () => {
+  const fake = new FakeRedisClient();
+  const auth = signAuth({ auth_id: "redis-auth-r1" });
+  const guard = OxDeAIGuard(makeGuardConfig(auth, fake));
+
+  let executed = false;
+  await guard(makeAction(), async () => { executed = true; });
+  assert.ok(executed);
+});
+
+// ---------------------------------------------------------------------------
+// RS-R2: Second consumeAuthId (same id) → false (replay)
+// ---------------------------------------------------------------------------
+
+test("RS-R2 second consumeAuthId via guard: replay blocked", async () => {
+  const fake = new FakeRedisClient();
+  const auth = signAuth({ auth_id: "redis-auth-r2" });
+  const guard = OxDeAIGuard(makeGuardConfig(auth, fake));
+  const action = makeAction();
+
+  let executions = 0;
+  await guard(action, async () => { executions++; });
+
+  await assert.rejects(
+    () => guard(action, async () => { executions++; }),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError);
+      assert.match(err.message, /replay detected/i);
+      return true;
+    }
+  );
+
+  assert.equal(executions, 1);
+});
+
+// ---------------------------------------------------------------------------
+// RS-R3: After TTL elapses, key is reusable
+// ---------------------------------------------------------------------------
+
+test("RS-R3 after TTL expiry, key can be re-consumed (store level)", async () => {
+  const fake = new FakeRedisClient();
+  const store = createRedisReplayStore({ client: fake });
+  const now = Math.floor(Date.now() / 1000);
+
+  // First consume: expiry 2 seconds from now → TTL = 2
+  const first = await store.consumeAuthId("r3-id", { expiry: now + 2 });
+  assert.equal(first, true);
+
+  // Second consume before expiry: replay
+  const second = await store.consumeAuthId("r3-id", { expiry: now + 2 });
+  assert.equal(second, false);
+
+  // Advance fake clock past the TTL
+  fake.advanceClock(3);
+
+  // After eviction, the same id can be consumed again
+  const third = await store.consumeAuthId("r3-id", { expiry: now + 10 });
+  assert.equal(third, true);
+});
+
+// ---------------------------------------------------------------------------
+// RS-R4: Concurrent calls — exactly one returns true (NX atomicity)
+// ---------------------------------------------------------------------------
+
+test("RS-R4 concurrent consumeAuthId: exactly one succeeds", async () => {
+  const fake = new FakeRedisClient();
+  const store = createRedisReplayStore({ client: fake });
+  const now = Math.floor(Date.now() / 1000);
+
+  // Fire 20 concurrent consume calls for the same id.
+  const results = await Promise.all(
+    Array.from({ length: 20 }, () =>
+      store.consumeAuthId("r4-id", { expiry: now + 300 })
+    )
+  );
+
+  const trueCount = results.filter(Boolean).length;
+  const falseCount = results.filter((r) => !r).length;
+  assert.equal(trueCount, 1, "exactly one call must win the NX race");
+  assert.equal(falseCount, 19, "all other callers must see replay");
+});
+
+// ---------------------------------------------------------------------------
+// RS-R5: consumeDelegationId: first use → true; replay → false
+// ---------------------------------------------------------------------------
+
+test("RS-R5 consumeDelegationId: first use true, replay false", async () => {
+  const fake = new FakeRedisClient();
+  const store = createRedisReplayStore({ client: fake });
+  const now = Math.floor(Date.now() / 1000);
+
+  const first = await store.consumeDelegationId!("r5-del-id", { expiry: now + 300 });
+  assert.equal(first, true);
+
+  const second = await store.consumeDelegationId!("r5-del-id", { expiry: now + 300 });
+  assert.equal(second, false);
+});
+
+// ---------------------------------------------------------------------------
+// RS-R6: Redis error in consumeAuthId → throws (fail-closed)
+// ---------------------------------------------------------------------------
+
+test("RS-R6 Redis error in consumeAuthId: throws OxDeAIAuthorizationError via guard", async () => {
+  const errClient = new ErrorRedisClient("connection refused");
+  const auth = signAuth({ auth_id: "redis-auth-r6" });
+  const guard = OxDeAIGuard(makeGuardConfig(auth, errClient));
+
+  let executed = false;
+  await assert.rejects(
+    () => guard(makeAction(), async () => { executed = true; }),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError);
+      assert.match(err.message, /[Rr]eplay store unavailable/);
+      assert.match(err.message, /connection refused/);
+      return true;
+    }
+  );
+
+  assert.equal(executed, false, "execute must not be called when Redis throws");
+});
+
+// ---------------------------------------------------------------------------
+// RS-R7: Redis error in consumeDelegationId → throws (fail-closed)
+// ---------------------------------------------------------------------------
+
+test("RS-R7 Redis error in consumeDelegationId: throws OxDeAIAuthorizationError via guard", async () => {
+  // consumeAuthId passes (won't be reached — delegation_id is checked first),
+  // but consumeDelegationId throws.
+  const hybridClient: RedisClient = {
+    async set(key: string): Promise<"OK" | null> {
+      if (key.startsWith("replay:delegation:")) {
+        throw new Error("replica read-only");
+      }
+      return "OK";
+    },
+  };
+
+  const { makeParentAuthWithScope, makeDelegationWithScope } = await import("./helpers/fixtures.js");
+  const parentAuth = makeParentAuthWithScope(
+    { tools: ["pay"], max_amount: 1_000_000n },
+    { auth_id: "redis-parent-r7", audience: "agent-redis" }
+  );
+  const delegation = makeDelegationWithScope(parentAuth, { tools: ["pay"], max_amount: 1_000_000n });
+
+  let storedState = makeBaseState();
+  const guard = OxDeAIGuard({
+    engine: { evaluatePure: () => { throw new Error("should not reach engine"); } } as any,
+    getState: async () => storedState,
+    setState: async (s) => { storedState = s; },
+    trustedKeySets: [TEST_KEYSET],
+    replayStore: createRedisReplayStore({ client: hybridClient }),
+  });
+
+  let executed = false;
+  await assert.rejects(
+    () => guard(makeAction(), async () => { executed = true; }, { delegation: { delegation, parentAuth } }),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError);
+      assert.match(err.message, /[Rr]eplay store unavailable/);
+      assert.match(err.message, /replica read-only/);
+      return true;
+    }
+  );
+
+  assert.equal(executed, false);
+});
+
+// ---------------------------------------------------------------------------
+// RS-R8: Multiple guard instances sharing one Redis client: cross-instance replay
+// ---------------------------------------------------------------------------
+
+test("RS-R8 shared Redis client: replay blocked across two distinct guard instances", async () => {
+  // Simulates two processes sharing a Redis cluster via a shared FakeRedisClient.
+  const sharedFake = new FakeRedisClient();
+  const auth = signAuth({ auth_id: "redis-auth-r8" });
+
+  const sharedStore = createRedisReplayStore({ client: sharedFake });
+
+  let stateA = makeBaseState();
+  const guardA = OxDeAIGuard({
+    engine: makeFakeEngine(auth) as any,
+    getState: async () => stateA,
+    setState: async (s) => { stateA = s; },
+    trustedKeySets: [TEST_KEYSET],
+    replayStore: sharedStore,
+  });
+
+  let stateB = makeBaseState();
+  const guardB = OxDeAIGuard({
+    engine: makeFakeEngine(auth) as any,
+    getState: async () => stateB,
+    setState: async (s) => { stateB = s; },
+    trustedKeySets: [TEST_KEYSET],
+    replayStore: sharedStore,
+  });
+
+  let executions = 0;
+  await guardA(makeAction(), async () => { executions++; });
+
+  // guardB reuses the same auth_id → replay detected via shared fake.
+  await assert.rejects(
+    () => guardB(makeAction(), async () => { executions++; }),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError);
+      assert.match(err.message, /replay detected/i);
+      return true;
+    }
+  );
+
+  assert.equal(executions, 1, "only the first instance's execute must run");
+});
+
+// ---------------------------------------------------------------------------
+// RS-R9: createRedisReplayStore rejects invalid client at construction time
+// ---------------------------------------------------------------------------
+
+test("RS-R9 createRedisReplayStore throws on invalid client", () => {
+  assert.throws(
+    () => createRedisReplayStore({ client: null as any }),
+    (err: unknown) => {
+      assert.ok(err instanceof TypeError);
+      assert.match(err.message, /RedisClient/);
+      return true;
+    }
+  );
+
+  assert.throws(
+    () => createRedisReplayStore({ client: {} as any }),
+    (err: unknown) => {
+      assert.ok(err instanceof TypeError);
+      return true;
+    }
+  );
+});


### PR DESCRIPTION
…orcement

- introduce createRedisReplayStore with atomic SET NX EX semantics
- enforce cross-instance replay protection for auth_id and delegation_id
- preserve fail-closed behavior on store errors
- add Redis replay store test suite (RS-R1 → RS-R9)
- document replay store tiers (in-memory vs Redis vs custom backends)

This extends replay enforcement from single-process to distributed execution environments.