### PR TITLE
test(sift): add property-based tests and test build config

### DIFF
--- a/packages/sift/package.json
+++ b/packages/sift/package.json
@@ -5,14 +5,18 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc --noEmit",
-    "test": "echo \"no tests yet\""
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "typecheck:test": "tsc --noEmit -p tsconfig.test.json",
+    "test": "node --test dist/test/**/*.test.js"
   },
-  "dependencies": {},
   "devDependencies": {
+    "@types/node": "^22.19.11",
+    "fast-check": "^4.6.0",
     "typescript": "^5.6.0"
   }
 }

--- a/packages/sift/test/helpers/propertyArbitraries.ts
+++ b/packages/sift/test/helpers/propertyArbitraries.ts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Reusable fast-check arbitraries for the Sift adapter property tests.
+ *
+ * Design constraints that mirror the OxDeAI invariants under test:
+ *   - deterministic arbitraries contain only values normalization accepts
+ *   - "__proto__" is handled explicitly and never via prototype-mutating assignment
+ *   - unsupported arbitraries cover every explicitly rejected category
+ *   - no floats, NaN, Infinity, or unsafe integers in deterministic arbitraries
+ */
+
+import * as fc from "fast-check";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Cast any Arbitrary<T> to Arbitrary<unknown> without losing fast-check metadata. */
+function u<T>(a: fc.Arbitrary<T>): fc.Arbitrary<unknown> {
+  return a as fc.Arbitrary<unknown>;
+}
+
+// ─── Safe integers ─────────────────────────────────────────────────────────────
+
+/**
+ * Generates numbers within the safe integer range
+ * [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER].
+ * Never produces floats, NaN, or Infinity.
+ */
+export function arbSafeInteger(): fc.Arbitrary<number> {
+  return fc.integer({
+    min: Number.MIN_SAFE_INTEGER,
+    max: Number.MAX_SAFE_INTEGER,
+  });
+}
+
+// ─── Scalar leaves ─────────────────────────────────────────────────────────────
+
+/**
+ * Generates leaf values accepted by normalization:
+ *   null | boolean | string | safe integer
+ *
+ * Does NOT generate floats, NaN, Infinity, bigint, symbol,
+ * undefined, or any object type.
+ */
+export function arbDeterministicScalar(): fc.Arbitrary<
+  string | number | boolean | null
+> {
+  return fc.oneof(
+    fc.constant(null),
+    fc.boolean(),
+    fc.string({ minLength: 0, maxLength: 48 }),
+    arbSafeInteger()
+  );
+}
+
+// ─── Recursive deterministic values ───────────────────────────────────────────
+
+/**
+ * Generates any value accepted by normalization: scalar, array, or plain object.
+ *
+ * Depth-bounded to prevent combinatorial blowup during generation and
+ * shrinking. At maxDepth 0 the generator falls back to scalars only.
+ */
+export function arbDeterministicValue(maxDepth = 2): fc.Arbitrary<unknown> {
+  if (maxDepth <= 0) {
+    return u(arbDeterministicScalar());
+  }
+  return fc.oneof(
+    { weight: 4, arbitrary: u(arbDeterministicScalar()) },
+    {
+      weight: 1,
+      arbitrary: u(
+        fc.array(arbDeterministicValue(maxDepth - 1), { maxLength: 5 })
+      ),
+    },
+    { weight: 1, arbitrary: u(arbDeterministicObject(maxDepth - 1)) }
+  );
+}
+
+/**
+ * Generates a plain object (Object.prototype) with:
+ *   - non-empty string keys (never "__proto__" — see arbPojoWithProtoKey)
+ *   - deterministic leaf values at nested levels
+ *
+ * "__proto__" is excluded from key generation to prevent the
+ * Object.prototype.__proto__ setter from silently mutating the prototype
+ * chain during fast-check's internal object construction via assignment.
+ * Use arbPojoWithProtoKey to exercise the __proto__-as-own-property path.
+ */
+export function arbDeterministicObject(
+  maxDepth = 2
+): fc.Arbitrary<Record<string, unknown>> {
+  return fc.dictionary(
+    fc
+      .string({ minLength: 1, maxLength: 16 })
+      .filter((k: string) => k !== "__proto__"),
+    arbDeterministicValue(maxDepth > 0 ? maxDepth - 1 : 0),
+    { minKeys: 0, maxKeys: 6 }
+  );
+}
+
+// ─── Proto-key object ─────────────────────────────────────────────────────────
+
+/**
+ * Generates a null-prototype object that includes "__proto__" as a genuine
+ * own enumerable data property.
+ *
+ * Uses Object.create(null) so that the assignment `obj["__proto__"] = value`
+ * stores the value as an own data property instead of invoking the
+ * Object.prototype.__proto__ setter (which would silently change the
+ * prototype and not create an own property at all).
+ *
+ * The resulting objects pass normalizeState / normalizeIntent's
+ * isStrictPlainObject guard because it accepts null-prototype objects:
+ *   Object.getPrototypeOf(obj) === null → true
+ *
+ * Object.keys() on a null-prototype object includes "__proto__" as a normal
+ * own enumerable key, which is exactly the invariant the normalizers must
+ * preserve in their output.
+ */
+export function arbPojoWithProtoKey(
+  maxDepth = 1
+): fc.Arbitrary<Record<string, unknown>> {
+  return fc
+    .tuple(arbDeterministicObject(maxDepth), arbDeterministicScalar())
+    .map(
+      ([base, protoVal]: [
+        Record<string, unknown>,
+        string | number | boolean | null,
+      ]) => {
+        // Null-prototype object: assigning "__proto__" creates an own data
+        // property; there is no setter to intercept the write.
+        const obj = Object.create(null) as Record<string, unknown>;
+        for (const k of Object.keys(base)) {
+          obj[k] = base[k];
+        }
+        // Assign after copying other keys; safe on null-prototype objects.
+        obj["__proto__"] = protoVal;
+        return obj;
+      }
+    );
+}
+
+// ─── Unsupported values ────────────────────────────────────────────────────────
+
+/**
+ * Generates values that normalization MUST reject.
+ *
+ * Covers all explicitly disallowed categories:
+ *   - non-integer finite floats
+ *   - NaN, +Infinity, -Infinity
+ *   - undefined
+ *   - bigint
+ *   - symbol
+ *   - function
+ *   - Date, Map, Set, Buffer, Uint8Array (class instances / exotic objects)
+ *
+ * Use this arbitrary to drive fail-closed and no-coercion properties.
+ */
+export function arbUnsupportedValue(): fc.Arbitrary<unknown> {
+  const nonIntegerFloat = fc
+    .float({ noNaN: true, noDefaultInfinity: true })
+    .filter((n: number) => !Number.isInteger(n));
+
+  return fc.oneof(
+    u(nonIntegerFloat),
+    u(fc.constant(NaN)),
+    u(fc.constant(Infinity)),
+    u(fc.constant(-Infinity)),
+    u(fc.constant(undefined)),
+    u(fc.constant(new Date("2026-01-01T00:00:00.000Z"))),
+    u(fc.constant(new Map<string, string>([["k", "v"]]))),
+    u(fc.constant(new Set<number>([1, 2, 3]))),
+    u(fc.bigInt()),
+    u(fc.constant(function unsupportedFn() {})),
+    u(fc.constant(Symbol("unsupported"))),
+    u(fc.constant(Buffer.from("data"))),
+    u(fc.constant(new Uint8Array([0, 1, 2])))
+  );
+}

--- a/packages/sift/test/intent.property.test.ts
+++ b/packages/sift/test/intent.property.test.ts
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Property-based tests for normalizeIntent.
+ *
+ * Each property verifies an OxDeAI execution-boundary invariant:
+ *   P1  Determinism          — same input always produces same output
+ *   P2  Metadata exclusion   — intent exposes only type, tool, params
+ *   P3  __proto__ own key    — preserved in params, prototype intact
+ *   P4  Unsupported values   — fail closed without throwing
+ *   P5  Floats               — always fail, never silently coerced
+ *   P6  Invalid top-level    — non-plain-object params always fail
+ *   P7  Action / tool match  — exact matching; mismatch returns known error code
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fc from "fast-check";
+
+import {
+  normalizeIntent,
+  type NormalizeIntentResult,
+} from "../src/normalizeIntent.js";
+import type { SiftReceipt } from "../src/verifyReceipt.js";
+import {
+  arbDeterministicObject,
+  arbDeterministicValue,
+  arbPojoWithProtoKey,
+  arbUnsupportedValue,
+} from "./helpers/propertyArbitraries.js";
+
+// ─── Run budget ───────────────────────────────────────────────────────────────
+
+const RUNS = 200;
+
+// ─── Baseline receipt ─────────────────────────────────────────────────────────
+
+/**
+ * Builds a structurally valid SiftReceipt for use as a stable test baseline.
+ * normalizeIntent reads only receipt.action and receipt.tool, so the hash
+ * and signature fields are intentionally placeholder values.
+ */
+function makeReceipt(overrides: Partial<SiftReceipt> = {}): SiftReceipt {
+  return {
+    receipt_version: "1.0",
+    tenant_id: "tenant-test",
+    agent_id: "agent-test",
+    action: "transfer_funds",
+    tool: "payments_api",
+    decision: "ALLOW",
+    risk_tier: 1,
+    timestamp: "2026-04-14T12:00:00.000Z",
+    nonce: "11111111-1111-1111-1111-111111111111",
+    policy_matched: "payments-policy-v1",
+    receipt_hash: "sha256:" + "a".repeat(64),
+    signature: "base64-signature-placeholder",
+    ...overrides,
+  };
+}
+
+// Receipt governance fields that must never appear in normalized intent output.
+const RECEIPT_METADATA_KEYS: ReadonlyArray<keyof SiftReceipt> = [
+  "tenant_id",
+  "agent_id",
+  "timestamp",
+  "nonce",
+  "receipt_hash",
+  "signature",
+  "policy_matched",
+  "risk_tier",
+  "decision",
+];
+
+// ─── P1. Determinism ──────────────────────────────────────────────────────────
+
+test("P1: normalizeIntent is deterministic — same inputs always produce the same output", () => {
+  const receipt = makeReceipt();
+
+  fc.assert(
+    fc.property(
+      arbDeterministicObject(),
+      (params: Record<string, unknown>) => {
+        const r1 = normalizeIntent({ receipt, params });
+        const r2 = normalizeIntent({ receipt, params });
+        assert.deepStrictEqual(r1, r2);
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+// ─── P2. Receipt metadata exclusion ──────────────────────────────────────────
+
+test("P2: normalized intent contains only type, tool, and params — no receipt metadata at any level", () => {
+  const receipt = makeReceipt();
+
+  fc.assert(
+    fc.property(
+      arbDeterministicObject(),
+      (params: Record<string, unknown>) => {
+        const result = normalizeIntent({ receipt, params });
+
+        assert.equal(
+          result.ok,
+          true,
+          "normalization must succeed for deterministic params"
+        );
+        if (!result.ok) return;
+
+        // Exactly three top-level keys — no extras.
+        const intentKeys = Object.keys(result.intent).sort();
+        assert.deepStrictEqual(
+          intentKeys,
+          ["params", "tool", "type"],
+          "intent must have exactly the keys: type, tool, params"
+        );
+
+        // No receipt governance field must appear at the intent's top level.
+        for (const metaKey of RECEIPT_METADATA_KEYS) {
+          assert.equal(
+            Object.prototype.hasOwnProperty.call(result.intent, metaKey),
+            false,
+            `intent must not expose receipt governance field: ${metaKey}`
+          );
+        }
+
+        // Structural invariants on the fixed fields.
+        assert.equal(result.intent.type, "EXECUTE");
+        // tool must be sourced from receipt.tool — not invented or substituted.
+        assert.equal(
+          result.intent.tool,
+          receipt.tool,
+          "intent.tool must equal receipt.tool"
+        );
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+// ─── P3. __proto__ own key preservation in params ────────────────────────────
+
+test("P3: normalizeIntent preserves __proto__ as own data property in params and never mutates the prototype chain", () => {
+  const receipt = makeReceipt();
+
+  fc.assert(
+    fc.property(
+      arbPojoWithProtoKey(),
+      (params: Record<string, unknown>) => {
+        const protoValBefore = params["__proto__"];
+
+        const result = normalizeIntent({ receipt, params });
+
+        assert.equal(
+          result.ok,
+          true,
+          "normalization must succeed for params containing __proto__ as own key"
+        );
+        if (!result.ok) return;
+
+        // __proto__ must survive as an own enumerable property on normalized params.
+        assert.equal(
+          Object.prototype.hasOwnProperty.call(result.intent.params, "__proto__"),
+          true,
+          "__proto__ must be an own property of the normalized params object"
+        );
+
+        // The stored value must be identical to what was supplied.
+        assert.deepStrictEqual(
+          result.intent.params["__proto__"],
+          protoValBefore,
+          "__proto__ value must be preserved without modification"
+        );
+
+        // Normalized params are always Object.create(null); the prototype must
+        // never be changed regardless of the input key names.
+        assert.equal(
+          Object.getPrototypeOf(result.intent.params),
+          null,
+          "normalized params prototype must be null — __proto__ key must not mutate the prototype chain"
+        );
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+// ─── P4. Unsupported values fail closed ───────────────────────────────────────
+
+test("P4: normalizeIntent fails closed on unsupported values nested in params — never throws", () => {
+  const receipt = makeReceipt();
+
+  // Wrap the unsupported value as a field so the failure comes from recursive
+  // value validation, not from the top-level params shape guard (P6).
+  const arbParamsWithUnsupportedNested = fc
+    .tuple(
+      fc
+        .string({ minLength: 1, maxLength: 16 })
+        .filter((k: string) => k !== "__proto__"),
+      arbUnsupportedValue()
+    )
+    .map(([key, badVal]: [string, unknown]) => ({ [key]: badVal }));
+
+  fc.assert(
+    fc.property(
+      arbParamsWithUnsupportedNested,
+      (params: Record<string, unknown>) => {
+        let result: NormalizeIntentResult;
+        try {
+          result = normalizeIntent({ receipt, params });
+        } catch (e) {
+          assert.fail(
+            `normalizeIntent threw instead of returning { ok: false }: ${String(e)}`
+          );
+          return;
+        }
+        assert.equal(
+          result.ok,
+          false,
+          "normalization must return { ok: false } for params containing an unsupported nested value"
+        );
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+// ─── P5. Floats always fail ───────────────────────────────────────────────────
+
+test("P5: non-integer finite floats anywhere in params always cause normalization to fail", () => {
+  const receipt = makeReceipt();
+
+  const nonIntegerFloat = fc
+    .float({ noNaN: true, noDefaultInfinity: true })
+    .filter((n: number) => !Number.isInteger(n));
+
+  const arbParamsWithFloat = fc
+    .tuple(
+      fc
+        .string({ minLength: 1, maxLength: 16 })
+        .filter((k: string) => k !== "__proto__"),
+      nonIntegerFloat
+    )
+    .map(([key, floatVal]: [string, number]) => ({ [key]: floatVal }));
+
+  fc.assert(
+    fc.property(
+      arbParamsWithFloat,
+      (params: Record<string, unknown>) => {
+        const result = normalizeIntent({ receipt, params });
+        assert.equal(
+          result.ok,
+          false,
+          "params containing a float must not normalize successfully — floats are never silently coerced"
+        );
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+// ─── P6. Top-level params must be strict plain object ────────────────────────
+
+test("P6: non-plain-object top-level params always fail (null, undefined, array, primitives)", () => {
+  const receipt = makeReceipt();
+
+  const arbInvalidParams: fc.Arbitrary<unknown> = fc.oneof(
+    fc.constant(null),
+    fc.constant(undefined),
+    fc.array(arbDeterministicValue(1), { maxLength: 5 }),
+    fc.string({ minLength: 0, maxLength: 32 }),
+    fc.integer({ min: -100_000, max: 100_000 }),
+    fc.boolean()
+  );
+
+  fc.assert(
+    fc.property(arbInvalidParams, (invalidParams: unknown) => {
+      let result: NormalizeIntentResult;
+      try {
+        result = normalizeIntent({ receipt, params: invalidParams });
+      } catch (e) {
+        assert.fail(
+          `normalizeIntent threw on invalid top-level params instead of returning { ok: false }: ${String(e)}`
+        );
+        return;
+      }
+      assert.equal(
+        result.ok,
+        false,
+        "normalization must fail for any non-plain-object top-level params"
+      );
+    }),
+    { numRuns: RUNS }
+  );
+});
+
+// ─── P7. expectedAction / expectedTool exact matching ────────────────────────
+
+test("P7a: matching expectedAction and expectedTool both succeed", () => {
+  const receipt = makeReceipt();
+
+  fc.assert(
+    fc.property(
+      arbDeterministicObject(),
+      (params: Record<string, unknown>) => {
+        const result = normalizeIntent({
+          receipt,
+          params,
+          expectedAction: receipt.action,
+          expectedTool: receipt.tool,
+        });
+        assert.equal(
+          result.ok,
+          true,
+          "normalizeIntent must succeed when expectedAction and expectedTool match the receipt"
+        );
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+test("P7b: mismatched expectedAction fails with ACTION_MISMATCH", () => {
+  const receipt = makeReceipt();
+
+  fc.assert(
+    fc.property(
+      arbDeterministicObject(),
+      fc
+        .string({ minLength: 1, maxLength: 32 })
+        .filter((s: string) => s !== receipt.action),
+      (params: Record<string, unknown>, wrongAction: string) => {
+        const result = normalizeIntent({
+          receipt,
+          params,
+          expectedAction: wrongAction,
+        });
+
+        assert.equal(
+          result.ok,
+          false,
+          "normalizeIntent must fail when expectedAction does not match the receipt action"
+        );
+        if (!result.ok) {
+          assert.equal(
+            result.code,
+            "ACTION_MISMATCH",
+            "error code must be ACTION_MISMATCH for action mismatch"
+          );
+        }
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+test("P7c: mismatched expectedTool fails with TOOL_MISMATCH", () => {
+  const receipt = makeReceipt();
+
+  fc.assert(
+    fc.property(
+      arbDeterministicObject(),
+      fc
+        .string({ minLength: 1, maxLength: 32 })
+        .filter((s: string) => s !== receipt.tool),
+      (params: Record<string, unknown>, wrongTool: string) => {
+        const result = normalizeIntent({
+          receipt,
+          params,
+          expectedTool: wrongTool,
+        });
+
+        assert.equal(
+          result.ok,
+          false,
+          "normalizeIntent must fail when expectedTool does not match the receipt tool"
+        );
+        if (!result.ok) {
+          assert.equal(
+            result.code,
+            "TOOL_MISMATCH",
+            "error code must be TOOL_MISMATCH for tool mismatch"
+          );
+        }
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});

--- a/packages/sift/test/state.property.test.ts
+++ b/packages/sift/test/state.property.test.ts
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Property-based tests for normalizeState.
+ *
+ * Each property verifies an OxDeAI execution-boundary invariant:
+ *   P1  Determinism          — same input always produces same output
+ *   P2  __proto__ own key    — preserved as own data property, prototype intact
+ *   P3  Required keys        — present key passes; absent key fails with known code
+ *   P4  Unsupported values   — fail closed without throwing
+ *   P5  Floats               — always fail, never silently coerced
+ *   P6  Invalid top-level    — non-plain-object roots always fail
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fc from "fast-check";
+
+import {
+  normalizeState,
+  type NormalizeStateResult,
+} from "../src/state.js";
+import {
+  arbDeterministicObject,
+  arbDeterministicValue,
+  arbPojoWithProtoKey,
+  arbUnsupportedValue,
+} from "./helpers/propertyArbitraries.js";
+
+// ─── Run budget ───────────────────────────────────────────────────────────────
+
+/** Default run count. 200 gives good coverage without being slow. */
+const RUNS = 200;
+/**
+ * Reduced run count for properties that use .chain() or .filter() internally.
+ * Shrinking with dependent generators is more expensive.
+ */
+const RUNS_CHAIN = 100;
+
+// ─── P1. Determinism ──────────────────────────────────────────────────────────
+
+test("P1: normalizeState is deterministic — same input always produces the same output", () => {
+  fc.assert(
+    fc.property(
+      arbDeterministicObject(),
+      (state: Record<string, unknown>) => {
+        const r1 = normalizeState({ state });
+        const r2 = normalizeState({ state });
+        // deepStrictEqual checks prototype equality on nested objects:
+        // both r1.state and r2.state are Object.create(null), so prototypes match.
+        assert.deepStrictEqual(r1, r2);
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+// ─── P2. Own __proto__ key preservation ───────────────────────────────────────
+
+test("P2: normalizeState preserves __proto__ as own data property and never mutates the prototype chain", () => {
+  fc.assert(
+    fc.property(
+      arbPojoWithProtoKey(),
+      (state: Record<string, unknown>) => {
+        const protoValBefore = state["__proto__"];
+
+        const result = normalizeState({ state });
+
+        assert.equal(
+          result.ok,
+          true,
+          "normalization must succeed for valid state containing __proto__ as own key"
+        );
+        if (!result.ok) return;
+
+        // __proto__ must survive as an own enumerable property on the output,
+        // not be silently dropped or interpreted as a prototype assignment.
+        assert.equal(
+          Object.prototype.hasOwnProperty.call(result.state, "__proto__"),
+          true,
+          "__proto__ must be an own property of the normalized state object"
+        );
+
+        // The stored value must be identical to what was supplied.
+        assert.deepStrictEqual(
+          result.state["__proto__"],
+          protoValBefore,
+          "__proto__ value must be preserved without modification"
+        );
+
+        // The output object is always Object.create(null); its prototype must
+        // never be changed to anything else regardless of input key names.
+        assert.equal(
+          Object.getPrototypeOf(result.state),
+          null,
+          "normalized state prototype must be null — __proto__ key must not mutate the prototype chain"
+        );
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+// ─── P3. Required keys enforcement ───────────────────────────────────────────
+
+test("P3a: normalizeState succeeds when a required top-level key is present in state", () => {
+  // Generate an object guaranteed to have at least one key, then pick one of
+  // those keys as the required key.
+  const arbStateWithRequiredKey = fc
+    .dictionary(
+      fc
+        .string({ minLength: 1, maxLength: 16 })
+        .filter((k: string) => k !== "__proto__"),
+      arbDeterministicValue(1),
+      { minKeys: 1, maxKeys: 6 }
+    )
+    .chain((state: Record<string, unknown>) => {
+      const keys = Object.keys(state);
+      // Derive the picked key deterministically so shrinking stays coherent.
+      const key = keys[Math.floor(keys.length / 2)]!;
+      return fc.constant({ state, key });
+    });
+
+  fc.assert(
+    fc.property(
+      arbStateWithRequiredKey,
+      ({ state, key }: { state: Record<string, unknown>; key: string }) => {
+        const result = normalizeState({ state, requiredKeys: [key] });
+        assert.equal(
+          result.ok,
+          true,
+          `normalization must succeed when required key '${key}' is present`
+        );
+      }
+    ),
+    { numRuns: RUNS_CHAIN }
+  );
+});
+
+test("P3b: normalizeState returns MISSING_REQUIRED_STATE_KEY when a required key is absent", () => {
+  // Derive a key that is guaranteed absent from the generated state.
+  const arbStateAndMissingKey = arbDeterministicObject(1).chain(
+    (state: Record<string, unknown>) => {
+      const existingKeys = new Set(Object.keys(state));
+      return fc
+        .string({ minLength: 1, maxLength: 16 })
+        .filter((k: string) => !existingKeys.has(k) && k !== "__proto__")
+        .map((missingKey: string) => ({ state, missingKey }));
+    }
+  );
+
+  fc.assert(
+    fc.property(
+      arbStateAndMissingKey,
+      ({
+        state,
+        missingKey,
+      }: {
+        state: Record<string, unknown>;
+        missingKey: string;
+      }) => {
+        const result = normalizeState({ state, requiredKeys: [missingKey] });
+
+        assert.equal(
+          result.ok,
+          false,
+          `normalization must fail when required key '${missingKey}' is absent`
+        );
+        if (!result.ok) {
+          assert.equal(
+            result.code,
+            "MISSING_REQUIRED_STATE_KEY",
+            "error code must be MISSING_REQUIRED_STATE_KEY"
+          );
+        }
+      }
+    ),
+    { numRuns: RUNS_CHAIN }
+  );
+});
+
+// ─── P4. Unsupported values fail closed ───────────────────────────────────────
+
+test("P4: normalizeState fails closed on unsupported values nested in state — never throws", () => {
+  // Wrap the unsupported value as a field inside an otherwise-valid object so
+  // that the failure is triggered by recursive value validation, not by the
+  // top-level shape guard (which is tested separately in P6).
+  const arbStateWithUnsupportedNested = fc
+    .tuple(
+      fc
+        .string({ minLength: 1, maxLength: 16 })
+        .filter((k: string) => k !== "__proto__"),
+      arbUnsupportedValue()
+    )
+    .map(([key, badVal]: [string, unknown]) => ({ [key]: badVal }));
+
+  fc.assert(
+    fc.property(
+      arbStateWithUnsupportedNested,
+      (state: Record<string, unknown>) => {
+        let result: NormalizeStateResult;
+        try {
+          result = normalizeState({ state });
+        } catch (e) {
+          assert.fail(
+            `normalizeState threw instead of returning { ok: false }: ${String(e)}`
+          );
+          return;
+        }
+        assert.equal(
+          result.ok,
+          false,
+          "normalization must return { ok: false } for state containing an unsupported nested value"
+        );
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+// ─── P5. Floats always fail ───────────────────────────────────────────────────
+
+test("P5: non-integer finite floats anywhere in state always cause normalization to fail", () => {
+  const nonIntegerFloat = fc
+    .float({ noNaN: true, noDefaultInfinity: true })
+    .filter((n: number) => !Number.isInteger(n));
+
+  const arbStateWithFloat = fc
+    .tuple(
+      fc
+        .string({ minLength: 1, maxLength: 16 })
+        .filter((k: string) => k !== "__proto__"),
+      nonIntegerFloat
+    )
+    .map(([key, floatVal]: [string, number]) => ({ [key]: floatVal }));
+
+  fc.assert(
+    fc.property(
+      arbStateWithFloat,
+      (state: Record<string, unknown>) => {
+        const result = normalizeState({ state });
+        assert.equal(
+          result.ok,
+          false,
+          "state containing a float must not normalize successfully — floats are never silently coerced to integers"
+        );
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+// ─── P6. Invalid top-level roots fail ────────────────────────────────────────
+
+test("P6: invalid top-level state (null, undefined, array, primitive) always fails", () => {
+  // These are rejected at the top-level shape guard before any field
+  // normalization is attempted. Covers both the null/primitive paths and the
+  // class-instance path (Date, Map, Set have non-Object.prototype prototypes
+  // and therefore fail isStrictPlainObject regardless of their contents).
+  const arbInvalidRoot: fc.Arbitrary<unknown> = fc.oneof(
+    fc.constant(null),
+    fc.constant(undefined),
+    fc.array(arbDeterministicValue(1), { maxLength: 5 }),
+    fc.string({ minLength: 0, maxLength: 32 }),
+    fc.integer({ min: -100_000, max: 100_000 }),
+    fc.boolean(),
+    fc.constant(new Date("2026-01-01T00:00:00.000Z")),
+    fc.constant(new Map<string, string>()),
+    fc.constant(new Set<number>()),
+    fc.constant(Buffer.from("data")),
+    fc.constant(new Uint8Array([0, 1]))
+  );
+
+  fc.assert(
+    fc.property(arbInvalidRoot, (invalidRoot: unknown) => {
+      let result: NormalizeStateResult;
+      try {
+        result = normalizeState({ state: invalidRoot });
+      } catch (e) {
+        assert.fail(
+          `normalizeState threw on invalid top-level root instead of returning { ok: false }: ${String(e)}`
+        );
+        return;
+      }
+      assert.equal(
+        result.ok,
+        false,
+        "normalization must fail for any non-plain-object top-level state"
+      );
+    }),
+    { numRuns: RUNS }
+  );
+});

--- a/packages/sift/test/tsconfig.json
+++ b/packages/sift/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  }
+}

--- a/packages/sift/test/verifyReceipt.property.test.ts
+++ b/packages/sift/test/verifyReceipt.property.test.ts
@@ -1,0 +1,786 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Property-based tests for verifyReceipt.
+ *
+ * Each property verifies a security invariant at the execution boundary:
+ *   P1  Valid receipts verify        — correct structure, hash, signature, fresh ts
+ *   P2  Determinism                  — same inputs always return the same result
+ *   P3  Post-signature mutation      — any signed field change after signing fails
+ *   P4  Receipt hash mismatch        — wrong or malformed hash always fails
+ *   P5  DENY decision enforcement    — DENY fails by default; bypassed with flag
+ *   P6  Freshness window             — stale / too-future receipts rejected
+ *   P7  Structural invalidity        — bad field types, missing fields, non-objects fail
+ *   P8  Wrong public key             — verification with wrong key always fails
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fc from "fast-check";
+import {
+  createHash,
+  generateKeyPairSync,
+  sign as cryptoSign,
+} from "node:crypto";
+
+import {
+  verifyReceipt,
+  type VerifyReceiptOptions,
+} from "../src/verifyReceipt.js";
+
+// ─── Run budget ───────────────────────────────────────────────────────────────
+
+const RUNS = 50;
+
+// ─── Canonical JSON ───────────────────────────────────────────────────────────
+//
+// Mirrors source exactly: lexicographically sorted keys, no whitespace, UTF-8.
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonObject = { [key: string]: JsonValue };
+type JsonArray = JsonValue[];
+type JsonValue = JsonPrimitive | JsonArray | JsonObject;
+
+function canonicalize(value: unknown): JsonValue {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError(`Non-finite: ${value}`);
+    return value;
+  }
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (typeof value === "object") {
+    const out: JsonObject = {};
+    for (const k of Object.keys(value as object).sort()) {
+      out[k] = canonicalize((value as Record<string, unknown>)[k]);
+    }
+    return out;
+  }
+  throw new TypeError(`Unsupported type: ${typeof value}`);
+}
+
+function canonicalBytes(value: unknown): Buffer {
+  return Buffer.from(JSON.stringify(canonicalize(value)), "utf-8");
+}
+
+// ─── Receipt hash ─────────────────────────────────────────────────────────────
+//
+// SHA-256 over canonical JSON of the receipt EXCLUDING `signature` and
+// `receipt_hash` — the two fields outside the hash scope.
+// Mirrors source computeReceiptHash exactly.
+
+function computeTestHash(receipt: Record<string, unknown>): string {
+  const { signature: _s, receipt_hash: _h, ...payload } = receipt;
+  return createHash("sha256").update(canonicalBytes(payload)).digest("hex");
+}
+
+// ─── Ed25519 helpers ──────────────────────────────────────────────────────────
+
+interface KeyPair {
+  publicKeyPem: string;
+  privateKeyPem: string;
+}
+
+function makeKeyPair(): KeyPair {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519", {
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  return { publicKeyPem: publicKey, privateKeyPem: privateKey };
+}
+
+// Mirrors source signature scope: canonical JSON of the receipt EXCLUDING
+// `signature` (receipt_hash IS included — it is part of the signed object).
+// Caller passes a payload that already contains receipt_hash but not signature.
+function signPayload(payload: Record<string, unknown>, privateKeyPem: string): string {
+  return cryptoSign(null, canonicalBytes(payload), privateKeyPem).toString("base64");
+}
+
+// ─── Valid receipt builder ────────────────────────────────────────────────────
+
+interface SignedReceiptFixture {
+  receipt: Record<string, unknown>;
+  publicKeyPem: string;
+  privateKeyPem: string;
+}
+
+/**
+ * Fixed baseline `now` for all freshness-sensitive tests.
+ * Receipts built with the default timestamp are fresh relative to FIXED_NOW.
+ */
+const FIXED_NOW = new Date("2026-04-14T12:00:00.000Z");
+const BASELINE_TIMESTAMP = FIXED_NOW.toISOString();
+
+/**
+ * Builds a structurally valid, correctly signed receipt.
+ *
+ * Build order (matching the verification pipeline):
+ *   1. Apply overrides to base fields — overrides are part of the hash preimage.
+ *   2. Compute receipt_hash = SHA-256(canonical(base)).
+ *      Neither `signature` nor `receipt_hash` is in `base` at this point;
+ *      their absence from the preimage is guaranteed by construction.
+ *   3. Format receipt_hash as bare hex or "sha256:<hex>".
+ *   4. Sign canonical(base + receipt_hash).
+ *      No `signature` field is present yet.
+ *   5. Attach signature to produce the complete receipt.
+ */
+function makeSignedReceipt(
+  overrides: Record<string, unknown> = {},
+  hashFormat: "hex" | "sha256:hex" = "hex",
+  keypair?: KeyPair
+): SignedReceiptFixture {
+  const kp = keypair ?? makeKeyPair();
+
+  // Base payload fields.  `signature` and `receipt_hash` are intentionally
+  // absent here — both are computed below.
+  const base: Record<string, unknown> = {
+    receipt_version: "1.0",
+    tenant_id: "tenant-test",
+    agent_id: "agent-test",
+    action: "transfer_funds",
+    tool: "payments_api",
+    decision: "ALLOW",
+    risk_tier: 1,
+    timestamp: BASELINE_TIMESTAMP,
+    nonce: "11111111-1111-1111-1111-111111111111",
+    policy_matched: "payments-policy-v1",
+    ...overrides,
+  };
+
+  // Hash preimage = base (computeTestHash strips sig+hash; no-op on base).
+  const hashHex = computeTestHash(base);
+  const receiptHash = hashFormat === "sha256:hex" ? `sha256:${hashHex}` : hashHex;
+
+  // Signature preimage = base + receipt_hash (no signature field yet).
+  const withHash: Record<string, unknown> = { ...base, receipt_hash: receiptHash };
+  const signature = signPayload(withHash, kp.privateKeyPem);
+
+  return {
+    receipt: { ...withHash, signature },
+    publicKeyPem: kp.publicKeyPem,
+    privateKeyPem: kp.privateKeyPem,
+  };
+}
+
+// ─── Mutation helper ──────────────────────────────────────────────────────────
+
+/** Shallow-clones receipt with one field replaced — does NOT re-sign. */
+function cloneWithField(
+  receipt: Record<string, unknown>,
+  field: string,
+  value: unknown
+): Record<string, unknown> {
+  return { ...receipt, [field]: value };
+}
+
+// ─── Arbitraries ──────────────────────────────────────────────────────────────
+
+const arbNonEmptyString = fc.string({ minLength: 1, maxLength: 32 });
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// P1. Valid signed receipts verify successfully
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test("P1: valid signed receipts with diverse payloads always verify successfully", () => {
+  fc.assert(
+    fc.property(
+      fc.record({
+        tenant_id: arbNonEmptyString,
+        agent_id: arbNonEmptyString,
+        action: arbNonEmptyString,
+        tool: arbNonEmptyString,
+        risk_tier: fc.integer({ min: 0, max: 10 }),
+        nonce: fc.uuid(),
+        policy_matched: arbNonEmptyString,
+        hashFormat: fc.constantFrom("hex" as const, "sha256:hex" as const),
+      }),
+      ({ tenant_id, agent_id, action, tool, risk_tier, nonce, policy_matched, hashFormat }) => {
+        const { receipt, publicKeyPem } = makeSignedReceipt(
+          { tenant_id, agent_id, action, tool, risk_tier, nonce, policy_matched },
+          hashFormat
+        );
+
+        const result = verifyReceipt(receipt, {
+          publicKeyPem,
+          now: FIXED_NOW,
+          maxAgeMs: 30_000,
+        });
+
+        assert.equal(
+          result.ok,
+          true,
+          `valid signed receipt must verify; got code: ${
+            result.ok ? "(ok)" : (result as { code: string }).code
+          }`
+        );
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// P2. Determinism
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test("P2: verifyReceipt is deterministic — identical inputs always produce identical results", () => {
+  fc.assert(
+    fc.property(
+      fc.record({
+        tenant_id: arbNonEmptyString,
+        agent_id: arbNonEmptyString,
+      }),
+      ({ tenant_id, agent_id }) => {
+        const { receipt, publicKeyPem } = makeSignedReceipt({ tenant_id, agent_id });
+        const options: VerifyReceiptOptions = { publicKeyPem, now: FIXED_NOW };
+
+        const r1 = verifyReceipt(receipt, options);
+        const r2 = verifyReceipt(receipt, options);
+
+        assert.deepStrictEqual(
+          r1,
+          r2,
+          "two calls with identical inputs must return deeply equal results"
+        );
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// P3. Post-signature mutation always fails
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// All fields covered by the receipt hash preimage or the signature scope are
+// listed below.  Mutating any of them after signing must cause verification to
+// fail regardless of which step detects the change.
+//
+// Expected detection paths per field (verification order: structural → version
+// → ALLOW/DENY → freshness → hash → signature):
+//
+//   decision     → DENY_DECISION (step 3) — tampered to "DENY", structurally valid
+//   timestamp    → INVALID_RECEIPT_HASH (step 5) — different valid ISO in hash preimage
+//   receipt_hash → INVALID_RECEIPT_HASH (step 5) — claimed hash no longer matches
+//   all others   → INVALID_RECEIPT_HASH (step 5) — fields are in the hash preimage
+
+const SIGNED_FIELDS = [
+  "action",
+  "tool",
+  "tenant_id",
+  "agent_id",
+  "policy_matched",
+  "nonce",
+  "decision",
+  "risk_tier",
+  "timestamp",
+  "receipt_hash",
+] as const;
+
+type SignedField = (typeof SIGNED_FIELDS)[number];
+
+// A timestamp 1 ms earlier than the baseline — structurally valid, still fresh,
+// but different from BASELINE_TIMESTAMP so the hash preimage changes.
+const TAMPERED_TIMESTAMP = new Date(FIXED_NOW.getTime() - 1).toISOString();
+
+test("P3: mutating any covered field after signing always causes verification to fail without throwing", () => {
+  // Fixed receipt; the property varies over which field is tampered.
+  const { receipt, publicKeyPem } = makeSignedReceipt();
+
+  fc.assert(
+    fc.property(
+      fc.constantFrom<SignedField>(...SIGNED_FIELDS),
+      (field) => {
+        const original = receipt[field];
+
+        // Use structurally valid replacement values where possible so that
+        // detection reaches the hash / signature checks rather than being
+        // short-circuited by a structural guard.
+        let tampered: unknown;
+        if (field === "decision") {
+          // "DENY" is a valid decision value; fails at DENY_DECISION (step 3).
+          tampered = "DENY";
+        } else if (field === "timestamp") {
+          // Different valid ISO string still within freshness; fails at
+          // INVALID_RECEIPT_HASH (step 5) because timestamp is in hash preimage.
+          tampered = TAMPERED_TIMESTAMP;
+        } else if (field === "receipt_hash") {
+          // A well-formed 64-char hex hash that differs from the correct one;
+          // fails at INVALID_RECEIPT_HASH (step 5).
+          tampered = "0".repeat(64);
+        } else if (typeof original === "number") {
+          // Different non-negative integer; fails at INVALID_RECEIPT_HASH (step 5).
+          tampered = (original as number) + 1;
+        } else {
+          // Different non-empty string; fails at INVALID_RECEIPT_HASH (step 5).
+          tampered = String(original) + "_tampered";
+        }
+
+        const mutated = cloneWithField(receipt, field, tampered);
+
+        let result;
+        try {
+          result = verifyReceipt(mutated, { publicKeyPem, now: FIXED_NOW });
+        } catch (e) {
+          assert.fail(
+            `verifyReceipt threw instead of returning { ok: false } for tampered field '${field}': ${String(e)}`
+          );
+          return;
+        }
+
+        assert.equal(
+          result.ok,
+          false,
+          `tampering field '${field}' must cause verification to fail`
+        );
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// P4. Receipt hash mismatch or malformed hash
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test("P4a: wrong receipt_hash (correct format, wrong content) always fails with INVALID_RECEIPT_HASH", () => {
+  // Fixed receipt so the correct hash is stable across all runs.
+  const { receipt, publicKeyPem } = makeSignedReceipt();
+  const correctHash = computeTestHash(receipt);
+
+  fc.assert(
+    fc.property(
+      // 64-char lowercase hex strings, excluding the correct hash.
+      // For every such string: it is a non-empty value (passes structural check),
+      // steps 1–4 all pass with the unchanged receipt, and step 5 fires because
+      // claimedHash ≠ recomputedHash.
+      fc
+        .string({
+          unit: fc.constantFrom("0","1","2","3","4","5","6","7","8","9","a","b","c","d","e","f"),
+          minLength: 64,
+          maxLength: 64,
+        })
+        .filter((h: string) => h !== correctHash),
+      (wrongHex) => {
+        const mutated = cloneWithField(receipt, "receipt_hash", wrongHex);
+
+        let result;
+        try {
+          result = verifyReceipt(mutated, { publicKeyPem, now: FIXED_NOW });
+        } catch (e) {
+          assert.fail(`verifyReceipt threw on wrong receipt_hash: ${String(e)}`);
+          return;
+        }
+
+        assert.equal(result.ok, false, "wrong receipt_hash must fail verification");
+        if (!result.ok) {
+          // The generated hash is structurally valid so steps 1–4 pass; step 5
+          // (hash integrity check) is the first to fire and must produce this code.
+          assert.equal(result.code, "INVALID_RECEIPT_HASH");
+        }
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+test("P4b: malformed receipt_hash (any short non-hash string) always fails without throwing", () => {
+  // Any string of length 1–32 is too short to be a 64-char hex hash or a
+  // "sha256:<64 hex chars>" (71 chars), so it will always mismatch at step 5
+  // (or fail the non-empty check if it were empty, but minLength: 1 prevents that).
+  const { receipt, publicKeyPem } = makeSignedReceipt();
+
+  fc.assert(
+    fc.property(
+      fc.string({ minLength: 1, maxLength: 32 }),
+      (badHash) => {
+        const mutated = cloneWithField(receipt, "receipt_hash", badHash);
+
+        let result;
+        try {
+          result = verifyReceipt(mutated, { publicKeyPem, now: FIXED_NOW });
+        } catch (e) {
+          assert.fail(`verifyReceipt threw on malformed receipt_hash: ${String(e)}`);
+          return;
+        }
+
+        assert.equal(result.ok, false, "malformed receipt_hash must fail verification");
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// P5. DENY decision enforcement
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test("P5a: DENY decision always fails with default options (requireAllowDecision defaults to true)", () => {
+  fc.assert(
+    fc.property(
+      arbNonEmptyString,
+      (tenant_id) => {
+        const { receipt, publicKeyPem } = makeSignedReceipt({ tenant_id, decision: "DENY" });
+
+        let result;
+        try {
+          result = verifyReceipt(receipt, { publicKeyPem, now: FIXED_NOW });
+        } catch (e) {
+          assert.fail(`verifyReceipt threw on DENY receipt: ${String(e)}`);
+          return;
+        }
+
+        assert.equal(result.ok, false, "DENY receipt must fail by default");
+        if (!result.ok) {
+          assert.equal(
+            result.code,
+            "DENY_DECISION",
+            "error code must be DENY_DECISION for a denied receipt"
+          );
+        }
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+test("P5b: DENY decision with requireAllowDecision: false passes when receipt is otherwise valid", () => {
+  const { receipt, publicKeyPem } = makeSignedReceipt({ decision: "DENY" });
+
+  const result = verifyReceipt(receipt, {
+    publicKeyPem,
+    now: FIXED_NOW,
+    requireAllowDecision: false,
+  });
+
+  assert.equal(
+    result.ok,
+    true,
+    "valid DENY receipt must pass when requireAllowDecision is false"
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// P6. Freshness window
+//
+// ageMs = nowMs − receiptMs
+//   fresh:              ageMs ∈ [0, MAX_AGE_MS]     boundary MAX_AGE_MS is included
+//                                                     (source uses strict >)
+//   stale:              ageMs > MAX_AGE_MS            strict; min = MAX_AGE_MS + 1
+//   future within skew: ageMs ∈ [−MAX_SKEW_MS, 0)   boundary −MAX_SKEW_MS included
+//                                                     (source uses strict <)
+//   future too far:     ageMs < −MAX_SKEW_MS          strict; min skewMs = MAX_SKEW_MS + 1
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const NOW_MS    = FIXED_NOW.getTime();
+const MAX_AGE_MS  = 30_000;  // DEFAULT_MAX_AGE_MS in source
+const MAX_SKEW_MS =  5_000;  // MAX_FUTURE_SKEW_MS in source
+
+test("P6a: receipts within the freshness window always verify successfully", () => {
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 0, max: MAX_AGE_MS }),
+      (ageMs) => {
+        const timestamp = new Date(NOW_MS - ageMs).toISOString();
+        const { receipt, publicKeyPem } = makeSignedReceipt({ timestamp });
+
+        const result = verifyReceipt(receipt, {
+          publicKeyPem,
+          now: FIXED_NOW,
+          maxAgeMs: MAX_AGE_MS,
+        });
+
+        assert.equal(
+          result.ok,
+          true,
+          `receipt with age ${ageMs}ms must be within the freshness window`
+        );
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+test("P6b: stale receipts (age > maxAgeMs) are rejected with STALE_RECEIPT", () => {
+  fc.assert(
+    fc.property(
+      // min = MAX_AGE_MS + 1: strictly over the boundary (source: ageMs > maxAgeMs).
+      fc.integer({ min: MAX_AGE_MS + 1, max: MAX_AGE_MS + 3_600_000 }),
+      (ageMs) => {
+        const timestamp = new Date(NOW_MS - ageMs).toISOString();
+        const { receipt, publicKeyPem } = makeSignedReceipt({ timestamp });
+
+        let result;
+        try {
+          result = verifyReceipt(receipt, {
+            publicKeyPem,
+            now: FIXED_NOW,
+            maxAgeMs: MAX_AGE_MS,
+          });
+        } catch (e) {
+          assert.fail(`verifyReceipt threw on stale receipt: ${String(e)}`);
+          return;
+        }
+
+        assert.equal(result.ok, false, `receipt with age ${ageMs}ms must be stale`);
+        if (!result.ok) {
+          assert.equal(result.code, "STALE_RECEIPT");
+        }
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+test("P6c: receipts slightly in the future (within skew tolerance) verify successfully", () => {
+  fc.assert(
+    fc.property(
+      // max = MAX_SKEW_MS: boundary is included (source: ageMs < -MAX_FUTURE_SKEW_MS,
+      // so ageMs = -MAX_SKEW_MS does NOT fail).
+      fc.integer({ min: 1, max: MAX_SKEW_MS }),
+      (skewMs) => {
+        const timestamp = new Date(NOW_MS + skewMs).toISOString();
+        const { receipt, publicKeyPem } = makeSignedReceipt({ timestamp });
+
+        const result = verifyReceipt(receipt, {
+          publicKeyPem,
+          now: FIXED_NOW,
+          maxAgeMs: MAX_AGE_MS,
+        });
+
+        assert.equal(
+          result.ok,
+          true,
+          `receipt ${skewMs}ms in the future (≤ ${MAX_SKEW_MS}ms skew) must pass`
+        );
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+test("P6d: receipts too far in the future (beyond skew tolerance) are rejected with INVALID_TIMESTAMP", () => {
+  fc.assert(
+    fc.property(
+      // min = MAX_SKEW_MS + 1: strictly beyond the boundary.
+      fc.integer({ min: MAX_SKEW_MS + 1, max: MAX_SKEW_MS + 3_600_000 }),
+      (skewMs) => {
+        const timestamp = new Date(NOW_MS + skewMs).toISOString();
+        const { receipt, publicKeyPem } = makeSignedReceipt({ timestamp });
+
+        let result;
+        try {
+          result = verifyReceipt(receipt, {
+            publicKeyPem,
+            now: FIXED_NOW,
+            maxAgeMs: MAX_AGE_MS,
+          });
+        } catch (e) {
+          assert.fail(`verifyReceipt threw on future receipt: ${String(e)}`);
+          return;
+        }
+
+        assert.equal(result.ok, false, `receipt ${skewMs}ms too far in future must fail`);
+        if (!result.ok) {
+          assert.equal(result.code, "INVALID_TIMESTAMP");
+        }
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// P7. Structural invalidity fails closed
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test("P7a: invalid values in required string fields always fail without throwing", () => {
+  const REQUIRED_STRING_FIELDS = [
+    "receipt_version",
+    "tenant_id",
+    "agent_id",
+    "action",
+    "tool",
+    "timestamp",
+    "nonce",
+    "policy_matched",
+    "receipt_hash",
+    "signature",
+  ] as const;
+
+  // Values rejected by isNonEmptyString — every required string field rejects these.
+  const arbInvalidStringValue: fc.Arbitrary<unknown> = fc.oneof(
+    fc.constant(""),
+    fc.constant(null),
+    fc.constant(undefined),
+    fc.constant(0),
+    fc.constant(false),
+    fc.constant([]),
+    fc.constant({}),
+  );
+
+  const { receipt, publicKeyPem } = makeSignedReceipt();
+
+  fc.assert(
+    fc.property(
+      fc.constantFrom(...REQUIRED_STRING_FIELDS),
+      arbInvalidStringValue,
+      (field, badValue) => {
+        const mutated = cloneWithField(receipt, field, badValue);
+
+        let result;
+        try {
+          result = verifyReceipt(mutated, { publicKeyPem, now: FIXED_NOW });
+        } catch (e) {
+          assert.fail(`verifyReceipt threw on bad value for '${field}': ${String(e)}`);
+          return;
+        }
+
+        assert.equal(result.ok, false, `invalid value for '${field}' must fail`);
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+test("P7b: invalid risk_tier values (float, negative, non-number) always fail without throwing", () => {
+  const arbInvalidRiskTier: fc.Arbitrary<unknown> = fc.oneof(
+    fc.float({ noNaN: true, noDefaultInfinity: true }).filter((n: number) => !Number.isInteger(n)),
+    fc.integer({ min: -1_000_000, max: -1 }),
+    fc.constant(null),
+    fc.constant("1"),
+    fc.constant(true),
+    fc.constant([]),
+    fc.constant({}),
+  );
+
+  const { receipt, publicKeyPem } = makeSignedReceipt();
+
+  fc.assert(
+    fc.property(arbInvalidRiskTier, (badTier) => {
+      const mutated = cloneWithField(receipt, "risk_tier", badTier);
+
+      let result;
+      try {
+        result = verifyReceipt(mutated, { publicKeyPem, now: FIXED_NOW });
+      } catch (e) {
+        assert.fail(`verifyReceipt threw on invalid risk_tier: ${String(e)}`);
+        return;
+      }
+
+      assert.equal(result.ok, false, "invalid risk_tier must fail structural validation");
+    }),
+    { numRuns: RUNS }
+  );
+});
+
+test("P7c: missing required fields always fail without throwing", () => {
+  const REQUIRED_FIELDS = [
+    "receipt_version",
+    "tenant_id",
+    "agent_id",
+    "action",
+    "tool",
+    "decision",
+    "risk_tier",
+    "timestamp",
+    "nonce",
+    "policy_matched",
+    "receipt_hash",
+    "signature",
+  ] as const;
+
+  const { receipt, publicKeyPem } = makeSignedReceipt();
+
+  fc.assert(
+    fc.property(
+      fc.constantFrom(...REQUIRED_FIELDS),
+      (field) => {
+        const withoutField: Record<string, unknown> = {};
+        for (const k of Object.keys(receipt)) {
+          if (k !== field) withoutField[k] = receipt[k];
+        }
+
+        let result;
+        try {
+          result = verifyReceipt(withoutField, { publicKeyPem, now: FIXED_NOW });
+        } catch (e) {
+          assert.fail(`verifyReceipt threw on missing field '${field}': ${String(e)}`);
+          return;
+        }
+
+        assert.equal(result.ok, false, `missing field '${field}' must fail`);
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});
+
+test("P7d: non-object top-level input (null, array, primitive) always fails without throwing", () => {
+  // parseReceipt rejects anything that is not a non-null plain object.
+  // This exercises the top-level structural guard before any field validation.
+  const { publicKeyPem } = makeSignedReceipt();
+
+  const arbNonObject: fc.Arbitrary<unknown> = fc.oneof(
+    fc.constant(null),
+    fc.constant(undefined),
+    fc.array(arbNonEmptyString, { maxLength: 5 }),
+    fc.string({ minLength: 0, maxLength: 32 }),
+    fc.integer({ min: -100_000, max: 100_000 }),
+    fc.boolean(),
+  );
+
+  fc.assert(
+    fc.property(arbNonObject, (badReceipt) => {
+      let result;
+      try {
+        result = verifyReceipt(badReceipt, { publicKeyPem, now: FIXED_NOW });
+      } catch (e) {
+        assert.fail(`verifyReceipt threw on non-object input: ${String(e)}`);
+        return;
+      }
+
+      assert.equal(result.ok, false, "non-object receipt must fail with MALFORMED_RECEIPT");
+      if (!result.ok) {
+        assert.equal(result.code, "MALFORMED_RECEIPT");
+      }
+    }),
+    { numRuns: RUNS }
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// P8. Wrong public key always fails
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// Pre-generate a wrong keypair once.  This avoids 50 extra generateKeyPairSync
+// calls inside the property while still demonstrating the invariant across
+// receipts with different payloads (via varied tenant_id).
+const WRONG_KEYPAIR = makeKeyPair();
+
+test("P8: verifying a receipt with the wrong Ed25519 public key always fails without throwing", () => {
+  fc.assert(
+    fc.property(
+      arbNonEmptyString,
+      (tenant_id) => {
+        // Sign with keypair A; attempt verification with the unrelated keypair B.
+        const { receipt } = makeSignedReceipt({ tenant_id });
+
+        let result;
+        try {
+          result = verifyReceipt(receipt, {
+            publicKeyPem: WRONG_KEYPAIR.publicKeyPem,
+            now: FIXED_NOW,
+          });
+        } catch (e) {
+          assert.fail(`verifyReceipt threw on wrong public key: ${String(e)}`);
+          return;
+        }
+
+        assert.equal(result.ok, false, "wrong public key must cause verification to fail");
+      }
+    ),
+    { numRuns: RUNS }
+  );
+});

--- a/packages/sift/tsconfig.test.json
+++ b/packages/sift/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src", "test"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,12 @@ importers:
 
   packages/sift:
     devDependencies:
+      '@types/node':
+        specifier: ^22.19.11
+        version: 22.19.13
+      fast-check:
+        specifier: ^4.6.0
+        version: 4.6.0
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -992,6 +998,10 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
 
+  fast-check@4.6.0:
+    resolution: {integrity: sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==}
+    engines: {node: '>=12.17.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1345,6 +1355,9 @@ packages:
     resolution: {integrity: sha512-IxQbDq93XHVVLWHrAkFP7F7iHvb9o0mgfsSIMlhHb+JM+JjM1V4v4MNSQfcRWJopx9dsNOr9adYv0U5fm9BJBQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -2190,6 +2203,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fast-check@4.6.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
@@ -2558,6 +2575,8 @@ snapshots:
       - supports-color
       - typescript
       - utf-8-validate
+
+  pure-rand@8.4.0: {}
 
   rc@1.2.8:
     dependencies:

--- a/scripts/adapter-check/tsconfig.json
+++ b/scripts/adapter-check/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  }
+}


### PR DESCRIPTION
- add property-based tests for:
  - normalizeState (determinism, fail-closed, __proto__ safety, requiredKeys)
  - normalizeIntent (determinism, metadata exclusion, strict param validation)
  - verifyReceipt (hash/signature integrity, freshness, replay surface, fail-closed)

- introduce deterministic arbitraries:
  - arbDeterministicObject / arbDeterministicValue
  - arbPojoWithProtoKey for __proto__ preservation
  - arbUnsupportedValue for negative testing

- enforce critical invariants:
  - same input → identical output (no hidden state)
  - no silent key dropping (__proto__ must survive)
  - unsupported values always fail (no coercion)
  - post-signature mutation always rejected
  - freshness window correctly enforced (past + future skew)
  - public key mismatch always rejected

- add tsconfig.test.json for test typechecking (isolated from build config)
- add test tsconfig for adapter-check script
- update package.json and pnpm-lock.yaml for test dependencies (fast-check)

no impact on production build or runtime behavior