### PR TITLE
docs(example/sift): align example and docs with live Sift verifier co…

### DIFF
--- a/docs/adapters/sift.md
+++ b/docs/adapters/sift.md
@@ -43,16 +43,17 @@ Nothing upstream of the PEP Gateway can authorize execution.
 
 2. **Sift returns a signed receipt.**
    The receipt contains the decision (`ALLOW`/`DENY`), action metadata, nonce, and timestamp.
-   It is signed with an Ed25519 key.
+   It is signed with an Ed25519 key identified by a `kid` that corresponds to an entry in the Sift JWKS endpoint.
 
 3. **Adapter verifies the receipt signature locally.**
-   The adapter MUST verify the Ed25519 signature against a pinned or trusted Sift public key before any transformation occurs.
+   The adapter MUST verify the Ed25519 signature against a trusted Sift public key before any transformation occurs.
+   The public key is a raw 32-byte Ed25519 key obtained by decoding the JWKS `x` field (base64url, no padding) for the matching `kid`.
    Verification MUST be performed locally. The adapter MUST NOT call a remote `/verify-receipt` endpoint at execution time.
 
 4. **Adapter validates receipt fields.**
-   - `decision == ALLOW` - any non-ALLOW value MUST halt the flow immediately
-   - freshness - `timestamp` MUST be within the adapter's configured bounded window
-   - replay protection - the mapped `auth_id` MUST NOT have been previously consumed
+   - `decision == ALLOW` — any non-ALLOW value MUST halt the flow immediately
+   - freshness — `timestamp` MUST be within the adapter's configured bounded window
+   - replay protection — the mapped `auth_id` MUST NOT have been previously consumed
 
 5. **Adapter normalizes intent deterministically.**
    The adapter MUST transform Sift receipt fields into a deterministic OxDeAI intent object conforming to canonicalization-v1.
@@ -97,11 +98,11 @@ A Sift receipt MUST NOT directly authorize execution. A receipt alone cannot tri
 
 ### Gaps the adapter MUST fill
 
-**Audience** - Sift receipts carry no audience binding. Without it, an `AuthorizationV1` issued for one service could be replayed against another. The adapter MUST inject the trusted audience identifier from its own configuration before issuing `AuthorizationV1`.
+**Audience** — Sift receipts carry no audience binding. Without it, an `AuthorizationV1` issued for one service could be replayed against another. The adapter MUST inject the trusted audience identifier from its own configuration before issuing `AuthorizationV1`.
 
-**State binding** - Sift receipts carry no policy state reference. Without it, a receipt issued under one policy state could be replayed after state has changed. The adapter MUST derive, canonicalize, and hash the current execution-relevant policy state and bind it as `state_hash`.
+**State binding** — Sift receipts carry no policy state reference. Without it, a receipt issued under one policy state could be replayed after state has changed. The adapter MUST derive, canonicalize, and hash the current execution-relevant policy state and bind it as `state_hash`.
 
-**Canonical intent** - Sift action fields are not in OxDeAI canonical form. The adapter MUST normalize them into deterministic canonical bytes under canonicalization-v1 before computing `intent_hash`. Canonicalization failure MUST produce DENY.
+**Canonical intent** — Sift action fields are not in OxDeAI canonical form. The adapter MUST normalize them into deterministic canonical bytes under canonicalization-v1 before computing `intent_hash`. Canonicalization failure MUST produce DENY.
 
 ---
 
@@ -113,13 +114,14 @@ A Sift receipt MUST NOT directly authorize execution. A receipt alone cannot tri
 - The adapter MUST NOT call `/verify-receipt` or any remote Sift endpoint in the runtime execution path. Remote verification introduces a network dependency that would produce indeterminate outcomes on failure, violating the fail-closed invariant.
 - The following conditions MUST result in DENY and MUST NOT proceed to `AuthorizationV1` issuance:
 
-| Condition                   | Required behavior   |
-|-----------------------------|----------------------|
-| Invalid Ed25519 signature   | DENY, no execution  |
-| Unknown or untrusted key    | DENY, no execution  |
-| Malformed receipt payload   | DENY, no execution  |
-| `receipt_hash` integrity mismatch | DENY, no execution |
-| Verification ambiguity      | DENY, no execution  |
+| Condition                         | Required behavior   |
+|-----------------------------------|----------------------|
+| Invalid Ed25519 signature         | DENY, no execution  |
+| Unknown or untrusted key          | DENY, no execution  |
+| Revoked key (KRL check required)  | DENY, no execution  |
+| Malformed receipt payload         | DENY, no execution  |
+| `receipt_hash` integrity mismatch | DENY, no execution  |
+| Verification ambiguity            | DENY, no execution  |
 
 ### Receipt hash integrity
 
@@ -128,10 +130,17 @@ A Sift receipt MUST NOT directly authorize execution. A receipt alone cannot tri
 - `signature` excluded
 - `receipt_hash` excluded
 
-Canonicalization requirements:
+Canonicalization requirements (Sift wire format):
+
 - lexicographic key ordering
-- no whitespace
-- UTF-8 encoding
+- no whitespace between tokens
+- `ensure_ascii=True` — every UTF-16 code unit above U+007F is escaped as `\uXXXX` (lowercase four-digit hex); supplementary characters (U+10000+) are encoded as two `\uXXXX` surrogate escapes each
+- UTF-8 encoding of the resulting ASCII-only string
+
+Equivalent to Python:
+```python
+json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+```
 
 The adapter MUST:
 
@@ -156,38 +165,61 @@ The adapter MUST NOT:
 - verify signature before validating `receipt_hash`
 - mutate payload before verification
 
+The signature is a raw Ed25519 signature over the UTF-8 bytes of the Sift-canonical JSON of the signed scope.
+It is encoded as base64url without padding (RFC 4648 §5).
+
 ### Verification ordering
 
 The adapter MUST perform verification in the following order:
 
-1. `receipt_hash` integrity validation
-2. signature verification
-3. semantic validation (decision, freshness, replay prechecks, etc.)
+1. Structural validation (field presence, types)
+2. Version check (supported receipt_version values)
+3. `receipt_hash` integrity validation
+4. Ed25519 signature verification
+5. Semantic validation (decision, freshness, replay prechecks, etc.)
 
 The adapter MUST NOT proceed to a later step if an earlier step fails.
+Integrity and authenticity checks MUST complete before any semantic interpretation of receipt fields.
 
-### Key management and rotation
+### Key management and JWKS/KRL surface
 
-The adapter verifies Sift receipts using trusted Ed25519 public keys.
+The adapter verifies Sift receipts using trusted Ed25519 public keys distributed via the Sift JWKS endpoint.
 
-Production deployments SHOULD support key rotation via a key set:
+**Key format.** Sift public keys are raw 32-byte Ed25519 key material encoded as the `x` field in a JWKS entry (RFC 8037 OKP). No PEM wrapper is required or expected at this boundary.
 
-- multiple public keys identified by `kid`
-- deterministic key selection
-- ability to revoke keys without downtime
+JWKS entry shape:
 
-Minimum requirements:
+```json
+{
+  "kty": "OKP",
+  "crv": "Ed25519",
+  "alg": "EdDSA",
+  "use": "sig",
+  "kid": "<key-id>",
+  "x": "<base64url-no-padding 32-byte raw public key>"
+}
+```
 
-- support multiple active keys
-- fail closed if key cannot be resolved
+The `alg: "EdDSA"` field is JWKS metadata for key-discovery tooling. It is distinct from the `AuthorizationV1.signature.alg` runtime literal (see §4). Do not conflate these two surfaces.
+
+**`kid` resolution.** The `kid` identifying the signing key is present in the receipt. The adapter MUST use it to select the correct JWKS entry. The adapter MUST NOT guess or fall back to an arbitrary key.
+
+**KRL enforcement.** The Sift verifier contract provides a Key Revocation List (KRL). The adapter MUST check the KRL before trusting any key:
+
+1. Extract `kid` from the receipt.
+2. Check `kid` against the KRL. If revoked → DENY immediately; do not proceed to signature verification.
+3. Look up the JWKS entry for `kid`. If not found → attempt a JWKS refresh (cache may be stale). Retry once.
+4. If still not found after refresh → DENY. Do not guess.
+5. Decode `x` (base64url → 32 bytes) and verify the signature.
+
+**Minimum requirements:**
+
+- support multiple active keys identified by `kid`
+- check the KRL before trusting any key
+- refresh JWKS on unknown `kid` before failing closed
+- fail closed if the key cannot be resolved after refresh
 - no fallback guessing
-
-If the receipt includes a key identifier (`kid`), it MUST be used to select the correct key.
-
-If the receipt does not include a `kid`, key selection MUST be deterministic and externally configured.
-
-If no matching key is found:
-→ verification MUST fail
+- deterministic key selection
 
 ---
 
@@ -213,7 +245,7 @@ Example canonical intent shape:
 }
 ```
 
-`intent_hash` is computed over the canonical serialization of this object under canonicalization-v1. It is NOT derived from `receipt_hash` unless the adapter's normalization contract explicitly defines and proves that relationship.
+`intent_hash` is computed as SHA-256 over the Sift-canonical JSON bytes of this object (ensure_ascii=True, sort_keys). It is NOT derived from `receipt_hash` unless the adapter's normalization contract explicitly defines and proves that relationship.
 
 ---
 
@@ -225,7 +257,7 @@ Example canonical intent shape:
   - account or permission state
   - resource quota or rate-limit counters
   - prior execution or consumption history relevant to policy
-- The state snapshot MUST be canonicalized under canonicalization-v1 before hashing. The same state content MUST produce the same `state_hash` regardless of field insertion order.
+- The state snapshot MUST be canonicalized under canonicalization-v1 (ensure_ascii=True) before hashing. The same state content MUST produce the same `state_hash` regardless of field insertion order.
 - If the required state cannot be deterministically derived, validated, or hashed, the adapter MUST DENY.
 - State ambiguity MUST NOT fall back to receipt-only authorization. There is no partial state binding.
 
@@ -247,7 +279,7 @@ Example canonical intent shape:
 - The adapter MUST define a maximum acceptable receipt age window. This window is a security parameter and MUST be configurable per deployment. If the Sift receipt contract does not provide sufficient expiry semantics, the adapter MUST define and enforce its own bounded freshness policy.
 - If receipt freshness cannot be determined deterministically (e.g., missing or unparseable `timestamp`), the adapter MUST DENY.
 - Stale, expired, or time-ambiguous receipts MUST NOT be converted into `AuthorizationV1`.
-- `AuthorizationV1.expiry` MUST be set to a short absolute TTL derived from `issued_at`. The PEP Gateway enforces `expiry > now` independently.
+- `AuthorizationV1.expires_at` MUST be set to a short absolute TTL derived from `issued_at`. The PEP Gateway enforces `expires_at > now` independently.
 
 ### Freshness window
 
@@ -290,34 +322,48 @@ The adapter MUST reject:
 
 `AuthorizationV1` MUST be generated by the adapter only after ALL of the following have succeeded:
 
-- receipt signature verified locally
+- receipt signature verified locally (Ed25519 over Sift-canonical bytes, base64url-decoded)
 - `receipt_hash` integrity confirmed
+- `kid` checked against KRL; not revoked
 - `decision == ALLOW`
 - receipt freshness confirmed within bounded window
 - `auth_id` prechecked for obvious replay at adapter (advisory, if implemented)
-- intent normalized, canonicalized, and `intent_hash` computed
-- state derived, canonicalized, and `state_hash` computed
+- intent normalized, canonicalized (ensure_ascii=True), and `intent_hash` computed
+- state derived, canonicalized (ensure_ascii=True), and `state_hash` computed
 - audience injected from trusted configuration
 
 If any prerequisite fails, the adapter MUST NOT produce `AuthorizationV1` and MUST return DENY.
 
 ### Required fields in `AuthorizationV1`
 
-| Field              | Source                                                        |
-|--------------------|---------------------------------------------------------------|
-| `intent_hash`      | SHA-256 of canonical intent bytes (canonicalization-v1)       |
-| `state_hash`       | SHA-256 of canonical state snapshot (canonicalization-v1)     |
-| `audience`         | Injected by adapter from trusted configuration                |
-| `expiry`           | Adapter-configured bounded TTL from `issued_at`               |
-| `auth_id`          | Explicitly mapped from Sift `nonce` per adapter contract      |
-| `decision`         | `ALLOW`                                                       |
-| `policy_id`        | Current policy version identifier                             |
-| `issuer`           | OxDeAI authorization issuer identity                          |
-| `signature.alg`    | Signature algorithm; produced by issuer per AuthorizationV1 signing rules |
-| `signature.kid`    | Key identifier; produced by issuer per AuthorizationV1 signing rules      |
-| `signature.sig`    | Signature bytes; produced by issuer per AuthorizationV1 signing rules     |
+| Field              | Source                                                                              |
+|--------------------|-------------------------------------------------------------------------------------|
+| `intent_hash`      | SHA-256 of Sift-canonical JSON bytes of the normalized intent (ensure_ascii=True)   |
+| `state_hash`       | SHA-256 of Sift-canonical JSON bytes of the normalized state (ensure_ascii=True)    |
+| `audience`         | Injected by adapter from trusted configuration                                      |
+| `expires_at`       | Adapter-configured bounded TTL from `issued_at` (Unix seconds)                     |
+| `auth_id`          | Explicitly mapped from Sift `nonce` per adapter contract                            |
+| `decision`         | `"ALLOW"`                                                                           |
+| `policy_id`        | Mapped from `receipt.policy_matched`                                                |
+| `issuer`           | OxDeAI authorization issuer identity                                                |
+| `signature.alg`    | `"ed25519"` — Sift contract runtime literal (lowercase); distinct from JWKS `alg: "EdDSA"` |
+| `signature.kid`    | Key identifier, nested in `signature`; identifies the issuer signing key            |
+| `signature.sig`    | Base64url-no-padding Ed25519 signature over the Sift-canonical signing payload      |
 
 A canonicalization failure at any field MUST produce DENY and MUST NOT produce a partial `AuthorizationV1`.
+
+### Authorization signing preimage
+
+The signing preimage for `signature.sig` is the `AuthorizationV1` payload with `signature.sig` **omitted entirely**. `signature.alg` and `signature.kid` MUST be present in the preimage.
+
+```text
+signingPayload = AuthorizationV1 MINUS signature.sig
+                 (signature.alg and signature.kid are INCLUDED)
+```
+
+The signer canonicalizes `signingPayload` under the Sift contract (ensure_ascii=True, sort_keys) and signs the resulting UTF-8 bytes with Ed25519. The resulting signature is base64url-encoded without padding and placed in `signature.sig`.
+
+The PEP Gateway reconstructs the same `signingPayload` to verify the signature. Any discrepancy in preimage construction between issuer and verifier will cause signature verification to fail.
 
 ---
 
@@ -330,20 +376,20 @@ The PEP Gateway is the only path to execution. It is non-bypassable.
 Before executing any side effect, the PEP MUST verify, in order:
 
 1. Parse `AuthorizationV1` and reject malformed payloads.
-2. Verify signature and key resolution (`alg`, `kid`, trusted issuer keyset).
-3. Verify issuer and audience binding - exact match required.
+2. Verify signature — resolve `signature.kid` against the trusted issuer keyset; verify the Ed25519 signature over the reconstructed signing payload (authorization minus `signature.sig`; `signature.alg` and `signature.kid` present).
+3. Verify issuer and audience binding — exact match required.
 4. Verify `decision == ALLOW`.
-5. Verify not expired (`expiry > now`).
+5. Verify not expired (`expires_at > floor(now / 1000)`).
 6. Verify policy binding (`policy_id` matches expected policy context).
-7. Verify intent binding (`intent_hash` equals hash of the canonical form of the exact action about to execute).
-8. Verify state binding (`state_hash` matches current canonical state snapshot).
+7. Verify intent binding (`intent_hash` equals SHA-256 of the Sift-canonical form of the exact action about to execute).
+8. Verify state binding (`state_hash` matches SHA-256 of the current canonical state snapshot).
 9. Verify replay protection (`auth_id` not previously consumed).
 
 If any step fails, execution MUST NOT occur.
 
 On successful verification:
 1. Execute the side effect.
-2. Persist `auth_id` as consumed - this write MUST be durable and atomic with respect to execution.
+2. Persist `auth_id` as consumed — this write MUST be durable and atomic with respect to execution.
 3. Emit audit evidence.
 
 ### Upstream isolation
@@ -353,9 +399,9 @@ The PEP Gateway is the sole execution entry point.
 
 ### Issuer Trust Model
 
-- The PEP Gateway MUST verify AuthorizationV1 using a configured trusted key set.
+- The PEP Gateway MUST verify `AuthorizationV1` using a configured trusted key set.
 - The `issuer` field alone is not sufficient to establish trust.
-- Key resolution MUST use (`issuer`, `kid`, `alg`) against the trusted key set.
+- Key resolution MUST use (`issuer`, `signature.kid`, `signature.alg`) against the trusted key set.
 - If the issuer is unknown or the key is not trusted, verification MUST fail and result in DENY.
 
 No implicit trust is allowed.
@@ -397,98 +443,104 @@ Sift receipts do not provide the following. The adapter MUST compensate for each
 
 ```json
 {
-  "action": "transfer_funds",
+  "receipt_version": "1.0",
+  "tenant_id": "tenant-abc",
+  "agent_id": "agent-xyz",
+  "action": "call_tool",
   "tool": "payments_api",
-  "parameters": {
-    "amount": 500,
-    "currency": "USD",
-    "destination": "acct_9f3a"
-  },
   "decision": "ALLOW",
+  "risk_tier": 1,
   "nonce": "b3c4d5e6-1234-5678-abcd-ef0123456789",
-  "timestamp": 1744574400,
-  "receipt_hash": "sha256:aabbcc...",
-  "signature": "ed25519:<base64-signature>"
+  "timestamp": "2026-04-15T12:00:00.000Z",
+  "policy_matched": "payments-policy-v4",
+  "receipt_hash": "aabbcc...",
+  "signature": "<base64url-no-padding Ed25519 signature>"
 }
 ```
 
 ### Adapter processing (success path)
 
 ```text
-1. Verify Ed25519 signature over signed payload using pinned Sift public key
+1. Structural validation
+   → all required fields present; types valid
+
+2. Version check
+   → receipt_version "1.0" supported
+
+3. Recompute receipt_hash over sift_canonical(receipt MINUS signature AND receipt_hash)
+   → matches provided receipt_hash
+
+4. Resolve kid → check KRL (not revoked) → decode JWKS x → 32-byte raw key
+   Verify Ed25519 signature over sift_canonical(receipt MINUS signature, WITH receipt_hash)
    → valid
 
-2. Verify receipt_hash integrity over payload bytes
-   → match
-
-3. Check decision == ALLOW
+5. Check decision == ALLOW
    → pass
 
-4. Check timestamp freshness: now (1744574412) - timestamp (1744574400) = 12s < 30s window
+6. Check timestamp freshness: age = 12s < 30s window
    → pass
 
-5. Precheck mapped auth_id "b3c4d5e6-..." against duplicate cache (advisory)
+7. Precheck mapped auth_id "b3c4d5e6-..." against duplicate cache (advisory)
    → not seen; proceed (authoritative single-use enforcement occurs at PEP)
 
-6. Normalize intent to canonical OxDeAI form:
+8. Normalize intent to canonical OxDeAI form:
    {
      "type": "EXECUTE",
      "tool": "payments_api",
-     "params": {
-       "amount": 500,
-       "currency": "USD",
-       "destination": "acct_9f3a"
-     }
+     "params": { "amount": 500, "currency": "USD", "destination": "acct_9f3a" }
    }
-   → canonicalize under canonicalization-v1
-   → compute intent_hash: sha256:1122dd...
+   → sift_canonical (ensure_ascii=True, sort_keys)
+   → intent_hash: sha256:1122dd...
 
-7. Derive state snapshot from execution environment:
-   {
-     "available_budget": 10000,
-     "account_status": "active",
-     "prior_transfers_today": 2
-   }
-   → canonicalize → compute state_hash: sha256:334455...
+9. Derive state snapshot from execution environment:
+   { "available_budget": 10000, "account_status": "active", "prior_transfers_today": 2 }
+   → sift_canonical (ensure_ascii=True, sort_keys)
+   → state_hash: sha256:334455...
 
-8. Inject audience from adapter config: "payments-service-prod"
+10. Inject audience from adapter config: "payments-service-prod"
 
-9. Issue AuthorizationV1
+11. Issue AuthorizationV1
 ```
 
 ### `AuthorizationV1` issued by adapter
 
 ```json
 {
+  "version": "AuthorizationV1",
   "decision": "ALLOW",
   "issuer": "did:example:oxdeai-issuer-1",
   "audience": "payments-service-prod",
   "auth_id": "b3c4d5e6-1234-5678-abcd-ef0123456789",
   "policy_id": "payments-policy-v4",
-  "intent_hash": "sha256:1122dd...",
-  "state_hash": "sha256:334455...",
+  "intent_hash": "1122dd...",
+  "state_hash": "334455...",
   "issued_at": 1744574412,
-  "expiry": 1744574442,
+  "expires_at": 1744574442,
   "signature": {
-    "alg": "EdDSA",
+    "alg": "ed25519",
     "kid": "2026-rot-01",
-    "sig": "<base64-signature-bytes>"
+    "sig": "<base64url-no-padding Ed25519 signature over signing payload>"
   }
 }
 ```
 
+Note: `signature.alg` is the Sift contract runtime literal `"ed25519"` (lowercase). This is distinct from the JWKS entry field `"alg": "EdDSA"` used for key-discovery metadata. The `kid` is nested inside `signature`, not at the top level of `AuthorizationV1`.
+
 ### PEP Gateway verification (success path)
 
 ```text
-1. Parse AuthorizationV1            → ok
-2. Verify engine signature          → valid
-3. Verify audience                  → "payments-service-prod" == own identifier → match
-4. Verify decision == ALLOW         → pass
-5. Verify expiry > now              → 1744574442 > 1744574415 → pass
-6. Verify policy_id                 → "payments-policy-v4" == expected → match
-7. Verify intent_hash               → hash(canonical action) == sha256:1122dd... → match
-8. Verify state_hash                → hash(current state snapshot) == sha256:334455... → match
-9. Verify auth_id not consumed      → not consumed → pass; persist as consumed
+1. Parse AuthorizationV1                     → ok
+2. Resolve signature.kid against issuer keyset;
+   verify Ed25519 sig over signing payload
+   (AuthorizationV1 minus signature.sig;
+    signature.alg and signature.kid present)  → valid
+3. Verify audience                            → "payments-service-prod" == own identifier → match
+4. Verify decision == ALLOW                   → pass
+5. Verify expires_at > now                    → 1744574442 > 1744574415 → pass
+6. Verify policy_id                           → "payments-policy-v4" == expected → match
+7. Verify intent_hash                         → sha256(sift_canonical(action)) == 1122dd... → match
+8. Verify state_hash                          → sha256(sift_canonical(state)) == 334455... → match
+9. Verify auth_id not consumed                → not consumed → pass; persist as consumed
 
 → EXECUTE
 ```
@@ -499,6 +551,12 @@ Each of the following independently terminates in DENY with no execution:
 
 ```text
 Invalid Ed25519 signature
+  → adapter: DENY → NO EXECUTION
+
+Revoked kid (KRL check)
+  → adapter: DENY → NO EXECUTION
+
+receipt_hash mismatch
   → adapter: DENY → NO EXECUTION
 
 Receipt timestamp outside freshness window
@@ -532,6 +590,6 @@ AuthorizationV1 absent
 
 Sift decides. OxDeAI enforces.
 
-Execution requires `AuthorizationV1`. A Sift receipt is a governance decision artifact. It is not an authorization artifact. The adapter translates between them - but only after verifying the receipt locally, normalizing intent deterministically, deriving and hashing state, injecting audience, and mapping replay identity. Each of these steps is mandatory and non-delegable.
+Execution requires `AuthorizationV1`. A Sift receipt is a governance decision artifact. It is not an authorization artifact. The adapter translates between them — but only after verifying the receipt locally (Ed25519 over Sift-canonical bytes; `kid` checked against the KRL; JWKS key resolved by `kid`), normalizing intent deterministically (Sift-canonical JSON, ensure_ascii=True), deriving and hashing state, injecting audience, and mapping replay identity. Each of these steps is mandatory and non-delegable.
 
 The PEP Gateway is the only path to execution. Any failure at any verification step produces DENY. There is no partial authorization and no fallback execution path.

--- a/examples/sift/README.md
+++ b/examples/sift/README.md
@@ -14,16 +14,16 @@ governance receipt to a PEP execution decision.
 
 The example makes three architectural invariants concrete and observable:
 
-1. **A Sift receipt is not execution authorization.**  It is upstream governance
-   input — evidence that a policy engine evaluated a requested action.  Receipt
-   verification is a necessary precondition, not a sufficient one.
+1. **Sift is the decision layer.**  A receipt is evidence that a Sift policy
+   engine evaluated a requested action.  Receipt verification is a necessary
+   precondition for authorization — not execution authorization itself.
 
-2. **Execution requires a signed `AuthorizationV1` artifact.**  The artifact is
-   constructed locally after verification, intent normalization, and state
-   normalization all succeed.  The issuer signs only the fields that were
-   verified.
+2. **OxDeAI is the authorization and enforcement boundary.**  Execution requires
+   a signed `AuthorizationV1` artifact.  The artifact is constructed locally
+   after verification, intent normalization, and state normalization all succeed.
+   The issuer signs only the fields that were verified.
 
-3. **The PEP is the execution boundary.**  The Policy Enforcement Point checks
+3. **The PEP is the execution gate.**  The Policy Enforcement Point checks
    audience, expiry, issuer signature, intent binding, state binding, and replay
    before allowing any execution.  Replay protection lives here — not in the
    adapter.
@@ -36,8 +36,8 @@ The example makes three architectural invariants concrete and observable:
 Mock Sift receipt
        │
        ▼
- verifyReceipt()          ← structural check, version, freshness,
-       │                     receipt_hash integrity, Ed25519 signature
+ verifyReceipt()          ← struct, version, receipt_hash integrity,
+       │                     Ed25519 signature, decision, freshness
        ▼
  normalizeIntent()        ← binds receipt.tool / action to explicit params
        │
@@ -48,7 +48,7 @@ Mock Sift receipt
  receiptToAuthorization() ← constructs AuthorizationV1 payload +
        │                     signingPayload (hash bindings, time derivation)
        ▼
- sign( signingPayload )   ← demo issuer Ed25519 signature over canonical JSON
+ sign( signingPayload )   ← demo issuer Ed25519 signature over Sift-canonical JSON
        │
        ▼
  pepVerify()              ← execution gate:
@@ -59,6 +59,55 @@ Mock Sift receipt
 The Sift key pair and the OxDeAI issuer key pair are distinct.  Verifying a
 receipt (with the Sift key) is separate from verifying an authorization (with
 the issuer key).
+
+---
+
+## Wire format
+
+The Sift staging verifier uses a specific canonicalization and encoding contract.
+`helpers.ts` and `@oxdeai/sift` implement the same contract so digests and
+signatures computed locally match what the Sift service produces.
+
+| Surface | Format |
+|---|---|
+| Canonical JSON | Python `json.dumps(sort_keys=True, separators=(",",":"), ensure_ascii=True)` — keys sorted lexicographically, no whitespace, non-ASCII UTF-16 code units escaped as `\uXXXX` |
+| Signatures | Ed25519 over canonical JSON UTF-8 bytes, encoded base64url without padding (RFC 4648 §5) |
+| Public keys | Raw 32-byte Ed25519 key material — matches the `x` field of a JWKS entry (RFC 8037 OKP) |
+
+The `ensure_ascii=True` requirement means supplementary characters (U+10000+)
+are encoded as two `\uXXXX` escapes (one per UTF-16 surrogate), matching Python
+behavior exactly.
+
+---
+
+## Production verifier surface (not implemented in demo)
+
+In production, public keys are not bundled with the code.  The runtime follows
+this path for each incoming receipt:
+
+1. Read `kid` from the receipt's implicit or explicit key identifier.
+2. Check the **KRL (Key Revocation List)** — if `kid` is revoked, reject
+   immediately before any signature work.
+3. Look up the JWKS entry whose `kid` matches.  If not found, trigger a JWKS
+   refresh (cache may be stale) and retry once.
+4. Decode the `x` field (base64url → raw 32 bytes) and verify the signature.
+
+JWKS entry shape (RFC 8037 OKP):
+
+```json
+{
+  "kty": "OKP",
+  "crv": "Ed25519",
+  "alg": "EdDSA",
+  "use": "sig",
+  "kid": "<key-id>",
+  "x": "<base64url-raw-32-byte-key>"
+}
+```
+
+The `alg: "EdDSA"` field is JWKS metadata.  The runtime artifact uses
+`alg: "ed25519"` (lowercase) as the Sift contract literal in
+`AuthorizationV1Payload.signature.alg`.
 
 ---
 
@@ -85,6 +134,10 @@ Expected output:
 
 ```
 OxDeAI Sift Integration Demo
+
+Key material (JWKS x, base64url no-padding):
+  sift key  kid=sift-demo-key-1    x=<base64url>
+  issuer key kid=demo-issuer-key-1  x=<base64url>
 
 Scenario 1 — ALLOW
   receipt verification: OK
@@ -124,33 +177,46 @@ examples/sift/
 Self-contained implementations of:
 
 - **Canonical JSON** (`canonicalize` + `canonicalBytes` + `canonicalHash`) —
-  mirrors the algorithm used internally by `@oxdeai/sift` so hashes computed in
-  the PEP match the hashes stored in the authorization.
-- **Ed25519 utilities** (`makeKeyPair`, `signCanonical`, `verifyCanonical`).
+  mirrors the Sift contract algorithm (`ensure_ascii=True`) so digests computed
+  in the PEP match the digests stored in the authorization.
+- **base64url utilities** (`b64uEncode`, `b64uDecode`) — RFC 4648 §5 encoding;
+  `b64uDecode` normalizes standard base64 input so both formats decode to
+  identical bytes.
+- **JWKS key utilities** (`decodeJwksX`) — decodes a JWKS `x` field value
+  (base64url) to a raw 32-byte Ed25519 public key.
+- **Ed25519 utilities** (`makeKeyPair`, `signCanonical`, `verifyCanonical`) —
+  key generation (exports raw key + JWKS x + PKCS8 PEM), signing, and
+  verification against raw 32-byte keys.
 - **Mock receipt builder** (`buildMockReceipt`) — constructs a structurally
-  valid receipt with a correct `receipt_hash` preimage and real Ed25519
-  signature.
+  valid receipt with a correct `receipt_hash` preimage and a real Ed25519
+  signature using base64url encoding.
 - **Authorization signer** (`signAuthorization`) — signs the `signingPayload`
-  returned by `receiptToAuthorization` and fills `authorization.signature.sig`.
+  returned by `receiptToAuthorization` and fills `authorization.signature.sig`
+  with a base64url-no-padding Ed25519 signature.
 - **PEP simulation** (`pepVerify`) — enforces all execution-boundary checks
-  including an in-memory replay store.
+  including audience, expiry, Ed25519 signature (over Sift-canonical JSON),
+  intent_hash, state_hash, and an in-memory replay store.  Takes
+  `issuerPublicKeyRaw` (raw 32-byte key, JWKS `x` format).
 
 ### `run.ts`
 
 Orchestrates the three scenarios.  All keys are generated at startup and shared
 across scenarios so Scenario 3 can reuse Scenario 1's authorization verbatim.
+Prints key material in JWKS `x` format at startup so the wire format is
+observable.
 
 ---
 
 ## Preimage reference
 
 The following preimage conventions are critical for signatures and hashes to
-verify correctly:
+verify correctly.  All canonical JSON uses `ensure_ascii=True`; all signatures
+are base64url without padding.
 
 | Field | Preimage |
 |---|---|
-| `receipt_hash` | `sha256( canonical( receipt MINUS signature AND receipt_hash ) )` |
-| Sift `signature` | `sign( canonical( receipt MINUS signature, WITH receipt_hash ) )` |
-| Authorization `signature.sig` | `sign( canonical( signingPayload ) )` where `signingPayload` = authorization without `signature.sig` |
-| `intent_hash` | `sha256( canonical( OxDeAIIntent ) )` |
-| `state_hash` | `sha256( canonical( NormalizedState ) )` |
+| `receipt_hash` | `sha256( sift_canonical( receipt MINUS signature AND receipt_hash ) )` |
+| Sift `signature` | `sign( sift_canonical( receipt MINUS signature, WITH receipt_hash ) )` → base64url |
+| Authorization `signature.sig` | `sign( sift_canonical( signingPayload ) )` → base64url; `signingPayload` = authorization without `signature.sig` (`signature.alg` and `signature.kid` present) |
+| `intent_hash` | `sha256( sift_canonical( OxDeAIIntent ) )` |
+| `state_hash` | `sha256( sift_canonical( NormalizedState ) )` |

--- a/examples/sift/src/helpers.ts
+++ b/examples/sift/src/helpers.ts
@@ -2,22 +2,27 @@
 /**
  * Self-contained helpers for the Sift integration demo.
  *
- * These implementations are intentionally explicit about every preimage so
- * the demo is pedagogically clear.  No internals from @oxdeai/sift are
- * imported — only its public types.
+ * Updated to match the live Sift staging verifier contract:
+ *   - ensure_ascii=True canonicalization (Python json.dumps equivalent)
+ *   - base64url-no-padding signatures
+ *   - raw 32-byte Ed25519 public keys (JWKS `x` field format)
  *
- * Preimage conventions that must match packages/sift/src/verifyReceipt.ts:
+ * No internals from @oxdeai/sift are imported — only its public types.
+ *
+ * Preimage conventions matching packages/sift/src/verifyReceipt.ts:
  *
  *   receipt_hash preimage:  canonical( receipt  MINUS  signature  AND  receipt_hash )
  *   receipt signature:      canonical( receipt  MINUS  signature,  WITH receipt_hash )
  *
- * Preimage convention that must match packages/sift/src/receiptToAuthorization.ts:
+ * Preimage convention matching packages/sift/src/receiptToAuthorization.ts:
  *
  *   authorization signature:  canonical( signingPayload )
  *                             where signingPayload = authorization WITHOUT signature.sig
+ *                             (signature.alg and signature.kid ARE present)
  */
 
 import {
+  createPublicKey,
   generateKeyPairSync,
   sign as nodeCryptoSign,
   verify as nodeCryptoVerify,
@@ -32,9 +37,13 @@ import type {
   SigningPayload,
 } from "@oxdeai/sift";
 
-// ─── Canonical JSON ──────────────────────────────────────────────────────────
-// Mirrors the canonicalize + canonicalJsonHash logic inside the sift package.
-// Keys sorted lexicographically at every object level; arrays preserve order.
+// ─── Canonical JSON with ensure_ascii ────────────────────────────────────────
+//
+// Matches packages/sift/src/siftCanonical.ts exactly:
+//   json.dumps(payload, sort_keys=True, separators=(",",":"), ensure_ascii=True)
+//
+// This is the function that hashes computed here (intent_hash, state_hash,
+// receipt_hash) match those computed inside the @oxdeai/sift package.
 
 type JsonValue =
   | string
@@ -62,9 +71,32 @@ function canonicalize(value: unknown): JsonValue {
   throw new TypeError(`Unsupported type: ${typeof value}`);
 }
 
-/** UTF-8 bytes of the sorted-key minified JSON encoding of `value`. */
+/**
+ * Applies Python ensure_ascii=True semantics: every UTF-16 code unit above
+ * U+007F is escaped as \uXXXX.  Supplementary characters (U+10000+) are
+ * encoded as UTF-16 surrogate pairs, each individually escaped — matching
+ * Python's behavior exactly.
+ */
+function applyEnsureAscii(json: string): string {
+  let out = "";
+  for (let i = 0; i < json.length; i++) {
+    const code = json.charCodeAt(i);
+    if (code > 0x7f) {
+      out += "\\u" + code.toString(16).padStart(4, "0");
+    } else {
+      out += json[i];
+    }
+  }
+  return out;
+}
+
+/**
+ * UTF-8 bytes of the Sift-canonical JSON encoding of `value`.
+ * Equivalent to Python:
+ *   json.dumps(value, sort_keys=True, separators=(",",":"), ensure_ascii=True).encode("utf-8")
+ */
 export function canonicalBytes(value: unknown): Buffer {
-  return Buffer.from(JSON.stringify(canonicalize(value)), "utf-8");
+  return Buffer.from(applyEnsureAscii(JSON.stringify(canonicalize(value))), "utf-8");
 }
 
 /** SHA-256 lowercase hex of `data`. */
@@ -72,65 +104,146 @@ export function sha256Hex(data: Buffer): string {
   return createHash("sha256").update(data).digest("hex");
 }
 
-/** SHA-256 lowercase hex of canonical JSON of `value`. */
+/** SHA-256 lowercase hex of Sift-canonical JSON of `value`. */
 export function canonicalHash(value: unknown): string {
   return sha256Hex(canonicalBytes(value));
 }
 
-// ─── Ed25519 key management ──────────────────────────────────────────────────
+// ─── base64url helpers ────────────────────────────────────────────────────────
+
+/** Encodes a Buffer to base64url without padding (RFC 4648 §5). */
+export function b64uEncode(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+}
+
+/**
+ * Decodes a base64url-no-padding string to a Buffer.
+ * Also accepts standard base64 input (normalises + → - and / → _ before
+ * decoding) so both encodings produce identical bytes.
+ */
+export function b64uDecode(s: string): Buffer {
+  const normalized = s
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+  return Buffer.from(normalized, "base64url");
+}
+
+// ─── Raw Ed25519 key import ───────────────────────────────────────────────────
+
+// Ed25519 SPKI DER prefix (12 bytes):  30 2a 30 05 06 03 2b 65 70 03 21 00
+const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+/** Creates a Node.js KeyObject from a raw 32-byte Ed25519 public key buffer. */
+function publicKeyObjectFromRaw(raw: Buffer): ReturnType<typeof createPublicKey> {
+  if (raw.length !== 32) {
+    throw new TypeError(`Ed25519 public key must be 32 bytes, got ${raw.length}`);
+  }
+  const der = Buffer.concat([ED25519_SPKI_PREFIX, raw]);
+  return createPublicKey({ key: der, format: "der", type: "spki" });
+}
+
+// ─── JWKS x decode helper ─────────────────────────────────────────────────────
+
+/**
+ * Decodes a JWKS `x` field value (base64url-no-padding) into a raw 32-byte
+ * Ed25519 public key.
+ *
+ * In production the `x` value is fetched from the Sift JWKS endpoint.  The
+ * caller then selects the entry whose `kid` matches the receipt's `kid` field
+ * (and checks the KRL before trusting it).  Here the value is an inline demo
+ * constant — no network call needed.
+ *
+ * Example JWKS entry shape (RFC 8037 OKP):
+ *   {
+ *     "kty": "OKP", "crv": "Ed25519", "alg": "EdDSA",
+ *     "use": "sig", "kid": "<key-id>", "x": "<base64url-raw-key>"
+ *   }
+ */
+export function decodeJwksX(x: string): Buffer {
+  const raw = b64uDecode(x);
+  if (raw.length !== 32) {
+    throw new TypeError(`JWKS x must decode to 32 bytes, got ${raw.length}`);
+  }
+  return raw;
+}
+
+// ─── Ed25519 key management ───────────────────────────────────────────────────
 
 export interface DemoKeyPair {
-  publicKeyPem: string;
+  /** Raw 32-byte Ed25519 public key — what a JWKS `x` field encodes. */
+  publicKeyRaw: Buffer;
+  /**
+   * Base64url-no-padding encoding of publicKeyRaw.
+   * This is the `x` field value a JWKS endpoint would serve for this key.
+   */
+  publicKeyJwksX: string;
+  /** PEM-encoded PKCS8 private key — used by Node.js signing helpers. */
   privateKeyPem: string;
 }
 
 export function makeKeyPair(): DemoKeyPair {
-  const { publicKey, privateKey } = generateKeyPairSync("ed25519", {
-    publicKeyEncoding: { type: "spki", format: "pem" },
-    privateKeyEncoding: { type: "pkcs8", format: "pem" },
-  });
-  return { publicKeyPem: publicKey, privateKeyPem: privateKey };
+  // Generate as KeyObjects and export in the formats we need.
+  const { publicKey: pubObj, privateKey: privObj } = generateKeyPairSync("ed25519");
+
+  // Extract raw 32-byte key by stripping the 12-byte SPKI DER header.
+  const spkiDer = pubObj.export({ type: "spki", format: "der" }) as Buffer;
+  const publicKeyRaw = spkiDer.subarray(ED25519_SPKI_PREFIX.length); // last 32 bytes
+
+  return {
+    publicKeyRaw,
+    publicKeyJwksX: b64uEncode(publicKeyRaw),
+    privateKeyPem: privObj.export({ type: "pkcs8", format: "pem" }) as string,
+  };
 }
 
+// ─── Signing and verification ─────────────────────────────────────────────────
+
 /**
- * Signs canonical JSON bytes of `value` with the given Ed25519 private key.
- * Returns the signature as base64.
+ * Signs Sift-canonical JSON bytes of `value` with the given Ed25519 private key.
+ * Returns the signature as base64url without padding.
  */
 export function signCanonical(value: unknown, privateKeyPem: string): string {
-  return nodeCryptoSign(null, canonicalBytes(value), privateKeyPem).toString("base64");
+  return b64uEncode(nodeCryptoSign(null, canonicalBytes(value), privateKeyPem));
 }
 
 /**
- * Verifies an Ed25519 base64 signature over canonical JSON bytes of `value`.
+ * Verifies an Ed25519 signature over Sift-canonical JSON bytes of `value`.
+ *
+ * `sigB64U` may be base64url-no-padding (Sift-native) or standard base64;
+ * both are decoded to the same bytes.
+ * `publicKeyRaw` is a raw 32-byte Buffer (JWKS `x` decoded).
+ *
  * Returns false on any error rather than throwing.
  */
 export function verifyCanonical(
   value: unknown,
-  sigBase64: string,
-  publicKeyPem: string
+  sigB64U: string,
+  publicKeyRaw: Buffer
 ): boolean {
   try {
-    return nodeCryptoVerify(
-      null,
-      canonicalBytes(value),
-      publicKeyPem,
-      Buffer.from(sigBase64, "base64")
-    );
+    const pubKey = publicKeyObjectFromRaw(publicKeyRaw);
+    const sigBytes = b64uDecode(sigB64U);
+    return nodeCryptoVerify(null, canonicalBytes(value), pubKey, sigBytes);
   } catch {
     return false;
   }
 }
 
-// ─── Mock Sift receipt builder ───────────────────────────────────────────────
-// Produces a structurally valid receipt with a correctly-computed receipt_hash
-// and a real Ed25519 signature.  This simulates a receipt that would arrive
-// from the Sift governance service.
+// ─── Mock Sift receipt builder ────────────────────────────────────────────────
 //
-// Preimage order (critical — must match verifyReceipt.ts computeReceiptHash):
+// Produces a structurally valid receipt with a correctly-computed receipt_hash
+// and a real Ed25519 signature using the Sift contract wire format.
+//
+// Preimage order (must match packages/sift/src/verifyReceipt.ts):
 //   ① Build body (no receipt_hash, no signature)
-//   ② receipt_hash = sha256( canonical( ① ) )
+//   ② receipt_hash = sha256( sift_canonical( ① ) )
 //   ③ signed payload = ① + receipt_hash   (signature field absent)
-//   ④ signature = sign( canonical( ③ ) )
+//   ④ signature = sign( sift_canonical( ③ ) )   — base64url, no padding
 
 export interface BuildReceiptOptions {
   decision: SiftDecision;
@@ -165,24 +278,26 @@ export function buildMockReceipt(opts: BuildReceiptOptions): Record<string, unkn
     policy_matched: "policy-tools-v1",
   };
 
-  // ② receipt_hash = SHA-256( canonical( body ) )
+  // ② receipt_hash = SHA-256( sift_canonical( body ) )
   const receipt_hash = canonicalHash(base);
 
   // ③ Signed payload = body + receipt_hash  (signature still absent)
   const withHash = { ...base, receipt_hash };
 
-  // ④ signature = sign( canonical( ③ ) )
+  // ④ signature = sign( sift_canonical( ③ ) )  → base64url, no padding
   const signature = signCanonical(withHash, keypair.privateKeyPem);
 
   return { ...withHash, signature };
 }
 
-// ─── Authorization signing ───────────────────────────────────────────────────
+// ─── Authorization signing ────────────────────────────────────────────────────
+//
 // Fills the `sig` placeholder in authorization.signature by signing the
 // signingPayload returned by receiptToAuthorization.
 //
-// The signingPayload is already the correct preimage — it is the full
-// authorization with signature.sig intentionally absent.
+// The signingPayload is the correct preimage — it is the full authorization
+// with signature.sig intentionally absent (signature.alg and signature.kid
+// ARE present, as required by the contract).
 
 export function signAuthorization(
   authorization: AuthorizationV1Payload,
@@ -193,24 +308,32 @@ export function signAuthorization(
   return { ...authorization, signature: { ...authorization.signature, sig } };
 }
 
-// ─── PEP simulation ──────────────────────────────────────────────────────────
+// ─── PEP simulation ───────────────────────────────────────────────────────────
+//
 // A minimal local Policy Enforcement Point.
 //
-// The Sift receipt is NOT the execution gate — it is upstream governance input.
-// The PEP is the execution boundary.  A signed AuthorizationV1 artifact,
-// verified here, is required before any execution can proceed.
+// Sift is the decision layer — it evaluates policy and issues a receipt.
+// OxDeAI is the authorization and enforcement boundary — it constructs a
+// signed AuthorizationV1 artifact from the verified receipt, then the PEP
+// enforces it here.
+//
+// This demo does not implement JWKS fetching or KRL checks.  In production:
+//   - the issuer's kid is looked up in a JWKS endpoint
+//   - the KRL is checked before trusting any key
+//   - unknown kids trigger a JWKS refresh before failing
 //
 // Checks performed in order:
 //   1. Audience exact match
 //   2. Expiry (expires_at > floor(now / 1000))
 //   3. Ed25519 signature on reconstructed signingPayload
+//      (signature.alg and signature.kid included; signature.sig omitted)
 //   4. intent_hash matches the provided intent
 //   5. state_hash matches the provided state
 //   6. Replay: auth_id must not have been seen before
 
 export type PepResult =
-  | { ok: true; decision: "ALLOW"; executed: true; auth_id: string }
-  | { ok: false; decision: "DENY"; executed: false; reason: string };
+  | { ok: true;  decision: "ALLOW"; executed: true;  auth_id: string }
+  | { ok: false; decision: "DENY";  executed: false; reason: string };
 
 // In-memory replay store — scoped to this demo process.
 const pepReplayStore = new Set<string>();
@@ -220,12 +343,17 @@ export interface PepVerifyInput {
   intent: OxDeAIIntent;
   state: NormalizedState;
   audience: string;
-  issuerPublicKeyPem: string;
+  /**
+   * Raw 32-byte Ed25519 public key for the issuer.
+   * In production this is obtained by decoding the JWKS `x` field for the
+   * matching `kid`, after consulting the KRL.
+   */
+  issuerPublicKeyRaw: Buffer;
   now: Date;
 }
 
 export function pepVerify(input: PepVerifyInput): PepResult {
-  const { authorization, intent, state, audience, issuerPublicKeyPem, now } = input;
+  const { authorization, intent, state, audience, issuerPublicKeyRaw, now } = input;
 
   // 1. Audience
   if (authorization.audience !== audience) {
@@ -238,22 +366,27 @@ export function pepVerify(input: PepVerifyInput): PepResult {
     return { ok: false, decision: "DENY", executed: false, reason: "EXPIRED" };
   }
 
-  // 3. Signature — reconstruct signing payload (authorization without signature.sig)
-  //    Must produce the same canonical bytes that were signed by the issuer.
+  // 3. Signature — reconstruct signing payload (authorization without signature.sig).
+  //    signature.alg and signature.kid are present; signature.sig is absent.
+  //    This must produce the same canonical bytes that were signed by the issuer.
   const signingPayload: SigningPayload = {
-    version: authorization.version,
-    auth_id: authorization.auth_id,
-    issuer: authorization.issuer,
-    audience: authorization.audience,
-    decision: authorization.decision,
+    version:     authorization.version,
+    auth_id:     authorization.auth_id,
+    issuer:      authorization.issuer,
+    audience:    authorization.audience,
+    decision:    authorization.decision,
     intent_hash: authorization.intent_hash,
-    state_hash: authorization.state_hash,
-    policy_id: authorization.policy_id,
-    issued_at: authorization.issued_at,
-    expires_at: authorization.expires_at,
-    signature: { alg: authorization.signature.alg, kid: authorization.signature.kid },
+    state_hash:  authorization.state_hash,
+    policy_id:   authorization.policy_id,
+    issued_at:   authorization.issued_at,
+    expires_at:  authorization.expires_at,
+    signature: {
+      alg: authorization.signature.alg,
+      kid: authorization.signature.kid,
+      // sig intentionally absent — this is the preimage
+    },
   };
-  if (!verifyCanonical(signingPayload, authorization.signature.sig, issuerPublicKeyPem)) {
+  if (!verifyCanonical(signingPayload, authorization.signature.sig, issuerPublicKeyRaw)) {
     return { ok: false, decision: "DENY", executed: false, reason: "INVALID_SIGNATURE" };
   }
 

--- a/examples/sift/src/run.ts
+++ b/examples/sift/src/run.ts
@@ -5,13 +5,22 @@
  * Demonstrates the full path from a Sift receipt to a PEP execution decision.
  *
  * Architectural invariants:
- *   - A Sift receipt is upstream governance input — not execution authorization.
- *   - Execution requires a signed AuthorizationV1 artifact that is issued only
- *     after local receipt verification, intent normalization, and state
- *     normalization all succeed.
- *   - The PEP is the execution boundary.  Replay is enforced there, not in
- *     the adapter.
+ *   - Sift is the decision layer.  A receipt is evidence that a Sift policy
+ *     engine evaluated a requested action — not execution authorization.
+ *   - OxDeAI is the authorization and enforcement boundary.  Execution requires
+ *     a signed AuthorizationV1 artifact issued only after local receipt
+ *     verification, intent normalization, and state normalization all succeed.
+ *   - The PEP is the execution gate.  Replay is enforced there, not in the
+ *     adapter.
  *   - The system fails closed: any unresolvable ambiguity blocks execution.
+ *
+ * Wire format (Sift contract):
+ *   - Canonical JSON: Python json.dumps(sort_keys=True, separators=(",",":"),
+ *     ensure_ascii=True) — non-ASCII UTF-16 code units are \uXXXX-escaped.
+ *   - Signatures: Ed25519 over Sift-canonical bytes, encoded as base64url
+ *     without padding (RFC 4648 §5).
+ *   - Public keys: raw 32-byte Ed25519 key material, matching the JWKS `x`
+ *     field (RFC 8037 OKP).  No PEM wrapper needed at this boundary.
  *
  * Three scenarios:
  *   1. ALLOW  — valid receipt, valid intent, valid state, fresh authorization
@@ -41,6 +50,9 @@ const KEY_ID   = "demo-issuer-key-1";
 // ─── Key material  (generated once, shared across scenarios) ─────────────────
 
 // Sift signing key — simulates the key held by the Sift governance service.
+// In production this key is fetched from the Sift JWKS endpoint; the caller
+// selects the entry whose `kid` matches the receipt's kid field and checks
+// the KRL (Key Revocation List) before trusting the key.
 const siftKeypair = makeKeyPair();
 
 // OxDeAI issuer key — simulates the adapter issuer that signs AuthorizationV1.
@@ -56,6 +68,12 @@ function blank(): void            { console.log(); }
 console.log("OxDeAI Sift Integration Demo");
 blank();
 
+// Display key material in JWKS x format so the wire format is observable.
+console.log("Key material (JWKS x, base64url no-padding):");
+step(`sift key  kid=sift-demo-key-1    x=${siftKeypair.publicKeyJwksX}`);
+step(`issuer key kid=${KEY_ID}  x=${issuerKeypair.publicKeyJwksX}`);
+blank();
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Scenario 1 — ALLOW
 //
@@ -67,9 +85,11 @@ console.log("Scenario 1 — ALLOW");
 // 1. Build a valid ALLOW receipt (simulates arrival from Sift).
 const allowRawReceipt = buildMockReceipt({ decision: "ALLOW", keypair: siftKeypair });
 
-// 2. Verify the receipt locally — structural, version, freshness, hash, signature.
+// 2. Verify the receipt locally — structural, version, receipt_hash integrity,
+//    Ed25519 signature, decision, freshness (in that order).
+//    publicKeyRaw is the raw 32-byte key matching the JWKS `x` field.
 const verifyAllowResult = verifyReceipt(allowRawReceipt, {
-  publicKeyPem: siftKeypair.publicKeyPem,
+  publicKeyRaw: siftKeypair.publicKeyRaw,
 });
 if (!verifyAllowResult.ok) {
   step(`receipt verification: FAILED (${verifyAllowResult.code})`);
@@ -110,7 +130,8 @@ const state = stateResult.state;
 
 // 5. Construct the AuthorizationV1 payload.
 //    Binds receipt.nonce → auth_id, policy_matched → policy_id,
-//    computes intent_hash and state_hash, sets issued_at / expires_at.
+//    computes intent_hash and state_hash with Sift-canonical JSON
+//    (ensure_ascii=True), sets issued_at / expires_at.
 const authResult = receiptToAuthorization({
   receipt,
   intent,
@@ -129,7 +150,8 @@ if (!authResult.ok) {
 
 // 6. Sign the signingPayload with the demo issuer key.
 //    signingPayload is the authorization with signature.sig absent — the
-//    correct preimage.  signAuthorization fills authorization.signature.sig.
+//    correct preimage per the Sift contract.  signAuthorization fills
+//    authorization.signature.sig with a base64url-no-padding Ed25519 signature.
 const signedAuthorization = signAuthorization(
   authResult.authorization,
   authResult.signingPayload,
@@ -137,13 +159,14 @@ const signedAuthorization = signAuthorization(
 );
 
 // 7. PEP enforcement — the execution boundary.
-//    Checks: audience, expiry, signature, intent_hash, state_hash, replay.
+//    Checks in order: audience, expiry, Ed25519 signature, intent_hash,
+//    state_hash, replay.  issuerPublicKeyRaw is the raw 32-byte key.
 const pep1 = pepVerify({
   authorization: signedAuthorization,
   intent,
   state,
   audience: AUDIENCE,
-  issuerPublicKeyPem: issuerKeypair.publicKeyPem,
+  issuerPublicKeyRaw: issuerKeypair.publicKeyRaw,
   now: new Date(),
 });
 
@@ -165,7 +188,7 @@ const denyRawReceipt = buildMockReceipt({ decision: "DENY", keypair: siftKeypair
 
 // requireAllowDecision defaults to true — DENY receipts are rejected here.
 const verifyDenyResult = verifyReceipt(denyRawReceipt, {
-  publicKeyPem: siftKeypair.publicKeyPem,
+  publicKeyRaw: siftKeypair.publicKeyRaw,
 });
 
 if (!verifyDenyResult.ok) {
@@ -193,7 +216,7 @@ const pep3 = pepVerify({
   intent,
   state,
   audience: AUDIENCE,
-  issuerPublicKeyPem: issuerKeypair.publicKeyPem,
+  issuerPublicKeyRaw: issuerKeypair.publicKeyRaw,
   now: new Date(),
 });
 

--- a/packages/sift/README.md
+++ b/packages/sift/README.md
@@ -28,6 +28,25 @@ This adapter bridges the two without weakening OxDeAI invariants:
 * local verification at execution time
 * no runtime dependency on remote receipt verification
 
+## Wire format
+
+The Sift verifier contract specifies a particular canonicalization and encoding scheme.
+This package implements it exactly so that digests and signatures computed locally
+match those produced by the Sift service.
+
+| Surface | Format |
+|---|---|
+| Canonical JSON | Python `json.dumps(sort_keys=True, separators=(",",":"), ensure_ascii=True)` — keys sorted lexicographically, no whitespace, non-ASCII UTF-16 code units escaped as `\uXXXX` (lowercase); supplementary characters (U+10000+) as two surrogate escapes each |
+| Signatures | Ed25519 over canonical JSON UTF-8 bytes, encoded as base64url without padding (RFC 4648 §5) |
+| Public keys | Raw 32-byte Ed25519 key material — matches the `x` field of a JWKS entry (RFC 8037 OKP); no PEM wrapper required at this boundary |
+
+**Algorithm naming.** There are two distinct surfaces:
+
+* `alg: "EdDSA"` — JWKS metadata field for key-discovery tooling (RFC 8037).
+* `alg: "ed25519"` — Sift contract runtime literal present in `AuthorizationV1.signature.alg` (lowercase).
+
+These are not interchangeable. The runtime artifact always uses `"ed25519"`.
+
 ## What this package does
 
 ### `verifyReceipt`
@@ -36,12 +55,21 @@ Validates and verifies a Sift receipt locally.
 
 Responsibilities:
 
-* structural validation
+* structural validation (field presence and types)
 * receipt version validation
+* receipt hash integrity validation (Sift-canonical JSON, ensure_ascii=True)
+* Ed25519 signature verification (raw 32-byte key; base64url-decoded signature)
+* `ALLOW` / `DENY` decision enforcement
 * bounded freshness validation (`maxAgeMs` — configurable per deployment; treat as a security parameter)
-* `ALLOW` / `DENY` handling
-* receipt hash integrity validation
-* local Ed25519 signature verification
+
+Verification order (integrity before semantics):
+
+1. Structural validation
+2. Version check
+3. `receipt_hash` integrity
+4. Ed25519 signature
+5. Decision (`ALLOW` / `DENY`)
+6. Freshness
 
 Properties:
 
@@ -49,6 +77,13 @@ Properties:
 * no network calls
 * explicit typed errors
 * deterministic behavior
+
+**Public key input.** `verifyReceipt` accepts the public key as:
+
+* `publicKeyRaw` — raw 32-byte Ed25519 key material, either as a `Uint8Array` or a base64url-no-padding string matching the JWKS `x` field. This is the primary Sift-contract-native path.
+* `publicKeyPem` — PEM-encoded SPKI Ed25519 public key. Accepted for backward compatibility. `publicKeyRaw` takes precedence when both are provided.
+
+In production, the raw key is obtained by decoding the JWKS `x` field for the `kid` matching the receipt, after confirming the key is not revoked in the KRL.
 
 ### `normalizeIntent`
 
@@ -86,18 +121,31 @@ Builds an unsigned `AuthorizationV1`-style payload from:
 
 Explicit bindings:
 
-| Authorization field | Source                          |
-| ------------------- | ------------------------------- |
-| `auth_id`           | `receipt.nonce`                 |
-| `policy_id`         | `receipt.policy_matched`        |
-| `intent_hash`       | SHA-256 of canonicalized intent |
-| `state_hash`        | SHA-256 of canonicalized state  |
-| `issued_at`         | single captured adapter time    |
-| `expires_at`        | derived from configured TTL     |
-| `audience`          | caller-supplied                 |
-| `issuer`            | caller-supplied                 |
+| Authorization field | Source                                                              |
+| ------------------- | ------------------------------------------------------------------- |
+| `auth_id`           | `receipt.nonce`                                                     |
+| `policy_id`         | `receipt.policy_matched`                                            |
+| `intent_hash`       | SHA-256 of Sift-canonical JSON bytes of intent (ensure_ascii=True)  |
+| `state_hash`        | SHA-256 of Sift-canonical JSON bytes of state (ensure_ascii=True)   |
+| `issued_at`         | single captured adapter time (Unix seconds)                         |
+| `expires_at`        | derived from configured TTL                                         |
+| `audience`          | caller-supplied                                                     |
+| `issuer`            | caller-supplied                                                     |
+| `signature.alg`     | `"ed25519"` — Sift contract runtime literal (lowercase)             |
+| `signature.kid`     | caller-supplied `keyId`                                             |
+| `signature.sig`     | `""` placeholder — caller MUST sign the returned `signingPayload`  |
 
-This file constructs the authorization payload. It does **not** sign it.
+This function constructs the payload. It does **not** sign it.
+
+**Signing preimage.** The returned `signingPayload` is `AuthorizationV1` with `signature.sig` **absent**.
+`signature.alg` and `signature.kid` are present. The caller MUST:
+
+1. Sift-canonicalize `signingPayload` (ensure_ascii=True, sort_keys).
+2. Sign the resulting UTF-8 bytes with Ed25519.
+3. Encode the signature as base64url without padding.
+4. Place the result in `authorization.signature.sig`.
+
+The PEP Gateway reconstructs the same `signingPayload` to verify the signature.
 
 ## What this package does not do
 
@@ -112,7 +160,7 @@ This package does **not**:
 
 ## Security model
 
-This package is designed around OxDeAI’s execution-boundary model.
+This package is designed around OxDeAI's execution-boundary model.
 
 ### Important constraint
 
@@ -151,14 +199,16 @@ The adapter MUST reject:
 
 ### Receipt hash integrity
 
-`receipt_hash` MUST be computed over the canonical JSON payload with:
+`receipt_hash` MUST be computed over the Sift-canonical JSON payload with:
 
 - `signature` excluded
 - `receipt_hash` excluded
 
-Canonicalization requirements:
+Canonicalization requirements (Sift wire format):
+
 - lexicographic key ordering
-- no whitespace
+- no whitespace between tokens
+- `ensure_ascii=True` — every UTF-16 code unit above U+007F escaped as `\uXXXX`; supplementary characters as two surrogate escapes each
 - UTF-8 encoding
 
 The adapter MUST:
@@ -169,7 +219,7 @@ The adapter MUST:
 
 ### Signature verification scope
 
-The Ed25519 signature is verified over the canonical payload with:
+The Ed25519 signature is verified over the Sift-canonical payload with:
 
 - `signature` excluded
 - `receipt_hash` INCLUDED
@@ -184,38 +234,42 @@ The adapter MUST NOT:
 - verify signature before validating `receipt_hash`
 - mutate payload before verification
 
-### Verification ordering
+Signatures are base64url without padding. The verifier accepts both base64url (Sift-native) and
+standard base64 — both normalize to the same underlying bytes before decoding.
 
-The adapter MUST perform verification in the following order:
+### Key management and JWKS/KRL surface
 
-1. `receipt_hash` integrity validation
-2. signature verification
-3. semantic validation (decision, freshness, replay prechecks, etc.)
+The adapter verifies Sift receipts using raw 32-byte Ed25519 keys distributed via the Sift JWKS endpoint.
 
-The adapter MUST NOT proceed to a later step if an earlier step fails.
+JWKS entry shape (RFC 8037 OKP):
 
-### Key management and rotation
+```json
+{
+  "kty": "OKP",
+  "crv": "Ed25519",
+  "alg": "EdDSA",
+  "use": "sig",
+  "kid": "<key-id>",
+  "x": "<base64url-no-padding 32-byte raw public key>"
+}
+```
 
-The adapter verifies Sift receipts using trusted Ed25519 public keys.
+Production key resolution sequence:
 
-Production deployments SHOULD support key rotation via a key set:
-
-- multiple public keys identified by `kid`
-- deterministic key selection
-- ability to revoke keys without downtime
+1. Extract `kid` from the receipt.
+2. Check `kid` against the KRL — if revoked, DENY immediately.
+3. Look up the JWKS entry for `kid`. If not found, trigger a JWKS refresh (cache may be stale) and retry once.
+4. If still not found → DENY. No fallback guessing.
+5. Decode `x` (base64url → 32 bytes) and pass as `publicKeyRaw` to `verifyReceipt`.
 
 Minimum requirements:
 
-- support multiple active keys
-- fail closed if key cannot be resolved
+- support multiple active keys identified by `kid`
+- check the KRL before trusting any key when KRL is available
+- refresh JWKS on unknown `kid` before failing closed
+- fail closed if the key cannot be resolved after refresh
 - no fallback guessing
-
-If the receipt includes a key identifier (`kid`), it MUST be used to select the correct key.
-
-If the receipt does not include a `kid`, key selection MUST be deterministic and externally configured.
-
-If no matching key is found:
-→ verification MUST fail
+- deterministic key selection
 
 ### Prototype safety
 
@@ -228,6 +282,7 @@ This prevents `__proto__` setter side effects and silent key loss during normali
 ```text
 packages/sift/
 ├── src/
+│   ├── siftCanonical.ts        ← Sift-contract canonicalization, base64url, raw key import
 │   ├── verifyReceipt.ts
 │   ├── normalizeIntent.ts
 │   ├── state.ts
@@ -237,6 +292,8 @@ packages/sift/
 ├── package.json
 └── tsconfig.json
 ```
+
+`siftCanonical.ts` is an internal module. It is not exported from `index.ts`. Use the public API (`verifyReceipt`, `receiptToAuthorization`, etc.) at integration boundaries.
 
 ## API surface
 
@@ -248,10 +305,10 @@ import { verifyReceipt } from "@oxdeai/sift";
 
 Verifies:
 
-* structure
-* freshness
-* receipt hash
-* Ed25519 signature
+* structure and version
+* receipt hash integrity (Sift-canonical, ensure_ascii=True)
+* Ed25519 signature (raw 32-byte key; base64url signature)
+* decision and freshness
 
 ### Intent normalization
 
@@ -283,7 +340,7 @@ Builds a deterministic state object suitable for later canonicalization and hash
 import { receiptToAuthorization } from "@oxdeai/sift";
 ```
 
-Builds an unsigned `AuthorizationV1` payload plus signing payload.
+Builds an unsigned `AuthorizationV1` payload plus the signing payload ready for Ed25519 signing.
 
 ## Example
 
@@ -295,10 +352,12 @@ import {
   receiptToAuthorization,
 } from "@oxdeai/sift";
 
+// publicKeyRaw is the raw 32-byte key decoded from the JWKS x field for the
+// matching kid, after confirming the key is not revoked in the KRL.
 const verified = verifyReceipt(receipt, {
-  publicKeyPem,
+  publicKeyRaw: jwksXDecoded,        // Uint8Array or base64url string (JWKS x field)
   requireAllowDecision: true,
-  maxAgeMs: 30_000, // configurable per deployment; treat as a security parameter
+  maxAgeMs: 30_000,                  // configurable per deployment; treat as a security parameter
 });
 
 if (!verified.ok) {
@@ -345,6 +404,9 @@ if (!authResult.ok) {
   throw new Error(`${authResult.code}: ${authResult.message}`);
 }
 
+// authResult.authorization.signature.sig is "" — sign it before use.
+// authResult.signingPayload is AuthorizationV1 with signature.sig absent.
+// Sign sift_canonical(signingPayload) with Ed25519 → base64url, no padding.
 console.log(authResult.authorization);
 console.log(authResult.signingPayload);
 ```
@@ -398,6 +460,20 @@ receipt.nonce → AuthorizationV1.auth_id
 ```
 
 No generated UUIDs. No mutation. No hidden prefixes.
+
+### Why `ensure_ascii=True`?
+
+The Sift staging verifier canonicalizes payloads with Python's `json.dumps(ensure_ascii=True)`.
+This escapes every non-ASCII UTF-16 code unit as `\uXXXX`, including both halves of surrogate pairs
+for supplementary characters. The TypeScript implementation must match this exactly so that hashes
+computed locally are identical to those the Sift service produces.
+
+### Why raw 32-byte keys instead of PEM?
+
+The Sift JWKS endpoint distributes Ed25519 public keys as raw 32-byte material in the `x` field
+(RFC 8037 OKP). Accepting the key in that form directly — rather than requiring a PEM-wrapped
+derivative — eliminates a conversion step and removes any ambiguity about which encoding is
+authoritative at the Sift contract boundary.
 
 ## Related docs
 


### PR DESCRIPTION
…ntract

- update examples/sift runtime helpers to match live wire contract:
  - ensure_ascii-compatible canonical JSON
  - base64url signatures without padding
  - raw 32-byte Ed25519 public keys from JWKS x
  - no PEM assumptions in example verification path

- update example runner:
  - verifyReceipt uses raw public key input
  - PEP verification uses raw issuer public key
  - startup output surfaces JWKS-derived key material
  - clarify wire-format expectations in module-level docs

- update examples/sift/README:
  - document exact wire format (canonical JSON, base64url, raw keys)
  - describe production verifier surface (JWKS + KRL)
  - clarify Sift = decision layer, OxDeAI = authorization + enforcement boundary
  - distinguish runtime literal "ed25519" from JWKS metadata "EdDSA"

- update docs/adapters/sift.md:
  - add ensure_ascii=True canonicalization requirement
  - define Authorization signing preimage explicitly
  - replace PEM references with raw JWKS x key material
  - document JWKS/KRL resolution flow and revocation behavior
  - normalize field names to expires_at
  - clarify signature encoding and nested signature.kid semantics
  - align verification ordering with runtime implementation

- update packages/sift/README:
  - reflect Sift-native key and signature model
  - document verification order, signing preimage, and JWKS/KRL flow
  - align examples and package guidance with staging contract

This removes remaining contract drift between implementation, example, and documentation for the live Sift staging verifier surface.