### PR TITLE
feat(example/sift): add end-to-end Sift → OxDeAI execution flow demo

### DIFF
--- a/examples/sift/README.md
+++ b/examples/sift/README.md
@@ -1,3 +1,156 @@
-# Sift Example
+# OxDeAI Sift Integration Demo
 
-Placeholder for end-to-end Sift -> OxDeAI adapter demo.
+A runnable end-to-end example that traces the full integration path from a Sift
+governance receipt to a PEP execution decision.
+
+> **This is a local simulation for engineering demonstration.  It does not
+> connect to any real Sift infrastructure, OxDeAI signing engine, or external
+> service.  All keys, receipts, and verifications are generated and performed
+> in-process.**
+
+---
+
+## Purpose
+
+The example makes three architectural invariants concrete and observable:
+
+1. **A Sift receipt is not execution authorization.**  It is upstream governance
+   input — evidence that a policy engine evaluated a requested action.  Receipt
+   verification is a necessary precondition, not a sufficient one.
+
+2. **Execution requires a signed `AuthorizationV1` artifact.**  The artifact is
+   constructed locally after verification, intent normalization, and state
+   normalization all succeed.  The issuer signs only the fields that were
+   verified.
+
+3. **The PEP is the execution boundary.**  The Policy Enforcement Point checks
+   audience, expiry, issuer signature, intent binding, state binding, and replay
+   before allowing any execution.  Replay protection lives here — not in the
+   adapter.
+
+---
+
+## Architecture
+
+```
+Mock Sift receipt
+       │
+       ▼
+ verifyReceipt()          ← structural check, version, freshness,
+       │                     receipt_hash integrity, Ed25519 signature
+       ▼
+ normalizeIntent()        ← binds receipt.tool / action to explicit params
+       │
+       ▼
+ normalizeState()         ← validates and normalizes runtime state snapshot
+       │
+       ▼
+ receiptToAuthorization() ← constructs AuthorizationV1 payload +
+       │                     signingPayload (hash bindings, time derivation)
+       ▼
+ sign( signingPayload )   ← demo issuer Ed25519 signature over canonical JSON
+       │
+       ▼
+ pepVerify()              ← execution gate:
+                             audience, expiry, signature,
+                             intent_hash, state_hash, replay store
+```
+
+The Sift key pair and the OxDeAI issuer key pair are distinct.  Verifying a
+receipt (with the Sift key) is separate from verifying an authorization (with
+the issuer key).
+
+---
+
+## Scenarios
+
+| Scenario | What it shows |
+|---|---|
+| **ALLOW** | Full happy path — every check passes, `executed: true` |
+| **DENY**  | DENY receipt blocked at `verifyReceipt`; adapter and PEP never reached |
+| **REPLAY** | Reusing the same `auth_id` from Scenario 1; PEP replay store returns DENY |
+
+---
+
+## Run
+
+```bash
+pnpm -C examples/sift start
+```
+
+The `start` script builds `packages/sift` first (`prebuild`), compiles this
+example, then runs it.  No environment variables or network access required.
+
+Expected output:
+
+```
+OxDeAI Sift Integration Demo
+
+Scenario 1 — ALLOW
+  receipt verification: OK
+  intent normalization: OK
+  state normalization: OK
+  authorization issued: auth_id=<uuid>
+  pep decision: ALLOW
+  executed: true
+
+Scenario 2 — DENY
+  receipt verification: DENY_DECISION
+  executed: false
+
+Scenario 3 — REPLAY
+  authorization reused: auth_id=<uuid>
+  pep decision: DENY
+  reason: REPLAY
+  executed: false
+```
+
+---
+
+## File layout
+
+```
+examples/sift/
+  src/
+    helpers.ts   — canonical JSON, Ed25519 helpers, mock receipt builder, PEP
+    run.ts       — three scenarios and output
+  package.json
+  tsconfig.json
+  README.md
+```
+
+### `helpers.ts`
+
+Self-contained implementations of:
+
+- **Canonical JSON** (`canonicalize` + `canonicalBytes` + `canonicalHash`) —
+  mirrors the algorithm used internally by `@oxdeai/sift` so hashes computed in
+  the PEP match the hashes stored in the authorization.
+- **Ed25519 utilities** (`makeKeyPair`, `signCanonical`, `verifyCanonical`).
+- **Mock receipt builder** (`buildMockReceipt`) — constructs a structurally
+  valid receipt with a correct `receipt_hash` preimage and real Ed25519
+  signature.
+- **Authorization signer** (`signAuthorization`) — signs the `signingPayload`
+  returned by `receiptToAuthorization` and fills `authorization.signature.sig`.
+- **PEP simulation** (`pepVerify`) — enforces all execution-boundary checks
+  including an in-memory replay store.
+
+### `run.ts`
+
+Orchestrates the three scenarios.  All keys are generated at startup and shared
+across scenarios so Scenario 3 can reuse Scenario 1's authorization verbatim.
+
+---
+
+## Preimage reference
+
+The following preimage conventions are critical for signatures and hashes to
+verify correctly:
+
+| Field | Preimage |
+|---|---|
+| `receipt_hash` | `sha256( canonical( receipt MINUS signature AND receipt_hash ) )` |
+| Sift `signature` | `sign( canonical( receipt MINUS signature, WITH receipt_hash ) )` |
+| Authorization `signature.sig` | `sign( canonical( signingPayload ) )` where `signingPayload` = authorization without `signature.sig` |
+| `intent_hash` | `sha256( canonical( OxDeAIIntent ) )` |
+| `state_hash` | `sha256( canonical( NormalizedState ) )` |

--- a/examples/sift/package.json
+++ b/examples/sift/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@oxdeai/example-sift",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "OxDeAI Sift adapter integration demo — receipt verification to AuthorizationV1 construction and PEP enforcement",
+  "scripts": {
+    "prebuild": "pnpm -C ../../packages/sift build",
+    "build": "tsc -p tsconfig.json",
+    "start": "pnpm build && node dist/run.js"
+  },
+  "dependencies": {
+    "@oxdeai/sift": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/examples/sift/src/helpers.ts
+++ b/examples/sift/src/helpers.ts
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Self-contained helpers for the Sift integration demo.
+ *
+ * These implementations are intentionally explicit about every preimage so
+ * the demo is pedagogically clear.  No internals from @oxdeai/sift are
+ * imported — only its public types.
+ *
+ * Preimage conventions that must match packages/sift/src/verifyReceipt.ts:
+ *
+ *   receipt_hash preimage:  canonical( receipt  MINUS  signature  AND  receipt_hash )
+ *   receipt signature:      canonical( receipt  MINUS  signature,  WITH receipt_hash )
+ *
+ * Preimage convention that must match packages/sift/src/receiptToAuthorization.ts:
+ *
+ *   authorization signature:  canonical( signingPayload )
+ *                             where signingPayload = authorization WITHOUT signature.sig
+ */
+
+import {
+  generateKeyPairSync,
+  sign as nodeCryptoSign,
+  verify as nodeCryptoVerify,
+  createHash,
+  randomUUID,
+} from "node:crypto";
+import type {
+  SiftDecision,
+  OxDeAIIntent,
+  NormalizedState,
+  AuthorizationV1Payload,
+  SigningPayload,
+} from "@oxdeai/sift";
+
+// ─── Canonical JSON ──────────────────────────────────────────────────────────
+// Mirrors the canonicalize + canonicalJsonHash logic inside the sift package.
+// Keys sorted lexicographically at every object level; arrays preserve order.
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [k: string]: JsonValue };
+
+function canonicalize(value: unknown): JsonValue {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError(`Non-finite number: ${value}`);
+    return value;
+  }
+  if (Array.isArray(value)) return (value as unknown[]).map(canonicalize);
+  if (typeof value === "object") {
+    const keys = Object.keys(value as object).sort();
+    const out = Object.create(null) as { [k: string]: JsonValue };
+    for (const k of keys) out[k] = canonicalize((value as Record<string, unknown>)[k]);
+    return out;
+  }
+  throw new TypeError(`Unsupported type: ${typeof value}`);
+}
+
+/** UTF-8 bytes of the sorted-key minified JSON encoding of `value`. */
+export function canonicalBytes(value: unknown): Buffer {
+  return Buffer.from(JSON.stringify(canonicalize(value)), "utf-8");
+}
+
+/** SHA-256 lowercase hex of `data`. */
+export function sha256Hex(data: Buffer): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+/** SHA-256 lowercase hex of canonical JSON of `value`. */
+export function canonicalHash(value: unknown): string {
+  return sha256Hex(canonicalBytes(value));
+}
+
+// ─── Ed25519 key management ──────────────────────────────────────────────────
+
+export interface DemoKeyPair {
+  publicKeyPem: string;
+  privateKeyPem: string;
+}
+
+export function makeKeyPair(): DemoKeyPair {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519", {
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  return { publicKeyPem: publicKey, privateKeyPem: privateKey };
+}
+
+/**
+ * Signs canonical JSON bytes of `value` with the given Ed25519 private key.
+ * Returns the signature as base64.
+ */
+export function signCanonical(value: unknown, privateKeyPem: string): string {
+  return nodeCryptoSign(null, canonicalBytes(value), privateKeyPem).toString("base64");
+}
+
+/**
+ * Verifies an Ed25519 base64 signature over canonical JSON bytes of `value`.
+ * Returns false on any error rather than throwing.
+ */
+export function verifyCanonical(
+  value: unknown,
+  sigBase64: string,
+  publicKeyPem: string
+): boolean {
+  try {
+    return nodeCryptoVerify(
+      null,
+      canonicalBytes(value),
+      publicKeyPem,
+      Buffer.from(sigBase64, "base64")
+    );
+  } catch {
+    return false;
+  }
+}
+
+// ─── Mock Sift receipt builder ───────────────────────────────────────────────
+// Produces a structurally valid receipt with a correctly-computed receipt_hash
+// and a real Ed25519 signature.  This simulates a receipt that would arrive
+// from the Sift governance service.
+//
+// Preimage order (critical — must match verifyReceipt.ts computeReceiptHash):
+//   ① Build body (no receipt_hash, no signature)
+//   ② receipt_hash = sha256( canonical( ① ) )
+//   ③ signed payload = ① + receipt_hash   (signature field absent)
+//   ④ signature = sign( canonical( ③ ) )
+
+export interface BuildReceiptOptions {
+  decision: SiftDecision;
+  keypair: DemoKeyPair;
+  nonce?: string;
+  tool?: string;
+  action?: string;
+  now?: Date;
+}
+
+export function buildMockReceipt(opts: BuildReceiptOptions): Record<string, unknown> {
+  const {
+    decision,
+    keypair,
+    nonce = randomUUID(),
+    tool = "query_database",
+    action = "call_tool",
+    now = new Date(),
+  } = opts;
+
+  // ① Receipt body — no receipt_hash, no signature.
+  const base = {
+    receipt_version: "1.0",
+    tenant_id: "demo-tenant",
+    agent_id: "demo-agent",
+    action,
+    tool,
+    decision,
+    risk_tier: 1,
+    timestamp: now.toISOString(),
+    nonce,
+    policy_matched: "policy-tools-v1",
+  };
+
+  // ② receipt_hash = SHA-256( canonical( body ) )
+  const receipt_hash = canonicalHash(base);
+
+  // ③ Signed payload = body + receipt_hash  (signature still absent)
+  const withHash = { ...base, receipt_hash };
+
+  // ④ signature = sign( canonical( ③ ) )
+  const signature = signCanonical(withHash, keypair.privateKeyPem);
+
+  return { ...withHash, signature };
+}
+
+// ─── Authorization signing ───────────────────────────────────────────────────
+// Fills the `sig` placeholder in authorization.signature by signing the
+// signingPayload returned by receiptToAuthorization.
+//
+// The signingPayload is already the correct preimage — it is the full
+// authorization with signature.sig intentionally absent.
+
+export function signAuthorization(
+  authorization: AuthorizationV1Payload,
+  signingPayload: SigningPayload,
+  issuerPrivateKeyPem: string
+): AuthorizationV1Payload {
+  const sig = signCanonical(signingPayload, issuerPrivateKeyPem);
+  return { ...authorization, signature: { ...authorization.signature, sig } };
+}
+
+// ─── PEP simulation ──────────────────────────────────────────────────────────
+// A minimal local Policy Enforcement Point.
+//
+// The Sift receipt is NOT the execution gate — it is upstream governance input.
+// The PEP is the execution boundary.  A signed AuthorizationV1 artifact,
+// verified here, is required before any execution can proceed.
+//
+// Checks performed in order:
+//   1. Audience exact match
+//   2. Expiry (expires_at > floor(now / 1000))
+//   3. Ed25519 signature on reconstructed signingPayload
+//   4. intent_hash matches the provided intent
+//   5. state_hash matches the provided state
+//   6. Replay: auth_id must not have been seen before
+
+export type PepResult =
+  | { ok: true; decision: "ALLOW"; executed: true; auth_id: string }
+  | { ok: false; decision: "DENY"; executed: false; reason: string };
+
+// In-memory replay store — scoped to this demo process.
+const pepReplayStore = new Set<string>();
+
+export interface PepVerifyInput {
+  authorization: AuthorizationV1Payload;
+  intent: OxDeAIIntent;
+  state: NormalizedState;
+  audience: string;
+  issuerPublicKeyPem: string;
+  now: Date;
+}
+
+export function pepVerify(input: PepVerifyInput): PepResult {
+  const { authorization, intent, state, audience, issuerPublicKeyPem, now } = input;
+
+  // 1. Audience
+  if (authorization.audience !== audience) {
+    return { ok: false, decision: "DENY", executed: false, reason: "AUDIENCE_MISMATCH" };
+  }
+
+  // 2. Expiry
+  const nowSec = Math.floor(now.getTime() / 1000);
+  if (authorization.expires_at <= nowSec) {
+    return { ok: false, decision: "DENY", executed: false, reason: "EXPIRED" };
+  }
+
+  // 3. Signature — reconstruct signing payload (authorization without signature.sig)
+  //    Must produce the same canonical bytes that were signed by the issuer.
+  const signingPayload: SigningPayload = {
+    version: authorization.version,
+    auth_id: authorization.auth_id,
+    issuer: authorization.issuer,
+    audience: authorization.audience,
+    decision: authorization.decision,
+    intent_hash: authorization.intent_hash,
+    state_hash: authorization.state_hash,
+    policy_id: authorization.policy_id,
+    issued_at: authorization.issued_at,
+    expires_at: authorization.expires_at,
+    signature: { alg: authorization.signature.alg, kid: authorization.signature.kid },
+  };
+  if (!verifyCanonical(signingPayload, authorization.signature.sig, issuerPublicKeyPem)) {
+    return { ok: false, decision: "DENY", executed: false, reason: "INVALID_SIGNATURE" };
+  }
+
+  // 4. Intent hash — recompute from the provided intent and compare.
+  if (authorization.intent_hash !== canonicalHash(intent)) {
+    return { ok: false, decision: "DENY", executed: false, reason: "INTENT_HASH_MISMATCH" };
+  }
+
+  // 5. State hash — recompute from the provided state and compare.
+  if (authorization.state_hash !== canonicalHash(state)) {
+    return { ok: false, decision: "DENY", executed: false, reason: "STATE_HASH_MISMATCH" };
+  }
+
+  // 6. Replay — the auth_id must be consumed exactly once.
+  if (pepReplayStore.has(authorization.auth_id)) {
+    return { ok: false, decision: "DENY", executed: false, reason: "REPLAY" };
+  }
+  pepReplayStore.add(authorization.auth_id);
+
+  return { ok: true, decision: "ALLOW", executed: true, auth_id: authorization.auth_id };
+}

--- a/examples/sift/src/run.ts
+++ b/examples/sift/src/run.ts
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * OxDeAI Sift Integration Demo
+ *
+ * Demonstrates the full path from a Sift receipt to a PEP execution decision.
+ *
+ * Architectural invariants:
+ *   - A Sift receipt is upstream governance input — not execution authorization.
+ *   - Execution requires a signed AuthorizationV1 artifact that is issued only
+ *     after local receipt verification, intent normalization, and state
+ *     normalization all succeed.
+ *   - The PEP is the execution boundary.  Replay is enforced there, not in
+ *     the adapter.
+ *   - The system fails closed: any unresolvable ambiguity blocks execution.
+ *
+ * Three scenarios:
+ *   1. ALLOW  — valid receipt, valid intent, valid state, fresh authorization
+ *   2. DENY   — DENY receipt blocked at the receipt verification boundary
+ *   3. REPLAY — same authorization reused; PEP replay store blocks execution
+ */
+
+import {
+  verifyReceipt,
+  normalizeIntent,
+  normalizeState,
+  receiptToAuthorization,
+} from "@oxdeai/sift";
+import {
+  makeKeyPair,
+  buildMockReceipt,
+  signAuthorization,
+  pepVerify,
+} from "./helpers.js";
+
+// ─── Demo constants ──────────────────────────────────────────────────────────
+
+const AUDIENCE = "demo-pep.oxdeai.local";
+const ISSUER   = "sift-demo-issuer.oxdeai.local";
+const KEY_ID   = "demo-issuer-key-1";
+
+// ─── Key material  (generated once, shared across scenarios) ─────────────────
+
+// Sift signing key — simulates the key held by the Sift governance service.
+const siftKeypair = makeKeyPair();
+
+// OxDeAI issuer key — simulates the adapter issuer that signs AuthorizationV1.
+const issuerKeypair = makeKeyPair();
+
+// ─── Output helpers ──────────────────────────────────────────────────────────
+
+function step(msg: string): void  { console.log(`  ${msg}`); }
+function blank(): void            { console.log(); }
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+console.log("OxDeAI Sift Integration Demo");
+blank();
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Scenario 1 — ALLOW
+//
+// Full happy path: receipt → intent → state → authorization → PEP → execute.
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log("Scenario 1 — ALLOW");
+
+// 1. Build a valid ALLOW receipt (simulates arrival from Sift).
+const allowRawReceipt = buildMockReceipt({ decision: "ALLOW", keypair: siftKeypair });
+
+// 2. Verify the receipt locally — structural, version, freshness, hash, signature.
+const verifyAllowResult = verifyReceipt(allowRawReceipt, {
+  publicKeyPem: siftKeypair.publicKeyPem,
+});
+if (!verifyAllowResult.ok) {
+  step(`receipt verification: FAILED (${verifyAllowResult.code})`);
+  step("executed: false");
+  process.exit(1);
+}
+step("receipt verification: OK");
+const receipt = verifyAllowResult.receipt;
+
+// 3. Normalize intent from explicit runtime params.
+//    The receipt binds the tool and action; params supply the call arguments.
+const intentResult = normalizeIntent({
+  receipt,
+  params: { query: "SELECT logs WHERE user_id = ?", limit: 100 },
+  expectedAction: "call_tool",
+  expectedTool: "query_database",
+});
+if (!intentResult.ok) {
+  step(`intent normalization: FAILED (${intentResult.code})`);
+  step("executed: false");
+  process.exit(1);
+}
+step("intent normalization: OK");
+const intent = intentResult.intent;
+
+// 4. Normalize runtime state.
+const stateResult = normalizeState({
+  state: { user_role: "operator", session_active: true, mfa_verified: true },
+  requiredKeys: ["user_role"],
+});
+if (!stateResult.ok) {
+  step(`state normalization: FAILED (${stateResult.code})`);
+  step("executed: false");
+  process.exit(1);
+}
+step("state normalization: OK");
+const state = stateResult.state;
+
+// 5. Construct the AuthorizationV1 payload.
+//    Binds receipt.nonce → auth_id, policy_matched → policy_id,
+//    computes intent_hash and state_hash, sets issued_at / expires_at.
+const authResult = receiptToAuthorization({
+  receipt,
+  intent,
+  state,
+  issuer: ISSUER,
+  audience: AUDIENCE,
+  keyId: KEY_ID,
+  ttlSeconds: 30,
+  now: new Date(),
+});
+if (!authResult.ok) {
+  step(`authorization construction: FAILED (${authResult.code})`);
+  step("executed: false");
+  process.exit(1);
+}
+
+// 6. Sign the signingPayload with the demo issuer key.
+//    signingPayload is the authorization with signature.sig absent — the
+//    correct preimage.  signAuthorization fills authorization.signature.sig.
+const signedAuthorization = signAuthorization(
+  authResult.authorization,
+  authResult.signingPayload,
+  issuerKeypair.privateKeyPem,
+);
+
+// 7. PEP enforcement — the execution boundary.
+//    Checks: audience, expiry, signature, intent_hash, state_hash, replay.
+const pep1 = pepVerify({
+  authorization: signedAuthorization,
+  intent,
+  state,
+  audience: AUDIENCE,
+  issuerPublicKeyPem: issuerKeypair.publicKeyPem,
+  now: new Date(),
+});
+
+step(`authorization issued: auth_id=${signedAuthorization.auth_id}`);
+step(`pep decision: ${pep1.decision}`);
+step(`executed: ${String(pep1.executed)}`);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Scenario 2 — DENY
+//
+// A DENY receipt is blocked at receipt verification.
+// receiptToAuthorization and the PEP are never reached.
+// ═══════════════════════════════════════════════════════════════════════════
+
+blank();
+console.log("Scenario 2 — DENY");
+
+const denyRawReceipt = buildMockReceipt({ decision: "DENY", keypair: siftKeypair });
+
+// requireAllowDecision defaults to true — DENY receipts are rejected here.
+const verifyDenyResult = verifyReceipt(denyRawReceipt, {
+  publicKeyPem: siftKeypair.publicKeyPem,
+});
+
+if (!verifyDenyResult.ok) {
+  step(`receipt verification: ${verifyDenyResult.code}`);
+  step("executed: false");
+} else {
+  // Unreachable with default requireAllowDecision; included for completeness.
+  step("receipt verification: unexpected OK on DENY receipt");
+  step("executed: false");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Scenario 3 — REPLAY
+//
+// The authorization from Scenario 1 is reused verbatim.
+// The PEP replay store has already recorded auth_id from Scenario 1 and
+// rejects the second attempt.  No re-issuance, no re-verification.
+// ═══════════════════════════════════════════════════════════════════════════
+
+blank();
+console.log("Scenario 3 — REPLAY");
+
+const pep3 = pepVerify({
+  authorization: signedAuthorization,    // same artifact — already consumed
+  intent,
+  state,
+  audience: AUDIENCE,
+  issuerPublicKeyPem: issuerKeypair.publicKeyPem,
+  now: new Date(),
+});
+
+step(`authorization reused: auth_id=${signedAuthorization.auth_id}`);
+step(`pep decision: ${pep3.decision}`);
+if (!pep3.ok) step(`reason: ${pep3.reason}`);
+step(`executed: ${String(pep3.executed)}`);
+
+blank();

--- a/examples/sift/tsconfig.json
+++ b/examples/sift/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,19 @@ importers:
         specifier: ^5.0.0
         version: 5.9.3
 
+  examples/sift:
+    dependencies:
+      '@oxdeai/sift':
+        specifier: workspace:*
+        version: link:../../packages/sift
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.13
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+
   packages/autogen:
     dependencies:
       '@oxdeai/core':


### PR DESCRIPTION
- add runnable example demonstrating full integration path: Sift receipt → adapter → AuthorizationV1 → PEP simulation → execution decision

- implement three explicit scenarios:
  - ALLOW: valid receipt produces AuthorizationV1 and passes PEP checks → execution allowed
  - DENY: receipt-level rejection blocks flow before authorization issuance
  - REPLAY: previously authorized auth_id rejected at PEP boundary (single-use enforcement)

- include local Sift receipt generation:
  - Ed25519 signing
  - receipt_hash computed over canonical payload (signature + receipt_hash excluded)

- include adapter flow:
  - verifyReceipt (local, fail-closed)
  - normalizeIntent (canonicalization-v1 compliant)
  - normalizeState (explicit execution state binding)
  - receiptToAuthorization (deterministic binding: nonce→auth_id, policy→policy_id)

- implement PEP simulation with enforcement checks:
  - signature verification
  - audience binding
  - expiry validation
  - intent_hash and state_hash recomputation
  - replay protection via in-memory store (auth_id single-use)

- no network dependencies; all verification is local and deterministic

- add example package config and build wiring:
  - prebuild compiles @oxdeai/sift
  - example compiles to dist/ and runs via node

this example demonstrates the OxDeAI execution boundary model: Sift decides, OxDeAI authorizes, PEP enforces