### PR TITLE
fix(sift): harden receipt integer and signature validation

### DIFF
--- a/packages/sift/README.md
+++ b/packages/sift/README.md
@@ -336,6 +336,12 @@ Key resolution sequence:
    - If still not found → `UNKNOWN_KID`.
 5. Call `verifyReceipt` with the resolved key.
 
+**KRL cache freshness.** Steps 2 and 4b check revocation against the in-memory cache only.
+A kid that is already in the key cache does **not** trigger a refresh, so a revocation added
+to the KRL after the last `refresh()` call will not be detected until the next explicit
+`refresh()`.  Callers SHOULD call `refresh()` on a schedule appropriate to their revocation
+latency requirements — not just on startup.
+
 ### Key store
 
 ```ts

--- a/packages/sift/src/verifyReceipt.ts
+++ b/packages/sift/src/verifyReceipt.ts
@@ -117,12 +117,10 @@ function isNonEmptyString(v: unknown): v is string {
 }
 
 function isFiniteNonNegativeInteger(v: unknown): v is number {
-  return (
-    typeof v === "number" &&
-    Number.isFinite(v) &&
-    Number.isInteger(v) &&
-    v >= 0
-  );
+  // Number.isSafeInteger implies finite and integer.  Unsafe integers (> 2^53 − 1)
+  // cannot be represented exactly in IEEE 754 doubles; JSON.stringify would produce
+  // a different decimal than Python's json.dumps, breaking receipt_hash verification.
+  return typeof v === "number" && Number.isSafeInteger(v) && v >= 0;
 }
 
 // ─── Structural validation ────────────────────────────────────────────────────
@@ -301,11 +299,29 @@ export function verifyReceipt(
 
     let signatureValid: boolean;
     try {
+      // ── Signature string validation ───────────────────────────────────────────
+      // Normalize before the character check so that standard base64 input
+      // (+ / =) is accepted on equal footing with base64url (- _) input.
+      const normalizedSigStr = signatureStr
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=/g, "");
+      // A 64-byte Ed25519 signature encodes to exactly 86 base64url characters
+      // (no padding).  Reject any string outside that format.
+      //
+      // Node.js's Buffer.from(..., "base64url") silently ignores characters
+      // not in the base64url alphabet, so without this guard a string like
+      // "<validBase64url>!!!" would decode to the same 64 bytes and verify
+      // successfully.  That must be INVALID_SIGNATURE, not a silent pass.
+      if (!/^[A-Za-z0-9_-]{86}$/.test(normalizedSigStr)) {
+        return fail(
+          "INVALID_SIGNATURE",
+          "Signature must be exactly 86 base64url characters (encoding a 64-byte Ed25519 signature)"
+        );
+      }
       // Sift-canonical bytes (ensure_ascii=True) for the signed scope.
       const sigInput = siftCanonicalJsonBytes(signedPayload);
-      // b64uDecode accepts both base64url (Sift-native) and standard base64
-      // (backward-compat) — see siftCanonical.ts for the normalization rationale.
-      const sigBytes = b64uDecode(signatureStr);
+      const sigBytes = Buffer.from(normalizedSigStr, "base64url");
       // null algorithm is the correct form for Ed25519 in Node.js crypto.
       signatureValid = verifySignature(null, sigInput, publicKey, sigBytes);
     } catch {

--- a/packages/sift/test/verifyReceipt.property.test.ts
+++ b/packages/sift/test/verifyReceipt.property.test.ts
@@ -784,3 +784,68 @@ test("P8: verifying a receipt with the wrong Ed25519 public key always fails wit
     { numRuns: RUNS }
   );
 });
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// H1. risk_tier must be a safe integer
+//
+// Number.isSafeInteger(Number.MAX_SAFE_INTEGER + 1) is false.  The value is
+// 9007199254740992 (= 2^53), which JavaScript stores exactly but which Python
+// json.dumps serialises differently from the JS JSON.stringify output for 2^53−1,
+// creating a cross-runtime receipt_hash mismatch.  This test confirms structural
+// validation rejects such values before any hash or signature work occurs.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test("H1: risk_tier > Number.MAX_SAFE_INTEGER is rejected without throwing", () => {
+  // Build a receipt object where risk_tier is one past the safe-integer boundary.
+  // We do not need a valid hash/signature — structural validation rejects the
+  // receipt before those checks run.
+  const { receipt, publicKeyPem } = makeSignedReceipt();
+  const mutated = cloneWithField(receipt, "risk_tier", Number.MAX_SAFE_INTEGER + 1);
+
+  let result;
+  try {
+    result = verifyReceipt(mutated, { publicKeyPem, now: FIXED_NOW });
+  } catch (e) {
+    assert.fail(`verifyReceipt threw on unsafe risk_tier: ${String(e)}`);
+    return;
+  }
+
+  assert.equal(result.ok, false, "risk_tier > MAX_SAFE_INTEGER must fail closed");
+  assert.ok(!result.ok);
+  assert.equal(result.code, "MALFORMED_RECEIPT");
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// H2. Signature strings with invalid trailing characters must be rejected
+//
+// Node.js's Buffer.from(..., "base64url") silently ignores characters not in
+// the base64url alphabet, so "<valid86chars>!!!" decodes to the same 64 bytes
+// as the clean signature.  The verifier must reject such strings rather than
+// accepting them because the underlying bytes happen to be valid.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test("H2: signature with appended invalid base64url characters is rejected with INVALID_SIGNATURE", () => {
+  const { receipt, publicKeyPem } = makeSignedReceipt();
+  const originalSig = receipt["signature"] as string;
+
+  // Confirm the original receipt verifies correctly before mutating.
+  const baseline = verifyReceipt(receipt, { publicKeyPem, now: FIXED_NOW });
+  assert.equal(baseline.ok, true, "baseline receipt must verify before mutation");
+
+  // Append three characters that are not in the base64url alphabet.
+  // Buffer.from would silently ignore them, yielding the same 64-byte signature.
+  const mutatedSig = originalSig + "!!!";
+  const mutated = cloneWithField(receipt, "signature", mutatedSig);
+
+  let result;
+  try {
+    result = verifyReceipt(mutated, { publicKeyPem, now: FIXED_NOW });
+  } catch (e) {
+    assert.fail(`verifyReceipt threw on garbage-appended signature: ${String(e)}`);
+    return;
+  }
+
+  assert.equal(result.ok, false, "signature with garbage suffix must be rejected");
+  assert.ok(!result.ok);
+  assert.equal(result.code, "INVALID_SIGNATURE");
+});


### PR DESCRIPTION
- require risk_tier to be a non-negative safe integer
- reject non-canonical signature strings before base64url decode
- document KRL refresh responsibility for cached keys
- add regression tests for unsafe integer and garbage-suffixed signature cases