### PR TITLE
fix(guard): propagate versioned state API across adapters and examples

### DIFF
--- a/examples/autogen/src/pep.ts
+++ b/examples/autogen/src/pep.ts
@@ -73,8 +73,8 @@ export async function guardedProvision(
   const guard = createAutoGenGuard({
     engine,
     agentId: AGENT_ID,
-    getState: () => state,
-    setState: (s: State) => { nextState = s; },
+    getState: () => ({ state, version: 0 }),
+    setState: (s) => { nextState = s; return true; },
     trustedKeySets: [DEMO_KEYSET],
     // Return the pre-built intent so nonce/intent_id are stable.
     mapActionToIntent: () => intent,

--- a/examples/crewai/src/pep.ts
+++ b/examples/crewai/src/pep.ts
@@ -73,8 +73,8 @@ export async function guardedProvision(
   const guard = createCrewAIGuard({
     engine,
     agentId: AGENT_ID,
-    getState: () => state,
-    setState: (s: State) => { nextState = s; },
+    getState: () => ({ state, version: 0 }),
+    setState: (s) => { nextState = s; return true; },
     trustedKeySets: [DEMO_KEYSET],
     // Return the pre-built intent so nonce/intent_id are stable.
     mapActionToIntent: () => intent,

--- a/examples/delegation-demo/src/scenario.ts
+++ b/examples/delegation-demo/src/scenario.ts
@@ -114,8 +114,8 @@ export async function runScenario(): Promise<ScenarioStep[]> {
 
   const guardA = OxDeAIGuard({
     engine,
-    getState: () => state,
-    setState: (s: State) => { state = s; },
+    getState: () => ({ state, version: 0 }),
+    setState: (s) => { state = s; return true; },
     expectedAudience: AGENT_A,
     mapActionToIntent: () => parentIntent,
     beforeExecute(_action, authorization) {
@@ -227,8 +227,8 @@ export async function runScenario(): Promise<ScenarioStep[]> {
 
   const guardB1 = OxDeAIGuard({
     engine,
-    getState: () => state,
-    setState: (s: State) => { state = s; },
+    getState: () => ({ state, version: 0 }),
+    setState: (s) => { state = s; return true; },
     expectedAudience: AGENT_A,
     mapActionToIntent: () => childIntent1,
     beforeExecute() {
@@ -291,8 +291,8 @@ export async function runScenario(): Promise<ScenarioStep[]> {
 
   const guardB2 = OxDeAIGuard({
     engine,
-    getState: () => state,
-    setState: (s: State) => { state = s; },
+    getState: () => ({ state, version: 0 }),
+    setState: (s) => { state = s; return true; },
     expectedAudience: AGENT_A,
     mapActionToIntent: () => childIntent2,
     beforeExecute() {

--- a/examples/execution-boundary-demo/src/scenario.ts
+++ b/examples/execution-boundary-demo/src/scenario.ts
@@ -87,8 +87,8 @@ export async function runScenario(): Promise<ScenarioStep[]> {
 
   const guard1 = OxDeAIGuard({
     engine,
-    getState: () => state,
-    setState: (s: State) => { state = s; },
+    getState: () => ({ state, version: 0 }),
+    setState: (s) => { state = s; return true; },
     expectedAudience: AGENT_ID,
     // chargeIntent is identical for both calls — only state differs
     mapActionToIntent: () => chargeIntent,
@@ -168,8 +168,8 @@ export async function runScenario(): Promise<ScenarioStep[]> {
 
   const guard2 = OxDeAIGuard({
     engine,
-    getState: () => state,
-    setState: (s: State) => { state = s; },
+    getState: () => ({ state, version: 0 }),
+    setState: (s) => { state = s; return true; },
     expectedAudience: AGENT_ID,
     mapActionToIntent: () => chargeIntent,
     beforeExecute() {

--- a/examples/langgraph/src/pep.ts
+++ b/examples/langgraph/src/pep.ts
@@ -73,8 +73,8 @@ export async function guardedProvision(
   const guard = createLangGraphGuard({
     engine,
     agentId: AGENT_ID,
-    getState: () => state,
-    setState: (s: State) => { nextState = s; },
+    getState: () => ({ state, version: 0 }),
+    setState: (s) => { nextState = s; return true; },
     trustedKeySets: [DEMO_KEYSET],
     // Return the pre-built intent so nonce/intent_id are stable.
     mapActionToIntent: () => intent,

--- a/examples/openai-agents-sdk/src/pep.ts
+++ b/examples/openai-agents-sdk/src/pep.ts
@@ -73,8 +73,8 @@ export async function guardedProvision(
   const guard = createOpenAIAgentsGuard({
     engine,
     agentId: AGENT_ID,
-    getState: () => state,
-    setState: (s: State) => { nextState = s; },
+    getState: () => ({ state, version: 0 }),
+    setState: (s) => { nextState = s; return true; },
     trustedKeySets: [DEMO_KEYSET],
     // Return the pre-built intent so nonce/intent_id are stable.
     mapActionToIntent: () => intent,

--- a/examples/openclaw/src/pep.ts
+++ b/examples/openclaw/src/pep.ts
@@ -71,8 +71,8 @@ export async function guardedProvision(
   const guard = createOpenClawGuard({
     engine,
     agentId: AGENT_ID,
-    getState: () => state,
-    setState: (s: State) => { nextState = s; },
+    getState: () => ({ state, version: 0 }),
+    setState: (s) => { nextState = s; return true; },
     trustedKeySets: [DEMO_KEYSET],
     // Return the pre-built intent so nonce/intent_id are stable.
     mapActionToIntent: () => intent,

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
       "langsmith": "0.5.20",
       "minimatch": ">=10.2.3",
       "lodash": ">=4.18.0",
-      "brace-expansion": ">=5.0.5"
+      "brace-expansion": ">=5.0.5",
+      "basic-ftp": ">=5.3.0"
     }
   },
   "type": "module"

--- a/packages/autogen/src/test/adapter.test.ts
+++ b/packages/autogen/src/test/adapter.test.ts
@@ -64,8 +64,8 @@ function makeGuardConfig(overrides: Partial<AutoGenGuardConfig> = {}): AutoGenGu
   return {
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
     ...overrides,
   };
@@ -109,8 +109,8 @@ test("adapter: DENY throws OxDeAIDenyError and does not call execute", async () 
   const guard = createAutoGenGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -275,8 +275,8 @@ test("adapter: ALLOW without authorization artifact throws OxDeAIAuthorizationEr
   const guard = createAutoGenGuard({
     engine: makeNoAuthEngine(state),
     agentId: AGENT_ID,
-    getState: () => state,
-    setState: () => {},
+    getState: () => ({ state, version: 0 }),
+    setState: () => true,
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -299,8 +299,8 @@ test("adapter: setState is called after successful execution", async () => {
   const guard = createAutoGenGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => makeState(),
-    setState: (s) => { storedState = s; },
+    getState: () => ({ state: makeState(), version: 0 }),
+    setState: (s) => { storedState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -317,8 +317,8 @@ test("adapter: setState is NOT called on DENY", async () => {
   const guard = createAutoGenGuard({
     engine: makeDenyEngine(),
     agentId: AGENT_ID,
-    getState: () => makeState(),
-    setState: () => { setStateCalled = true; },
+    getState: () => ({ state: makeState(), version: 0 }),
+    setState: () => { setStateCalled = true; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -346,8 +346,8 @@ test("adapter: onDecision receives DENY when blocked", async () => {
   const guard = createAutoGenGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     onDecision({ decision: d }) { decision = d; },
     trustedKeySets: [TEST_KEYSET],
   });
@@ -363,8 +363,8 @@ test("adapter: guard is reusable — multiple sequential calls work", async () =
   const guard = createAutoGenGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 

--- a/packages/autogen/src/types.ts
+++ b/packages/autogen/src/types.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import type { PolicyEngine, State } from "@oxdeai/core";
+import type { PolicyEngine } from "@oxdeai/core";
 import type { OxDeAIGuardConfig } from "@oxdeai/guard";
 
 /**
@@ -35,10 +35,10 @@ export type AutoGenToolCall = {
 export type AutoGenGuardConfig = {
   /** The PolicyEngine instance that evaluates intent policy. */
   engine: PolicyEngine;
-  /** Load the current policy state. May be async. */
-  getState: () => State | Promise<State>;
-  /** Persist the next state after a successful execution. May be async. */
-  setState: (state: State) => void | Promise<void>;
+  /** Load current state with its version token. The version is passed back to setState for CAS. May be async. */
+  getState: OxDeAIGuardConfig["getState"];
+  /** Persist next state using compare-and-set. Return true on success, false on version mismatch. May be async. */
+  setState: OxDeAIGuardConfig["setState"];
 
   /**
    * Identity of the acting agent. Injected as `context.agent_id` on every

--- a/packages/compat/src/test/cross-adapter.test.ts
+++ b/packages/compat/src/test/cross-adapter.test.ts
@@ -64,7 +64,7 @@ import {
   defaultNormalizeAction,
   OxDeAIDenyError,
 } from "@oxdeai/guard";
-import type { GuardDecisionRecord, ProposedAction } from "@oxdeai/guard";
+import type { GuardDecisionRecord, OxDeAIGuardConfig, ProposedAction } from "@oxdeai/guard";
 import { buildState } from "@oxdeai/sdk";
 
 import { createLangGraphGuard } from "@oxdeai/langgraph";
@@ -346,7 +346,7 @@ type RunnerOptions = {
    *
    * Defaults to () => structuredClone(POLICY_STATE).
    */
-  getState?: () => State;
+  getState?: OxDeAIGuardConfig["getState"];
   /**
    * Base normalizer applied before capture-wrapping. Use this to pin fields
    * (e.g. nonce) that the adapter's framework-native tool call cannot carry
@@ -363,8 +363,8 @@ async function runLangGraph(ca: ConceptualAction, opts: RunnerOptions = {}): Pro
 
   const guard = createLangGraphGuard({
     engine: opts.engine ?? ENGINE,
-    getState: opts.getState ?? (() => structuredClone(POLICY_STATE)),
-    setState: () => {},
+    getState: opts.getState ?? (() => ({ state: structuredClone(POLICY_STATE), version: 0 })),
+    setState: () => true,
     agentId: AGENT_ID,
     mapActionToIntent: norm.mapActionToIntent,
     onDecision: r => { record = r; },
@@ -403,8 +403,8 @@ async function runOpenAIAgents(ca: ConceptualAction, opts: RunnerOptions = {}): 
 
   const guard = createOpenAIAgentsGuard({
     engine: opts.engine ?? ENGINE,
-    getState: opts.getState ?? (() => structuredClone(POLICY_STATE)),
-    setState: () => {},
+    getState: opts.getState ?? (() => ({ state: structuredClone(POLICY_STATE), version: 0 })),
+    setState: () => true,
     agentId: AGENT_ID,
     mapActionToIntent: norm.mapActionToIntent,
     onDecision: r => { record = r; },
@@ -444,8 +444,8 @@ async function runCrewAI(ca: ConceptualAction, opts: RunnerOptions = {}): Promis
 
   const guard = createCrewAIGuard({
     engine: opts.engine ?? ENGINE,
-    getState: opts.getState ?? (() => structuredClone(POLICY_STATE)),
-    setState: () => {},
+    getState: opts.getState ?? (() => ({ state: structuredClone(POLICY_STATE), version: 0 })),
+    setState: () => true,
     agentId: AGENT_ID,
     mapActionToIntent: norm.mapActionToIntent,
     onDecision: r => { record = r; },
@@ -711,7 +711,7 @@ const CAP_CORPUS: ConceptualAction[] = [
 
 const capOpts: RunnerOptions = {
   engine: CAP_ENGINE,
-  getState: () => structuredClone(CAP_STATE),
+  getState: () => ({ state: structuredClone(CAP_STATE), version: 0 }),
 };
 
 for (const ca of CAP_CORPUS) {
@@ -826,7 +826,7 @@ test("cross-adapter replay: same nonce as pre-recorded state → REPLAY_NONCE ac
 
   const replayOpts: RunnerOptions = {
     engine: ENGINE,
-    getState: () => structuredClone(REPLAY_STATE),
+    getState: () => ({ state: structuredClone(REPLAY_STATE), version: 0 }),
     baseNormalizer: withFixedNonce(PINNED_NONCE),
   };
 
@@ -862,7 +862,7 @@ test("cross-adapter concurrent isolation: 30 parallel calls all ALLOW with isola
 
   const concOpts: RunnerOptions = {
     engine: CONCURRENCY_ENGINE,
-    getState: () => structuredClone(CONCURRENCY_STATE),
+    getState: () => ({ state: structuredClone(CONCURRENCY_STATE), version: 0 }),
   };
 
   const ca: ConceptualAction = {

--- a/packages/crewai/src/test/adapter.test.ts
+++ b/packages/crewai/src/test/adapter.test.ts
@@ -64,8 +64,8 @@ function makeGuardConfig(overrides: Partial<CrewAIGuardConfig> = {}): CrewAIGuar
   return {
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
     ...overrides,
   };
@@ -109,8 +109,8 @@ test("adapter: DENY throws OxDeAIDenyError and does not call execute", async () 
   const guard = createCrewAIGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -275,8 +275,8 @@ test("adapter: ALLOW without authorization artifact throws OxDeAIAuthorizationEr
   const guard = createCrewAIGuard({
     engine: makeNoAuthEngine(state),
     agentId: AGENT_ID,
-    getState: () => state,
-    setState: () => {},
+    getState: () => ({ state, version: 0 }),
+    setState: () => true,
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -299,8 +299,8 @@ test("adapter: setState is called after successful execution", async () => {
   const guard = createCrewAIGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => makeState(),
-    setState: (s) => { storedState = s; },
+    getState: () => ({ state: makeState(), version: 0 }),
+    setState: (s) => { storedState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -317,8 +317,8 @@ test("adapter: setState is NOT called on DENY", async () => {
   const guard = createCrewAIGuard({
     engine: makeDenyEngine(),
     agentId: AGENT_ID,
-    getState: () => makeState(),
-    setState: () => { setStateCalled = true; },
+    getState: () => ({ state: makeState(), version: 0 }),
+    setState: () => { setStateCalled = true; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -346,8 +346,8 @@ test("adapter: onDecision receives DENY when blocked", async () => {
   const guard = createCrewAIGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     onDecision({ decision: d }) { decision = d; },
     trustedKeySets: [TEST_KEYSET],
   });
@@ -363,8 +363,8 @@ test("adapter: guard is reusable — multiple sequential calls work", async () =
   const guard = createCrewAIGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 

--- a/packages/crewai/src/types.ts
+++ b/packages/crewai/src/types.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import type { PolicyEngine, State } from "@oxdeai/core";
+import type { PolicyEngine } from "@oxdeai/core";
 import type { OxDeAIGuardConfig } from "@oxdeai/guard";
 
 /**
@@ -35,10 +35,10 @@ export type CrewAIToolCall = {
 export type CrewAIGuardConfig = {
   /** The PolicyEngine instance that evaluates intent policy. */
   engine: PolicyEngine;
-  /** Load the current policy state. May be async. */
-  getState: () => State | Promise<State>;
-  /** Persist the next state after a successful execution. May be async. */
-  setState: (state: State) => void | Promise<void>;
+  /** Load current state with its version token. The version is passed back to setState for CAS. May be async. */
+  getState: OxDeAIGuardConfig["getState"];
+  /** Persist next state using compare-and-set. Return true on success, false on version mismatch. May be async. */
+  setState: OxDeAIGuardConfig["setState"];
 
   /**
    * Identity of the acting agent. Injected as `context.agent_id` on every

--- a/packages/guard/package.json
+++ b/packages/guard/package.json
@@ -30,6 +30,6 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "rm -rf dist && tsc -p tsconfig.json",
-    "test": "pnpm build && node --test \"dist/test/guard.test.js\" \"dist/test/guard.property.test.js\" \"dist/test/guard.delegation.test.js\" \"dist/test/guard.delegation.matrix.test.js\" \"dist/test/guard.delegation.property.test.js\" \"dist/test/guard.toctou.test.js\" \"dist/test/guard.boundary.test.js\" \"dist/test/guard.replay-store.test.js\" \"dist/test/guard.replay-store.redis.test.js\" \"dist/test/guard.authorization.test.js\" \"dist/test/guard.state-binding.test.js\""
+    "test": "pnpm build && node --test \"dist/test/guard.test.js\" \"dist/test/guard.property.test.js\" \"dist/test/guard.delegation.test.js\" \"dist/test/guard.delegation.matrix.test.js\" \"dist/test/guard.delegation.property.test.js\" \"dist/test/guard.toctou.test.js\" \"dist/test/guard.boundary.test.js\" \"dist/test/guard.replay-store.test.js\" \"dist/test/guard.replay-store.redis.test.js\" \"dist/test/guard.authorization.test.js\" \"dist/test/guard.state-binding.test.js\" \"dist/test/guard.cas.test.js\""
   }
 }

--- a/packages/guard/src/errors.ts
+++ b/packages/guard/src/errors.ts
@@ -47,6 +47,22 @@ export class OxDeAINormalizationError extends Error {
 }
 
 /**
+ * Thrown when a compare-and-set (CAS) state commit fails because the persisted
+ * version no longer matches the version read at evaluation time. This indicates
+ * a concurrent modification — another request updated state between this guard's
+ * getState() and setState() calls.
+ *
+ * Execution is blocked and no side effects are committed.
+ * Extends OxDeAIAuthorizationError so existing catch blocks remain valid.
+ */
+export class OxDeAIConflictError extends OxDeAIAuthorizationError {
+  constructor(message: string) {
+    super(message);
+    this.name = "OxDeAIConflictError";
+  }
+}
+
+/**
  * Thrown when DelegationV1 verification fails at the guard boundary.
  * Extends OxDeAIAuthorizationError so existing catch blocks remain valid.
  * The `violations` field carries structured delegation-specific failure codes.

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -8,6 +8,7 @@ import type { ReplayStore } from "./replayStore.js";
 import {
   OxDeAIDenyError,
   OxDeAIAuthorizationError,
+  OxDeAIConflictError,
   OxDeAIDelegationError,
   OxDeAIGuardConfigurationError,
   OxDeAINormalizationError,
@@ -57,16 +58,17 @@ async function fireDecision(
  *
  * Returns a reusable async guard function. Call it with a ProposedAction and
  * an execute callback. The guard will:
- *   1. Load current state.
+ *   1. Load current state + version.
  *   2. Normalize the action to an Intent.
  *   3. Evaluate policy via engine.evaluatePure().
  *   4. On DENY → throw OxDeAIDenyError (execute is never called).
  *   5. On ALLOW → verify the authorization artifact.
- *   6. Call optional beforeExecute hook.
- *   7. Invoke execute().
- *   8. Persist nextState.
- *   9. Fire onDecision audit hook.
- *  10. Return the execute() result.
+ *   6. Verify state_hash binding.
+ *   7. CAS setState(nextState, version) — throws OxDeAIConflictError on mismatch.
+ *   8. Call optional beforeExecute hook.
+ *   9. Invoke execute().
+ *  10. Fire onDecision audit hook.
+ *  11. Return the execute() result.
  *
  * Delegation path (when opts.delegation is provided):
  *   1. Normalize the action to an Intent (scope amount check).
@@ -81,6 +83,9 @@ async function fireDecision(
  *   - ALLOW without authorization → OxDeAIAuthorizationError (no execution).
  *   - ALLOW without nextState     → OxDeAIAuthorizationError (no execution).
  *   - verifyAuthorization failure → OxDeAIAuthorizationError (no execution).
+ *   - state_hash mismatch         → OxDeAIAuthorizationError (no execution, no setState).
+ *   - CAS setState returns false  → OxDeAIConflictError (no execution side effects).
+ *   - Missing version from store  → OxDeAIAuthorizationError (no execution).
  *   - Delegation chain failure    → OxDeAIDelegationError (no execution).
  *   - Scope violation             → OxDeAIDelegationError (no execution).
  *   - Normalization failure       → OxDeAINormalizationError (no execution).
@@ -112,8 +117,17 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
     execute: () => Promise<unknown>,
     opts?: GuardCallOptions
   ): Promise<unknown> {
-    // ── 1. Load state ──────────────────────────────────────────────────────
-    const state = await config.getState();
+    // ── 1. Load state + version ────────────────────────────────────────────
+    const versioned = await config.getState();
+    const state = versioned.state;
+    const version = versioned.version;
+
+    // Fail closed if the store did not return a version.
+    if (version === undefined || version === null) {
+      throw new OxDeAIAuthorizationError(
+        "State store returned no version. Cannot enforce CAS invariant. Execution blocked."
+      );
+    }
 
     // ── 2. Normalize action → intent ───────────────────────────────────────
     let intent: Intent;
@@ -363,16 +377,24 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
       );
     }
 
-    // ── 7. beforeExecute hook ──────────────────────────────────────────────
+    // ── 7. CAS state commit (before execution side effects) ──────────────
+    // Commit the new state atomically. This must happen before execute() so
+    // that a version mismatch (concurrent modification) blocks execution
+    // without committing any side effects.
+    const casOk = await config.setState(nextState, version);
+    if (!casOk) {
+      throw new OxDeAIConflictError(
+        "State version mismatch: concurrent modification detected. Execution blocked."
+      );
+    }
+
+    // ── 8. beforeExecute hook ──────────────────────────────────────────────
     if (config.beforeExecute) {
       await config.beforeExecute(action, authorization);
     }
 
-    // ── 8. Execute the side effect ─────────────────────────────────────────
+    // ── 9. Execute the side effect ─────────────────────────────────────────
     const result = await execute();
-
-    // ── 9. Persist nextState ───────────────────────────────────────────────
-    await config.setState(nextState);
 
     // ── 10. Fire audit hook ────────────────────────────────────────────────
     await fireDecision(config.onDecision, {

--- a/packages/guard/src/index.ts
+++ b/packages/guard/src/index.ts
@@ -17,6 +17,7 @@ export type { RedisClient, RedisReplayStoreConfig } from "./replayStore.redis.js
 export {
   OxDeAIDenyError,
   OxDeAIAuthorizationError,
+  OxDeAIConflictError,
   OxDeAIDelegationError,
   OxDeAIGuardConfigurationError,
   OxDeAINormalizationError,
@@ -27,4 +28,6 @@ export type {
   GuardDecisionRecord,
   GuardDelegationInput,
   GuardCallOptions,
+  StateVersion,
+  VersionedState,
 } from "./types.js";

--- a/packages/guard/src/test/guard.authorization.test.ts
+++ b/packages/guard/src/test/guard.authorization.test.ts
@@ -64,10 +64,11 @@ function makeFakeEngine(auth: AuthorizationV1) {
 
 function makeGuardConfig(auth: AuthorizationV1, overrides?: Partial<OxDeAIGuardConfig>): OxDeAIGuardConfig {
   let storedState = makeBaseState();
+  let storedVersion = 0;
   return {
     engine: makeFakeEngine(auth) as any,
-    getState: async () => storedState,
-    setState: async (s) => { storedState = s; },
+    getState: async () => ({ state: storedState, version: storedVersion }),
+    setState: async (s, v) => { if (v !== storedVersion) return false; storedState = s; storedVersion++; return true; },
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "aud-test",
     ...overrides,
@@ -202,8 +203,8 @@ test("A-5 missing trustedKeySets: OxDeAIGuardConfigurationError thrown at constr
     () => {
       OxDeAIGuard({
         engine: makeFakeEngine(auth) as any,
-        getState: async () => makeBaseState(),
-        setState: async () => {},
+        getState: async () => ({ state: makeBaseState(), version: 0 }),
+        setState: async () => true,
         expectedAudience: "aud-test",
         // trustedKeySets intentionally omitted
       } as any);

--- a/packages/guard/src/test/guard.boundary.test.ts
+++ b/packages/guard/src/test/guard.boundary.test.ts
@@ -4,7 +4,7 @@ import assert from "node:assert/strict";
 import { generateKeyPairSync } from "node:crypto";
 
 import { OxDeAIGuard } from "../index.js";
-import type { ProposedAction } from "../types.js";
+import type { ProposedAction, StateVersion } from "../types.js";
 import type { State, Intent, Authorization, AuthorizationV1, KeySet } from "@oxdeai/core";
 import {
   PolicyEngine,
@@ -74,18 +74,30 @@ function makeEngine(policyVersion = "policy-test") {
 }
 
 // ---------------------------------------------------------------------------
+// Helpers
+
+function makeVersionedStore(initial: State): {
+  getState: () => { state: State; version: StateVersion };
+  setState: (s: State, v: StateVersion) => boolean;
+} {
+  let stored = initial;
+  let version: StateVersion = 0;
+  return {
+    getState: () => ({ state: stored, version }),
+    setState: (s, v) => { if (v !== version) return false; stored = s; version = (version as number) + 1; return true; },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 
 test("expired authorization is denied (execute not called)", async () => {
   const engine = makeEngine();
   const state = makeState();
-  let storedState = state;
+  const store = makeVersionedStore(state);
   const guard = OxDeAIGuard({
     engine,
-    getState: async () => storedState,
-    setState: async (s) => {
-      storedState = s;
-    },
+    ...store,
     trustedKeySets: [TRUSTED_KEYSET],
     expectedAudience: "aud-test",
   });
@@ -106,7 +118,7 @@ test("expired authorization is denied (execute not called)", async () => {
 test("audience tampering is denied by strict verifier", async () => {
   const engine = makeEngine();
   const state = makeState();
-  let storedState = state;
+  const store = makeVersionedStore(state);
 
   const originalEval = engine.evaluatePure.bind(engine);
   engine.evaluatePure = ((intent: Intent, st: State) => {
@@ -120,10 +132,7 @@ test("audience tampering is denied by strict verifier", async () => {
 
   const guard = OxDeAIGuard({
     engine,
-    getState: async () => storedState,
-    setState: async (s) => {
-      storedState = s;
-    },
+    ...store,
     trustedKeySets: [TRUSTED_KEYSET],
     expectedAudience: "aud-test",
   });
@@ -172,13 +181,10 @@ test("auth_id replay is denied on second use", async () => {
     }
   }
 
-  let storedState = replayState;
+  const store = makeVersionedStore(replayState);
   const guard = OxDeAIGuard({
     engine: new FakeEngine() as any,
-    getState: async () => storedState,
-    setState: async (s) => {
-      storedState = s;
-    },
+    ...store,
     trustedKeySets: [TRUSTED_KEYSET],
     expectedAudience: "aud-test",
   });
@@ -231,13 +237,10 @@ test("delegation tool widening is denied", async () => {
   );
 
   const state = makeState();
-  let storedState = state;
+  const store = makeVersionedStore(state);
   const guard = OxDeAIGuard({
     engine: makeEngine(),
-    getState: async () => storedState,
-    setState: async (s) => {
-      storedState = s;
-    },
+    ...store,
     trustedKeySets: [TRUSTED_KEYSET],
     expectedAudience: "child",
   });
@@ -287,13 +290,10 @@ test("delegation amount widening is denied", async () => {
   );
 
   const state = makeState();
-  let storedState = state;
+  const store = makeVersionedStore(state);
   const guard = OxDeAIGuard({
     engine: makeEngine(),
-    getState: async () => storedState,
-    setState: async (s) => {
-      storedState = s;
-    },
+    ...store,
     trustedKeySets: [TRUSTED_KEYSET],
     expectedAudience: "child",
   });
@@ -343,13 +343,10 @@ test("delegation narrowing is allowed", async () => {
   );
 
   const state = makeState();
-  let storedState = state;
+  const store = makeVersionedStore(state);
   const guard = OxDeAIGuard({
     engine: makeEngine(),
-    getState: async () => storedState,
-    setState: async (s) => {
-      storedState = s;
-    },
+    ...store,
     trustedKeySets: [TRUSTED_KEYSET],
     expectedAudience: "child",
   });
@@ -398,13 +395,10 @@ test("delegation replay is denied", async () => {
   );
 
   const state = makeState();
-  let storedState = state;
+  const store = makeVersionedStore(state);
   const guard = OxDeAIGuard({
     engine: makeEngine(),
-    getState: async () => storedState,
-    setState: async (s) => {
-      storedState = s;
-    },
+    ...store,
     trustedKeySets: [TRUSTED_KEYSET],
     expectedAudience: "child",
   });
@@ -462,13 +456,10 @@ test("unsigned delegation is denied", async () => {
   (unsignedDelegation as any).signature = "";
 
   const state = makeState();
-  let storedState = state;
+  const store = makeVersionedStore(state);
   const guard = OxDeAIGuard({
     engine: makeEngine(),
-    getState: async () => storedState,
-    setState: async (s) => {
-      storedState = s;
-    },
+    ...store,
     trustedKeySets: [TRUSTED_KEYSET],
     expectedAudience: "child",
   });
@@ -518,13 +509,10 @@ test("tampered delegation signature is denied", async () => {
   (delegation as any).signature = "invalid-signature";
 
   const state = makeState();
-  let storedState = state;
+  const store = makeVersionedStore(state);
   const guard = OxDeAIGuard({
     engine: makeEngine(),
-    getState: async () => storedState,
-    setState: async (s) => {
-      storedState = s;
-    },
+    ...store,
     trustedKeySets: [TRUSTED_KEYSET],
     expectedAudience: "child",
   });
@@ -555,13 +543,10 @@ test("verifier failure (throws) blocks execution", async () => {
 
   const engine = makeEngine();
   const state = makeState();
-  let storedState = state;
+  const store = makeVersionedStore(state);
   const guard = OxDeAIGuard({
     engine,
-    getState: async () => storedState,
-    setState: async (s) => {
-      storedState = s;
-    },
+    ...store,
     trustedKeySets: [evilKeyset],
     expectedAudience: "aud-test",
   });
@@ -603,13 +588,10 @@ test("missing required auth fields is denied before execution", async () => {
   }
 
   const state = makeState();
-  let storedState = state;
+  const store = makeVersionedStore(state);
   const guard = OxDeAIGuard({
     engine: new FakeEngineBadAuth() as any,
-    getState: async () => storedState,
-    setState: async (s) => {
-      storedState = s;
-    },
+    ...store,
     trustedKeySets: [TRUSTED_KEYSET],
     expectedAudience: "aud-test",
   });

--- a/packages/guard/src/test/guard.cas.test.ts
+++ b/packages/guard/src/test/guard.cas.test.ts
@@ -1,0 +1,488 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * guard.cas.test.ts
+ *
+ * Regression tests for the compare-and-set (CAS) state persistence protocol
+ * at the reusable PEP boundary (issue #36).
+ *
+ * Protocol requirements:
+ *   - getState() returns { state, version }
+ *   - setState(nextState, expectedVersion) returns true on success,
+ *     false on version mismatch (concurrent modification)
+ *   - The guard throws OxDeAIConflictError and blocks execution on false
+ *   - The CAS commit happens BEFORE execute() — a mismatch has no side effects
+ *   - Missing version from the store is fail-closed (OxDeAIAuthorizationError)
+ *
+ * Test IDs: CAS-1 through CAS-6.
+ *
+ *   CAS-1  Matching version → execution allowed, setState called with correct version
+ *   CAS-2  Concurrent write advances version between read and commit → OxDeAIConflictError, execute not called
+ *   CAS-3  Concurrent double-execution simulation → second call denied via CAS
+ *   CAS-4  Missing version from store → OxDeAIAuthorizationError (fail-closed)
+ *   CAS-5  CAS failure: engine's nextState not committed, beforeExecute and execute never called
+ *   CAS-6  Determinism: identical inputs produce identical outcomes across independent guard instances
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { Authorization, Intent, State } from "@oxdeai/core";
+import { stateSnapshotHash } from "@oxdeai/core";
+
+import { OxDeAIGuard } from "../guard.js";
+import {
+  OxDeAIAuthorizationError,
+  OxDeAIConflictError,
+} from "../errors.js";
+import { TEST_KEYSET, signAuth } from "./helpers/fixtures.js";
+import type { OxDeAIGuardConfig, ProposedAction, StateVersion } from "../types.js";
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+const ACTION: ProposedAction = {
+  name: "transfer",
+  args: { amount: 100 },
+  estimatedCost: 0,
+  context: { agent_id: "agent-cas" },
+};
+
+function makeBaseState(): State {
+  return {
+    policy_version: "cas-policy",
+    period_id: "cas-p1",
+    kill_switch: { global: false, agents: {} },
+    allowlists: {},
+    budget: {
+      budget_limit: { "agent-cas": 1_000_000n },
+      spent_in_period: { "agent-cas": 0n },
+    },
+    max_amount_per_action: { "agent-cas": 1_000_000n },
+    velocity: { config: { window_seconds: 3600, max_actions: 100 }, counters: {} },
+    replay: { window_seconds: 3600, max_nonces_per_agent: 256, nonces: {} },
+    concurrency: { max_concurrent: { "agent-cas": 10 }, active: {}, active_auths: {} },
+    recursion: { max_depth: { "agent-cas": 5 } },
+    tool_limits: { window_seconds: 3600, max_calls: { "agent-cas": 100 }, calls: {} },
+  };
+}
+
+function makeFakeEngine(auth: ReturnType<typeof signAuth>) {
+  return {
+    evaluatePure(_intent: Intent, s: State) {
+      return {
+        decision: "ALLOW" as const,
+        reasons: [],
+        authorization: auth as unknown as Authorization,
+        nextState: s,
+      };
+    },
+    computeStateHash: (s: State) => stateSnapshotHash(s),
+  };
+}
+
+/**
+ * Build a CAS-aware state store.
+ * Returns { getState, setState } ready to spread into OxDeAIGuardConfig,
+ * plus helpers for inspecting and manipulating the store in tests.
+ */
+function makeCasStore(initial: State, startVersion: StateVersion = 0): {
+  getState: () => { state: State; version: StateVersion };
+  setState: (s: State, v: StateVersion) => boolean;
+  forceVersion: (v: StateVersion) => void;
+  currentVersion: () => StateVersion;
+  currentState: () => State;
+} {
+  let stored = initial;
+  let version: StateVersion = startVersion;
+  return {
+    getState: () => ({ state: stored, version }),
+    setState: (s, v) => {
+      if (v !== version) return false;
+      stored = s;
+      version = typeof version === "number"
+        ? version + 1
+        : `${parseInt(String(version), 10) + 1}`;
+      return true;
+    },
+    forceVersion: (v) => { version = v; },
+    currentVersion: () => version,
+    currentState: () => stored,
+  };
+}
+
+// ── CAS-1: Matching version → execution allowed ────────────────────────────────
+
+test("CAS-1 matching version: execution allowed and setState is called with the version read by getState", async () => {
+  const state = makeBaseState();
+  const auth = signAuth({
+    auth_id: "cas1-auth",
+    audience: "aud-test",
+    state_hash: stateSnapshotHash(state),
+  });
+
+  const store = makeCasStore(state, 0);
+  let setStateCalled = false;
+  let capturedVersion: StateVersion | undefined;
+
+  const config: OxDeAIGuardConfig = {
+    engine: makeFakeEngine(auth) as any,
+    getState: store.getState,
+    setState: (s, v) => {
+      setStateCalled = true;
+      capturedVersion = v;
+      return store.setState(s, v);
+    },
+    trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
+  };
+
+  const guard = OxDeAIGuard(config);
+  let executed = false;
+  await guard(ACTION, async () => { executed = true; });
+
+  assert.ok(executed, "execute must be called when version matches");
+  assert.ok(setStateCalled, "setState must be called on ALLOW");
+  assert.equal(capturedVersion, 0, "setState must receive the version that getState returned");
+  assert.equal(store.currentVersion(), 1, "version must be incremented after successful setState");
+});
+
+// ── CAS-2: Concurrent write advances version → OxDeAIConflictError ─────────────
+//
+// Story: guard reads version 0, a concurrent writer advances the store to
+// version 1 before the guard's setState reaches the store. The guard's
+// CAS attempt with stale version 0 is rejected.
+
+test("CAS-2 concurrent write advances version before commit: OxDeAIConflictError thrown, execute never called", async () => {
+  const state = makeBaseState();
+  const auth = signAuth({
+    auth_id: "cas2-auth",
+    audience: "aud-test",
+    state_hash: stateSnapshotHash(state),
+  });
+
+  const store = makeCasStore(state, 0);
+  let setStateAttempted = false;
+
+  const config: OxDeAIGuardConfig = {
+    engine: makeFakeEngine(auth) as any,
+    // getState returns version 0 — the version the guard will evaluate against.
+    getState: store.getState,
+    setState: (s, v) => {
+      setStateAttempted = true;
+      // Simulate: a concurrent writer commits between the guard's getState()
+      // and setState() calls, advancing the stored version from 0 to 1.
+      store.forceVersion(1);
+      // Guard presents version 0; stored version is now 1 → mismatch → false.
+      return store.setState(s, v);
+    },
+    trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
+  };
+
+  const guard = OxDeAIGuard(config);
+  let executed = false;
+
+  await assert.rejects(
+    () => guard(ACTION, async () => { executed = true; }),
+    (err: unknown) => {
+      assert.ok(
+        err instanceof OxDeAIConflictError,
+        `expected OxDeAIConflictError, got: ${Object.prototype.toString.call(err)}`
+      );
+      assert.ok(
+        err.message.includes("version mismatch") || err.message.includes("concurrent"),
+        `message must indicate version conflict, got: "${err.message}"`
+      );
+      return true;
+    }
+  );
+
+  assert.ok(!executed, "execute must not be called when concurrent write advanced the version");
+  assert.ok(setStateAttempted, "setState must have been attempted (CAS was reached before execute)");
+  // The store is at version 1 (the concurrent writer's version), not 2.
+  // The guard's proposed commit did not advance the version.
+  assert.equal(store.currentVersion(), 1,
+    "store version must reflect the concurrent write only — guard's stale commit must not have advanced it");
+});
+
+// ── CAS-3: Concurrent double-execution → second call denied via CAS ────────────
+
+test("CAS-3 concurrent double-execution: second guard call is denied when version has advanced", async () => {
+  // Simulate two guard calls racing on the same state.
+  // Both evaluate policy against version 0. The first call commits (version → 1).
+  // The second call then tries to CAS with stale version 0 → fails.
+  const state = makeBaseState();
+  const stateHash = stateSnapshotHash(state);
+
+  // Two separate auth_ids so replay detection doesn't interfere.
+  const auth1 = signAuth({ auth_id: "cas3-auth-a", audience: "aud-test", state_hash: stateHash });
+  const auth2 = signAuth({ auth_id: "cas3-auth-b", audience: "aud-test", state_hash: stateHash });
+
+  const store = makeCasStore(state, 0);
+
+  let callIndex = 0;
+  // The engine alternates auths so each guard call gets a unique auth_id.
+  const engine = {
+    evaluatePure(_intent: Intent, s: State) {
+      const auth = callIndex++ === 0 ? auth1 : auth2;
+      return {
+        decision: "ALLOW" as const,
+        reasons: [],
+        authorization: auth as unknown as Authorization,
+        nextState: s,
+      };
+    },
+    computeStateHash: (s: State) => stateSnapshotHash(s),
+  };
+
+  const config: OxDeAIGuardConfig = {
+    engine: engine as any,
+    getState: store.getState,
+    setState: store.setState,
+    trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
+  };
+
+  const guard = OxDeAIGuard(config);
+
+  // First call: succeeds, version advances to 1.
+  let firstExecuted = false;
+  await guard(ACTION, async () => { firstExecuted = true; });
+  assert.ok(firstExecuted, "first call must execute");
+  assert.equal(store.currentVersion(), 1, "version must be 1 after first call");
+
+  // Simulate stale read: a "concurrent" guard call that evaluated state at version 0.
+  // Achieved by making getState return version 0 while the real store is at version 1.
+  const staleConfig: OxDeAIGuardConfig = {
+    engine: engine as any,
+    // Frozen snapshot at version 0 — simulates a concurrent request that read state
+    // before the first call committed.
+    getState: () => ({ state, version: 0 }),
+    setState: store.setState, // shared store that will reject the stale version
+    trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
+  };
+
+  const staleGuard = OxDeAIGuard(staleConfig);
+  let secondExecuted = false;
+
+  await assert.rejects(
+    () => staleGuard(ACTION, async () => { secondExecuted = true; }),
+    (err: unknown) => {
+      assert.ok(
+        err instanceof OxDeAIConflictError,
+        `expected OxDeAIConflictError on stale CAS, got: ${Object.prototype.toString.call(err)}`
+      );
+      return true;
+    }
+  );
+
+  assert.ok(!secondExecuted, "second (stale) call must not execute");
+  assert.equal(store.currentVersion(), 1,
+    "version must remain 1 — stale CAS must not commit or advance the version");
+});
+
+// ── CAS-4: Missing version from store → OxDeAIAuthorizationError ──────────────
+
+test("CAS-4 missing version from store: OxDeAIAuthorizationError thrown (fail-closed)", async () => {
+  const state = makeBaseState();
+  const auth = signAuth({ auth_id: "cas4-auth", audience: "aud-test" });
+
+  const config: OxDeAIGuardConfig = {
+    engine: makeFakeEngine(auth) as any,
+    // Return undefined version — simulates a misconfigured or legacy store.
+    getState: () => ({ state, version: undefined as unknown as number }),
+    setState: () => true,
+    trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
+  };
+
+  const guard = OxDeAIGuard(config);
+  let executed = false;
+
+  await assert.rejects(
+    () => guard(ACTION, async () => { executed = true; }),
+    (err: unknown) => {
+      assert.ok(
+        err instanceof OxDeAIAuthorizationError,
+        `expected OxDeAIAuthorizationError, got: ${Object.prototype.toString.call(err)}`
+      );
+      // Must NOT be OxDeAIConflictError — missing version is a config error, not a race.
+      assert.ok(
+        !(err instanceof OxDeAIConflictError),
+        "missing version must throw OxDeAIAuthorizationError, not OxDeAIConflictError"
+      );
+      assert.ok(
+        err.message.includes("version") || err.message.includes("CAS"),
+        `message must indicate missing version, got: "${err.message}"`
+      );
+      return true;
+    }
+  );
+
+  assert.ok(!executed, "execute must not be called when version is missing");
+});
+
+// ── CAS-5: CAS failure — no side effects, proposed nextState not committed ─────
+//
+// Guards three invariants simultaneously:
+//   (a) beforeExecute hook is not invoked
+//   (b) execute callback is not invoked
+//   (c) the engine's proposed nextState is NOT written to the store
+//
+// Uses a distinctly modified nextState (period_id changed) so invariant (c)
+// is independently verifiable via store.currentState().
+
+test("CAS-5 CAS failure: engine's nextState not committed, beforeExecute and execute never called", async () => {
+  const state = makeBaseState();
+  const stateHash = stateSnapshotHash(state);
+  const auth = signAuth({ auth_id: "cas5-auth", audience: "aud-test", state_hash: stateHash });
+
+  const store = makeCasStore(state, 0);
+  let beforeExecuteCalled = false;
+  let executeCalled = false;
+
+  // Engine returns a structurally distinct nextState so we can verify it was not committed.
+  // state_hash in auth is computed from the current state — the binding check passes.
+  // The modified nextState is only relevant at commit time.
+  const engine = {
+    evaluatePure(_intent: Intent, s: State) {
+      const nextState: State = { ...s, period_id: "modified-by-engine" };
+      return {
+        decision: "ALLOW" as const,
+        reasons: [],
+        authorization: auth as unknown as Authorization,
+        nextState,
+      };
+    },
+    computeStateHash: (s: State) => stateSnapshotHash(s),
+  };
+
+  const config: OxDeAIGuardConfig = {
+    engine: engine as any,
+    getState: store.getState,   // returns version 0
+    setState: (s, v) => {
+      // Simulate concurrent write advancing the version before this guard commits.
+      store.forceVersion(1);
+      return store.setState(s, v); // v=0 !== stored=1 → false
+    },
+    beforeExecute: async () => { beforeExecuteCalled = true; },
+    trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
+  };
+
+  const guard = OxDeAIGuard(config);
+
+  await assert.rejects(
+    () => guard(ACTION, async () => { executeCalled = true; }),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIConflictError,
+        "must throw OxDeAIConflictError on CAS failure");
+      return true;
+    }
+  );
+
+  // (a) beforeExecute must not run
+  assert.ok(!beforeExecuteCalled,
+    "beforeExecute must NOT be called when CAS setState fails");
+
+  // (b) execute must not run
+  assert.ok(!executeCalled,
+    "execute must NOT be called when CAS setState fails");
+
+  // (c) the engine's modified nextState must not have been written to the store
+  assert.equal(store.currentState().period_id, state.period_id,
+    "store must still hold the original state — engine's nextState must not have been committed");
+
+  // Version reflects only the simulated concurrent write, not a guard-initiated commit.
+  assert.equal(store.currentVersion(), 1,
+    "version must reflect the concurrent write (1), not a successful guard commit");
+});
+
+// ── CAS-6: Determinism ─────────────────────────────────────────────────────────
+//
+// Given identical input state, version, and authorization shape, independent
+// guard instances must produce identical outcomes. Proves there is no hidden
+// mutable state in the guard factory that makes results non-deterministic.
+//
+// Each run uses a fresh guard instance (own replay store) and structurally
+// identical state + version. The same auth_id is legal here because each
+// guard has its own in-memory replay store.
+
+test("CAS-6 determinism: identical inputs produce identical outcomes across independent guard instances", async () => {
+  const RUNS = 5;
+
+  // All runs start from a structurally identical state at version 0.
+  // The auth state_hash is computed from this canonical state.
+  const canonicalState = makeBaseState();
+  const canonicalStateHash = stateSnapshotHash(canonicalState);
+
+  // Same auth shape on every run — deterministic because Ed25519 signing is
+  // deterministic (RFC 8032) and all inputs are identical.
+  const auth = signAuth({
+    auth_id: "cas6-auth",
+    audience: "aud-test",
+    state_hash: canonicalStateHash,
+  });
+
+  const engine = makeFakeEngine(auth);
+
+  type RunOutcome = {
+    executed: boolean;
+    result: unknown;
+    setStateCalledWith: StateVersion;
+    versionAfterCommit: StateVersion;
+  };
+
+  const outcomes: RunOutcome[] = [];
+
+  for (let i = 0; i < RUNS; i++) {
+    // Fresh store and guard instance each run — no shared state between runs.
+    const store = makeCasStore(makeBaseState(), 0);
+    let capturedVersion: StateVersion | undefined;
+
+    const config: OxDeAIGuardConfig = {
+      engine: engine as any,
+      getState: store.getState,
+      setState: (s, v) => {
+        capturedVersion = v;
+        return store.setState(s, v);
+      },
+      trustedKeySets: [TEST_KEYSET],
+      expectedAudience: "aud-test",
+    };
+
+    const guard = OxDeAIGuard(config);
+    let executed = false;
+    const result = await guard(ACTION, async () => {
+      executed = true;
+      return "ok";
+    });
+
+    outcomes.push({
+      executed,
+      result,
+      setStateCalledWith: capturedVersion!,
+      versionAfterCommit: store.currentVersion(),
+    });
+  }
+
+  // Each run must individually satisfy the expected outcome.
+  for (let i = 0; i < RUNS; i++) {
+    const o = outcomes[i];
+    assert.ok(o.executed,
+      `run ${i}: execute must be called on ALLOW`);
+    assert.equal(o.result, "ok",
+      `run ${i}: result must be "ok"`);
+    assert.equal(o.setStateCalledWith, 0,
+      `run ${i}: setState must be called with the version read by getState (0)`);
+    assert.equal(o.versionAfterCommit, 1,
+      `run ${i}: store version must advance to 1 after successful commit`);
+  }
+
+  // All runs must produce structurally identical outcomes — guard is deterministic.
+  const reference = outcomes[0];
+  for (let i = 1; i < RUNS; i++) {
+    assert.deepEqual(outcomes[i], reference,
+      `run ${i} must produce an identical outcome to run 0`);
+  }
+});

--- a/packages/guard/src/test/guard.delegation.matrix.test.ts
+++ b/packages/guard/src/test/guard.delegation.matrix.test.ts
@@ -81,8 +81,8 @@ function makeGuard(overrides?: Partial<OxDeAIGuardConfig>) {
   });
   return OxDeAIGuard({
     engine: new PolicyEngine({ policy_version: "v1", engine_secret: "test-secret-must-be-at-least-32-chars!!" }),
-    getState: () => state,
-    setState: () => {},
+    getState: () => ({ state, version: 0 }),
+    setState: () => true,
     trustedKeySets: [KEYSET],
     expectedAudience: "agent-A",
     ...overrides,
@@ -147,7 +147,7 @@ test("CASE-7c: delegation path does not call setState", async () => {
   );
 
   let setStateCalled = false;
-  const guard = makeGuard({ setState: () => { setStateCalled = true; } });
+  const guard = makeGuard({ setState: () => { setStateCalled = true; return true; } });
 
   await guard(action, async () => {}, { delegation: { delegation, parentAuth: parent } });
 
@@ -317,7 +317,7 @@ test("CASE-8f: setState is NOT called when delegation verification fails", async
   );
 
   let setStateCalled = false;
-  const guard = makeGuard({ setState: () => { setStateCalled = true; } });
+  const guard = makeGuard({ setState: () => { setStateCalled = true; return true; } });
 
   await assert.rejects(() => guard(action, async () => {}, { delegation: { delegation, parentAuth: parent } }));
 

--- a/packages/guard/src/test/guard.delegation.property.test.ts
+++ b/packages/guard/src/test/guard.delegation.property.test.ts
@@ -141,8 +141,8 @@ function makeGuardConfig(overrides?: Partial<OxDeAIGuardConfig>): OxDeAIGuardCon
       policy_version: "v1-test",
       engine_secret: "test-secret-must-be-at-least-32-chars!!",
     }),
-    getState: () => buildState({ agent_id: "child-agent", allow_action_types: ["PROVISION"] }),
-    setState: () => {},
+    getState: () => ({ state: buildState({ agent_id: "child-agent", allow_action_types: ["PROVISION"] }), version: 0 }),
+    setState: () => true,
     trustedKeySets: [KEYSET],
     expectedAudience: "parent-agent",
     ...overrides,
@@ -176,7 +176,7 @@ test("G-D1: any action matching delegation scope.tools is allowed; setState is n
     let executeCalled = false;
     let setStateCalled = false;
 
-    const config = makeGuardConfig({ setState: () => { setStateCalled = true; } });
+    const config = makeGuardConfig({ setState: () => { setStateCalled = true; return true; } });
     const guard = OxDeAIGuard(config);
     const action = makeAction(toolName, T_NOW);
 
@@ -268,7 +268,7 @@ test("G-D2: any invalid delegation class always blocks execution (fail-closed)",
     let executeCalled = false;
     let setStateCalled = false;
 
-    const config = makeGuardConfig({ setState: () => { setStateCalled = true; } });
+    const config = makeGuardConfig({ setState: () => { setStateCalled = true; return true; } });
     const guard = OxDeAIGuard(config);
 
     await assert.rejects(
@@ -355,7 +355,7 @@ test("G-D3: delegation presented with wrong parent authorization is rejected (DE
     let executeCalled = false;
     let setStateCalled = false;
 
-    const config = makeGuardConfig({ setState: () => { setStateCalled = true; } });
+    const config = makeGuardConfig({ setState: () => { setStateCalled = true; return true; } });
     const guard = OxDeAIGuard(config);
 
     await assert.rejects(

--- a/packages/guard/src/test/guard.delegation.test.ts
+++ b/packages/guard/src/test/guard.delegation.test.ts
@@ -88,8 +88,8 @@ function makeGuardConfig(overrides?: Partial<OxDeAIGuardConfig>): OxDeAIGuardCon
       authorization_ttl_seconds: 600,
       authorization_private_key_pem: TEST_KEYPAIR.privateKey.toString(),
     }),
-    getState: () => state,
-    setState: () => {},
+    getState: () => ({ state, version: 0 }),
+    setState: () => true,
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "agent-A",
     ...overrides,
@@ -131,7 +131,7 @@ test("delegation: does not call setState", async () => {
   const delegation = makeDelegation(parentAuth);
   let setStateCalled = false;
 
-  const config = makeGuardConfig({ setState: () => { setStateCalled = true; } });
+  const config = makeGuardConfig({ setState: () => { setStateCalled = true; return true; } });
   const guard = OxDeAIGuard(config);
 
   await guard(baseAction, async () => {}, { delegation: { delegation, parentAuth } });

--- a/packages/guard/src/test/guard.property.test.ts
+++ b/packages/guard/src/test/guard.property.test.ts
@@ -441,10 +441,11 @@ test("G1 engine DENY always prevents execute() and setState() for any ProposedAc
     let executeCalled = false;
     let setStateCalled = false;
 
+    let currentVersion = 0;
     const config: OxDeAIGuardConfig = {
       engine: makeDenyEngine(),
-      getState: () => currentState,
-      setState: (s) => { setStateCalled = true; currentState = s; },
+      getState: () => ({ state: currentState, version: currentVersion }),
+      setState: (s, v) => { setStateCalled = true; if (v !== currentVersion) return false; currentState = s; currentVersion++; return true; },
       ...BASE_TRUST,
     };
 
@@ -474,10 +475,11 @@ test("G2 missing agent_id always prevents execute() for any ProposedAction", asy
     let currentState = state;
     let executeCalled = false;
 
+    let currentVersion = 0;
     const config: OxDeAIGuardConfig = {
       engine: makeAllowEngine(currentState),
-      getState: () => currentState,
-      setState: (s) => { currentState = s; },
+      getState: () => ({ state: currentState, version: currentVersion }),
+      setState: (s, v) => { if (v !== currentVersion) return false; currentState = s; currentVersion++; return true; },
       ...BASE_TRUST,
     };
 
@@ -510,10 +512,11 @@ test("G3 ALLOW without authorization artifact always prevents execute() for any 
     let currentState = state;
     let executeCalled = false;
 
+    let currentVersion = 0;
     const config: OxDeAIGuardConfig = {
       engine: makeAllowEngineNoAuth(currentState),
-      getState: () => currentState,
-      setState: (s) => { currentState = s; },
+      getState: () => ({ state: currentState, version: currentVersion }),
+      setState: (s, v) => { if (v !== currentVersion) return false; currentState = s; currentVersion++; return true; },
       ...BASE_TRUST,
     };
 
@@ -546,10 +549,11 @@ test("G4 failed verifyAuthorization always prevents execute() for any ProposedAc
     let currentState = state;
     let executeCalled = false;
 
+    let currentVersion = 0;
     const config: OxDeAIGuardConfig = {
       engine: makeAuthFailEngine(currentState),
-      getState: () => currentState,
-      setState: (s) => { currentState = s; },
+      getState: () => ({ state: currentState, version: currentVersion }),
+      setState: (s, v) => { if (v !== currentVersion) return false; currentState = s; currentVersion++; return true; },
       ...BASE_TRUST,
     };
 
@@ -575,9 +579,9 @@ test("G4 failed verifyAuthorization always prevents execute() for any ProposedAc
   }
 });
 
-// ── G5: ALLOW always calls execute and setState ───────────────────────────────
+// ── G5: ALLOW always calls setState then execute ──────────────────────────────
 
-test("G5 successful ALLOW always calls execute() then setState() and returns result for any ProposedAction", async () => {
+test("G5 successful ALLOW always calls setState() before execute() and returns result for any ProposedAction", async () => {
   const SENTINEL = Symbol("execution-result");
 
   for (const seed of seeds()) {
@@ -586,6 +590,7 @@ test("G5 successful ALLOW always calls execute() then setState() and returns res
     const agentId = action.context?.agent_id as string;
     const state = makePermissiveState(agentId);
     let currentState = state;
+    let currentVersion = 0;
 
     let executeCalled = false;
     let setStateCalled = false;
@@ -593,11 +598,14 @@ test("G5 successful ALLOW always calls execute() then setState() and returns res
 
     const config: OxDeAIGuardConfig = {
       engine: makeAllowEngine(currentState),
-      getState: () => currentState,
-      setState: (s) => {
+      getState: () => ({ state: currentState, version: currentVersion }),
+      setState: (s, v) => {
         callOrder.push("setState");
         setStateCalled = true;
+        if (v !== currentVersion) return false;
         currentState = s;
+        currentVersion++;
+        return true;
       },
       ...BASE_TRUST,
     };
@@ -613,9 +621,9 @@ test("G5 successful ALLOW always calls execute() then setState() and returns res
     assert.ok(setStateCalled, `seed=${seed} setState must be called on ALLOW`);
     assert.equal(result, SENTINEL, `seed=${seed} guard must return the execute() result`);
 
-    // execute must happen before setState
-    assert.equal(callOrder[0], "execute", `seed=${seed} execute must be called before setState`);
-    assert.equal(callOrder[1], "setState", `seed=${seed} setState must be called after execute`);
+    // setState (CAS commit) must happen before execute
+    assert.equal(callOrder[0], "setState", `seed=${seed} setState must be called before execute`);
+    assert.equal(callOrder[1], "execute", `seed=${seed} execute must be called after setState`);
   }
 });
 
@@ -631,11 +639,12 @@ test("G6 onDecision always receives correct decision value for any outcome", asy
 
     // DENY path
     let denyDecision: string | undefined;
+    let denyVersion = 0;
     await assert.rejects(
       () => OxDeAIGuard({
         engine: makeDenyEngine(),
-        getState: () => currentState,
-        setState: (s) => { currentState = s; },
+        getState: () => ({ state: currentState, version: denyVersion }),
+        setState: (s, v) => { if (v !== denyVersion) return false; currentState = s; denyVersion++; return true; },
         onDecision: ({ decision }) => { denyDecision = decision; },
         ...BASE_TRUST,
       })(action, async () => {}),
@@ -645,10 +654,11 @@ test("G6 onDecision always receives correct decision value for any outcome", asy
 
     // ALLOW path
     let allowDecision: string | undefined;
+    let allowVersion = 0;
     await OxDeAIGuard({
       engine: makeAllowEngine(currentState),
-      getState: () => currentState,
-      setState: (s) => { currentState = s; },
+      getState: () => ({ state: currentState, version: allowVersion }),
+      setState: (s, v) => { if (v !== allowVersion) return false; currentState = s; allowVersion++; return true; },
       onDecision: ({ decision }) => { allowDecision = decision; },
       ...BASE_TRUST,
     })(action, async () => {});
@@ -666,10 +676,11 @@ test("G7 onDecision hook errors never surface to the caller for any ProposedActi
     const state = makePermissiveState(agentId);
     let currentState = state;
 
+    let currentVersion = 0;
     const guard = OxDeAIGuard({
       engine: makeAllowEngine(currentState),
-      getState: () => currentState,
-      setState: (s) => { currentState = s; },
+      getState: () => ({ state: currentState, version: currentVersion }),
+      setState: (s, v) => { if (v !== currentVersion) return false; currentState = s; currentVersion++; return true; },
       onDecision: () => { throw new Error(`seed=${seed} hook explosion`); },
       ...BASE_TRUST,
     });

--- a/packages/guard/src/test/guard.replay-store.redis.test.ts
+++ b/packages/guard/src/test/guard.replay-store.redis.test.ts
@@ -149,12 +149,18 @@ function makeGuardConfig(
   stateOverride?: { get: () => State; set: (s: State) => void }
 ): OxDeAIGuardConfig {
   let storedState = makeBaseState();
+  let storedVersion = 0;
   const get = stateOverride?.get ?? (() => storedState);
   const set = stateOverride?.set ?? ((s: State) => { storedState = s; });
   return {
     engine: makeFakeEngine(auth) as any,
-    getState: async () => get(),
-    setState: async (s) => set(s),
+    getState: async () => ({ state: get(), version: storedVersion }),
+    setState: async (s, v) => {
+      if (v !== storedVersion) return false;
+      set(s);
+      storedVersion++;
+      return true;
+    },
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "aud-test",
     replayStore: createRedisReplayStore({ client: redisClient }),
@@ -309,11 +315,10 @@ test("RS-R7 Redis error in consumeDelegationId: throws OxDeAIAuthorizationError 
   );
   const delegation = makeDelegationWithScope(parentAuth, { tools: ["pay"], max_amount: 1_000_000n });
 
-  let storedState = makeBaseState();
   const guard = OxDeAIGuard({
     engine: { evaluatePure: () => { throw new Error("should not reach engine"); } } as any,
-    getState: async () => storedState,
-    setState: async (s) => { storedState = s; },
+    getState: async () => ({ state: makeBaseState(), version: 0 }),
+    setState: async () => true,
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "agent-redis",
     replayStore: createRedisReplayStore({ client: hybridClient }),
@@ -345,20 +350,22 @@ test("RS-R8 shared Redis client: replay blocked across two distinct guard instan
   const sharedStore = createRedisReplayStore({ client: sharedFake });
 
   let stateA = makeBaseState();
+  let versionA = 0;
   const guardA = OxDeAIGuard({
     engine: makeFakeEngine(auth) as any,
-    getState: async () => stateA,
-    setState: async (s) => { stateA = s; },
+    getState: async () => ({ state: stateA, version: versionA }),
+    setState: async (s, v) => { if (v !== versionA) return false; stateA = s; versionA++; return true; },
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "aud-test",
     replayStore: sharedStore,
   });
 
   let stateB = makeBaseState();
+  let versionB = 0;
   const guardB = OxDeAIGuard({
     engine: makeFakeEngine(auth) as any,
-    getState: async () => stateB,
-    setState: async (s) => { stateB = s; },
+    getState: async () => ({ state: stateB, version: versionB }),
+    setState: async (s, v) => { if (v !== versionB) return false; stateB = s; versionB++; return true; },
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "aud-test",
     replayStore: sharedStore,

--- a/packages/guard/src/test/guard.replay-store.test.ts
+++ b/packages/guard/src/test/guard.replay-store.test.ts
@@ -75,10 +75,11 @@ function makeGuardConfig(
   overrides: Partial<OxDeAIGuardConfig> = {}
 ): OxDeAIGuardConfig {
   let storedState = makeBaseState();
+  let storedVersion = 0;
   return {
     engine: makeFakeEngine(auth) as any,
-    getState: async () => storedState,
-    setState: async (s) => { storedState = s; },
+    getState: async () => ({ state: storedState, version: storedVersion }),
+    setState: async (s, v) => { if (v !== storedVersion) return false; storedState = s; storedVersion++; return true; },
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "aud-test",
     ...overrides,
@@ -118,11 +119,10 @@ test("RS-2 default store: delegation_id replay blocked on second call to same gu
   );
   const delegation = makeDelegationWithScope(parentAuth, { tools: ["pay"], max_amount: 1_000_000n });
 
-  let storedState = makeBaseState();
   const guard = OxDeAIGuard({
     engine: { evaluatePure: () => { throw new Error("should not reach engine on delegation path"); } } as any,
-    getState: async () => storedState,
-    setState: async (s) => { storedState = s; },
+    getState: async () => ({ state: makeBaseState(), version: 0 }),
+    setState: async () => true,
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "agent-rs",
   });
@@ -183,11 +183,10 @@ test("RS-4 shared store: delegation_id replay blocked across two distinct guard 
   const delegation = makeDelegationWithScope(parentAuth, { tools: ["pay"], max_amount: 1_000_000n });
 
   function makeDelGuard() {
-    let storedState = makeBaseState();
     return OxDeAIGuard({
       engine: { evaluatePure: () => { throw new Error("should not reach engine"); } } as any,
-      getState: async () => storedState,
-      setState: async (s) => { storedState = s; },
+      getState: async () => ({ state: makeBaseState(), version: 0 }),
+      setState: async () => true,
       trustedKeySets: [TEST_KEYSET],
       expectedAudience: "agent-rs",
       replayStore: sharedStore,
@@ -260,11 +259,10 @@ test("RS-6 failing consumeDelegationId: execution blocked when store throws on d
   );
   const delegation = makeDelegationWithScope(parentAuth, { tools: ["pay"], max_amount: 1_000_000n });
 
-  let storedState = makeBaseState();
   const guard = OxDeAIGuard({
     engine: { evaluatePure: () => { throw new Error("should not reach engine"); } } as any,
-    getState: async () => storedState,
-    setState: async (s) => { storedState = s; },
+    getState: async () => ({ state: makeBaseState(), version: 0 }),
+    setState: async () => true,
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "agent-rs",
     replayStore: failingStore,
@@ -304,11 +302,10 @@ test("RS-7 store without consumeDelegationId: delegation executes; parentAuth re
   );
   const delegation = makeDelegationWithScope(parentAuth, { tools: ["pay"], max_amount: 1_000_000n });
 
-  let storedState = makeBaseState();
   const guard = OxDeAIGuard({
     engine: { evaluatePure: () => { throw new Error("should not reach engine"); } } as any,
-    getState: async () => storedState,
-    setState: async (s) => { storedState = s; },
+    getState: async () => ({ state: makeBaseState(), version: 0 }),
+    setState: async () => true,
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "agent-rs",
     replayStore: authOnlyStore,
@@ -375,11 +372,10 @@ test("RS-9 store unavailable for parentAuth auth_id: execution blocked on delega
   );
   const delegation = makeDelegationWithScope(parentAuth, { tools: ["pay"], max_amount: 1_000_000n });
 
-  let storedState = makeBaseState();
   const guard = OxDeAIGuard({
     engine: { evaluatePure: () => { throw new Error("should not reach engine"); } } as any,
-    getState: async () => storedState,
-    setState: async (s) => { storedState = s; },
+    getState: async () => ({ state: makeBaseState(), version: 0 }),
+    setState: async () => true,
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "agent-rs",
     replayStore: partialFailStore,

--- a/packages/guard/src/test/guard.state-binding.test.ts
+++ b/packages/guard/src/test/guard.state-binding.test.ts
@@ -76,10 +76,11 @@ function makeGuardConfig(
   overrides?: Partial<OxDeAIGuardConfig>
 ): OxDeAIGuardConfig {
   let stored = state;
+  let storedVersion = 0;
   return {
     engine: makeFakeEngine(auth, state) as any,
-    getState: async () => stored,
-    setState: async (s) => { stored = s; },
+    getState: async () => ({ state: stored, version: storedVersion }),
+    setState: async (s, v) => { if (v !== storedVersion) return false; stored = s; storedVersion++; return true; },
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "aud-test",
     ...overrides,
@@ -308,9 +309,9 @@ test("SB-7 null execution state: computeStateHash throws and execution is blocke
 
   const config: OxDeAIGuardConfig = {
     engine: engineWithNullGuard as any,
-    // getState returns null — simulates a broken/uninitialized state store.
-    getState: async () => null as unknown as State,
-    setState: async () => {},
+    // getState returns null state — simulates a broken/uninitialized state store.
+    getState: async () => ({ state: null as unknown as State, version: 0 }),
+    setState: async () => true,
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "aud-test",
   };
@@ -355,7 +356,7 @@ test("SB-8 boundary integrity: state_hash mismatch blocks beforeExecute, execute
 
   const config = makeGuardConfig(auth, executionState, {
     beforeExecute: async () => { beforeExecuteCalled = true; },
-    setState: async () => { setStateCalled = true; },
+    setState: async () => { setStateCalled = true; return true; },
   });
 
   const guard = OxDeAIGuard(config);

--- a/packages/guard/src/test/guard.test.ts
+++ b/packages/guard/src/test/guard.test.ts
@@ -81,10 +81,11 @@ const stubAuth: Authorization = {
 
 function makeGuardConfig(overrides: Partial<OxDeAIGuardConfig> = {}): OxDeAIGuardConfig {
   let currentState = makeState();
+  let currentVersion = 0;
   return {
     engine: makeEngine(),
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: currentVersion }),
+    setState: (s, v) => { if (v !== currentVersion) return false; currentState = s; currentVersion++; return true; },
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "aud-test",
     ...overrides,
@@ -206,11 +207,12 @@ test("defaultNormalizeAction: metadata_hash is deterministic for same args", () 
 test("guard: uses custom mapActionToIntent when provided", async () => {
   let mapperCalled = false;
   let currentState = makeState();
+  let currentVersion = 0;
 
   const config: OxDeAIGuardConfig = {
     engine: makeEngine(),
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: currentVersion }),
+    setState: (s, v) => { if (v !== currentVersion) return false; currentState = s; currentVersion++; return true; },
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "aud-test",
     mapActionToIntent(action) {
@@ -241,11 +243,12 @@ test("guard: DENY throws OxDeAIDenyError and does not call execute", async () =>
     kill_switch: { global: true, agents: {} },
   };
   let currentState = deniedState;
+  let currentVersion = 0;
 
   const config: OxDeAIGuardConfig = {
     engine: makeEngine(),
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: currentVersion }),
+    setState: (s, v) => { if (v !== currentVersion) return false; currentState = s; currentVersion++; return true; },
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "aud-test",
   };
@@ -272,13 +275,14 @@ test("guard: DENY fires onDecision hook with DENY decision", async () => {
     kill_switch: { global: true, agents: {} },
   };
   let currentState = deniedState;
+  let currentVersion = 0;
   let decisionFired = false;
   let capturedDecision: string | undefined;
 
   const config: OxDeAIGuardConfig = {
     engine: makeEngine(),
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: currentVersion }),
+    setState: (s, v) => { if (v !== currentVersion) return false; currentState = s; currentVersion++; return true; },
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "aud-test",
     onDecision({ decision }) {
@@ -340,6 +344,7 @@ test("guard: ALLOW calls beforeExecute before execute", async () => {
 
 test("guard: ALLOW without authorization artifact throws OxDeAIAuthorizationError", async () => {
   let currentState = makeState();
+  let currentVersion = 0;
 
   const mockEngine = {
     evaluatePure: () => ({
@@ -353,8 +358,8 @@ test("guard: ALLOW without authorization artifact throws OxDeAIAuthorizationErro
 
   const config: OxDeAIGuardConfig = {
     engine: mockEngine,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: currentVersion }),
+    setState: (s, v) => { if (v !== currentVersion) return false; currentState = s; currentVersion++; return true; },
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "aud-test",
   };
@@ -376,6 +381,7 @@ test("guard: ALLOW without authorization artifact throws OxDeAIAuthorizationErro
 
 test("guard: ALLOW without nextState throws OxDeAIAuthorizationError", async () => {
   let currentState = makeState();
+  let currentVersion = 0;
 
   const mockEngine = {
     evaluatePure: () => ({
@@ -389,8 +395,8 @@ test("guard: ALLOW without nextState throws OxDeAIAuthorizationError", async () 
 
   const config: OxDeAIGuardConfig = {
     engine: mockEngine,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: currentVersion }),
+    setState: (s, v) => { if (v !== currentVersion) return false; currentState = s; currentVersion++; return true; },
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "aud-test",
   };
@@ -414,6 +420,7 @@ test("guard: ALLOW without nextState throws OxDeAIAuthorizationError", async () 
 
 test("guard: failed verifyAuthorization throws OxDeAIAuthorizationError", async () => {
   let currentState = makeState();
+  let currentVersion = 0;
   // A properly-signed but expired artifact — the strict verifier will reject it with AUTH_EXPIRED.
   const expiredAuth = signAuth({ auth_id: "stub-expired", issued_at: 1_000, expiry: 2_000 });
 
@@ -428,8 +435,8 @@ test("guard: failed verifyAuthorization throws OxDeAIAuthorizationError", async 
 
   const config: OxDeAIGuardConfig = {
     engine: mockEngine,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: currentVersion }),
+    setState: (s, v) => { if (v !== currentVersion) return false; currentState = s; currentVersion++; return true; },
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "aud-test",
   };
@@ -454,11 +461,12 @@ test("guard: failed verifyAuthorization throws OxDeAIAuthorizationError", async 
 test("guard: setState is called with nextState after successful execution", async () => {
   let storedState: State | undefined;
   const initialState = makeState();
+  let storedVersion = 0;
 
   const config: OxDeAIGuardConfig = {
     engine: makeEngine(),
-    getState: () => initialState,
-    setState: (s) => { storedState = s; },
+    getState: () => ({ state: initialState, version: storedVersion }),
+    setState: (s, _v) => { storedState = s; storedVersion++; return true; },
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "aud-test",
   };
@@ -480,11 +488,12 @@ test("guard: setState is NOT called when execution is denied", async () => {
   };
   let setStateCalled = false;
   let currentState = deniedState;
+  let currentVersion = 0;
 
   const config: OxDeAIGuardConfig = {
     engine: makeEngine(),
-    getState: () => currentState,
-    setState: (s) => { setStateCalled = true; currentState = s; },
+    getState: () => ({ state: currentState, version: currentVersion }),
+    setState: (s, v) => { setStateCalled = true; if (v !== currentVersion) return false; currentState = s; currentVersion++; return true; },
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "aud-test",
   };
@@ -499,7 +508,7 @@ test("guard: setState is NOT called when execution is denied", async () => {
 
 test("OxDeAIGuard: throws OxDeAIGuardConfigurationError when engine missing", () => {
   assert.throws(
-    () => OxDeAIGuard({ engine: null as unknown as PolicyEngine, getState: () => makeState(), setState: () => {}, expectedAudience: "aud-test" }),
+    () => OxDeAIGuard({ engine: null as unknown as PolicyEngine, getState: () => ({ state: makeState(), version: 0 }), setState: () => true, expectedAudience: "aud-test" }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIGuardConfigurationError);
       return true;
@@ -509,7 +518,7 @@ test("OxDeAIGuard: throws OxDeAIGuardConfigurationError when engine missing", ()
 
 test("OxDeAIGuard: throws OxDeAIGuardConfigurationError when getState missing", () => {
   assert.throws(
-    () => OxDeAIGuard({ engine: makeEngine(), getState: null as unknown as () => State, setState: () => {}, expectedAudience: "aud-test" }),
+    () => OxDeAIGuard({ engine: makeEngine(), getState: null as unknown as () => { state: State; version: number }, setState: () => true, expectedAudience: "aud-test" }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIGuardConfigurationError);
       return true;

--- a/packages/guard/src/test/guard.toctou.test.ts
+++ b/packages/guard/src/test/guard.toctou.test.ts
@@ -47,10 +47,11 @@ function makeStatefulConfig(
   overrides: Partial<OxDeAIGuardConfig> = {}
 ): OxDeAIGuardConfig {
   let current = initialState;
+  let version = 0;
   return {
     engine,
-    getState: () => current,
-    setState: (s) => { current = s; },
+    getState: () => ({ state: current, version }),
+    setState: (s, v) => { if (v !== version) return false; current = s; version++; return true; },
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "aud-test",
     ...overrides,
@@ -182,10 +183,11 @@ test("G-3 reverification: state mutated between calls → policy re-evaluated ea
   });
 
   let current = initial;
+  let version = 0;
   const config: OxDeAIGuardConfig = {
     engine,
-    getState: () => current,
-    setState: (s) => { current = s; },
+    getState: () => ({ state: current, version }),
+    setState: (s, v) => { if (v !== version) return false; current = s; version++; return true; },
     trustedKeySets: [TEST_KEYSET],
     expectedAudience: "aud-test",
   };

--- a/packages/guard/src/types.ts
+++ b/packages/guard/src/types.ts
@@ -57,14 +57,41 @@ export type GuardDecisionRecord = {
   reasons?: string[];
 };
 
+/**
+ * Opaque version token associated with a state snapshot.
+ * Returned by getState() and passed back to setState() to enforce CAS semantics.
+ * Use a monotonically-increasing integer, ETag, or any comparable value.
+ */
+export type StateVersion = string | number;
+
+/**
+ * A state snapshot paired with its version token.
+ * Returned by getState() so the guard can detect concurrent modifications.
+ */
+export type VersionedState = {
+  state: State;
+  version: StateVersion;
+};
+
 /** Configuration for OxDeAIGuard. */
 export type OxDeAIGuardConfig = {
   /** The PolicyEngine instance that evaluates intent policy. */
   engine: PolicyEngine;
-  /** Load the current policy state. May be async. */
-  getState: () => State | Promise<State>;
-  /** Persist the next state after a successful execution. May be async. */
-  setState: (state: State) => void | Promise<void>;
+  /**
+   * Load the current policy state together with its version token.
+   * The version is passed back to setState() to enforce CAS semantics.
+   * May be async.
+   */
+  getState: () => VersionedState | Promise<VersionedState>;
+  /**
+   * Persist the next state using compare-and-set semantics.
+   * Must atomically verify that the persisted version still equals
+   * `expectedVersion` before committing `state`. Return `true` on
+   * success, `false` on version mismatch (concurrent modification).
+   * The guard throws OxDeAIConflictError and blocks execution on `false`.
+   * May be async.
+   */
+  setState: (state: State, expectedVersion: StateVersion) => boolean | Promise<boolean>;
 
   /**
    * Optional custom mapping from a ProposedAction to an OxDeAI Intent.

--- a/packages/langgraph/src/test/adapter.test.ts
+++ b/packages/langgraph/src/test/adapter.test.ts
@@ -65,8 +65,8 @@ function makeGuardConfig(overrides: Partial<LangGraphGuardConfig> = {}): LangGra
   return {
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
     ...overrides,
   };
@@ -110,8 +110,8 @@ test("adapter: DENY throws OxDeAIDenyError and does not call execute", async () 
   const guard = createLangGraphGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -276,8 +276,8 @@ test("adapter: ALLOW without authorization artifact throws OxDeAIAuthorizationEr
   const guard = createLangGraphGuard({
     engine: makeNoAuthEngine(state),
     agentId: AGENT_ID,
-    getState: () => state,
-    setState: () => {},
+    getState: () => ({ state, version: 0 }),
+    setState: () => true,
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -300,8 +300,8 @@ test("adapter: setState is called after successful execution", async () => {
   const guard = createLangGraphGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => makeState(),
-    setState: (s) => { storedState = s; },
+    getState: () => ({ state: makeState(), version: 0 }),
+    setState: (s) => { storedState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -318,8 +318,8 @@ test("adapter: setState is NOT called on DENY", async () => {
   const guard = createLangGraphGuard({
     engine: makeDenyEngine(),
     agentId: AGENT_ID,
-    getState: () => makeState(),
-    setState: () => { setStateCalled = true; },
+    getState: () => ({ state: makeState(), version: 0 }),
+    setState: () => { setStateCalled = true; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -347,8 +347,8 @@ test("adapter: onDecision receives DENY when blocked", async () => {
   const guard = createLangGraphGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     onDecision({ decision: d }) { decision = d; },
     trustedKeySets: [TEST_KEYSET],
   });
@@ -364,8 +364,8 @@ test("adapter: guard is reusable — multiple sequential calls work", async () =
   const guard = createLangGraphGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 

--- a/packages/langgraph/src/types.ts
+++ b/packages/langgraph/src/types.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import type { PolicyEngine, State } from "@oxdeai/core";
+import type { PolicyEngine } from "@oxdeai/core";
 import type { OxDeAIGuardConfig, ProposedAction } from "@oxdeai/guard";
 
 /**
@@ -37,10 +37,10 @@ export type LangGraphToolCall = {
 export type LangGraphGuardConfig = {
   /** The PolicyEngine instance that evaluates intent policy. */
   engine: PolicyEngine;
-  /** Load the current policy state. May be async. */
-  getState: () => State | Promise<State>;
-  /** Persist the next state after a successful execution. May be async. */
-  setState: (state: State) => void | Promise<void>;
+  /** Load current state with its version token. The version is passed back to setState for CAS. May be async. */
+  getState: OxDeAIGuardConfig["getState"];
+  /** Persist next state using compare-and-set. Return true on success, false on version mismatch. May be async. */
+  setState: OxDeAIGuardConfig["setState"];
 
   /**
    * Identity of the acting agent. Injected as `context.agent_id` on every

--- a/packages/openai-agents/src/test/adapter.test.ts
+++ b/packages/openai-agents/src/test/adapter.test.ts
@@ -64,8 +64,8 @@ function makeGuardConfig(overrides: Partial<OpenAIAgentsGuardConfig> = {}): Open
   return {
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
     ...overrides,
   };
@@ -109,8 +109,8 @@ test("adapter: DENY throws OxDeAIDenyError and does not call execute", async () 
   const guard = createOpenAIAgentsGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -275,8 +275,8 @@ test("adapter: ALLOW without authorization artifact throws OxDeAIAuthorizationEr
   const guard = createOpenAIAgentsGuard({
     engine: makeNoAuthEngine(state),
     agentId: AGENT_ID,
-    getState: () => state,
-    setState: () => {},
+    getState: () => ({ state, version: 0 }),
+    setState: () => true,
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -299,8 +299,8 @@ test("adapter: setState is called after successful execution", async () => {
   const guard = createOpenAIAgentsGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => makeState(),
-    setState: (s) => { storedState = s; },
+    getState: () => ({ state: makeState(), version: 0 }),
+    setState: (s) => { storedState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -317,8 +317,8 @@ test("adapter: setState is NOT called on DENY", async () => {
   const guard = createOpenAIAgentsGuard({
     engine: makeDenyEngine(),
     agentId: AGENT_ID,
-    getState: () => makeState(),
-    setState: () => { setStateCalled = true; },
+    getState: () => ({ state: makeState(), version: 0 }),
+    setState: () => { setStateCalled = true; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -346,8 +346,8 @@ test("adapter: onDecision receives DENY when blocked", async () => {
   const guard = createOpenAIAgentsGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     onDecision({ decision: d }) { decision = d; },
     trustedKeySets: [TEST_KEYSET],
   });
@@ -363,8 +363,8 @@ test("adapter: guard is reusable - multiple sequential calls work", async () => 
   const guard = createOpenAIAgentsGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 

--- a/packages/openai-agents/src/types.ts
+++ b/packages/openai-agents/src/types.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import type { PolicyEngine, State } from "@oxdeai/core";
+import type { PolicyEngine } from "@oxdeai/core";
 import type { OxDeAIGuardConfig } from "@oxdeai/guard";
 
 /**
@@ -37,10 +37,10 @@ export type OpenAIAgentsToolCall = {
 export type OpenAIAgentsGuardConfig = {
   /** The PolicyEngine instance that evaluates intent policy. */
   engine: PolicyEngine;
-  /** Load the current policy state. May be async. */
-  getState: () => State | Promise<State>;
-  /** Persist the next state after a successful execution. May be async. */
-  setState: (state: State) => void | Promise<void>;
+  /** Load current state with its version token. The version is passed back to setState for CAS. May be async. */
+  getState: OxDeAIGuardConfig["getState"];
+  /** Persist next state using compare-and-set. Return true on success, false on version mismatch. May be async. */
+  setState: OxDeAIGuardConfig["setState"];
 
   /**
    * Identity of the acting agent. Injected as `context.agent_id` on every

--- a/packages/openclaw/src/test/adapter.test.ts
+++ b/packages/openclaw/src/test/adapter.test.ts
@@ -65,8 +65,8 @@ function makeGuardConfig(overrides: Partial<OpenClawGuardConfig> = {}): OpenClaw
   return {
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
     ...overrides,
   };
@@ -110,8 +110,8 @@ test("adapter: DENY throws OxDeAIDenyError and does not call execute", async () 
   const guard = createOpenClawGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -293,8 +293,8 @@ test("adapter: ALLOW without authorization artifact throws OxDeAIAuthorizationEr
   const guard = createOpenClawGuard({
     engine: makeNoAuthEngine(state),
     agentId: AGENT_ID,
-    getState: () => state,
-    setState: () => {},
+    getState: () => ({ state, version: 0 }),
+    setState: () => true,
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -317,8 +317,8 @@ test("adapter: setState is called after successful execution", async () => {
   const guard = createOpenClawGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => makeState(),
-    setState: (s) => { storedState = s; },
+    getState: () => ({ state: makeState(), version: 0 }),
+    setState: (s) => { storedState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -335,8 +335,8 @@ test("adapter: setState is NOT called on DENY", async () => {
   const guard = createOpenClawGuard({
     engine: makeDenyEngine(),
     agentId: AGENT_ID,
-    getState: () => makeState(),
-    setState: () => { setStateCalled = true; },
+    getState: () => ({ state: makeState(), version: 0 }),
+    setState: () => { setStateCalled = true; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 
@@ -364,8 +364,8 @@ test("adapter: onDecision receives DENY when blocked", async () => {
   const guard = createOpenClawGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     onDecision({ decision: d }) { decision = d; },
     trustedKeySets: [TEST_KEYSET],
   });
@@ -381,8 +381,8 @@ test("adapter: guard is reusable — multiple sequential calls work", async () =
   const guard = createOpenClawGuard({
     engine: makeEngine(),
     agentId: AGENT_ID,
-    getState: () => currentState,
-    setState: (s) => { currentState = s; },
+    getState: () => ({ state: currentState, version: 0 }),
+    setState: (s) => { currentState = s; return true; },
     trustedKeySets: [TEST_KEYSET],
   });
 

--- a/packages/openclaw/src/types.ts
+++ b/packages/openclaw/src/types.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import type { PolicyEngine, State } from "@oxdeai/core";
+import type { PolicyEngine } from "@oxdeai/core";
 import type { OxDeAIGuardConfig } from "@oxdeai/guard";
 
 /**
@@ -40,10 +40,10 @@ export type OpenClawAction = {
 export type OpenClawGuardConfig = {
   /** The PolicyEngine instance that evaluates intent policy. */
   engine: PolicyEngine;
-  /** Load the current policy state. May be async. */
-  getState: () => State | Promise<State>;
-  /** Persist the next state after a successful execution. May be async. */
-  setState: (state: State) => void | Promise<void>;
+  /** Load current state with its version token. The version is passed back to setState for CAS. May be async. */
+  getState: OxDeAIGuardConfig["getState"];
+  /** Persist next state using compare-and-set. Return true on success, false on version mismatch. May be async. */
+  setState: OxDeAIGuardConfig["setState"];
 
   /**
    * Identity of the acting agent. Injected as `context.agent_id` on every

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   minimatch: '>=10.2.3'
   lodash: '>=4.18.0'
   brace-expansion: '>=5.0.5'
+  basic-ftp: '>=5.3.0'
 
 importers:
 
@@ -804,8 +805,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  basic-ftp@5.2.2:
-    resolution: {integrity: sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==}
+  basic-ftp@5.3.0:
+    resolution: {integrity: sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==}
     engines: {node: '>=10.0.0'}
 
   bl@4.1.0:
@@ -2006,7 +2007,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  basic-ftp@5.2.2: {}
+  basic-ftp@5.3.0: {}
 
   bl@4.1.0:
     dependencies:
@@ -2288,7 +2289,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.2.2
+      basic-ftp: 5.3.0
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:


### PR DESCRIPTION
Complete the CAS-backed reusable guard transition by propagating the new VersionedState getState/setState contract across all dependent packages, tests, and example PEP paths.

Guard boundary:
- introduce version-aware state persistence and CAS failure handling
- export updated guard surface and conflict error
- add guard.cas.test.ts and broaden reusable-boundary coverage

Adapter compatibility:
- update adapter type surfaces to derive getState/setState directly from OxDeAIGuardConfig indexed access types
- remove stale raw-State assumptions from adapter packages
- keep adapter config shapes synchronized with guard contract

Tests and examples:
- migrate adapter tests, compat cross-adapter tests, and example PEP/demo files to versioned state returns:
    - getState() → { state, version }
    - setState(nextState, expectedVersion) → boolean
- use explicit CAS success/failure semantics instead of blind writes
- preserve fail-closed behavior on missing version or stale commit

CI impact:
- restores monorepo typecheck/build/test compatibility after #36
- fixes cross-package breakage caused by old guard API assumptions
- keeps boundary semantics consistent across reusable integrations, demos, and adapter validation paths

Security properties preserved:
- state binding at execution boundary
- CAS-backed stale write rejection
- no side effects on conflict
- no blind state commit path

Result:
- guard versioned-state contract is now propagated across adapters, compat tests, and examples
- branch is aligned for pnpm typecheck, build, test, and adapter validation