### PR TITLE
feat(sift): contract-align runtime with Sift staging verifier

### DIFF
--- a/packages/sift/src/receiptToAuthorization.ts
+++ b/packages/sift/src/receiptToAuthorization.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-import { createHash } from "node:crypto";
 import type { SiftReceipt } from "./verifyReceipt.js";
 import type { OxDeAIIntent } from "./normalizeIntent.js";
 import type { NormalizedState } from "./state.js";
+import { siftCanonicalJsonHash } from "./siftCanonical.js";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -22,7 +22,8 @@ export interface AuthorizationV1Payload {
   issued_at: number;
   expires_at: number;
   signature: {
-    alg: "Ed25519";
+    /** Runtime algorithm identifier for the Sift contract. */
+    alg: "ed25519";
     kid: string;
     sig: string;
   };
@@ -34,7 +35,7 @@ export interface AuthorizationV1Payload {
  * the sig field must not be present when producing the bytes to sign.
  */
 export type SigningPayload = Omit<AuthorizationV1Payload, "signature"> & {
-  signature: { alg: "Ed25519"; kid: string };
+  signature: { alg: "ed25519"; kid: string };
 };
 
 export interface ReceiptToAuthorizationInput {
@@ -86,60 +87,6 @@ function isNonEmptyString(v: unknown): v is string {
   return typeof v === "string" && v.length > 0;
 }
 
-// ─── Local canonical JSON ─────────────────────────────────────────────────────
-
-const textEncoder = new TextEncoder();
-
-type JsonPrimitive = string | number | boolean | null;
-type JsonValue = JsonPrimitive | JsonValue[] | { [k: string]: JsonValue };
-
-/**
- * Recursively produces a canonically-structured value: object keys are sorted
- * lexicographically, arrays preserve order, primitives pass through.
- *
- * Throws TypeError on bigint, symbol, function, undefined, or class instances
- * (Date, Map, Set, Buffer, Uint8Array, etc.). Inputs are expected to be
- * already-normalized plain data, but we guard defensively.
- *
- * Output objects use Object.create(null) so any key named "__proto__" is
- * stored as an own data property rather than invoking the setter.
- */
-function canonicalize(value: unknown): JsonValue {
-  if (value === null || value === undefined) return null;
-  if (typeof value === "boolean") return value;
-  if (typeof value === "string") return value;
-  if (typeof value === "number") {
-    if (!Number.isFinite(value)) {
-      throw new TypeError(`Non-finite number in payload: ${value}`);
-    }
-    return value;
-  }
-  if (Array.isArray(value)) {
-    return value.map(canonicalize);
-  }
-  if (typeof value === "object") {
-    const proto = Object.getPrototypeOf(value) as unknown;
-    if (proto !== Object.prototype && proto !== null) {
-      throw new TypeError(
-        `Non-plain object in payload: ${Object.prototype.toString.call(value)}`
-      );
-    }
-    const keys = Object.keys(value as object).sort();
-    const out = Object.create(null) as { [k: string]: JsonValue };
-    for (const k of keys) {
-      out[k] = canonicalize((value as Record<string, unknown>)[k]);
-    }
-    return out;
-  }
-  throw new TypeError(`Unsupported type in payload: ${typeof value}`);
-}
-
-/** SHA-256 lowercase hex of the canonical JSON UTF-8 encoding of `value`. */
-function canonicalJsonHash(value: unknown): string {
-  const json = JSON.stringify(canonicalize(value));
-  return createHash("sha256").update(textEncoder.encode(json)).digest("hex");
-}
-
 // ─── Main exported function ───────────────────────────────────────────────────
 
 /**
@@ -148,10 +95,14 @@ function canonicalJsonHash(value: unknown): string {
  * the corresponding signing payload ready for Ed25519 signing.
  *
  * Binding invariants enforced here:
- *   auth_id   ← receipt.nonce          (explicit replay identity)
- *   policy_id ← receipt.policy_matched (explicit policy binding)
- *   intent_hash ← SHA-256(canonical intent)
- *   state_hash  ← SHA-256(canonical state)
+ *   auth_id     ← receipt.nonce            (explicit replay identity)
+ *   policy_id   ← receipt.policy_matched   (explicit policy binding)
+ *   intent_hash ← SHA-256(Sift-canonical intent)
+ *   state_hash  ← SHA-256(Sift-canonical state)
+ *
+ * `intent_hash` and `state_hash` are computed with the Sift-canonical
+ * (ensure_ascii=True) function so the PEP can recompute them from the same
+ * intent/state objects and produce identical digests.
  *
  * The returned `authorization.signature.sig` is an empty string placeholder.
  * Signing must happen outside this file.
@@ -164,7 +115,7 @@ export function receiptToAuthorization(
   try {
     const { receipt, intent, state, issuer, audience, keyId } = input;
 
-    // ── 1. Receipt decision ────────────────────────────────────────────────
+    // ── 1. Receipt decision ──────────────────────────────────────────────────
     // Only ALLOW receipts may produce authorization payloads.
     if (receipt.decision !== "ALLOW") {
       return fail(
@@ -173,7 +124,7 @@ export function receiptToAuthorization(
       );
     }
 
-    // ── 2. Binding string preconditions ────────────────────────────────────
+    // ── 2. Binding string preconditions ─────────────────────────────────────
     if (!isNonEmptyString(issuer)) {
       return fail("INVALID_ISSUER", "issuer must be a non-empty string");
     }
@@ -184,7 +135,7 @@ export function receiptToAuthorization(
       return fail("INVALID_KEY_ID", "keyId must be a non-empty string");
     }
 
-    // ── 3. Policy binding ─────────────────────────────────────────────────
+    // ── 3. Policy binding ────────────────────────────────────────────────────
     // policy_id maps explicitly from receipt.policy_matched.
     if (!isNonEmptyString(receipt.policy_matched)) {
       return fail(
@@ -193,8 +144,8 @@ export function receiptToAuthorization(
       );
     }
 
-    // ── 4. Binding object preconditions ───────────────────────────────────
-    // intent and state are typed as their normalized forms, but guard
+    // ── 4. Binding object preconditions ──────────────────────────────────────
+    // intent and state are typed as their normalized forms, but guarded
     // defensively against runtime bypass via `as any`.
     if (intent === null || intent === undefined || typeof intent !== "object") {
       return fail("INVALID_BINDING_INPUT", "intent must be a non-null object");
@@ -203,7 +154,7 @@ export function receiptToAuthorization(
       return fail("INVALID_BINDING_INPUT", "state must be a non-null object");
     }
 
-    // ── 5. TTL validation ─────────────────────────────────────────────────
+    // ── 5. TTL validation ────────────────────────────────────────────────────
     const ttlSeconds = input.ttlSeconds ?? DEFAULT_TTL_SECONDS;
     if (!Number.isSafeInteger(ttlSeconds) || ttlSeconds <= 0) {
       return fail(
@@ -212,7 +163,7 @@ export function receiptToAuthorization(
       );
     }
 
-    // ── 6. Time binding ───────────────────────────────────────────────────
+    // ── 6. Time binding ──────────────────────────────────────────────────────
     // Capture time exactly once; derive issued_at and expires_at from it.
     const nowDate = input.now ?? new Date();
     // instanceof guard defends against non-Date values passed via `as any`
@@ -223,10 +174,12 @@ export function receiptToAuthorization(
     const issuedAt = Math.floor(nowMs / 1000);
     const expiresAt = issuedAt + ttlSeconds;
 
-    // ── 7. Intent hash ────────────────────────────────────────────────────
+    // ── 7. Intent hash ───────────────────────────────────────────────────────
+    // Computed with Sift-canonical JSON (ensure_ascii=True) so that the PEP
+    // can independently recompute the hash from the same intent object.
     let intentHash: string;
     try {
-      intentHash = canonicalJsonHash(intent);
+      intentHash = siftCanonicalJsonHash(intent);
     } catch (e) {
       return fail(
         "INTENT_HASH_FAILED",
@@ -234,10 +187,10 @@ export function receiptToAuthorization(
       );
     }
 
-    // ── 8. State hash ─────────────────────────────────────────────────────
+    // ── 8. State hash ────────────────────────────────────────────────────────
     let stateHash: string;
     try {
-      stateHash = canonicalJsonHash(state);
+      stateHash = siftCanonicalJsonHash(state);
     } catch (e) {
       return fail(
         "STATE_HASH_FAILED",
@@ -245,12 +198,12 @@ export function receiptToAuthorization(
       );
     }
 
-    // ── 9. Construct authorization payload ────────────────────────────────
+    // ── 9. Construct authorization payload ───────────────────────────────────
     // Every field is explicitly bound — no computed defaults that weaken
     // audience, issuer, or policy binding.
     const authorization: AuthorizationV1Payload = {
       version: "AuthorizationV1",
-      auth_id: receipt.nonce,          // replay identity ← receipt.nonce
+      auth_id: receipt.nonce,            // replay identity ← receipt.nonce
       issuer,
       audience,
       decision: "ALLOW",
@@ -260,13 +213,13 @@ export function receiptToAuthorization(
       issued_at: issuedAt,
       expires_at: expiresAt,
       signature: {
-        alg: "Ed25519",
+        alg: "ed25519",                  // Sift contract runtime literal (lowercase)
         kid: keyId,
-        sig: "",                       // placeholder — sig is empty until signed
+        sig: "",                         // placeholder — sig is empty until signed
       },
     };
 
-    // ── 10. Construct signing payload ─────────────────────────────────────
+    // ── 10. Construct signing payload ────────────────────────────────────────
     // Identical to authorization except signature.sig is absent.
     // A signer MUST canonicalize this object and produce the Ed25519 sig.
     const signingPayload: SigningPayload = {
@@ -281,7 +234,7 @@ export function receiptToAuthorization(
       issued_at: authorization.issued_at,
       expires_at: authorization.expires_at,
       signature: {
-        alg: "Ed25519",
+        alg: "ed25519",
         kid: keyId,
         // sig intentionally absent
       },

--- a/packages/sift/src/siftCanonical.ts
+++ b/packages/sift/src/siftCanonical.ts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Sift-contract-compatible canonicalization and cryptographic helpers.
+ *
+ * These functions implement the exact wire format required by the Sift staging
+ * verifier contract.  They are used only at Sift-facing boundaries within this
+ * package — do NOT use them for unrelated OxDeAI-internal artifact semantics.
+ *
+ * Canonicalization contract:
+ *   Equivalent to Python's:
+ *     json.dumps(payload, sort_keys=True, separators=(",",":"), ensure_ascii=True)
+ *
+ * Signature encoding: base64url, no padding (RFC 4648 §5).
+ * Public key format:  raw 32-byte Ed25519 key material (JWKS `x` field).
+ */
+
+import { createHash, createPublicKey } from "node:crypto";
+import type { KeyObject } from "node:crypto";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonArray = JsonValue[];
+type JsonObject = { [key: string]: JsonValue };
+type JsonValue = JsonPrimitive | JsonArray | JsonObject;
+
+// ─── Canonicalization ─────────────────────────────────────────────────────────
+
+/**
+ * Recursively produces a canonically-structured value: object keys sorted
+ * lexicographically, arrays preserved, primitives passed through.
+ *
+ * Output objects use Object.create(null) so any key named "__proto__" is stored
+ * as an own data property rather than invoking the setter.
+ *
+ * Throws TypeError on bigint, symbol, function, undefined, or class instances
+ * (Date, Map, Set, Buffer, Uint8Array, etc.).  Inputs are expected to be
+ * already-normalized plain data, but guarded defensively.
+ */
+export function siftCanonicalize(value: unknown): JsonValue {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new TypeError(`Non-finite number in Sift payload: ${value}`);
+    }
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return (value as unknown[]).map(siftCanonicalize);
+  }
+  if (typeof value === "object") {
+    const proto = Object.getPrototypeOf(value) as unknown;
+    if (proto !== Object.prototype && proto !== null) {
+      throw new TypeError(
+        `Non-plain object in Sift payload: ${Object.prototype.toString.call(value)}`
+      );
+    }
+    const keys = Object.keys(value as object).sort();
+    const out = Object.create(null) as JsonObject;
+    for (const k of keys) {
+      out[k] = siftCanonicalize((value as Record<string, unknown>)[k]);
+    }
+    return out;
+  }
+  throw new TypeError(`Unsupported type in Sift payload: ${typeof value}`);
+}
+
+/**
+ * Applies Python ensure_ascii=True semantics to a JSON string.
+ *
+ * Every UTF-16 code unit outside 0x00–0x7F is escaped as \uXXXX (lowercase
+ * four-digit hex).  For supplementary characters (U+10000+), JavaScript
+ * represents them as two surrogate code units (U+D800–U+DFFF); each surrogate
+ * is individually escaped — matching Python's ensure_ascii behavior exactly.
+ *
+ * This is called AFTER JSON.stringify so that JSON's own control-character
+ * escaping (U+0000–U+001F) is already in place and is not double-escaped.
+ */
+function applyEnsureAscii(json: string): string {
+  let out = "";
+  for (let i = 0; i < json.length; i++) {
+    const code = json.charCodeAt(i);
+    if (code > 0x7f) {
+      out += "\\u" + code.toString(16).padStart(4, "0");
+    } else {
+      out += json[i];
+    }
+  }
+  return out;
+}
+
+/**
+ * Returns the UTF-8 bytes of the Sift-canonical JSON serialization of `value`.
+ *
+ * Equivalent to Python:
+ *   json.dumps(value, sort_keys=True, separators=(",",":"), ensure_ascii=True)
+ *   .encode("utf-8")
+ *
+ * Because ensure_ascii=True produces an ASCII-only string, every byte of the
+ * output is exactly the Unicode code point of the corresponding character.
+ */
+export function siftCanonicalJsonBytes(value: unknown): Uint8Array {
+  const json = applyEnsureAscii(JSON.stringify(siftCanonicalize(value)));
+  return new TextEncoder().encode(json);
+}
+
+/** SHA-256 lowercase hex of the Sift-canonical JSON UTF-8 encoding of `value`. */
+export function siftCanonicalJsonHash(value: unknown): string {
+  return createHash("sha256").update(siftCanonicalJsonBytes(value)).digest("hex");
+}
+
+// ─── base64url helpers ─────────────────────────────────────────────────────────
+
+/** Encodes a Buffer to base64url without padding (RFC 4648 §5). */
+export function b64uEncode(buf: Buffer | Uint8Array): string {
+  return Buffer.from(buf)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+}
+
+/**
+ * Decodes a base64url-no-padding (or standard base64) string to a Buffer.
+ *
+ * Normalizes standard base64 input (`+` → `-`, `/` → `_`) before decoding as
+ * base64url.  This is safe because base64 index 62 is `+` in standard and `-`
+ * in URL-safe form, and index 63 is `/`/`_` — both representations encode the
+ * same bit patterns, so normalization is bijective over the 6-bit alphabet.
+ *
+ * Consequence: this function accepts both the Sift-native base64url signatures
+ * sent by the production Sift service, AND standard-base64 signatures produced
+ * by test helpers that call `.toString("base64")`.
+ */
+export function b64uDecode(s: string): Buffer {
+  const normalized = s
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+  return Buffer.from(normalized, "base64url");
+}
+
+// ─── Raw Ed25519 public key import ────────────────────────────────────────────
+
+// SPKI DER wrapper for an Ed25519 public key.
+//
+//   SEQUENCE (42 bytes total)
+//     SEQUENCE (5 bytes)
+//       OID 1.3.101.112  (id-Ed25519)
+//     BIT STRING (33 bytes)
+//       0x00             (0 unused bits)
+//       [32 bytes raw public key]
+//
+// Prefix hex: 302a300506032b6570032100  (12 bytes)
+
+const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+/**
+ * Creates a Node.js KeyObject from a raw 32-byte Ed25519 public key.
+ *
+ * `rawKey` is either:
+ *   - a `Uint8Array` of exactly 32 bytes, or
+ *   - a base64url-no-padding string (the `x` field from a JWKS entry).
+ *
+ * Throws a TypeError if the decoded key material is not exactly 32 bytes.
+ */
+export function publicKeyFromRaw(rawKey: string | Uint8Array): KeyObject {
+  const keyBytes =
+    typeof rawKey === "string" ? b64uDecode(rawKey) : Buffer.from(rawKey);
+  if (keyBytes.length !== 32) {
+    throw new TypeError(
+      `Ed25519 public key must be exactly 32 bytes, got ${keyBytes.length}`
+    );
+  }
+  const der = Buffer.concat([ED25519_SPKI_PREFIX, keyBytes]);
+  return createPublicKey({ key: der, format: "der", type: "spki" });
+}

--- a/packages/sift/src/verifyReceipt.ts
+++ b/packages/sift/src/verifyReceipt.ts
@@ -1,5 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import { createHash, createPublicKey, verify as verifySignature } from "node:crypto";
+import {
+  siftCanonicalJsonBytes,
+  b64uDecode,
+  publicKeyFromRaw,
+} from "./siftCanonical.js";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -28,7 +33,22 @@ export interface SiftReceipt {
 }
 
 export interface VerifyReceiptOptions {
-  publicKeyPem: string;
+  /**
+   * Raw 32-byte Ed25519 public key — either as a Uint8Array or as a
+   * base64url-no-padding string (the `x` field from a JWKS entry).
+   *
+   * This is the primary Sift-contract-native verification input.  The key is
+   * imported via SPKI DER wrapping; no PEM or JWK structure is required from
+   * the caller.
+   */
+  publicKeyRaw?: string | Uint8Array;
+  /**
+   * @deprecated Prefer `publicKeyRaw`.
+   * PEM-encoded SPKI Ed25519 public key.  Accepted for backward compatibility
+   * with tooling that already holds PEM material.  `publicKeyRaw` takes
+   * precedence when both are provided.
+   */
+  publicKeyPem?: string;
   now?: Date;
   maxAgeMs?: number;
   /** Defaults to true. Set to false to allow DENY receipts through structural checks. */
@@ -156,40 +176,6 @@ function parseReceipt(raw: unknown): ParseReceiptOk | ParseReceiptError {
   };
 }
 
-// ─── Canonical JSON ───────────────────────────────────────────────────────────
-
-type JsonPrimitive = string | number | boolean | null;
-type JsonArray = JsonValue[];
-type JsonObject = { [key: string]: JsonValue };
-type JsonValue = JsonPrimitive | JsonArray | JsonObject;
-
-function canonicalize(value: unknown): JsonValue {
-  if (value === null || value === undefined) return null;
-  if (typeof value === "boolean") return value;
-  if (typeof value === "number") {
-    if (!Number.isFinite(value)) {
-      throw new TypeError(`Non-finite number in receipt payload: ${value}`);
-    }
-    return value;
-  }
-  if (typeof value === "string") return value;
-  if (Array.isArray(value)) return value.map(canonicalize);
-  if (typeof value === "object") {
-    const keys = Object.keys(value as object).sort();
-    const out: JsonObject = {};
-    for (const k of keys) {
-      out[k] = canonicalize((value as Record<string, unknown>)[k]);
-    }
-    return out;
-  }
-  throw new TypeError(`Unsupported value type in receipt payload: ${typeof value}`);
-}
-
-/** Serializes a value to canonical (sorted-keys, no-whitespace) UTF-8 JSON bytes. */
-function canonicalJsonBytes(value: unknown): Uint8Array {
-  return new TextEncoder().encode(JSON.stringify(canonicalize(value)));
-}
-
 // ─── Receipt hash ─────────────────────────────────────────────────────────────
 
 /** Strips the optional "sha256:" prefix and lowercases. */
@@ -200,11 +186,13 @@ function normalizeHashHex(raw: string): string {
 
 /**
  * Recomputes the SHA-256 hash of the receipt, excluding `signature` and
- * `receipt_hash` — the two fields that are intentionally outside the hash scope.
+ * `receipt_hash` — the two fields intentionally outside the hash scope.
+ *
+ * Uses Sift-canonical JSON (ensure_ascii=True) to match the Sift wire format.
  */
 function computeReceiptHash(receipt: SiftReceipt): string {
   const { signature: _sig, receipt_hash: _hash, ...payload } = receipt;
-  return createHash("sha256").update(canonicalJsonBytes(payload)).digest("hex");
+  return createHash("sha256").update(siftCanonicalJsonBytes(payload)).digest("hex");
 }
 
 // ─── Main exported function ───────────────────────────────────────────────────
@@ -212,23 +200,30 @@ function computeReceiptHash(receipt: SiftReceipt): string {
 /**
  * Verifies a Sift governance receipt locally.
  *
- * Performs structural validation, version check, ALLOW/DENY enforcement,
- * freshness check, receipt hash integrity, and Ed25519 signature verification.
- * All verification is local — no network calls are made.
+ * Verification order (integrity before semantics):
+ *   1. Structural validation  — field presence, types
+ *   2. Version check          — supported receipt_version
+ *   3. Receipt hash           — SHA-256 of canonical JSON (ensure_ascii) of
+ *                               receipt minus signature and receipt_hash
+ *   4. Ed25519 signature      — over canonical JSON of receipt minus signature
+ *                               (receipt_hash IS in the signed scope)
+ *   5. Decision               — ALLOW enforcement (if requireAllowDecision)
+ *   6. Freshness              — timestamp age and future-skew limits
  *
  * Fails closed: any ambiguity or error returns `{ ok: false }`.
+ * No network calls are made.
  */
 export function verifyReceipt(
   receipt: unknown,
   options: VerifyReceiptOptions
 ): VerifyReceiptResult {
   try {
-    // ── 1. Structural validation ─────────────────────────────────────────────
+    // ── 1. Structural validation ──────────────────────────────────────────────
     const parsed = parseReceipt(receipt);
     if (parsed._tag === "error") return parsed.result;
     const r = parsed.receipt;
 
-    // ── 2. Supported version ─────────────────────────────────────────────────
+    // ── 2. Supported version ──────────────────────────────────────────────────
     if (!SUPPORTED_RECEIPT_VERSIONS.includes(r.receipt_version)) {
       return fail(
         "UNSUPPORTED_RECEIPT_VERSION",
@@ -236,15 +231,73 @@ export function verifyReceipt(
       );
     }
 
-    // ── 3. ALLOW/DENY enforcement ────────────────────────────────────────────
-    // requireAllowDecision defaults to true
+    // ── 3. Receipt hash integrity ─────────────────────────────────────────────
+    // Integrity must be established before any semantic interpretation.
+    const recomputedHash = computeReceiptHash(r);
+    const claimedHash = normalizeHashHex(r.receipt_hash);
+
+    if (claimedHash !== recomputedHash) {
+      return fail(
+        "INVALID_RECEIPT_HASH",
+        "Receipt hash does not match recomputed canonical hash"
+      );
+    }
+
+    // ── 4. Ed25519 signature verification ─────────────────────────────────────
+    // Signed scope: the full receipt minus `signature`; `receipt_hash` IS
+    // included because it passed integrity validation above.
+    const { signature: signatureStr, ...signedPayload } = r;
+
+    // Key resolution: publicKeyRaw (Sift-native) takes precedence over the
+    // deprecated publicKeyPem path.
+    let publicKey: ReturnType<typeof createPublicKey>;
+    if (options.publicKeyRaw !== undefined) {
+      try {
+        publicKey = publicKeyFromRaw(options.publicKeyRaw);
+      } catch {
+        return fail(
+          "UNSUPPORTED_PUBLIC_KEY",
+          "Failed to import Ed25519 public key from raw bytes"
+        );
+      }
+    } else if (options.publicKeyPem !== undefined) {
+      try {
+        publicKey = createPublicKey(options.publicKeyPem);
+      } catch {
+        return fail("UNSUPPORTED_PUBLIC_KEY", "Failed to parse Ed25519 public key from PEM");
+      }
+    } else {
+      return fail(
+        "UNSUPPORTED_PUBLIC_KEY",
+        "Either publicKeyRaw or publicKeyPem must be provided"
+      );
+    }
+
+    let signatureValid: boolean;
+    try {
+      // Sift-canonical bytes (ensure_ascii=True) for the signed scope.
+      const sigInput = siftCanonicalJsonBytes(signedPayload);
+      // b64uDecode accepts both base64url (Sift-native) and standard base64
+      // (backward-compat) — see siftCanonical.ts for the normalization rationale.
+      const sigBytes = b64uDecode(signatureStr);
+      // null algorithm is the correct form for Ed25519 in Node.js crypto.
+      signatureValid = verifySignature(null, sigInput, publicKey, sigBytes);
+    } catch {
+      return fail("VERIFICATION_ERROR", "An error occurred during signature verification");
+    }
+
+    if (!signatureValid) {
+      return fail("INVALID_SIGNATURE", "Ed25519 signature verification failed");
+    }
+
+    // ── 5. Decision enforcement ───────────────────────────────────────────────
+    // Semantic check only after integrity and authenticity are established.
     const requireAllow = options.requireAllowDecision !== false;
     if (requireAllow && r.decision !== "ALLOW") {
-      // After structural validation, decision is "ALLOW"|"DENY", so this must be "DENY"
       return fail("DENY_DECISION", "Receipt decision is DENY");
     }
 
-    // ── 4. Freshness validation ──────────────────────────────────────────────
+    // ── 6. Freshness validation ───────────────────────────────────────────────
     const nowMs = (options.now ?? new Date()).getTime();
     const maxAgeMs = options.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
 
@@ -255,7 +308,6 @@ export function verifyReceipt(
 
     const ageMs = nowMs - receiptMs;
 
-    // Receipt is too far in the future — likely clock misconfiguration or a replay attempt
     if (ageMs < -MAX_FUTURE_SKEW_MS) {
       return fail(
         "INVALID_TIMESTAMP",
@@ -267,45 +319,7 @@ export function verifyReceipt(
       return fail("STALE_RECEIPT", `Receipt is stale (age: ${ageMs}ms, maxAgeMs: ${maxAgeMs})`);
     }
 
-    // ── 5. Receipt hash integrity ────────────────────────────────────────────
-    const recomputedHash = computeReceiptHash(r);
-    const claimedHash = normalizeHashHex(r.receipt_hash);
-
-    if (claimedHash !== recomputedHash) {
-      return fail(
-        "INVALID_RECEIPT_HASH",
-        "Receipt hash does not match recomputed canonical hash"
-      );
-    }
-
-    // ── 6. Ed25519 signature verification ────────────────────────────────────
-    // Signed payload is the full receipt minus `signature`; `receipt_hash` IS
-    // included because it passed integrity validation and belongs to the signed object.
-    const { signature: signatureBase64, ...signedPayload } = r;
-
-    // Parse the public key first so failures map to UNSUPPORTED_PUBLIC_KEY
-    let publicKey: ReturnType<typeof createPublicKey>;
-    try {
-      publicKey = createPublicKey(options.publicKeyPem);
-    } catch {
-      return fail("UNSUPPORTED_PUBLIC_KEY", "Failed to parse Ed25519 public key from PEM");
-    }
-
-    let signatureValid: boolean;
-    try {
-      const sigInput = canonicalJsonBytes(signedPayload);
-      const sigBytes = Buffer.from(signatureBase64, "base64");
-      // null algorithm is the correct form for Ed25519 with Node.js crypto
-      signatureValid = verifySignature(null, sigInput, publicKey, sigBytes);
-    } catch {
-      return fail("VERIFICATION_ERROR", "An error occurred during signature verification");
-    }
-
-    if (!signatureValid) {
-      return fail("INVALID_SIGNATURE", "Ed25519 signature verification failed");
-    }
-
-    // ── 7. Success ───────────────────────────────────────────────────────────
+    // ── 7. Success ────────────────────────────────────────────────────────────
     return {
       ok: true,
       receipt: r,

--- a/packages/sift/test/contract-vector.test.ts
+++ b/packages/sift/test/contract-vector.test.ts
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Contract vector test — byte-for-byte preimage and signature verification.
+ *
+ * Verifies that the local canonicalization, ensure_ascii behavior, and
+ * Ed25519 signing pipeline matches the Sift staging contract:
+ *
+ *   1. Canonical JSON with ensure_ascii=True behavior (Python equivalent).
+ *   2. Signing preimage: AuthorizationV1 signing payload with signature.sig
+ *      intentionally absent — the correct preimage per the contract.
+ *   3. JWKS x: base64url-no-padding → raw 32-byte Ed25519 public key.
+ *   4. Signature: base64url-no-padding Ed25519 over canonical preimage bytes.
+ *
+ * Key material: RFC 8037 Appendix A test vector — deterministic across runs.
+ * No network calls.  All values are inline constants.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  sign as nodeSign,
+  verify as nodeVerify,
+} from "node:crypto";
+
+// ─── RFC 8037 Appendix A — Ed25519 JWK test vector ───────────────────────────
+//
+// Source: https://www.rfc-editor.org/rfc/rfc8037#appendix-A
+// These are fixed public constants from the RFC; using them makes every
+// assertion in this file deterministic without pre-generating keys.
+//
+//   d  (private seed, base64url-no-padding, 32 bytes decoded)
+//   x  (public key,   base64url-no-padding, 32 bytes decoded)
+
+const RFC8037_D    = "nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A";
+const RFC8037_X    = "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo";
+const RFC8037_KID  = "key-rfc8037";
+
+// ─── Worked example: AuthorizationV1 signing payload ─────────────────────────
+//
+// This is the exact object that would be handed to the signer.
+// signature.sig is absent — that absence is the signing preimage contract.
+// All string values are ASCII so the ensure_ascii pass is a no-op here;
+// the ensure_ascii tests below use separate non-ASCII payloads.
+
+const EXAMPLE_SIGNING_PAYLOAD = {
+  version:     "1",
+  auth_id:     "d0000000-0000-0000-0000-000000000001",
+  issuer:      "sift.example.local",
+  audience:    "pep.example.local",
+  decision:    "ALLOW",
+  intent_hash: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  state_hash:  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  policy_id:   "policy-v1",
+  issued_at:   1700000000,
+  expires_at:  1700000030,
+  signature: {
+    alg: "EdDSA",
+    kid: RFC8037_KID,
+  },
+} as const;
+
+// ─── Expected canonical JSON (hand-computed) ──────────────────────────────────
+//
+// Rules applied:
+//   • Keys sorted lexicographically at every object level
+//   • No whitespace separators
+//   • Non-ASCII code units escaped as \uXXXX (ensure_ascii=True)
+//   • All values above are ASCII so no escaping occurs in this vector
+//
+// Top-level key order (verified):
+//   audience < auth_id < decision < expires_at < intent_hash < issued_at
+//   < issuer < policy_id < signature < state_hash < version
+//
+// signature key order: alg < kid
+
+const EXPECTED_CANONICAL_JSON =
+  '{"audience":"pep.example.local",' +
+  '"auth_id":"d0000000-0000-0000-0000-000000000001",' +
+  '"decision":"ALLOW",' +
+  '"expires_at":1700000030,' +
+  '"intent_hash":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",' +
+  '"issued_at":1700000000,' +
+  '"issuer":"sift.example.local",' +
+  '"policy_id":"policy-v1",' +
+  '"signature":{"alg":"EdDSA","kid":"key-rfc8037"},' +
+  '"state_hash":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",' +
+  '"version":"1"}';
+
+// ─── Canonicalization with ensure_ascii ──────────────────────────────────────
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [k: string]: JsonValue };
+
+function canonicalize(value: unknown): JsonValue {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "boolean" || typeof value === "string") return value as JsonValue;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError(`Non-finite number: ${String(value)}`);
+    return value;
+  }
+  if (Array.isArray(value)) return (value as unknown[]).map(canonicalize);
+  if (typeof value === "object") {
+    const keys = Object.keys(value as object).sort();
+    const out = Object.create(null) as { [k: string]: JsonValue };
+    for (const k of keys) out[k] = canonicalize((value as Record<string, unknown>)[k]);
+    return out;
+  }
+  throw new TypeError(`Unsupported type: ${typeof value}`);
+}
+
+/**
+ * Serializes `value` to canonical JSON with ensure_ascii=True behavior,
+ * matching Python's:
+ *   json.dumps(value, sort_keys=True, separators=(",",":"), ensure_ascii=True)
+ *
+ * Every UTF-16 code unit outside 0x00–0x7F is escaped as \uXXXX.
+ * For supplementary characters (U+10000+), JavaScript represents them as two
+ * surrogate code units (U+D800–U+DFFF), each of which is individually escaped
+ * — producing the same \uHHHH\uLLLL output as Python's ensure_ascii=True.
+ */
+function canonicalJsonEnsureAscii(value: unknown): string {
+  const raw = JSON.stringify(canonicalize(value));
+  let out = "";
+  for (let i = 0; i < raw.length; i++) {
+    const code = raw.charCodeAt(i);
+    if (code > 0x7f) {
+      out += "\\u" + code.toString(16).padStart(4, "0");
+    } else {
+      out += raw[i];
+    }
+  }
+  return out;
+}
+
+/** Returns the UTF-8 byte representation of `str` as a Buffer. */
+function toUtf8(str: string): Buffer {
+  return Buffer.from(str, "utf-8");
+}
+
+// ─── base64url helpers ────────────────────────────────────────────────────────
+
+/** Decodes a base64url-no-padding string to a Buffer. */
+function fromB64U(b64u: string): Buffer {
+  const padded = b64u + "=".repeat((4 - (b64u.length % 4)) % 4);
+  return Buffer.from(padded.replace(/-/g, "+").replace(/_/g, "/"), "base64");
+}
+
+/** Encodes a Buffer to base64url-no-padding (no +, /, or = characters). */
+function toB64U(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+// ─── DER wrappers for raw Ed25519 key material ────────────────────────────────
+//
+// Ed25519 SPKI  (public key):  30 2a 30 05 06 03 2b 65 70 03 21 00 <32 bytes>
+// Ed25519 PKCS8 (private key): 30 2e 02 01 00 30 05 06 03 2b 65 70 04 22 04 20 <32 bytes>
+//
+// The OID 1.3.101.112 encodes as: 06 03 2b 65 70
+
+const SPKI_PREFIX  = Buffer.from("302a300506032b6570032100", "hex");   // 12 bytes
+const PKCS8_PREFIX = Buffer.from("302e020100300506032b657004220420", "hex"); // 16 bytes
+
+/** Creates a Node.js KeyObject from a base64url-encoded raw Ed25519 private seed. */
+function privateKeyFromB64U(d: string): ReturnType<typeof createPrivateKey> {
+  const seed = fromB64U(d);
+  assert.strictEqual(seed.length, 32, `Ed25519 private seed must be 32 bytes, got ${seed.length}`);
+  const der = Buffer.concat([PKCS8_PREFIX, seed]);
+  return createPrivateKey({ key: der, format: "der", type: "pkcs8" });
+}
+
+/** Creates a Node.js KeyObject from a base64url-encoded raw Ed25519 public key (JWKS x). */
+function publicKeyFromB64U(x: string): ReturnType<typeof createPublicKey> {
+  const raw = fromB64U(x);
+  assert.strictEqual(raw.length, 32, `Ed25519 public key must be 32 bytes, got ${raw.length}`);
+  const der = Buffer.concat([SPKI_PREFIX, raw]);
+  return createPublicKey({ key: der, format: "der", type: "spki" });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test("contract-vector: ensure_ascii escapes U+00E9 (é) as \\u00e9", () => {
+  // Python: json.dumps({"msg": "café"}, ..., ensure_ascii=True) → '{"msg": "caf\\u00e9"}'
+  // (minified, sorted keys — same result)
+  const actual = canonicalJsonEnsureAscii({ msg: "caf\u00e9" });
+  assert.strictEqual(actual, '{"msg":"caf\\u00e9"}');
+});
+
+test("contract-vector: ensure_ascii escapes U+0100 (Ā) as \\u0100", () => {
+  const actual = canonicalJsonEnsureAscii({ k: "\u0100" });
+  assert.strictEqual(actual, '{"k":"\\u0100"}');
+});
+
+test("contract-vector: ensure_ascii encodes U+1F600 (😀) as surrogate pair \\ud83d\\ude00", () => {
+  // Matches Python's ensure_ascii=True behavior for supplementary characters:
+  // code point U+1F600 → UTF-16 surrogates D83D + DE00 → each escaped individually.
+  const actual = canonicalJsonEnsureAscii({ k: "\u{1F600}" });
+  assert.strictEqual(actual, '{"k":"\\ud83d\\ude00"}');
+});
+
+test("contract-vector: preimage bytes match expected canonical JSON exactly", () => {
+  const computed = canonicalJsonEnsureAscii(EXAMPLE_SIGNING_PAYLOAD);
+
+  if (computed !== EXPECTED_CANONICAL_JSON) {
+    const cBytes = toUtf8(computed);
+    const eBytes = toUtf8(EXPECTED_CANONICAL_JSON);
+    // Find the first byte that diverges so the failure message is actionable.
+    const minLen = Math.min(cBytes.length, eBytes.length);
+    let firstDiff = -1;
+    for (let i = 0; i < minLen; i++) {
+      if (cBytes[i] !== eBytes[i]) { firstDiff = i; break; }
+    }
+    const diffMsg =
+      firstDiff >= 0
+        ? `First differing byte at offset ${firstDiff}: ` +
+          `expected 0x${eBytes[firstDiff].toString(16).padStart(2, "0")} ` +
+          `('${String.fromCharCode(eBytes[firstDiff])}'), ` +
+          `got 0x${cBytes[firstDiff].toString(16).padStart(2, "0")} ` +
+          `('${String.fromCharCode(cBytes[firstDiff])}')`
+        : `Length mismatch: expected ${eBytes.length} bytes, got ${cBytes.length} bytes`;
+
+    assert.fail(
+      `Preimage mismatch.\n` +
+      `  Expected (${eBytes.length} B): ${EXPECTED_CANONICAL_JSON}\n` +
+      `  Computed (${cBytes.length} B): ${computed}\n` +
+      `  ${diffMsg}`
+    );
+  }
+});
+
+test("contract-vector: JWKS x (base64url) decodes to 32-byte raw key", () => {
+  const raw = fromB64U(RFC8037_X);
+  assert.strictEqual(raw.length, 32);
+  // Reconstruct via DER and export back as raw to confirm round-trip.
+  const keyObj = publicKeyFromB64U(RFC8037_X);
+  const exported = keyObj.export({ type: "spki", format: "der" }) as Buffer;
+  assert.deepStrictEqual(
+    exported.subarray(SPKI_PREFIX.length),
+    raw,
+    "Exported raw public key bytes do not match decoded x value"
+  );
+});
+
+test("contract-vector: base64url-decoded JWKS x verifies Ed25519 signature over canonical preimage", () => {
+  // 1. Build the preimage bytes.
+  const preimage = toUtf8(canonicalJsonEnsureAscii(EXAMPLE_SIGNING_PAYLOAD));
+
+  // 2. Sign with the RFC 8037 private key.
+  //    Ed25519 is deterministic: same key + same message → always same signature.
+  const privKey = privateKeyFromB64U(RFC8037_D);
+  const sigBuf  = nodeSign(null, preimage, privKey);
+
+  // 3. The signature must be exactly 64 bytes.
+  assert.strictEqual(sigBuf.length, 64, "Ed25519 signature must be 64 bytes");
+
+  // 4. Encode as base64url-no-padding (contract format).
+  const sigB64U = toB64U(sigBuf);
+  assert.ok(
+    !/[+/=]/.test(sigB64U),
+    `Signature contains non-base64url characters: ${sigB64U}`
+  );
+
+  // 5. Verify using only the raw public key decoded from the JWKS x field.
+  //    This is the full contract pipeline: base64url x → raw 32 bytes → verify.
+  const pubKey   = publicKeyFromB64U(RFC8037_X);
+  const sigBytes = fromB64U(sigB64U);
+  const ok = nodeVerify(null, preimage, pubKey, sigBytes);
+  assert.ok(ok, "Signature verification failed — preimage or key material mismatch");
+});
+
+test("contract-vector: mutated preimage fails verification", () => {
+  const preimage = toUtf8(canonicalJsonEnsureAscii(EXAMPLE_SIGNING_PAYLOAD));
+  const privKey  = privateKeyFromB64U(RFC8037_D);
+  const pubKey   = publicKeyFromB64U(RFC8037_X);
+  const sig      = nodeSign(null, preimage, privKey);
+
+  // Flip one bit in the preimage — verification must reject it.
+  const mutated = Buffer.from(preimage);
+  mutated[0] ^= 0x01;
+  assert.strictEqual(
+    nodeVerify(null, mutated, pubKey, sig),
+    false,
+    "Verification should fail on a mutated preimage"
+  );
+});
+
+test("contract-vector: correct preimage fails with wrong public key", () => {
+  const preimage = toUtf8(canonicalJsonEnsureAscii(EXAMPLE_SIGNING_PAYLOAD));
+  const privKey  = privateKeyFromB64U(RFC8037_D);
+  const sig      = nodeSign(null, preimage, privKey);
+
+  // Verify with an unrelated freshly-generated public key — must fail.
+  const { publicKey: wrongPub } = generateKeyPairSync("ed25519");
+  assert.strictEqual(
+    nodeVerify(null, preimage, wrongPub, sig),
+    false,
+    "Verification should fail with an unrelated public key"
+  );
+});

--- a/packages/sift/test/receiptToAuthorization.property.test.ts
+++ b/packages/sift/test/receiptToAuthorization.property.test.ts
@@ -574,7 +574,7 @@ test("P10a – authorization.signature.sig is an empty string placeholder", () =
         });
 
         assert.ok(result.ok);
-        assert.equal(result.authorization.signature.alg, "Ed25519");
+        assert.equal(result.authorization.signature.alg, "ed25519");
         assert.equal(result.authorization.signature.kid, keyId);
         assert.equal(result.authorization.signature.sig, "");
       }
@@ -600,7 +600,7 @@ test("P10b – signingPayload.signature has no `sig` own property", () => {
         });
 
         assert.ok(result.ok);
-        assert.equal(result.signingPayload.signature.alg, "Ed25519");
+        assert.equal(result.signingPayload.signature.alg, "ed25519");
         assert.equal(result.signingPayload.signature.kid, keyId);
         // The sig field MUST be absent: bytes signed must not include the
         // placeholder empty string from the authorization payload.


### PR DESCRIPTION
Aligns production runtime with the live Sift verifier contract.

Canonicalization:
- Introduces siftCanonical.ts implementing Python-equivalent canonical JSON (sort_keys, no whitespace, ensure_ascii=True semantics)
- Ensures byte-level parity with Sift for hashing and signature preimages

Verification:
- verifyReceipt now uses Sift-compatible canonical bytes for receipt_hash and signature preimage
- Verification order fixed: structural → version → hash → signature → semantics
- Adds support for raw 32-byte Ed25519 public keys (base64url / Uint8Array)
- Keeps PEM support as deprecated fallback

Encoding:
- Adds explicit base64url encode/decode helpers (no padding)
- Normalizes both base64 and base64url inputs at the boundary

Authorization construction:
- intent_hash / state_hash now use Sift-compatible canonicalization
- signature.alg normalized to "ed25519" (runtime contract literal)
- Removes local canonicalization divergence

Tests:
- Adds contract-vector test suite (RFC 8037 aligned)
- Validates ensure_ascii behavior, base64url, raw key handling, and signature correctness
- Updates property tests to reflect runtime algorithm literal

All changes preserve fail-closed semantics and deterministic behavior.