### PR TITLE
feat(sift): add JWKS/KRL keystore verification for live staging align…

### DIFF
--- a/examples/sift/package.json
+++ b/examples/sift/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "prebuild": "pnpm -C ../../packages/sift build",
     "build": "tsc -p tsconfig.json",
-    "start": "pnpm build && node dist/run.js"
+    "start": "pnpm build && node dist/run.js",
+    "verify:staging": "SIFT_STAGING_LIVE=1 pnpm test"
   },
   "dependencies": {
     "@oxdeai/sift": "workspace:*"

--- a/packages/sift/README.md
+++ b/packages/sift/README.md
@@ -283,7 +283,8 @@ This prevents `__proto__` setter side effects and silent key loss during normali
 packages/sift/
 ├── src/
 │   ├── siftCanonical.ts        ← Sift-contract canonicalization, base64url, raw key import
-│   ├── verifyReceipt.ts
+│   ├── siftKeyStore.ts         ← JWKS/KRL key store (SiftHttpKeyStore, createStagingKeyStore)
+│   ├── verifyReceipt.ts        ← verifyReceipt + verifyReceiptWithKeyStore
 │   ├── normalizeIntent.ts
 │   ├── state.ts
 │   ├── receiptToAuthorization.ts
@@ -297,11 +298,13 @@ packages/sift/
 
 ## API surface
 
-### Receipt verification
+### Receipt verification — local key path
 
 ```ts
 import { verifyReceipt } from "@oxdeai/sift";
 ```
+
+Synchronous.  Accepts the public key directly via `publicKeyRaw` (raw 32-byte `Uint8Array` or base64url string matching the JWKS `x` field) or the deprecated `publicKeyPem`.  No network calls.  Use this path for deterministic offline tests or when your application resolves the key externally.
 
 Verifies:
 
@@ -309,6 +312,58 @@ Verifies:
 * receipt hash integrity (Sift-canonical, ensure_ascii=True)
 * Ed25519 signature (raw 32-byte key; base64url signature)
 * decision and freshness
+
+### Receipt verification — keystore path
+
+```ts
+import { verifyReceiptWithKeyStore, createStagingKeyStore } from "@oxdeai/sift";
+
+const keyStore = createStagingKeyStore();
+const result   = await verifyReceiptWithKeyStore(receipt, { kid, keyStore });
+```
+
+Async.  Resolves the Ed25519 public key by `kid` from a `SiftKeyStore`.  Enforces KRL revocation, refresh-on-unknown-kid (once), and fail-closed on any unresolvable key.  After key resolution it delegates to `verifyReceipt` with the same verification ordering.
+
+Key resolution sequence:
+
+1. Reject empty `kid` → `MISSING_KID`.
+2. Check KRL → `REVOKED_KID` if revoked.
+3. Look up `kid` in the in-memory cache.
+4. If not found: call `keyStore.refresh()` once.
+   - On refresh failure → `JWKS_FETCH_FAILED` / `KRL_FETCH_FAILED` / `KEYSTORE_REFRESH_FAILED`.
+   - Re-check KRL after refresh.
+   - Re-check key lookup after refresh.
+   - If still not found → `UNKNOWN_KID`.
+5. Call `verifyReceipt` with the resolved key.
+
+### Key store
+
+```ts
+import { SiftHttpKeyStore, createStagingKeyStore, type SiftKeyStore } from "@oxdeai/sift";
+
+// Staging (Sift-hosted JWKS + KRL endpoints):
+const store = createStagingKeyStore();
+await store.refresh();
+
+// Custom endpoints:
+const custom = new SiftHttpKeyStore({ jwksUrl: "...", krlUrl: "..." });
+
+// Inject a mock fetch for tests:
+const testStore = new SiftHttpKeyStore({ jwksUrl, krlUrl, fetch: mockFetch });
+```
+
+`SiftKeyStore` is the interface.  `SiftHttpKeyStore` is the HTTP-backed implementation.  Both `getPublicKeyByKid` and `isKidRevoked` operate on the in-memory cache; only `refresh()` makes network calls.
+
+Staging endpoints:
+
+* JWKS: `https://sift-staging.walkosystems.com/sift-jwks.json`
+* KRL:  `https://sift-staging.walkosystems.com/sift-krl.json`
+
+To run the live staging integration test:
+
+```bash
+SIFT_STAGING_LIVE=1 pnpm -C packages/sift test
+```
 
 ### Intent normalization
 

--- a/packages/sift/src/index.ts
+++ b/packages/sift/src/index.ts
@@ -5,10 +5,11 @@ export type {
   SiftDecision,
   SiftReceipt,
   VerifyReceiptOptions,
+  KeyStoreVerifyOptions,
   VerifyReceiptErrorCode,
   VerifyReceiptResult,
 } from "./verifyReceipt.js";
-export { verifyReceipt } from "./verifyReceipt.js";
+export { verifyReceipt, verifyReceiptWithKeyStore } from "./verifyReceipt.js";
 
 // Intent normalization
 export type {
@@ -39,3 +40,15 @@ export type {
   ReceiptToAuthorizationResult,
 } from "./receiptToAuthorization.js";
 export { receiptToAuthorization } from "./receiptToAuthorization.js";
+
+// Key store
+export type {
+  SiftKeyStore,
+  SiftHttpKeyStoreOptions,
+  KeyStoreErrorCode,
+} from "./siftKeyStore.js";
+export {
+  KeyStoreError,
+  SiftHttpKeyStore,
+  createStagingKeyStore,
+} from "./siftKeyStore.js";

--- a/packages/sift/src/siftKeyStore.ts
+++ b/packages/sift/src/siftKeyStore.ts
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Sift JWKS + KRL key store for receipt signature verification.
+ *
+ * Responsibilities:
+ *   - JWKS fetch and parse (RFC 8037 OKP / Ed25519)
+ *   - KRL fetch and parse (revoked kid set)
+ *   - in-memory key cache keyed by `kid`
+ *   - refresh-on-unknown-kid (called externally; one retry is the contract)
+ *   - fail-closed on any parse or network failure
+ *
+ * No network calls are made at construction time.  The caller triggers I/O
+ * either explicitly via `refresh()` or implicitly via `verifyReceiptWithKeyStore`.
+ *
+ * The `fetch` option exists for test injection.  Production code leaves it
+ * unset, which falls back to `globalThis.fetch`.
+ */
+
+import { b64uDecode } from "./siftCanonical.js";
+
+// ─── Fetch abstraction ────────────────────────────────────────────────────────
+
+type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
+
+// ─── Error type ───────────────────────────────────────────────────────────────
+
+export type KeyStoreErrorCode =
+  | "JWKS_FETCH_FAILED"
+  | "KRL_FETCH_FAILED"
+  | "KEYSTORE_REFRESH_FAILED";
+
+export class KeyStoreError extends Error {
+  readonly code: KeyStoreErrorCode;
+
+  constructor(code: KeyStoreErrorCode, message: string) {
+    super(message);
+    this.name = "KeyStoreError";
+    this.code = code;
+  }
+}
+
+// ─── Public interface ─────────────────────────────────────────────────────────
+
+export interface SiftKeyStore {
+  /**
+   * Returns the raw 32-byte Ed25519 public key for `kid`, or null if the kid
+   * is not present in the current in-memory cache.  Does NOT trigger a refresh;
+   * the caller is responsible for calling refresh() before the first lookup or
+   * when an unknown kid is encountered.
+   */
+  getPublicKeyByKid(kid: string): Promise<Uint8Array | null>;
+
+  /**
+   * Returns true if `kid` is present in the current KRL revocation set.
+   * Does NOT trigger a refresh.
+   */
+  isKidRevoked(kid: string): Promise<boolean>;
+
+  /**
+   * Fetches and replaces the in-memory JWKS and KRL from the configured
+   * remote endpoints.  Both fetches run concurrently.  Throws a
+   * `KeyStoreError` on any network, HTTP, or parse failure.  The in-memory
+   * caches are only swapped if both fetches and parses succeed.
+   */
+  refresh(): Promise<void>;
+}
+
+// ─── JWKS parsing ─────────────────────────────────────────────────────────────
+
+/**
+ * Parses a JWKS response body into a Map of kid → raw 32-byte public key.
+ *
+ * Accepts only entries where:
+ *   - kty === "OKP"
+ *   - crv === "Ed25519"
+ *   - kid is a non-empty string
+ *   - x is a non-empty base64url string that decodes to exactly 32 bytes
+ *
+ * Invalid entries are silently skipped (ignoring them is safer than partially
+ * trusting a malformed entry).  If the response is not a valid JWKS object at
+ * all, throws `KeyStoreError("JWKS_FETCH_FAILED", ...)`.
+ */
+function parseJwks(body: unknown): Map<string, Uint8Array> {
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    !Array.isArray((body as Record<string, unknown>)["keys"])
+  ) {
+    throw new KeyStoreError(
+      "JWKS_FETCH_FAILED",
+      "JWKS response missing required 'keys' array"
+    );
+  }
+
+  const keys = (body as { keys: unknown[] }).keys;
+  const result = new Map<string, Uint8Array>();
+
+  for (const entry of keys) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const e = entry as Record<string, unknown>;
+
+    if (e["kty"] !== "OKP") continue;
+    if (e["crv"] !== "Ed25519") continue;
+    if (typeof e["kid"] !== "string" || e["kid"].length === 0) continue;
+    if (typeof e["x"] !== "string" || e["x"].length === 0) continue;
+
+    let raw: Buffer;
+    try {
+      raw = b64uDecode(e["x"] as string);
+    } catch {
+      continue; // invalid base64url — skip; do not partially trust
+    }
+
+    if (raw.length !== 32) continue; // wrong key size — skip
+
+    result.set(e["kid"] as string, raw);
+  }
+
+  return result;
+}
+
+// ─── KRL parsing ──────────────────────────────────────────────────────────────
+
+/**
+ * Parses a KRL response body into a Set of revoked kid strings.
+ *
+ * Requires `revoked_kids` to be a present array.  Non-string entries within
+ * the array are silently skipped (only known string values enter the revoked
+ * set — fail-closed: an unknown format entry cannot accidentally un-revoke a
+ * key).  Throws `KeyStoreError("KRL_FETCH_FAILED", ...)` if the top-level
+ * shape is not a valid KRL object.
+ *
+ * KRL signature verification is intentionally not implemented here.
+ * The structure is designed so that a verifier can be added later without
+ * refactoring: parse first, verify the parsed payload second.
+ */
+function parseKrl(body: unknown): Set<string> {
+  if (typeof body !== "object" || body === null) {
+    throw new KeyStoreError("KRL_FETCH_FAILED", "KRL response is not a JSON object");
+  }
+
+  const krl = body as Record<string, unknown>;
+
+  if (!Array.isArray(krl["revoked_kids"])) {
+    throw new KeyStoreError(
+      "KRL_FETCH_FAILED",
+      "KRL response missing required 'revoked_kids' array"
+    );
+  }
+
+  const result = new Set<string>();
+  for (const kid of krl["revoked_kids"] as unknown[]) {
+    if (typeof kid === "string") result.add(kid);
+    // Non-string entries are silently skipped.
+    // Fail-closed: only explicitly known revoked kids enter the set.
+  }
+
+  return result;
+}
+
+// ─── HTTP-backed implementation ───────────────────────────────────────────────
+
+export interface SiftHttpKeyStoreOptions {
+  jwksUrl: string;
+  krlUrl: string;
+  /**
+   * Custom fetch implementation.  Defaults to `globalThis.fetch`.
+   * Override in tests to avoid live network calls.
+   */
+  fetch?: FetchFn;
+}
+
+export class SiftHttpKeyStore implements SiftKeyStore {
+  private readonly jwksUrl: string;
+  private readonly krlUrl: string;
+  private readonly fetchFn: FetchFn;
+
+  private keyCache = new Map<string, Uint8Array>();
+  private revokedKids = new Set<string>();
+
+  constructor(opts: SiftHttpKeyStoreOptions) {
+    this.jwksUrl = opts.jwksUrl;
+    this.krlUrl = opts.krlUrl;
+    this.fetchFn = opts.fetch ?? globalThis.fetch.bind(globalThis);
+  }
+
+  async getPublicKeyByKid(kid: string): Promise<Uint8Array | null> {
+    return this.keyCache.get(kid) ?? null;
+  }
+
+  async isKidRevoked(kid: string): Promise<boolean> {
+    return this.revokedKids.has(kid);
+  }
+
+  async refresh(): Promise<void> {
+    // Fetch both endpoints concurrently.
+    let jwksRes: Response;
+    let krlRes: Response;
+    try {
+      [jwksRes, krlRes] = await Promise.all([
+        this.fetchFn(this.jwksUrl),
+        this.fetchFn(this.krlUrl),
+      ]);
+    } catch (err) {
+      throw new KeyStoreError(
+        "KEYSTORE_REFRESH_FAILED",
+        `Network error during JWKS/KRL refresh: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
+    if (!jwksRes.ok) {
+      throw new KeyStoreError(
+        "JWKS_FETCH_FAILED",
+        `JWKS endpoint returned HTTP ${jwksRes.status}`
+      );
+    }
+    if (!krlRes.ok) {
+      throw new KeyStoreError(
+        "KRL_FETCH_FAILED",
+        `KRL endpoint returned HTTP ${krlRes.status}`
+      );
+    }
+
+    let jwksBody: unknown;
+    let krlBody: unknown;
+    try {
+      [jwksBody, krlBody] = await Promise.all([
+        jwksRes.json() as Promise<unknown>,
+        krlRes.json() as Promise<unknown>,
+      ]);
+    } catch (err) {
+      throw new KeyStoreError(
+        "KEYSTORE_REFRESH_FAILED",
+        `Failed to parse JWKS/KRL JSON: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
+    // Parse both; use specific error codes on failure.
+    // Both parses must succeed before we swap the caches.
+    const newKeys = parseJwks(jwksBody);   // throws JWKS_FETCH_FAILED
+    const newRevoked = parseKrl(krlBody);  // throws KRL_FETCH_FAILED
+
+    // Atomic swap — only reached if both parses succeed.
+    this.keyCache = newKeys;
+    this.revokedKids = newRevoked;
+  }
+}
+
+// ─── Staging factory ──────────────────────────────────────────────────────────
+
+const STAGING_JWKS_URL = "https://sift-staging.walkosystems.com/sift-jwks.json";
+const STAGING_KRL_URL  = "https://sift-staging.walkosystems.com/sift-krl.json";
+
+/**
+ * Returns a new `SiftHttpKeyStore` pre-configured for the Sift staging
+ * endpoints.  No network calls are made at construction time.
+ *
+ * Usage:
+ *   const keyStore = createStagingKeyStore();
+ *   await keyStore.refresh();           // or let verifyReceiptWithKeyStore do it
+ *   const result = await verifyReceiptWithKeyStore(receipt, { kid, keyStore });
+ */
+export function createStagingKeyStore(): SiftHttpKeyStore {
+  return new SiftHttpKeyStore({
+    jwksUrl: STAGING_JWKS_URL,
+    krlUrl: STAGING_KRL_URL,
+  });
+}

--- a/packages/sift/src/verifyReceipt.ts
+++ b/packages/sift/src/verifyReceipt.ts
@@ -5,6 +5,10 @@ import {
   b64uDecode,
   publicKeyFromRaw,
 } from "./siftCanonical.js";
+import {
+  type SiftKeyStore,
+  KeyStoreError,
+} from "./siftKeyStore.js";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -55,6 +59,21 @@ export interface VerifyReceiptOptions {
   requireAllowDecision?: boolean;
 }
 
+/**
+ * Options for keystore-based receipt verification.
+ *
+ * The `kid` identifies which key in the keystore should be used to verify
+ * the receipt signature.  In production it comes from the receipt itself or
+ * from the receipt delivery context; here it is passed explicitly.
+ */
+export interface KeyStoreVerifyOptions {
+  kid: string;
+  keyStore: SiftKeyStore;
+  now?: Date;
+  maxAgeMs?: number;
+  requireAllowDecision?: boolean;
+}
+
 export type VerifyReceiptErrorCode =
   | "MALFORMED_RECEIPT"
   | "UNSUPPORTED_RECEIPT_VERSION"
@@ -65,7 +84,14 @@ export type VerifyReceiptErrorCode =
   | "INVALID_RECEIPT_HASH"
   | "INVALID_SIGNATURE"
   | "UNSUPPORTED_PUBLIC_KEY"
-  | "VERIFICATION_ERROR";
+  | "VERIFICATION_ERROR"
+  // ── keystore-path codes ──────────────────────────────────────────────────
+  | "MISSING_KID"
+  | "REVOKED_KID"
+  | "UNKNOWN_KID"
+  | "JWKS_FETCH_FAILED"
+  | "KRL_FETCH_FAILED"
+  | "KEYSTORE_REFRESH_FAILED";
 
 export type VerifyReceiptResult =
   | {
@@ -330,6 +356,92 @@ export function verifyReceipt(
     return fail(
       "VERIFICATION_ERROR",
       `Unexpected error during verification: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+
+// ─── Keystore-based verification ─────────────────────────────────────────────
+
+/**
+ * Verifies a Sift governance receipt using a `SiftKeyStore` for key resolution.
+ *
+ * Key resolution sequence:
+ *   1. Check `kid` is non-empty.
+ *   2. Check KRL — if `kid` is revoked → REVOKED_KID.
+ *   3. Look up `kid` in the keystore cache.
+ *   4. If not found (unknown kid):
+ *        a. Call `keyStore.refresh()` once.
+ *        b. Re-check KRL after refresh.
+ *        c. Re-check key lookup after refresh.
+ *        d. If still not found → UNKNOWN_KID.
+ *   5. Call `verifyReceipt` with the resolved raw key.
+ *
+ * Preserves the existing verification ordering (steps 1–6 in verifyReceipt):
+ * struct → version → receipt_hash → signature → decision → freshness.
+ * Key management (KRL + JWKS) is resolved before any receipt crypto work.
+ *
+ * No network calls are made unless the kid is unknown in the current cache
+ * or refresh() is explicitly needed.
+ */
+export async function verifyReceiptWithKeyStore(
+  receipt: unknown,
+  options: KeyStoreVerifyOptions
+): Promise<VerifyReceiptResult> {
+  const { kid, keyStore, ...verifyOpts } = options;
+
+  // 1. kid must be non-empty.
+  if (kid.length === 0) {
+    return fail("MISSING_KID", "A non-empty kid must be provided for keystore verification");
+  }
+
+  try {
+    // 2. Check revocation before any key work.
+    if (await keyStore.isKidRevoked(kid)) {
+      return fail("REVOKED_KID", `Key '${kid}' is revoked`);
+    }
+
+    // 3. Attempt key lookup from current cache.
+    let rawKey = await keyStore.getPublicKeyByKid(kid);
+
+    // 4. Unknown kid — refresh once and retry.
+    if (rawKey === null) {
+      try {
+        await keyStore.refresh();
+      } catch (err) {
+        // Map KeyStoreError codes to VerifyReceiptErrorCode directly —
+        // they are a subset of the same union type.
+        if (err instanceof KeyStoreError) {
+          return fail(err.code, err.message);
+        }
+        return fail(
+          "KEYSTORE_REFRESH_FAILED",
+          `Unexpected error during keystore refresh: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+
+      // 4b. Re-check revocation after refresh — the KRL may have been updated.
+      if (await keyStore.isKidRevoked(kid)) {
+        return fail("REVOKED_KID", `Key '${kid}' is revoked`);
+      }
+
+      // 4c. Re-check key lookup after refresh.
+      rawKey = await keyStore.getPublicKeyByKid(kid);
+
+      // 4d. Still unknown → fail closed.
+      if (rawKey === null) {
+        return fail("UNKNOWN_KID", `Key '${kid}' not found in JWKS after refresh`);
+      }
+    }
+
+    // 5. Delegate to the synchronous verifier with the resolved key.
+    return verifyReceipt(receipt, { ...verifyOpts, publicKeyRaw: rawKey });
+  } catch (err) {
+    if (err instanceof KeyStoreError) {
+      return fail(err.code, err.message);
+    }
+    return fail(
+      "VERIFICATION_ERROR",
+      `Unexpected error during keystore-based verification: ${err instanceof Error ? err.message : String(err)}`
     );
   }
 }

--- a/packages/sift/test/siftKeyStore.test.ts
+++ b/packages/sift/test/siftKeyStore.test.ts
@@ -1,0 +1,408 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Unit tests for SiftHttpKeyStore — JWKS parsing, KRL parsing, refresh
+ * lifecycle, and fail-closed behavior.
+ *
+ * All tests use an injected fetch mock.  No network calls are made.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  SiftHttpKeyStore,
+  KeyStoreError,
+} from "../src/siftKeyStore.js";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+//
+// RFC 8037 Appendix A test vector — deterministic across runs.
+//   d  (private seed, base64url-no-padding)
+//   x  (public key,   base64url-no-padding, decodes to 32 bytes)
+
+const RFC8037_X   = "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo";
+const RFC8037_KID = "key-rfc8037";
+
+const VALID_JWKS = {
+  keys: [
+    {
+      kty: "OKP",
+      crv: "Ed25519",
+      alg: "EdDSA",
+      use: "sig",
+      kid: RFC8037_KID,
+      x: RFC8037_X,
+    },
+  ],
+};
+
+const EMPTY_KRL = {
+  version: 1,
+  issuer: "sift-staging",
+  algorithm: "ed25519",
+  generated_at: "2026-01-01T00:00:00Z",
+  revoked_kids: [],
+};
+
+const KRL_WITH_REVOKED = {
+  ...EMPTY_KRL,
+  revoked_kids: [RFC8037_KID],
+};
+
+// ─── Mock fetch factory ───────────────────────────────────────────────────────
+
+type MockResponse = { status: number; body: unknown } | { status: number; error: string };
+
+function makeFetch(
+  routes: Record<string, MockResponse>
+): typeof globalThis.fetch {
+  return async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const route = routes[url];
+    if (!route) {
+      return new Response(null, { status: 404 }) as Response;
+    }
+    if ("error" in route) {
+      throw new Error(route.error);
+    }
+    return new Response(JSON.stringify(route.body), {
+      status: route.status,
+      headers: { "content-type": "application/json" },
+    }) as Response;
+  };
+}
+
+const JWKS_URL = "https://sift-staging.example.test/sift-jwks.json";
+const KRL_URL  = "https://sift-staging.example.test/sift-krl.json";
+
+function makeStore(routes: Record<string, MockResponse>): SiftHttpKeyStore {
+  return new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL,
+    krlUrl: KRL_URL,
+    fetch: makeFetch(routes),
+  });
+}
+
+function happyRoutes(): Record<string, MockResponse> {
+  return {
+    [JWKS_URL]: { status: 200, body: VALID_JWKS },
+    [KRL_URL]:  { status: 200, body: EMPTY_KRL },
+  };
+}
+
+// ─── Tests: initial state (before refresh) ───────────────────────────────────
+
+test("siftKeyStore: getPublicKeyByKid returns null before refresh", async () => {
+  const store = makeStore(happyRoutes());
+  const key = await store.getPublicKeyByKid(RFC8037_KID);
+  assert.strictEqual(key, null);
+});
+
+test("siftKeyStore: isKidRevoked returns false before refresh", async () => {
+  const store = makeStore(happyRoutes());
+  const revoked = await store.isKidRevoked(RFC8037_KID);
+  assert.strictEqual(revoked, false);
+});
+
+// ─── Tests: successful refresh ────────────────────────────────────────────────
+
+test("siftKeyStore: refresh populates key cache from JWKS", async () => {
+  const store = makeStore(happyRoutes());
+  await store.refresh();
+  const key = await store.getPublicKeyByKid(RFC8037_KID);
+  assert.ok(key !== null, "key should be found after refresh");
+  assert.strictEqual(key.length, 32, "raw key must be 32 bytes");
+});
+
+test("siftKeyStore: refreshed key matches RFC 8037 x-field decode", async () => {
+  const store = makeStore(happyRoutes());
+  await store.refresh();
+  const key = await store.getPublicKeyByKid(RFC8037_KID);
+  assert.ok(key !== null);
+
+  // Decode x manually and compare.
+  const normalized = RFC8037_X.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+  const expected = Buffer.from(normalized, "base64url");
+  assert.deepStrictEqual(Buffer.from(key), expected);
+});
+
+test("siftKeyStore: refresh loads empty KRL — no kids revoked", async () => {
+  const store = makeStore(happyRoutes());
+  await store.refresh();
+  const revoked = await store.isKidRevoked(RFC8037_KID);
+  assert.strictEqual(revoked, false);
+});
+
+test("siftKeyStore: refresh loads KRL with revoked kids", async () => {
+  const store = makeStore({
+    [JWKS_URL]: { status: 200, body: VALID_JWKS },
+    [KRL_URL]:  { status: 200, body: KRL_WITH_REVOKED },
+  });
+  await store.refresh();
+  const revoked = await store.isKidRevoked(RFC8037_KID);
+  assert.strictEqual(revoked, true);
+});
+
+test("siftKeyStore: unknown kid is not in cache after refresh", async () => {
+  const store = makeStore(happyRoutes());
+  await store.refresh();
+  const key = await store.getPublicKeyByKid("nonexistent-kid");
+  assert.strictEqual(key, null);
+});
+
+// ─── Tests: JWKS parsing edge cases ──────────────────────────────────────────
+
+test("siftKeyStore: JWKS entries with wrong kty are ignored", async () => {
+  const store = makeStore({
+    [JWKS_URL]: {
+      status: 200,
+      body: {
+        keys: [
+          { kty: "RSA", crv: "Ed25519", kid: "rsa-key", x: RFC8037_X },
+          { kty: "OKP", crv: "Ed25519", kid: RFC8037_KID, x: RFC8037_X },
+        ],
+      },
+    },
+    [KRL_URL]: { status: 200, body: EMPTY_KRL },
+  });
+  await store.refresh();
+  assert.strictEqual(await store.getPublicKeyByKid("rsa-key"), null);
+  assert.ok((await store.getPublicKeyByKid(RFC8037_KID)) !== null);
+});
+
+test("siftKeyStore: JWKS entries with wrong crv are ignored", async () => {
+  const store = makeStore({
+    [JWKS_URL]: {
+      status: 200,
+      body: {
+        keys: [
+          { kty: "OKP", crv: "P-256", kid: "p256-key", x: RFC8037_X },
+        ],
+      },
+    },
+    [KRL_URL]: { status: 200, body: EMPTY_KRL },
+  });
+  await store.refresh();
+  assert.strictEqual(await store.getPublicKeyByKid("p256-key"), null);
+});
+
+test("siftKeyStore: JWKS entries with empty kid are ignored", async () => {
+  const store = makeStore({
+    [JWKS_URL]: {
+      status: 200,
+      body: { keys: [{ kty: "OKP", crv: "Ed25519", kid: "", x: RFC8037_X }] },
+    },
+    [KRL_URL]: { status: 200, body: EMPTY_KRL },
+  });
+  await store.refresh();
+  assert.strictEqual(await store.getPublicKeyByKid(""), null);
+});
+
+test("siftKeyStore: JWKS entries with invalid base64url x are ignored", async () => {
+  const store = makeStore({
+    [JWKS_URL]: {
+      status: 200,
+      body: { keys: [{ kty: "OKP", crv: "Ed25519", kid: "bad-x", x: "!!!not-base64url!!!" }] },
+    },
+    [KRL_URL]: { status: 200, body: EMPTY_KRL },
+  });
+  // Should not throw — invalid entries are skipped.
+  await store.refresh();
+  assert.strictEqual(await store.getPublicKeyByKid("bad-x"), null);
+});
+
+test("siftKeyStore: JWKS entries with x decoding to wrong byte length are ignored", async () => {
+  // "AAEC" decodes to 3 bytes — not 32.
+  const store = makeStore({
+    [JWKS_URL]: {
+      status: 200,
+      body: { keys: [{ kty: "OKP", crv: "Ed25519", kid: "short-key", x: "AAEC" }] },
+    },
+    [KRL_URL]: { status: 200, body: EMPTY_KRL },
+  });
+  await store.refresh();
+  assert.strictEqual(await store.getPublicKeyByKid("short-key"), null);
+});
+
+test("siftKeyStore: JWKS missing keys array throws JWKS_FETCH_FAILED", async () => {
+  const store = makeStore({
+    [JWKS_URL]: { status: 200, body: { notKeys: [] } },
+    [KRL_URL]:  { status: 200, body: EMPTY_KRL },
+  });
+  await assert.rejects(
+    () => store.refresh(),
+    (err) => {
+      assert.ok(err instanceof KeyStoreError);
+      assert.strictEqual(err.code, "JWKS_FETCH_FAILED");
+      return true;
+    }
+  );
+});
+
+test("siftKeyStore: JWKS null body throws JWKS_FETCH_FAILED", async () => {
+  const store = makeStore({
+    [JWKS_URL]: { status: 200, body: null },
+    [KRL_URL]:  { status: 200, body: EMPTY_KRL },
+  });
+  await assert.rejects(
+    () => store.refresh(),
+    (err) => {
+      assert.ok(err instanceof KeyStoreError);
+      assert.strictEqual(err.code, "JWKS_FETCH_FAILED");
+      return true;
+    }
+  );
+});
+
+// ─── Tests: KRL parsing edge cases ───────────────────────────────────────────
+
+test("siftKeyStore: KRL missing revoked_kids throws KRL_FETCH_FAILED", async () => {
+  const store = makeStore({
+    [JWKS_URL]: { status: 200, body: VALID_JWKS },
+    [KRL_URL]:  { status: 200, body: { version: 1 } },
+  });
+  await assert.rejects(
+    () => store.refresh(),
+    (err) => {
+      assert.ok(err instanceof KeyStoreError);
+      assert.strictEqual(err.code, "KRL_FETCH_FAILED");
+      return true;
+    }
+  );
+});
+
+test("siftKeyStore: KRL null body throws KRL_FETCH_FAILED", async () => {
+  const store = makeStore({
+    [JWKS_URL]: { status: 200, body: VALID_JWKS },
+    [KRL_URL]:  { status: 200, body: null },
+  });
+  await assert.rejects(
+    () => store.refresh(),
+    (err) => {
+      assert.ok(err instanceof KeyStoreError);
+      assert.strictEqual(err.code, "KRL_FETCH_FAILED");
+      return true;
+    }
+  );
+});
+
+test("siftKeyStore: KRL with non-string entries in revoked_kids ignores them", async () => {
+  const store = makeStore({
+    [JWKS_URL]: { status: 200, body: VALID_JWKS },
+    [KRL_URL]:  { status: 200, body: { ...EMPTY_KRL, revoked_kids: [42, null, "real-kid", {}] } },
+  });
+  await store.refresh();
+  // Only string entries enter the revoked set.
+  assert.strictEqual(await store.isKidRevoked("real-kid"), true);
+  assert.strictEqual(await store.isKidRevoked("42"), false);
+});
+
+// ─── Tests: HTTP failures ─────────────────────────────────────────────────────
+
+test("siftKeyStore: JWKS HTTP 500 throws JWKS_FETCH_FAILED", async () => {
+  const store = makeStore({
+    [JWKS_URL]: { status: 500, body: null },
+    [KRL_URL]:  { status: 200, body: EMPTY_KRL },
+  });
+  await assert.rejects(
+    () => store.refresh(),
+    (err) => {
+      assert.ok(err instanceof KeyStoreError);
+      assert.strictEqual(err.code, "JWKS_FETCH_FAILED");
+      return true;
+    }
+  );
+});
+
+test("siftKeyStore: KRL HTTP 503 throws KRL_FETCH_FAILED", async () => {
+  const store = makeStore({
+    [JWKS_URL]: { status: 200, body: VALID_JWKS },
+    [KRL_URL]:  { status: 503, body: null },
+  });
+  await assert.rejects(
+    () => store.refresh(),
+    (err) => {
+      assert.ok(err instanceof KeyStoreError);
+      assert.strictEqual(err.code, "KRL_FETCH_FAILED");
+      return true;
+    }
+  );
+});
+
+test("siftKeyStore: network error throws KEYSTORE_REFRESH_FAILED", async () => {
+  const store = makeStore({
+    [JWKS_URL]: { status: 0, error: "connection refused" },
+    [KRL_URL]:  { status: 0, error: "connection refused" },
+  });
+  await assert.rejects(
+    () => store.refresh(),
+    (err) => {
+      assert.ok(err instanceof KeyStoreError);
+      assert.strictEqual(err.code, "KEYSTORE_REFRESH_FAILED");
+      return true;
+    }
+  );
+});
+
+// ─── Tests: atomicity — caches only swapped on full success ──────────────────
+
+test("siftKeyStore: failed refresh does not corrupt existing cache", async () => {
+  // Stateful fetch: first JWKS call returns valid data; second returns a parse
+  // failure.  Both calls are against the SAME store instance, so this test
+  // actually exercises the atomic cache-swap property.
+  const jwksCallCount = { n: 0 };
+
+  const statefulFetch: typeof globalThis.fetch = async (input) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+
+    if (url === JWKS_URL) {
+      jwksCallCount.n += 1;
+      const body =
+        jwksCallCount.n === 1
+          ? VALID_JWKS          // first refresh: valid
+          : { notKeys: [] };    // second refresh: parse failure → JWKS_FETCH_FAILED
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }) as Response;
+    }
+
+    if (url === KRL_URL) {
+      return new Response(JSON.stringify(EMPTY_KRL), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }) as Response;
+    }
+
+    return new Response(null, { status: 404 }) as Response;
+  };
+
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL,
+    krlUrl: KRL_URL,
+    fetch: statefulFetch,
+  });
+
+  // First refresh — populates the cache.
+  await store.refresh();
+  const keyBefore = await store.getPublicKeyByKid(RFC8037_KID);
+  assert.ok(keyBefore !== null, "key should be present after first refresh");
+
+  // Second refresh — JWKS parse failure; cache MUST remain intact.
+  await assert.rejects(
+    () => store.refresh(),
+    (err) => {
+      assert.ok(err instanceof KeyStoreError);
+      assert.strictEqual(err.code, "JWKS_FETCH_FAILED");
+      return true;
+    }
+  );
+
+  const keyAfter = await store.getPublicKeyByKid(RFC8037_KID);
+  assert.ok(keyAfter !== null, "key must survive a failed second refresh on the same instance");
+});

--- a/packages/sift/test/verifyReceiptWithKeyStore.test.ts
+++ b/packages/sift/test/verifyReceiptWithKeyStore.test.ts
@@ -1,0 +1,459 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Tests for verifyReceiptWithKeyStore — keystore-based key resolution, KRL
+ * enforcement, refresh-on-unknown-kid, and fail-closed behavior.
+ *
+ * All unit tests use an injected fetch mock.  No network calls are made unless
+ * SIFT_STAGING_LIVE=1 is set.
+ *
+ * Receipt building uses Sift-canonical JSON (ensure_ascii=True) and
+ * base64url-no-padding signatures to match the full contract wire format.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createHash,
+  generateKeyPairSync,
+  sign as nodeSign,
+} from "node:crypto";
+
+import { verifyReceiptWithKeyStore } from "../src/verifyReceipt.js";
+import { SiftHttpKeyStore } from "../src/siftKeyStore.js";
+import { siftCanonicalJsonBytes, b64uEncode } from "../src/siftCanonical.js";
+
+// ─── Receipt building helpers ─────────────────────────────────────────────────
+//
+// Build order matches verifyReceipt.ts exactly:
+//   ① base (no receipt_hash, no signature) → sha256(siftCanonical(①)) = receipt_hash
+//   ② withHash = ① + receipt_hash
+//   ③ signature = b64u( sign( siftCanonical( ② ) ) )
+
+interface TestKeyPair {
+  /** Raw 32-byte public key — what JWKS x encodes. */
+  publicKeyRaw: Uint8Array;
+  /** base64url of publicKeyRaw — used as JWKS x field. */
+  publicKeyJwksX: string;
+  /** PKCS8 PEM — used by Node.js signing. */
+  privateKeyPem: string;
+}
+
+const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+function makeTestKeyPair(): TestKeyPair {
+  const { publicKey: pubObj, privateKey: privObj } = generateKeyPairSync("ed25519");
+  const spkiDer = pubObj.export({ type: "spki", format: "der" }) as Buffer;
+  const publicKeyRaw = spkiDer.subarray(ED25519_SPKI_PREFIX.length);
+  return {
+    publicKeyRaw,
+    publicKeyJwksX: b64uEncode(publicKeyRaw),
+    privateKeyPem: privObj.export({ type: "pkcs8", format: "pem" }) as string,
+  };
+}
+
+const FIXED_NOW = new Date("2026-04-14T12:00:00.000Z");
+
+function buildSignedReceipt(
+  kp: TestKeyPair,
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    receipt_version: "1.0",
+    tenant_id: "tenant-test",
+    agent_id: "agent-test",
+    action: "call_tool",
+    tool: "query_database",
+    decision: "ALLOW",
+    risk_tier: 1,
+    timestamp: FIXED_NOW.toISOString(),
+    nonce: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    policy_matched: "policy-v1",
+    ...overrides,
+  };
+
+  // ① receipt_hash over base (no signature, no receipt_hash in scope)
+  const receipt_hash = createHash("sha256")
+    .update(siftCanonicalJsonBytes(base))
+    .digest("hex");
+
+  // ② signed payload = base + receipt_hash (no signature yet)
+  const withHash = { ...base, receipt_hash };
+
+  // ③ signature = base64url( sign( siftCanonical( withHash ) ) )
+  const sigBuf = nodeSign(null, siftCanonicalJsonBytes(withHash), kp.privateKeyPem);
+  const signature = b64uEncode(sigBuf);
+
+  return { ...withHash, signature };
+}
+
+// ─── Mock fetch factory ───────────────────────────────────────────────────────
+
+const JWKS_URL = "https://sift-staging.example.test/sift-jwks.json";
+const KRL_URL  = "https://sift-staging.example.test/sift-krl.json";
+
+function makeJwksBody(kp: TestKeyPair, kid: string): unknown {
+  return {
+    keys: [
+      { kty: "OKP", crv: "Ed25519", alg: "EdDSA", use: "sig", kid, x: kp.publicKeyJwksX },
+    ],
+  };
+}
+
+function makeKrlBody(revokedKids: string[] = []): unknown {
+  return {
+    version: 1,
+    issuer: "sift-staging",
+    algorithm: "ed25519",
+    generated_at: "2026-01-01T00:00:00Z",
+    revoked_kids: revokedKids,
+  };
+}
+
+type MockRoutes = Record<string, { status: number; body: unknown }>;
+
+function makeFetch(routes: MockRoutes): typeof globalThis.fetch {
+  return async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const route = routes[url];
+    if (!route) return new Response(null, { status: 404 }) as Response;
+    return new Response(JSON.stringify(route.body), {
+      status: route.status,
+      headers: { "content-type": "application/json" },
+    }) as Response;
+  };
+}
+
+function makeStore(routes: MockRoutes): SiftHttpKeyStore {
+  return new SiftHttpKeyStore({ jwksUrl: JWKS_URL, krlUrl: KRL_URL, fetch: makeFetch(routes) });
+}
+
+// ─── Tests: happy path ────────────────────────────────────────────────────────
+
+test("verifyReceiptWithKeyStore: resolves key and verifies valid receipt", async () => {
+  const kp  = makeTestKeyPair();
+  const kid = "test-key-1";
+  const receipt = buildSignedReceipt(kp);
+
+  const store = makeStore({
+    [JWKS_URL]: { status: 200, body: makeJwksBody(kp, kid) },
+    [KRL_URL]:  { status: 200, body: makeKrlBody() },
+  });
+  // Pre-populate cache (avoids a refresh triggered by unknown kid).
+  await store.refresh();
+
+  const result = await verifyReceiptWithKeyStore(receipt, {
+    kid,
+    keyStore: store,
+    now: FIXED_NOW,
+    maxAgeMs: 30_000,
+  });
+
+  assert.ok(result.ok, `Expected ok but got: ${JSON.stringify(!result.ok && result)}`);
+  assert.strictEqual(result.receipt.decision, "ALLOW");
+});
+
+// ─── Tests: revocation ────────────────────────────────────────────────────────
+
+test("verifyReceiptWithKeyStore: REVOKED_KID — kid revoked before lookup", async () => {
+  const kp  = makeTestKeyPair();
+  const kid = "revoked-key";
+  const receipt = buildSignedReceipt(kp);
+
+  const store = makeStore({
+    [JWKS_URL]: { status: 200, body: makeJwksBody(kp, kid) },
+    [KRL_URL]:  { status: 200, body: makeKrlBody([kid]) },
+  });
+  await store.refresh();
+
+  const result = await verifyReceiptWithKeyStore(receipt, {
+    kid,
+    keyStore: store,
+    now: FIXED_NOW,
+    maxAgeMs: 30_000,
+  });
+
+  assert.strictEqual(result.ok, false);
+  assert.ok(!result.ok);
+  assert.strictEqual(result.code, "REVOKED_KID");
+});
+
+// ─── Tests: unknown kid — refresh-on-unknown-kid ──────────────────────────────
+
+test("verifyReceiptWithKeyStore: unknown kid triggers refresh and succeeds", async () => {
+  const kp  = makeTestKeyPair();
+  const kid = "new-key-after-refresh";
+  const receipt = buildSignedReceipt(kp);
+
+  // Store starts empty (no keys in cache) — kid will be unknown on first lookup.
+  // On refresh it will find the key in JWKS.
+  const store = makeStore({
+    [JWKS_URL]: { status: 200, body: makeJwksBody(kp, kid) },
+    [KRL_URL]:  { status: 200, body: makeKrlBody() },
+  });
+  // Do NOT pre-populate cache — this exercises the refresh-on-unknown-kid path.
+
+  const result = await verifyReceiptWithKeyStore(receipt, {
+    kid,
+    keyStore: store,
+    now: FIXED_NOW,
+    maxAgeMs: 30_000,
+  });
+
+  assert.ok(result.ok, `Expected ok after refresh but got: ${JSON.stringify(!result.ok && result)}`);
+});
+
+test("verifyReceiptWithKeyStore: unknown kid — still unknown after refresh → UNKNOWN_KID", async () => {
+  const kp  = makeTestKeyPair();
+  const kid = "nonexistent-kid";
+  const receipt = buildSignedReceipt(kp);
+
+  // JWKS doesn't contain this kid — even after refresh.
+  const store = makeStore({
+    [JWKS_URL]: { status: 200, body: { keys: [] } },
+    [KRL_URL]:  { status: 200, body: makeKrlBody() },
+  });
+
+  const result = await verifyReceiptWithKeyStore(receipt, {
+    kid,
+    keyStore: store,
+    now: FIXED_NOW,
+    maxAgeMs: 30_000,
+  });
+
+  assert.strictEqual(result.ok, false);
+  assert.ok(!result.ok);
+  assert.strictEqual(result.code, "UNKNOWN_KID");
+});
+
+test("verifyReceiptWithKeyStore: kid revoked after refresh → REVOKED_KID", async () => {
+  const kp  = makeTestKeyPair();
+  const kid = "key-revoked-on-refresh";
+  const receipt = buildSignedReceipt(kp);
+
+  // Key is in JWKS (so lookup succeeds after refresh) BUT also in KRL.
+  // This exercises the post-refresh revocation re-check.
+  const store = makeStore({
+    [JWKS_URL]: { status: 200, body: makeJwksBody(kp, kid) },
+    [KRL_URL]:  { status: 200, body: makeKrlBody([kid]) },
+  });
+  // Do NOT pre-populate — forces the refresh path, which then re-checks KRL.
+
+  const result = await verifyReceiptWithKeyStore(receipt, {
+    kid,
+    keyStore: store,
+    now: FIXED_NOW,
+    maxAgeMs: 30_000,
+  });
+
+  assert.strictEqual(result.ok, false);
+  assert.ok(!result.ok);
+  assert.strictEqual(result.code, "REVOKED_KID");
+});
+
+// ─── Tests: refresh failures ──────────────────────────────────────────────────
+
+test("verifyReceiptWithKeyStore: JWKS fetch failure on refresh → JWKS_FETCH_FAILED", async () => {
+  const kp  = makeTestKeyPair();
+  const kid = "any-kid";
+  const receipt = buildSignedReceipt(kp);
+
+  const store = makeStore({
+    [JWKS_URL]: { status: 500, body: null },
+    [KRL_URL]:  { status: 200, body: makeKrlBody() },
+  });
+
+  const result = await verifyReceiptWithKeyStore(receipt, {
+    kid,
+    keyStore: store,
+    now: FIXED_NOW,
+    maxAgeMs: 30_000,
+  });
+
+  assert.strictEqual(result.ok, false);
+  assert.ok(!result.ok);
+  assert.strictEqual(result.code, "JWKS_FETCH_FAILED");
+});
+
+test("verifyReceiptWithKeyStore: KRL fetch failure on refresh → KRL_FETCH_FAILED", async () => {
+  const kp  = makeTestKeyPair();
+  const kid = "any-kid";
+  const receipt = buildSignedReceipt(kp);
+
+  const store = makeStore({
+    [JWKS_URL]: { status: 200, body: makeJwksBody(kp, kid) },
+    [KRL_URL]:  { status: 503, body: null },
+  });
+
+  const result = await verifyReceiptWithKeyStore(receipt, {
+    kid,
+    keyStore: store,
+    now: FIXED_NOW,
+    maxAgeMs: 30_000,
+  });
+
+  assert.strictEqual(result.ok, false);
+  assert.ok(!result.ok);
+  assert.strictEqual(result.code, "KRL_FETCH_FAILED");
+});
+
+// ─── Tests: MISSING_KID guard ─────────────────────────────────────────────────
+
+test("verifyReceiptWithKeyStore: empty kid → MISSING_KID", async () => {
+  const kp  = makeTestKeyPair();
+  const receipt = buildSignedReceipt(kp);
+
+  const store = makeStore({
+    [JWKS_URL]: { status: 200, body: makeJwksBody(kp, "some-kid") },
+    [KRL_URL]:  { status: 200, body: makeKrlBody() },
+  });
+
+  const result = await verifyReceiptWithKeyStore(receipt, {
+    kid: "",
+    keyStore: store,
+    now: FIXED_NOW,
+    maxAgeMs: 30_000,
+  });
+
+  assert.strictEqual(result.ok, false);
+  assert.ok(!result.ok);
+  assert.strictEqual(result.code, "MISSING_KID");
+});
+
+// ─── Tests: crypto failures still propagate correctly ─────────────────────────
+
+test("verifyReceiptWithKeyStore: wrong key in JWKS → INVALID_SIGNATURE", async () => {
+  const kp       = makeTestKeyPair(); // used to sign the receipt
+  const wrongKp  = makeTestKeyPair(); // different key stored in JWKS
+  const kid      = "wrong-key";
+  const receipt  = buildSignedReceipt(kp);
+
+  const store = makeStore({
+    [JWKS_URL]: { status: 200, body: makeJwksBody(wrongKp, kid) },
+    [KRL_URL]:  { status: 200, body: makeKrlBody() },
+  });
+  await store.refresh();
+
+  const result = await verifyReceiptWithKeyStore(receipt, {
+    kid,
+    keyStore: store,
+    now: FIXED_NOW,
+    maxAgeMs: 30_000,
+  });
+
+  assert.strictEqual(result.ok, false);
+  assert.ok(!result.ok);
+  assert.strictEqual(result.code, "INVALID_SIGNATURE");
+});
+
+test("verifyReceiptWithKeyStore: malformed receipt → MALFORMED_RECEIPT", async () => {
+  const kp  = makeTestKeyPair();
+  const kid = "test-key";
+
+  const store = makeStore({
+    [JWKS_URL]: { status: 200, body: makeJwksBody(kp, kid) },
+    [KRL_URL]:  { status: 200, body: makeKrlBody() },
+  });
+  await store.refresh();
+
+  const result = await verifyReceiptWithKeyStore(
+    { not_a_receipt: true },
+    { kid, keyStore: store, now: FIXED_NOW }
+  );
+
+  assert.strictEqual(result.ok, false);
+  assert.ok(!result.ok);
+  assert.strictEqual(result.code, "MALFORMED_RECEIPT");
+});
+
+test("verifyReceiptWithKeyStore: DENY receipt → DENY_DECISION", async () => {
+  const kp  = makeTestKeyPair();
+  const kid = "test-key";
+  const receipt = buildSignedReceipt(kp, { decision: "DENY" });
+
+  const store = makeStore({
+    [JWKS_URL]: { status: 200, body: makeJwksBody(kp, kid) },
+    [KRL_URL]:  { status: 200, body: makeKrlBody() },
+  });
+  await store.refresh();
+
+  const result = await verifyReceiptWithKeyStore(receipt, {
+    kid,
+    keyStore: store,
+    now: FIXED_NOW,
+    maxAgeMs: 30_000,
+  });
+
+  assert.strictEqual(result.ok, false);
+  assert.ok(!result.ok);
+  assert.strictEqual(result.code, "DENY_DECISION");
+});
+
+// ─── Live staging integration test (opt-in) ───────────────────────────────────
+//
+// Gated by SIFT_STAGING_LIVE=1.  Not executed in CI by default.
+//
+// Validates:
+//   - JWKS endpoint is reachable and parses correctly
+//   - Every JWKS key decodes to exactly 32 bytes
+//   - KRL endpoint is reachable and parses correctly
+//
+// Does NOT attempt to verify a receipt — no live Sift-issued receipt is
+// available in this environment.
+
+if (process.env["SIFT_STAGING_LIVE"] === "1") {
+  const STAGING_JWKS = "https://sift-staging.walkosystems.com/sift-jwks.json";
+  const STAGING_KRL  = "https://sift-staging.walkosystems.com/sift-krl.json";
+
+  test("live: staging JWKS parses and all keys decode to 32 bytes", async () => {
+    const res = await fetch(STAGING_JWKS);
+    assert.ok(res.ok, `JWKS fetch failed: HTTP ${res.status}`);
+
+    const body = await res.json() as Record<string, unknown>;
+    assert.ok(Array.isArray(body["keys"]), "JWKS must have a 'keys' array");
+
+    const keys = body["keys"] as unknown[];
+    assert.ok(keys.length > 0, "JWKS must contain at least one key");
+
+    for (const entry of keys) {
+      if (typeof entry !== "object" || entry === null) continue;
+      const e = entry as Record<string, unknown>;
+      if (e["kty"] !== "OKP" || e["crv"] !== "Ed25519") continue;
+      if (typeof e["x"] !== "string") continue;
+
+      const normalized = (e["x"] as string)
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=/g, "");
+      const raw = Buffer.from(normalized, "base64url");
+      assert.strictEqual(
+        raw.length,
+        32,
+        `JWKS key kid=${String(e["kid"])} x field decoded to ${raw.length} bytes, expected 32`
+      );
+    }
+  });
+
+  test("live: staging KRL parses and has revoked_kids array", async () => {
+    const res = await fetch(STAGING_KRL);
+    assert.ok(res.ok, `KRL fetch failed: HTTP ${res.status}`);
+
+    const body = await res.json() as Record<string, unknown>;
+    assert.ok(Array.isArray(body["revoked_kids"]), "KRL must have a 'revoked_kids' array");
+
+    const revokedKids = body["revoked_kids"] as unknown[];
+    for (const kid of revokedKids) {
+      assert.strictEqual(typeof kid, "string", `revoked_kids entry is not a string: ${String(kid)}`);
+    }
+  });
+
+  test("live: createStagingKeyStore refresh succeeds and loads at least one key", async () => {
+    const { createStagingKeyStore } = await import("../src/siftKeyStore.js");
+    const store = createStagingKeyStore();
+    await store.refresh();
+
+    // Probe the cache with a sentinel kid that won't match anything — just
+    // confirms the store hydrated without throwing.
+    const notFound = await store.getPublicKeyByKid("__probe__");
+    assert.strictEqual(notFound, null, "probe kid should not match any real key");
+  });
+}


### PR DESCRIPTION
- add siftKeyStore runtime module
  - HTTP-backed JWKS + KRL loader
  - kid-based key lookup
  - revoked-kid enforcement
  - refresh-on-unknown-kid
  - fail-closed cache update semantics

- extend verifyReceipt with keystore-based verification path
  - supports kid-driven verification against resolved raw Ed25519 keys
  - preserves direct local-key verification path
  - adds typed errors for missing, unknown, revoked, and refresh-failed key states

- export keystore surface from package entrypoint
  - SiftKeyStore
  - SiftHttpKeyStore
  - createStagingKeyStore
  - verifyReceiptWithKeyStore
  - keystore-related error codes and types

- add unit coverage for staging verifier path
  - JWKS parsing and filtering
  - KRL parsing
  - revoked-kid behavior
  - refresh-on-unknown-kid
  - fail-closed refresh and cache atomicity
  - keystore-backed receipt verification

- update package README
  - document local-key vs keystore verification paths
  - document staging JWKS/KRL surface
  - document live staging validation flow

- update example package script surface for staging verification workflow

This change moves @oxdeai/sift from local contract reproduction to live staging verifier alignment against the real Sift key-distribution surface.