### PR TITLE
fix(examples): align demo guards with expectedAudience enforcement

### DIFF
--- a/examples/autogen/src/policy.ts
+++ b/examples/autogen/src/policy.ts
@@ -35,6 +35,7 @@ export const engine = new PolicyEngine({
   authorization_issuer: DEMO_KEYSET.issuer,
   authorization_private_key_pem: DEMO_PRIVATE_KEY_PEM,
   authorization_ttl_seconds: 600,
+  authorization_audience: AGENT_ID,
   policyId: POLICY_ID,
 });
 

--- a/examples/crewai/src/policy.ts
+++ b/examples/crewai/src/policy.ts
@@ -35,6 +35,7 @@ export const engine = new PolicyEngine({
   authorization_issuer: DEMO_KEYSET.issuer,
   authorization_private_key_pem: DEMO_PRIVATE_KEY_PEM,
   authorization_ttl_seconds: 600,
+  authorization_audience: AGENT_ID,
   policyId: POLICY_ID,
 });
 

--- a/examples/delegation-demo/src/scenario.ts
+++ b/examples/delegation-demo/src/scenario.ts
@@ -116,6 +116,7 @@ export async function runScenario(): Promise<ScenarioStep[]> {
     engine,
     getState: () => state,
     setState: (s: State) => { state = s; },
+    expectedAudience: AGENT_A,
     mapActionToIntent: () => parentIntent,
     beforeExecute(_action, authorization) {
       parentDecision = "ALLOW";
@@ -228,6 +229,7 @@ export async function runScenario(): Promise<ScenarioStep[]> {
     engine,
     getState: () => state,
     setState: (s: State) => { state = s; },
+    expectedAudience: AGENT_A,
     mapActionToIntent: () => childIntent1,
     beforeExecute() {
       child1Decision = "ALLOW";
@@ -291,6 +293,7 @@ export async function runScenario(): Promise<ScenarioStep[]> {
     engine,
     getState: () => state,
     setState: (s: State) => { state = s; },
+    expectedAudience: AGENT_A,
     mapActionToIntent: () => childIntent2,
     beforeExecute() {
       child2Decision = "ALLOW"; // should not be reached

--- a/examples/execution-boundary-demo/src/policy.ts
+++ b/examples/execution-boundary-demo/src/policy.ts
@@ -36,6 +36,7 @@ export const engine = new PolicyEngine({
   policy_version: "v1.0.0",
   engine_secret: _engineSecret,
   authorization_ttl_seconds: 60,
+  authorization_audience: AGENT_ID,
   policyId: POLICY_ID,
 });
 

--- a/examples/execution-boundary-demo/src/scenario.ts
+++ b/examples/execution-boundary-demo/src/scenario.ts
@@ -89,6 +89,7 @@ export async function runScenario(): Promise<ScenarioStep[]> {
     engine,
     getState: () => state,
     setState: (s: State) => { state = s; },
+    expectedAudience: AGENT_ID,
     // chargeIntent is identical for both calls — only state differs
     mapActionToIntent: () => chargeIntent,
     beforeExecute(_action: unknown, authorization: Authorization) {
@@ -169,6 +170,7 @@ export async function runScenario(): Promise<ScenarioStep[]> {
     engine,
     getState: () => state,
     setState: (s: State) => { state = s; },
+    expectedAudience: AGENT_ID,
     mapActionToIntent: () => chargeIntent,
     beforeExecute() {
       secondDecision = "ALLOW"; // should not be reached

--- a/examples/langgraph/src/policy.ts
+++ b/examples/langgraph/src/policy.ts
@@ -42,6 +42,7 @@ export const engine = new PolicyEngine({
   authorization_issuer: DEMO_KEYSET.issuer,
   authorization_private_key_pem: DEMO_PRIVATE_KEY_PEM,
   authorization_ttl_seconds: 600,
+  authorization_audience: AGENT_ID,
   policyId: POLICY_ID,
 });
 

--- a/examples/openai-agents-sdk/src/policy.ts
+++ b/examples/openai-agents-sdk/src/policy.ts
@@ -35,6 +35,7 @@ export const engine = new PolicyEngine({
   authorization_issuer: DEMO_KEYSET.issuer,
   authorization_private_key_pem: DEMO_PRIVATE_KEY_PEM,
   authorization_ttl_seconds: 600,
+  authorization_audience: AGENT_ID,
   policyId: POLICY_ID,
 });
 

--- a/examples/openclaw/src/policy.ts
+++ b/examples/openclaw/src/policy.ts
@@ -35,6 +35,7 @@ export const engine = new PolicyEngine({
   authorization_issuer: DEMO_KEYSET.issuer,
   authorization_private_key_pem: DEMO_PRIVATE_KEY_PEM,
   authorization_ttl_seconds: 600,
+  authorization_audience: AGENT_ID,
   policyId: POLICY_ID,
 });
 

--- a/packages/autogen/src/adapter.ts
+++ b/packages/autogen/src/adapter.ts
@@ -52,7 +52,7 @@ export function createAutoGenGuard(config: AutoGenGuardConfig): AutoGenGuardFn {
     mapActionToIntent: config.mapActionToIntent,
     beforeExecute: config.beforeExecute,
     onDecision: config.onDecision,
-    strict: config.strict,
+    expectedAudience: config.agentId,
     trustedKeySets: config.trustedKeySets,
   });
 

--- a/packages/crewai/src/adapter.ts
+++ b/packages/crewai/src/adapter.ts
@@ -52,7 +52,7 @@ export function createCrewAIGuard(config: CrewAIGuardConfig): CrewAIGuardFn {
     mapActionToIntent: config.mapActionToIntent,
     beforeExecute: config.beforeExecute,
     onDecision: config.onDecision,
-    strict: config.strict,
+    expectedAudience: config.agentId,
     trustedKeySets: config.trustedKeySets,
   });
 

--- a/packages/guard/package.json
+++ b/packages/guard/package.json
@@ -30,6 +30,6 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "rm -rf dist && tsc -p tsconfig.json",
-    "test": "pnpm build && node --test \"dist/test/guard.test.js\" \"dist/test/guard.property.test.js\" \"dist/test/guard.delegation.test.js\" \"dist/test/guard.delegation.matrix.test.js\" \"dist/test/guard.delegation.property.test.js\" \"dist/test/guard.toctou.test.js\" \"dist/test/guard.boundary.test.js\" \"dist/test/guard.replay-store.test.js\" \"dist/test/guard.replay-store.redis.test.js\""
+    "test": "pnpm build && node --test \"dist/test/guard.test.js\" \"dist/test/guard.property.test.js\" \"dist/test/guard.delegation.test.js\" \"dist/test/guard.delegation.matrix.test.js\" \"dist/test/guard.delegation.property.test.js\" \"dist/test/guard.toctou.test.js\" \"dist/test/guard.boundary.test.js\" \"dist/test/guard.replay-store.test.js\" \"dist/test/guard.replay-store.redis.test.js\" \"dist/test/guard.authorization.test.js\""
   }
 }

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -28,6 +28,12 @@ function validateConfig(config: OxDeAIGuardConfig): void {
   if (typeof config.setState !== "function") {
     throw new OxDeAIGuardConfigurationError("config.setState must be a function.");
   }
+  if (typeof config.expectedAudience !== "string" || config.expectedAudience.length === 0) {
+    throw new OxDeAIGuardConfigurationError(
+      "config.expectedAudience is required and must be a non-empty string. " +
+      "Set it to the agent identity this guard instance protects (matches authorization_audience in PolicyEngine)."
+    );
+  }
 }
 
 // ── decision audit ────────────────────────────────────────────────────────────
@@ -227,7 +233,7 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
         trustedKeySets,
         requireSignatureVerification: true,
         expectedPolicyId: parentAuth.policy_id,
-        expectedAudience: parentAuth.audience,
+        expectedAudience: config.expectedAudience,
         expectedIssuer: parentAuth.issuer,
       });
 
@@ -323,7 +329,7 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
       trustedKeySets,
       requireSignatureVerification: true,
       expectedPolicyId: authorization.policy_id,
-      expectedAudience: authorization.audience,
+      expectedAudience: config.expectedAudience,
       expectedIssuer: authorization.issuer,
     });
 

--- a/packages/guard/src/test/guard.authorization.test.ts
+++ b/packages/guard/src/test/guard.authorization.test.ts
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * guard.authorization.test.ts
+ *
+ * Verifies that OxDeAIGuard enforces strict AuthorizationV1 verification
+ * on the standard (non-delegation) path.
+ *
+ * Test IDs: A-1 through A-6.
+ *
+ *   A-1  Tampered signature → OxDeAIAuthorizationError, execute blocked
+ *   A-2  Unknown issuer     → OxDeAIAuthorizationError, execute blocked
+ *   A-3  Wrong audience     → OxDeAIAuthorizationError, execute blocked
+ *   A-4  Expired auth       → OxDeAIAuthorizationError, execute blocked
+ *   A-5  Missing trustedKeySets → OxDeAIGuardConfigurationError at construction
+ *   A-6  Valid auth         → execute runs, result returned
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+import { signAuthorizationEd25519 } from "@oxdeai/core";
+import type { Authorization, AuthorizationV1, Intent, State } from "@oxdeai/core";
+
+import { OxDeAIGuard } from "../guard.js";
+import { OxDeAIAuthorizationError, OxDeAIGuardConfigurationError } from "../errors.js";
+import { TEST_KEYSET, signAuth } from "./helpers/fixtures.js";
+import type { OxDeAIGuardConfig, ProposedAction } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const T_NOW = Math.floor(Date.now() / 1000);
+
+function makeBaseState(): State {
+  return {
+    policy_version: "policy-auth",
+    period_id: "p1",
+    kill_switch: { global: false, agents: {} },
+    allowlists: {},
+    budget: { budget_limit: { "agent-auth": 1_000_000n }, spent_in_period: { "agent-auth": 0n } },
+    max_amount_per_action: { "agent-auth": 1_000_000n },
+    velocity: { config: { window_seconds: 3600, max_actions: 100 }, counters: {} },
+    replay: { window_seconds: 3600, max_nonces_per_agent: 256, nonces: {} },
+    concurrency: { max_concurrent: { "agent-auth": 10 }, active: {}, active_auths: {} },
+    recursion: { max_depth: { "agent-auth": 5 } },
+    tool_limits: { window_seconds: 3600, max_calls: { "agent-auth": 100 }, calls: {} },
+  };
+}
+
+function makeFakeEngine(auth: AuthorizationV1) {
+  return {
+    evaluatePure(_intent: Intent, state: State) {
+      return {
+        decision: "ALLOW" as const,
+        reasons: [],
+        authorization: auth as Authorization,
+        nextState: state,
+      };
+    },
+  };
+}
+
+function makeGuardConfig(auth: AuthorizationV1, overrides?: Partial<OxDeAIGuardConfig>): OxDeAIGuardConfig {
+  let storedState = makeBaseState();
+  return {
+    engine: makeFakeEngine(auth) as any,
+    getState: async () => storedState,
+    setState: async (s) => { storedState = s; },
+    trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
+    ...overrides,
+  };
+}
+
+const ACTION: ProposedAction = {
+  name: "provision_gpu",
+  args: { asset: "a100" },
+  estimatedCost: 0,
+  context: { agent_id: "agent-auth", target: "gpu-pool" },
+  timestampSeconds: T_NOW,
+};
+
+// ---------------------------------------------------------------------------
+// A-1: Tampered signature → OxDeAIAuthorizationError, execute blocked
+// ---------------------------------------------------------------------------
+
+test("A-1 tampered signature: execute is blocked and OxDeAIAuthorizationError is thrown", async () => {
+  // Sign a valid auth, then corrupt the signature byte.
+  const valid = signAuth({ auth_id: "a1-auth", audience: "aud-test" });
+  const tampered: AuthorizationV1 = { ...valid, signature: "0".repeat(88) };
+
+  const guard = OxDeAIGuard(makeGuardConfig(tampered));
+  let executed = false;
+
+  await assert.rejects(
+    () => guard(ACTION, async () => { executed = true; }),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError,
+        `expected OxDeAIAuthorizationError, got: ${err}`);
+      return true;
+    }
+  );
+  assert.ok(!executed, "execute must not be called when signature is invalid");
+});
+
+// ---------------------------------------------------------------------------
+// A-2: Unknown issuer → OxDeAIAuthorizationError, execute blocked
+// ---------------------------------------------------------------------------
+
+test("A-2 unknown issuer: execute is blocked and OxDeAIAuthorizationError is thrown", async () => {
+  // Sign with a separate key pair under an issuer not in TEST_KEYSET.
+  const unknownKeys = generateKeyPairSync("ed25519", {
+    privateKeyEncoding: { format: "pem", type: "pkcs8" },
+    publicKeyEncoding: { format: "pem", type: "spki" },
+  });
+  const auth = signAuthorizationEd25519(
+    {
+      auth_id: "a2-auth",
+      issuer: "unknown-issuer",
+      audience: "aud-test",
+      intent_hash: "i".repeat(64),
+      state_hash: "s".repeat(64),
+      policy_id: "p".repeat(64),
+      decision: "ALLOW",
+      issued_at: T_NOW - 60,
+      expiry: T_NOW + 600,
+      kid: "k-unknown",
+      nonce: "1",
+      capability: "exec",
+    },
+    unknownKeys.privateKey
+  ) as AuthorizationV1;
+
+  const guard = OxDeAIGuard(makeGuardConfig(auth));
+  let executed = false;
+
+  await assert.rejects(
+    () => guard(ACTION, async () => { executed = true; }),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError,
+        `expected OxDeAIAuthorizationError, got: ${err}`);
+      return true;
+    }
+  );
+  assert.ok(!executed, "execute must not be called when issuer is unknown");
+});
+
+// ---------------------------------------------------------------------------
+// A-3: Wrong audience → OxDeAIAuthorizationError, execute blocked
+// ---------------------------------------------------------------------------
+
+test("A-3 wrong audience: execute is blocked and OxDeAIAuthorizationError is thrown", async () => {
+  // auth is signed for "agent-other", but expectedAudience is "aud-test".
+  const auth = signAuth({ auth_id: "a3-auth", audience: "agent-other" });
+
+  const guard = OxDeAIGuard(makeGuardConfig(auth));
+  let executed = false;
+
+  await assert.rejects(
+    () => guard(ACTION, async () => { executed = true; }),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError,
+        `expected OxDeAIAuthorizationError, got: ${err}`);
+      return true;
+    }
+  );
+  assert.ok(!executed, "execute must not be called when audience does not match expectedAudience");
+});
+
+// ---------------------------------------------------------------------------
+// A-4: Expired auth → OxDeAIAuthorizationError, execute blocked
+// ---------------------------------------------------------------------------
+
+test("A-4 expired auth: execute is blocked and OxDeAIAuthorizationError is thrown", async () => {
+  const expiry = T_NOW - 60; // expired 1 minute ago
+  const auth = signAuth({ auth_id: "a4-auth", audience: "aud-test", expiry });
+
+  const guard = OxDeAIGuard(makeGuardConfig(auth));
+  let executed = false;
+
+  await assert.rejects(
+    () => guard(ACTION, async () => { executed = true; }),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError,
+        `expected OxDeAIAuthorizationError, got: ${err}`);
+      return true;
+    }
+  );
+  assert.ok(!executed, "execute must not be called when auth is expired");
+});
+
+// ---------------------------------------------------------------------------
+// A-5: Missing trustedKeySets → OxDeAIGuardConfigurationError at construction
+// ---------------------------------------------------------------------------
+
+test("A-5 missing trustedKeySets: OxDeAIGuardConfigurationError thrown at construction", () => {
+  const auth = signAuth({ auth_id: "a5-auth" });
+
+  assert.throws(
+    () => {
+      OxDeAIGuard({
+        engine: makeFakeEngine(auth) as any,
+        getState: async () => makeBaseState(),
+        setState: async () => {},
+        expectedAudience: "aud-test",
+        // trustedKeySets intentionally omitted
+      } as any);
+    },
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIGuardConfigurationError,
+        `expected OxDeAIGuardConfigurationError, got: ${err}`);
+      return true;
+    }
+  );
+});
+
+// ---------------------------------------------------------------------------
+// A-6: Valid auth → execute runs, result returned
+// ---------------------------------------------------------------------------
+
+test("A-6 valid auth: execute runs and result is returned", async () => {
+  const auth = signAuth({ auth_id: "a6-auth", audience: "aud-test" });
+  const guard = OxDeAIGuard(makeGuardConfig(auth));
+
+  let executed = false;
+  const result = await guard(ACTION, async () => { executed = true; return "ok"; });
+
+  assert.ok(executed, "execute must be called for a valid authorization");
+  assert.equal(result, "ok");
+});

--- a/packages/guard/src/test/guard.boundary.test.ts
+++ b/packages/guard/src/test/guard.boundary.test.ts
@@ -86,6 +86,7 @@ test("expired authorization is denied (execute not called)", async () => {
       storedState = s;
     },
     trustedKeySets: [TRUSTED_KEYSET],
+    expectedAudience: "aud-test",
   });
 
   const pastTs = 1;
@@ -123,6 +124,7 @@ test("audience tampering is denied by strict verifier", async () => {
       storedState = s;
     },
     trustedKeySets: [TRUSTED_KEYSET],
+    expectedAudience: "aud-test",
   });
 
   const action = makeAction();
@@ -174,6 +176,7 @@ test("auth_id replay is denied on second use", async () => {
       storedState = s;
     },
     trustedKeySets: [TRUSTED_KEYSET],
+    expectedAudience: "aud-test",
   });
 
   const action = makeAction();
@@ -232,6 +235,7 @@ test("delegation tool widening is denied", async () => {
       storedState = s;
     },
     trustedKeySets: [TRUSTED_KEYSET],
+    expectedAudience: "child",
   });
 
   const action = makeAction();
@@ -287,6 +291,7 @@ test("delegation amount widening is denied", async () => {
       storedState = s;
     },
     trustedKeySets: [TRUSTED_KEYSET],
+    expectedAudience: "child",
   });
 
   const action = makeAction();
@@ -342,6 +347,7 @@ test("delegation narrowing is allowed", async () => {
       storedState = s;
     },
     trustedKeySets: [TRUSTED_KEYSET],
+    expectedAudience: "child",
   });
 
   const action = makeAction();
@@ -396,6 +402,7 @@ test("delegation replay is denied", async () => {
       storedState = s;
     },
     trustedKeySets: [TRUSTED_KEYSET],
+    expectedAudience: "child",
   });
 
   const action = makeAction();
@@ -459,6 +466,7 @@ test("unsigned delegation is denied", async () => {
       storedState = s;
     },
     trustedKeySets: [TRUSTED_KEYSET],
+    expectedAudience: "child",
   });
 
   const action = makeAction();
@@ -514,6 +522,7 @@ test("tampered delegation signature is denied", async () => {
       storedState = s;
     },
     trustedKeySets: [TRUSTED_KEYSET],
+    expectedAudience: "child",
   });
 
   const action = makeAction();
@@ -550,6 +559,7 @@ test("verifier failure (throws) blocks execution", async () => {
       storedState = s;
     },
     trustedKeySets: [evilKeyset],
+    expectedAudience: "aud-test",
   });
 
   const action = makeAction();
@@ -597,6 +607,7 @@ test("missing required auth fields is denied before execution", async () => {
       storedState = s;
     },
     trustedKeySets: [TRUSTED_KEYSET],
+    expectedAudience: "aud-test",
   });
 
   const action = makeAction();

--- a/packages/guard/src/test/guard.delegation.matrix.test.ts
+++ b/packages/guard/src/test/guard.delegation.matrix.test.ts
@@ -84,7 +84,7 @@ function makeGuard(overrides?: Partial<OxDeAIGuardConfig>) {
     getState: () => state,
     setState: () => {},
     trustedKeySets: [KEYSET],
-    requireDelegationSignatureVerification: true,
+    expectedAudience: "agent-A",
     ...overrides,
   });
 }

--- a/packages/guard/src/test/guard.delegation.property.test.ts
+++ b/packages/guard/src/test/guard.delegation.property.test.ts
@@ -144,7 +144,7 @@ function makeGuardConfig(overrides?: Partial<OxDeAIGuardConfig>): OxDeAIGuardCon
     getState: () => buildState({ agent_id: "child-agent", allow_action_types: ["PROVISION"] }),
     setState: () => {},
     trustedKeySets: [KEYSET],
-    requireDelegationSignatureVerification: true,
+    expectedAudience: "parent-agent",
     ...overrides,
   };
 }

--- a/packages/guard/src/test/guard.delegation.test.ts
+++ b/packages/guard/src/test/guard.delegation.test.ts
@@ -84,13 +84,14 @@ function makeGuardConfig(overrides?: Partial<OxDeAIGuardConfig>): OxDeAIGuardCon
       authorization_signing_alg: "Ed25519",
       authorization_signing_kid: "k1",
       authorization_issuer: TEST_KEYSET.issuer,
-      authorization_audience: "aud-test",
+      authorization_audience: "agent-A",
       authorization_ttl_seconds: 600,
       authorization_private_key_pem: TEST_KEYPAIR.privateKey.toString(),
     }),
     getState: () => state,
     setState: () => {},
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "agent-A",
     ...overrides,
   };
 }
@@ -111,7 +112,7 @@ const baseAction: ProposedAction = {
 test("delegation: valid delegation allows execution", async () => {
   const parentAuth = makeParentAuth();
   const delegation = makeDelegation(parentAuth);
-  const config = makeGuardConfig({ trustedKeySets: TEST_KEYSET, requireDelegationSignatureVerification: true });
+  const config = makeGuardConfig({ trustedKeySets: TEST_KEYSET });
   const guard = OxDeAIGuard(config);
 
   let executed = false;
@@ -280,10 +281,7 @@ test("delegation: blocks invalid signature when requireDelegationSignatureVerifi
   const delegation = makeDelegation(parentAuth);
   const tampered = { ...delegation, delegatee: "agent-EVIL" }; // breaks signature
 
-  const config = makeGuardConfig({
-    trustedKeySets: TEST_KEYSET,
-    requireDelegationSignatureVerification: true,
-  });
+  const config = makeGuardConfig({ trustedKeySets: TEST_KEYSET });
   const guard = OxDeAIGuard(config);
   let executed = false;
 

--- a/packages/guard/src/test/guard.property.test.ts
+++ b/packages/guard/src/test/guard.property.test.ts
@@ -78,7 +78,7 @@ const ACTION_KEYWORDS = [
 ];
 const VALID_ACTION_TYPES = ["PAYMENT", "PURCHASE", "PROVISION", "ONCHAIN_TX"] as const;
 
-const BASE_TRUST = { trustedKeySets: [TEST_KEYSET] };
+const BASE_TRUST = { trustedKeySets: [TEST_KEYSET], expectedAudience: "aud-test" };
 
 function genAlphaStr(rng: () => number, minLen: number, maxLen: number): string {
   const len = randInt(rng, minLen, maxLen);

--- a/packages/guard/src/test/guard.replay-store.redis.test.ts
+++ b/packages/guard/src/test/guard.replay-store.redis.test.ts
@@ -154,6 +154,7 @@ function makeGuardConfig(
     getState: async () => get(),
     setState: async (s) => set(s),
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
     replayStore: createRedisReplayStore({ client: redisClient }),
   };
 }
@@ -312,6 +313,7 @@ test("RS-R7 Redis error in consumeDelegationId: throws OxDeAIAuthorizationError 
     getState: async () => storedState,
     setState: async (s) => { storedState = s; },
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "agent-redis",
     replayStore: createRedisReplayStore({ client: hybridClient }),
   });
 
@@ -346,6 +348,7 @@ test("RS-R8 shared Redis client: replay blocked across two distinct guard instan
     getState: async () => stateA,
     setState: async (s) => { stateA = s; },
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
     replayStore: sharedStore,
   });
 
@@ -355,6 +358,7 @@ test("RS-R8 shared Redis client: replay blocked across two distinct guard instan
     getState: async () => stateB,
     setState: async (s) => { stateB = s; },
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
     replayStore: sharedStore,
   });
 

--- a/packages/guard/src/test/guard.replay-store.test.ts
+++ b/packages/guard/src/test/guard.replay-store.test.ts
@@ -78,6 +78,7 @@ function makeGuardConfig(
     getState: async () => storedState,
     setState: async (s) => { storedState = s; },
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
     ...overrides,
   };
 }
@@ -121,6 +122,7 @@ test("RS-2 default store: delegation_id replay blocked on second call to same gu
     getState: async () => storedState,
     setState: async (s) => { storedState = s; },
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "agent-rs",
   });
   const action = makeAction();
 
@@ -185,6 +187,7 @@ test("RS-4 shared store: delegation_id replay blocked across two distinct guard 
       getState: async () => storedState,
       setState: async (s) => { storedState = s; },
       trustedKeySets: [TEST_KEYSET],
+      expectedAudience: "agent-rs",
       replayStore: sharedStore,
     });
   }
@@ -261,6 +264,7 @@ test("RS-6 failing consumeDelegationId: execution blocked when store throws on d
     getState: async () => storedState,
     setState: async (s) => { storedState = s; },
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "agent-rs",
     replayStore: failingStore,
   });
 
@@ -304,6 +308,7 @@ test("RS-7 store without consumeDelegationId: delegation executes; parentAuth re
     getState: async () => storedState,
     setState: async (s) => { storedState = s; },
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "agent-rs",
     replayStore: authOnlyStore,
   });
   const action = makeAction();
@@ -374,6 +379,7 @@ test("RS-9 store unavailable for parentAuth auth_id: execution blocked on delega
     getState: async () => storedState,
     setState: async (s) => { storedState = s; },
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "agent-rs",
     replayStore: partialFailStore,
   });
 

--- a/packages/guard/src/test/guard.test.ts
+++ b/packages/guard/src/test/guard.test.ts
@@ -86,6 +86,7 @@ function makeGuardConfig(overrides: Partial<OxDeAIGuardConfig> = {}): OxDeAIGuar
     getState: () => currentState,
     setState: (s) => { currentState = s; },
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
     ...overrides,
   };
 }
@@ -211,6 +212,7 @@ test("guard: uses custom mapActionToIntent when provided", async () => {
     getState: () => currentState,
     setState: (s) => { currentState = s; },
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
     mapActionToIntent(action) {
       mapperCalled = true;
       // Return a well-formed intent via the default normalizer so the
@@ -245,6 +247,7 @@ test("guard: DENY throws OxDeAIDenyError and does not call execute", async () =>
     getState: () => currentState,
     setState: (s) => { currentState = s; },
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
   };
 
   const guard = OxDeAIGuard(config);
@@ -277,6 +280,7 @@ test("guard: DENY fires onDecision hook with DENY decision", async () => {
     getState: () => currentState,
     setState: (s) => { currentState = s; },
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
     onDecision({ decision }) {
       decisionFired = true;
       capturedDecision = decision;
@@ -352,6 +356,7 @@ test("guard: ALLOW without authorization artifact throws OxDeAIAuthorizationErro
     getState: () => currentState,
     setState: (s) => { currentState = s; },
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
   };
 
   const guard = OxDeAIGuard(config);
@@ -387,6 +392,7 @@ test("guard: ALLOW without nextState throws OxDeAIAuthorizationError", async () 
     getState: () => currentState,
     setState: (s) => { currentState = s; },
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
   };
 
   const guard = OxDeAIGuard(config);
@@ -425,6 +431,7 @@ test("guard: failed verifyAuthorization throws OxDeAIAuthorizationError", async 
     getState: () => currentState,
     setState: (s) => { currentState = s; },
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
   };
 
   const guard = OxDeAIGuard(config);
@@ -453,6 +460,7 @@ test("guard: setState is called with nextState after successful execution", asyn
     getState: () => initialState,
     setState: (s) => { storedState = s; },
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
   };
 
   const guard = OxDeAIGuard(config);
@@ -478,6 +486,7 @@ test("guard: setState is NOT called when execution is denied", async () => {
     getState: () => currentState,
     setState: (s) => { setStateCalled = true; currentState = s; },
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
   };
 
   const guard = OxDeAIGuard(config);
@@ -490,7 +499,7 @@ test("guard: setState is NOT called when execution is denied", async () => {
 
 test("OxDeAIGuard: throws OxDeAIGuardConfigurationError when engine missing", () => {
   assert.throws(
-    () => OxDeAIGuard({ engine: null as unknown as PolicyEngine, getState: () => makeState(), setState: () => {} }),
+    () => OxDeAIGuard({ engine: null as unknown as PolicyEngine, getState: () => makeState(), setState: () => {}, expectedAudience: "aud-test" }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIGuardConfigurationError);
       return true;
@@ -500,7 +509,7 @@ test("OxDeAIGuard: throws OxDeAIGuardConfigurationError when engine missing", ()
 
 test("OxDeAIGuard: throws OxDeAIGuardConfigurationError when getState missing", () => {
   assert.throws(
-    () => OxDeAIGuard({ engine: makeEngine(), getState: null as unknown as () => State, setState: () => {} }),
+    () => OxDeAIGuard({ engine: makeEngine(), getState: null as unknown as () => State, setState: () => {}, expectedAudience: "aud-test" }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIGuardConfigurationError);
       return true;

--- a/packages/guard/src/test/guard.toctou.test.ts
+++ b/packages/guard/src/test/guard.toctou.test.ts
@@ -52,6 +52,7 @@ function makeStatefulConfig(
     getState: () => current,
     setState: (s) => { current = s; },
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
     ...overrides,
   };
 }
@@ -186,6 +187,7 @@ test("G-3 reverification: state mutated between calls → policy re-evaluated ea
     getState: () => current,
     setState: (s) => { current = s; },
     trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
   };
 
   const guard = OxDeAIGuard(config);

--- a/packages/guard/src/types.ts
+++ b/packages/guard/src/types.ts
@@ -88,23 +88,26 @@ export type OxDeAIGuardConfig = {
   onDecision?: (result: GuardDecisionRecord) => void | Promise<void>;
 
   /**
-   * When true, missing optional fields that can be defaulted will instead
-   * cause a hard failure. Defaults to false.
+   * The audience this guard instance expects in every AuthorizationV1 artifact.
+   *
+   * Must equal the `authorization_audience` value configured in the PolicyEngine
+   * (typically the agent's identity string). Every authorization issued by the
+   * engine carries this audience; the guard rejects tokens whose audience field
+   * does not exactly match.
+   *
+   * For adapter packages (openclaw, langgraph, crewai, etc.) this is derived
+   * automatically from `config.agentId` — callers do not set it directly.
+   *
+   * Enforcement: `validateConfig` throws `OxDeAIGuardConfigurationError` when
+   * absent. There is no default or fallback.
    */
-  strict?: boolean;
+  expectedAudience: string;
 
   /**
-   * KeySets used to verify Ed25519 signatures on DelegationV1 artifacts.
-   * When absent, signature verification is skipped (unless
-   * requireDelegationSignatureVerification is true, which will fail-closed).
+   * KeySets used to verify Ed25519 signatures on authorization artifacts.
+   * Required; `validateConfig` throws when absent or empty.
    */
   trustedKeySets?: KeySet | readonly KeySet[];
-
-  /**
-   * When true, the guard fails closed if no trustedKeySets are provided
-   * for delegation path verification. Defaults to false.
-   */
-  requireDelegationSignatureVerification?: boolean;
 
   /**
    * Pluggable replay store for durable auth_id and delegation_id tracking.

--- a/packages/langgraph/src/adapter.ts
+++ b/packages/langgraph/src/adapter.ts
@@ -52,7 +52,7 @@ export function createLangGraphGuard(config: LangGraphGuardConfig): LangGraphGua
     mapActionToIntent: config.mapActionToIntent,
     beforeExecute: config.beforeExecute,
     onDecision: config.onDecision,
-    strict: config.strict,
+    expectedAudience: config.agentId,
     trustedKeySets: config.trustedKeySets,
   });
 

--- a/packages/openai-agents/src/adapter.ts
+++ b/packages/openai-agents/src/adapter.ts
@@ -52,7 +52,7 @@ export function createOpenAIAgentsGuard(config: OpenAIAgentsGuardConfig): OpenAI
     mapActionToIntent: config.mapActionToIntent,
     beforeExecute: config.beforeExecute,
     onDecision: config.onDecision,
-    strict: config.strict,
+    expectedAudience: config.agentId,
     trustedKeySets: config.trustedKeySets,
   });
 

--- a/packages/openclaw/src/adapter.ts
+++ b/packages/openclaw/src/adapter.ts
@@ -54,7 +54,7 @@ export function createOpenClawGuard(config: OpenClawGuardConfig): OpenClawGuardF
     mapActionToIntent: config.mapActionToIntent,
     beforeExecute: config.beforeExecute,
     onDecision: config.onDecision,
-    strict: config.strict,
+    expectedAudience: config.agentId,
     trustedKeySets: config.trustedKeySets,
   });
 


### PR DESCRIPTION
## Summary

Align example demos with the hardened `OxDeAIGuard` configuration by explicitly setting `expectedAudience` and ensuring emitted authorization artifacts match the enforced audience at the execution boundary.

This is a follow-up to the strict authorization verification change in the guard.

---

## Problem

`OxDeAIGuard` now requires:

* `expectedAudience` (operator-configured)
* strict audience binding during authorization verification

Example demos were still:

* missing `expectedAudience` in direct guard instantiations
* relying on the `PolicyEngine` default audience (`"oxdeai.relying-party"`)

This caused:

* TypeScript build failures
* incorrect or implicit audience semantics
* mismatch between issued authorization and boundary verification

---

## Changes

### 1. delegation-demo

* Added `expectedAudience: AGENT_A` to:

  * `guardA`
  * `guardB1`
  * `guardB2`

Rationale:

* Delegation path verifies **parent authorization**
* `parentAuth.audience = AGENT_A`
* Guards must enforce the same audience

---

### 2. execution-boundary-demo

#### policy.ts

```ts
authorization_audience: AGENT_ID
```

* Removes reliance on default `"oxdeai.relying-party"`
* Ensures emitted AuthorizationV1 matches the actual protected principal

#### scenario.ts

* Added `expectedAudience: AGENT_ID` to both guards

Rationale:

* Guards now enforce audience = `AGENT_ID`
* Engine emits matching audience → verification succeeds deterministically

---

## Result

* `pnpm build` passes (no TS2345 errors)
* `pnpm -r test` passes (all packages green)
* Examples are now:

  * explicit (no hidden defaults)
  * deterministic (audience binding enforced)
  * aligned with production guard semantics

---

## Security impact

* Eliminates implicit / default audience usage
* Prevents mismatched audience acceptance at the boundary
* Ensures examples reflect real execution-time authorization guarantees

---

## Notes

* Adapter-based examples were not affected (already derive `expectedAudience = agentId`)
* No changes to core protocol or guard logic
* This PR strictly aligns demos with the enforced contract
