### PR TITLE
chore(infra): finalize release policy, preflight tooling, and docs al…

### DIFF
--- a/docs/adapters/adapter-stack-release-notes.md
+++ b/docs/adapters/adapter-stack-release-notes.md
@@ -4,6 +4,8 @@
 
 Non-normative (developer documentation)
 
+Historical release note. This file is not current release policy and must not be used as a release runbook. Current release policy is package-scoped and lives in [`docs/release/RELEASE.md`](../release/RELEASE.md).
+
 
 
 

--- a/docs/release/RELEASE.md
+++ b/docs/release/RELEASE.md
@@ -2,170 +2,314 @@
 
 ## Status
 
-Non-normative (developer documentation)
+Normative maintainer policy.
 
+Last updated: 2026-04-22
 
+This document is the source of truth for OxDeAI release governance. `docs/release/RELEASING.md` is the executable runbook for this policy. Announcement files under `docs/release/` are communication drafts only and do not define release policy.
 
+## 1. Release Model
 
+OxDeAI uses package-scoped versions and package-scoped release tags.
 
+Each published package owns its own version line. A release of one package does not imply that any other package has the same version or must be published.
 
-Last updated: 2026-03-19
+Multiple package releases may be coordinated on the same Git commit. In that case, each released package still gets its own version, tag, changelog entry, npm publication, and GitHub release record.
 
-This document is the single source of truth for OxDeAI release governance and release execution.
+A coordinated release commit does not create a shared package version line.
 
-## 1. Scope
+## 2. Released Packages
 
-This policy covers:
+Currently released package tag prefixes:
 
-- protocol specifications and artifacts
-- release governance for published packages
-- versioning rules and breaking-change boundaries
-- release workflow, tagging, and provenance
-- validation and publication checks
+| npm package | package path | tag prefix |
+|---|---|---|
+| `@oxdeai/core` | `packages/core` | `core-vX.Y.Z` |
+| `@oxdeai/sdk` | `packages/sdk` | `sdk-vX.Y.Z` |
+| `@oxdeai/conformance` | `packages/conformance` | `conformance-vX.Y.Z` |
+| `@oxdeai/guard` | `packages/guard` | `guard-vX.Y.Z` |
+| `@oxdeai/cli` | `packages/cli` | `cli-vX.Y.Z` |
 
-Audience: maintainers, contributors, and auditors.
+Other packages in `packages/` must not be released publicly unless their package-scoped tag prefix, changelog requirement, validation gates, and npm publish target are added to this policy first.
 
-## 2. Package Groups
+Examples, demos, benchmarks, and internal tests do not define release status.
 
-Protocol stack packages (coordinated releases):
+## 3. Tag Policy
 
-- `@oxdeai/core`
-- `@oxdeai/sdk`
-- `@oxdeai/conformance`
+All new package releases must use package-scoped tags:
 
-Adapter packages (coordinated, independent version line from protocol stack):
+```text
+<package-prefix>-v<package.json version>
+```
 
-- `@oxdeai/guard`
-- `@oxdeai/langgraph`
-- `@oxdeai/openai-agents`
-- `@oxdeai/crewai`
-- `@oxdeai/autogen`
-- `@oxdeai/openclaw`
+Allowed active prefixes:
 
-Tooling package (independent release line):
+```text
+core-vX.Y.Z
+sdk-vX.Y.Z
+conformance-vX.Y.Z
+guard-vX.Y.Z
+cli-vX.Y.Z
+```
 
-- `@oxdeai/cli`
+Rules:
 
-Non-release packages for protocol versioning:
+- The tag version must exactly match the released package's `package.json` version.
+- The tag must point to the exact commit used for npm publication.
+- Prefer annotated tags. Sign tags with `-s` when maintainer signing is available.
+- Multiple package-scoped tags may point to the same commit.
+- A package-scoped tag must not be reused or moved after publication.
 
-- examples (for example `examples/openai-tools`, `examples/langgraph`)
-- internal tests (for example `@oxdeai/tests`)
+Global `vX.Y.Z` tags are legacy. Do not create new global `vX.Y.Z` tags for package releases.
 
-Examples and internal tests do not define protocol release status.
+Global tags may only be introduced for a separately documented compatibility bundle or top-level announcement. Such a bundle tag must not replace package-scoped release tags and must include an explicit manifest mapping package names, package versions, package tags, npm versions, and the Git commit.
 
-## 3. Versioning Policy
+Historical or suspicious prefixes such as `adapters-vX.Y.Z` must not be reused unless this policy is updated first.
 
-- The protocol stack (`core`, `sdk`, `conformance`) MUST move on a shared version line.
-- Protocol milestones and compatibility claims MUST map to the shared protocol stack version.
-- `@oxdeai/cli` MAY release independently until declared stable under the protocol-stack line.
-- Examples/tests MUST NOT be used as authoritative protocol version indicators.
+Historical documentation and changelog entries may mention coordinated global `vX.Y.Z` releases or shared protocol-stack version lines. Those entries explain past releases only. They are not current release policy.
 
-## 4. SemVer Rules (Protocol Stack)
+## 4. Versioning Rules
 
-### Patch (`1.0.x`)
+Each released package follows SemVer on its own version line.
 
-- MUST be backward compatible with prior `1.0.y`.
-- MUST NOT change protocol semantics:
-  - canonicalization
-  - hashing/signature binding
-  - envelope `formatVersion` behavior
-  - verification result semantics
-- MAY include:
-  - documentation clarifications
-  - schema validation tightening aligned to existing behavior
-  - CI/tooling hardening
-  - non-breaking fixes
+Patch releases should be backward compatible for that package.
 
-### Minor (`1.x.0`, `x > 0`)
+Minor releases may add backward-compatible features for that package.
 
-- Adds backward-compatible capabilities.
-- MUST preserve stable protocol artifacts from `1.0.0`.
+Major releases are required for breaking changes in that package's public API, protocol-facing behavior, or documented runtime semantics.
 
-### Major (`2.0.0+`)
+For protocol-facing packages, breaking changes include changes to:
 
-- Required for breaking protocol/API changes.
+- canonicalization behavior
+- hashing or signature binding
+- `AuthorizationV1` semantics
+- verification result semantics
+- PEP enforcement semantics
+- stable test-vector meaning
+- documented public API symbols
 
-## 5. What Is Breaking
+The current package-scoped model does not require `core`, `sdk`, and `conformance` to share one version number.
 
-The following require a major release:
+## 5. Coordinated Release Commits
 
-- Changing `VerificationResult` in a non-backward-compatible way
-- Changing `VerificationEnvelopeV1` wire semantics
-- Changing violation-code semantics used by stateless verifiers
-- Changing canonical hashing behavior for stable artifacts
-- Removing/renaming documented public API symbols
+Maintainers may release multiple packages from one commit when changes are intentionally coordinated.
 
-## 6. Tagging Policy
+For each package in a coordinated release:
 
-- Coordinated protocol stack releases MUST use repo tags `vX.Y.Z`.
-- Tags MUST point to the exact commit used for publication.
-- Package-specific tags are discouraged for coordinated protocol releases.
-- Tooling-only releases SHOULD use package-scoped tags to avoid protocol-tag ambiguity (for example `cli-v0.2.0`).
-- If package-specific tags are introduced, mapping rules to protocol tags MUST be documented first.
+- bump that package's `package.json` version
+- update that package's changelog
+- create that package's tag
+- publish that package to npm
+- create that package's GitHub release
+- verify that package's npm version
 
-## 7. Changelog Requirements
+Example: one commit may carry all of these tags:
 
-Every protocol stack release MUST be documented in:
+```text
+core-v1.7.0
+sdk-v1.3.2
+conformance-v1.5.0
+guard-v1.0.2
+```
+
+Those tags on one commit mean the releases were coordinated. They do not mean the packages share a version line.
+
+## 6. Changelog Requirements
+
+Every released package must have a changelog entry before tagging.
+
+Existing changelog paths:
 
 - `packages/core/CHANGELOG.md`
 - `packages/sdk/CHANGELOG.md`
 - `packages/conformance/CHANGELOG.md`
+- `packages/guard/CHANGELOG.md`
+- `packages/cli/CHANGELOG.md`
 
-Release notes MUST map npm versions to Git history (commit/tag references).
+The changelog entry must include:
 
-## 8. Required Validation Gates
+- package name
+- package version
+- release date
+- user-visible changes
+- security-relevant changes, if any
+- breaking changes, if any
+- migration notes, if needed
 
-All required gates MUST pass before protocol tagging/publication:
+If a package does not have a changelog, add one before its first public release and update this policy.
 
-1. `pnpm install --frozen-lockfile`
-2. `pnpm build`
-3. `pnpm test`
-4. `pnpm -C packages/core api:check`
-5. `pnpm -C packages/core api:fingerprint:check`
-6. `pnpm -C packages/conformance validate`
-7. Demo smoke checks when affected
+## 7. Required Validation Gates
 
-## 9. API Report / Fingerprint Baseline
+Run the release preflight before every public package release:
 
-Update API baselines only when API change is intentional and reviewed.
+```bash
+pnpm release:preflight --package <package-short-name>
+```
 
-1. Run:
-   - `pnpm -C packages/core api:report`
-   - `pnpm -C packages/core api:fingerprint`
-2. Review diffs:
-   - `packages/core/temp/core.api.md`
-   - `packages/core/etc/core.api.md`
-   - `packages/core/API_FINGERPRINT`
-3. If approved, update baselines in the same PR with rationale.
-4. Re-run `api:check` and `api:fingerprint:check`.
+Use `--check-npm` before publishing when network access is available:
 
-## 10. Release Workflow (Protocol Stack)
+```bash
+pnpm release:preflight --package <package-short-name> --check-npm
+```
 
-1. Ensure clean working tree.
-2. Bump `core`, `sdk`, and `conformance` to one target version.
-3. Update changelogs and release notes.
-4. Run required validation gates.
-5. Commit release changes.
-6. Create/push coordinated tag (`vX.Y.Z`).
-7. Publish packages in order:
-   - `@oxdeai/core`
-   - `@oxdeai/sdk`
-   - `@oxdeai/conformance`
-8. Verify published npm versions.
+Run the repository-wide gates before every public package release:
 
-If publication fails, resolve and retry from the same committed state, or cut a new patch release with explicit notes.
+```bash
+pnpm install --frozen-lockfile
+pnpm build
+pnpm test
+```
 
-## 11. Security and Provenance
+Run package-specific gates for every package being released:
 
-- npm publication is immutable; Git tags/commits provide provenance context.
-- Published versions MUST correspond to committed and tagged repository state.
-- Post-release fixes MUST ship as new versions; published versions MUST NOT be rewritten.
-- Follow coordinated disclosure process in [SECURITY.md](../security/SECURITY.md).
-- Release notes MUST mention security-relevant changes.
-- Test signing material MUST be explicitly test-only and non-production.
+| Package | Required gates |
+|---|---|
+| `@oxdeai/core` | `pnpm -C packages/core api:check`; `pnpm -C packages/core api:fingerprint:check` |
+| `@oxdeai/sdk` | covered by repository-wide build/test unless package-specific gates are added |
+| `@oxdeai/conformance` | `pnpm -C packages/conformance validate` |
+| `@oxdeai/guard` | `pnpm -C packages/guard test` |
+| `@oxdeai/cli` | package build/test plus CLI smoke checks when CLI behavior changes |
 
-## 12. Future Evolution
+Run demos or smoke checks when the release changes demoed behavior, CLI flows, PEP enforcement, adapters, or public examples.
 
-Shared protocol-stack versioning is the current model.
+All required gates must pass before tags are created and before npm publication.
 
-If protocol package cadence diverges significantly, maintainers MAY adopt a new model. Any change MUST be documented here before use.
+## 8. API and Conformance Baselines
+
+Update baselines only when the underlying change is intentional and reviewed.
+
+For `@oxdeai/core` API changes:
+
+```bash
+pnpm -C packages/core api:report
+pnpm -C packages/core api:fingerprint
+pnpm -C packages/core api:check
+pnpm -C packages/core api:fingerprint:check
+```
+
+Review these files before committing baseline changes:
+
+- `packages/core/temp/core.api.md`
+- `packages/core/etc/core.api.md`
+- `packages/core/API_FINGERPRINT`
+
+Generated files under `temp/` are inspection outputs. Commit only the intended baseline files required by the package's API process.
+
+For conformance changes:
+
+```bash
+pnpm -C packages/conformance extract
+pnpm -C packages/conformance validate
+```
+
+Conformance vectors are protocol artifacts. Do not regenerate or edit vectors for a release unless the vector change is intentional, reviewed, and described in the changelog or release notes for the affected package.
+
+## 9. npm Publication Requirements
+
+Publish only from the committed and tagged state.
+
+Before publishing each package:
+
+```bash
+npm view <package-name> version --registry=https://registry.npmjs.org
+pnpm -C <package-path> pack --pack-destination /tmp
+```
+
+Inspect the package tarball when package contents changed.
+
+Publish with npm public registry targeting:
+
+```bash
+pnpm -C <package-path> publish --access public --registry=https://registry.npmjs.org
+```
+
+If npm provenance is required by the maintainer's environment, use the registry-supported provenance flag and document that in the release notes or release issue. Do not publish from an uncommitted or untagged state.
+
+After publishing:
+
+```bash
+npm view <package-name> version --registry=https://registry.npmjs.org
+npm view <package-name>@<version> dist.tarball --registry=https://registry.npmjs.org
+```
+
+The npm version must match the package's `package.json` and package-scoped Git tag.
+
+## 10. GitHub Release Requirements
+
+GitHub releases are required for public npm package releases.
+
+Create one GitHub release per package-scoped tag.
+
+The GitHub release must include:
+
+- package name
+- package version
+- Git tag
+- npm package/version
+- changelog summary or link
+- validation commands run
+- security notes, if any
+- compatibility notes, if any
+
+For coordinated releases, it is acceptable to create multiple GitHub releases pointing to tags on the same commit. A single top-level announcement may be added, but it does not replace the package-scoped GitHub releases.
+
+## 11. Failed Release and Partial Publish Recovery
+
+Git tags and npm publications are immutable release evidence.
+
+If a tag was created but npm publish did not occur:
+
+1. Do not move the tag if it was pushed.
+2. Fix only release-process issues that do not change package contents, then publish from the tagged commit.
+3. If package contents must change, create a new version and a new tag.
+
+If one package in a coordinated release publishes successfully and another fails:
+
+1. Do not unpublish or rewrite the successful package except under npm's emergency rules.
+2. Fix the failed package with a new version if package contents must change.
+3. Document the partial release and recovery in the failed package's changelog/GitHub release.
+4. Verify the final npm/GitHub/tag mapping after recovery.
+
+If a bad package was published:
+
+1. Publish a new corrective version.
+2. Mark the bad GitHub release with a warning.
+3. Do not move or reuse the original tag.
+
+## 12. Security and Provenance
+
+- Published versions must correspond to committed and tagged repository state.
+- Do not commit secrets, OTPs, private keys, or production signing material.
+- Test signing material must be clearly test-only.
+- Security-relevant changes must be mentioned in the package changelog and GitHub release.
+- Follow coordinated disclosure guidance in `docs/security/SECURITY.md`.
+
+## 13. Compatibility Bundles
+
+A compatibility bundle is optional and separate from package releases.
+
+Use a compatibility bundle only when maintainers need to announce that a set of independently versioned packages is known to work together.
+
+A compatibility bundle must include a manifest with:
+
+- bundle name
+- bundle date
+- Git commit
+- package names
+- package versions
+- package-scoped tags
+- npm package URLs or versions
+- validation commands run
+
+A compatibility bundle may use a global tag only if the manifest exists before the tag is created. The global tag must not be named in a way that implies shared package versions unless the manifest explicitly says so.
+
+## 14. Tag Hygiene
+
+Use:
+
+```bash
+pnpm tags:audit
+pnpm tags:cleanup:dry
+```
+
+Do not delete or rewrite remote release tags without maintainer approval and a written recovery note.

--- a/docs/release/RELEASING.md
+++ b/docs/release/RELEASING.md
@@ -2,44 +2,335 @@
 
 ## Status
 
-Non-normative (developer documentation)
+Normative release runbook.
 
+This runbook implements the package-scoped release policy in `docs/release/RELEASE.md`.
 
+## Active Model
 
+OxDeAI releases packages independently with package-scoped versions and package-scoped tags.
 
+Allowed new release tags:
 
+```text
+core-vX.Y.Z
+sdk-vX.Y.Z
+conformance-vX.Y.Z
+guard-vX.Y.Z
+cli-vX.Y.Z
+```
 
-This repo uses **package-scoped tags only**. Legacy global tags like `vX.Y.Z` are historical and must not be used for new releases.
+Global `vX.Y.Z` tags are legacy for package releases. Do not create them for normal package releases.
 
-## Tag format
+Multiple package tags may point to the same commit when the releases are coordinated. That does not imply shared package versions.
 
-All new releases must use package-level tags:
+## Preflight
 
-- core-v1.7.0
-- cli-v0.2.4
-- sdk-v1.3.2
-- guard-v1.0.2
-- conformance-v1.5.0
+From the repository root:
 
-Legacy global tags (vX.Y.Z) are deprecated and must not be used for new releases.
+```bash
+git fetch origin --tags --prune
+git status -sb
+pnpm install --frozen-lockfile
+pnpm release:preflight --package core
+```
 
-The following tags are currently classified as legacy / suspicious and should not be reused:
-- adapters-v1.0.0
-- adapters-v1.0.1
+The working tree must be clean before tagging or publishing.
 
-## Safe release flow
+The preflight package value is the short package name:
 
-1) Bump the package version (e.g., `packages/core/package.json`).
-2) Run checks (`pnpm lint`, `pnpm build`, `pnpm test` or targeted).
-3) Commit the release changes.
-4) Create the package tag: `git tag -a core-v1.7.0 -m "core v1.7.0"` (sign with `-s` if available).
-5) Push commit + tag: `git push origin main core-v1.7.0`.
-6) Publish the package (npm or internal registry as appropriate).
-7) Create a GitHub release if desired, referencing the package tag.
+```text
+core
+sdk
+conformance
+guard
+cli
+```
 
-## Tag hygiene
+The default preflight is local-only. Add `--check-npm` when network access is available and the release is close to publication:
 
-- Keep package tags matching the regex: `^(core|cli|conformance|guard|sdk)-v[0-9]+\.[0-9]+\.[0-9]+$`.
-- Global tags `vX.Y.Z` are considered legacy; do not create new ones.
-- For any other prefix (e.g., `adapters-v*`), treat as suspicious until a real package exists.
-- Use `pnpm tags:audit` to review tags and `pnpm tags:cleanup:dry` for a safe cleanup plan before deleting anything.
+```bash
+pnpm release:preflight --package core --check-npm
+```
+
+The preflight validates:
+
+- package exists and is configured for release
+- package name matches the release policy
+- `package.json` version is valid
+- planned tag is package-scoped and matches `package.json`
+- planned tag does not already exist locally
+- worktree is clean
+- `pnpm-lock.yaml` exists and has no uncommitted drift
+- changelog contains the target version
+- optional GitHub release metadata matches the planned tag
+- optional npm check confirms the version is not already published
+
+Examples:
+
+```bash
+pnpm release:preflight --package core
+pnpm release:preflight --package core --tag core-v1.7.1
+pnpm release:preflight --package core --check-npm
+pnpm release:preflight --package core --github-release-tag core-v1.7.1 --github-release-title "core v1.7.1"
+```
+
+Example pass:
+
+```text
+PASS package.json version is X.Y.Z: 1.7.1
+PASS tag uses package-scoped naming: core-v1.7.1
+PASS changelog contains target version: packages/core/CHANGELOG.md 1.7.1
+Release preflight PASSED
+```
+
+Example failure: tag mismatch.
+
+```bash
+pnpm release:preflight --package core --tag sdk-v1.7.1
+```
+
+```text
+FAIL tag uses package-scoped naming: sdk-v1.7.1
+FAIL tag version matches package.json version: sdk-v1.7.1 expected core-v1.7.1
+Release preflight FAILED
+```
+
+Example failure: missing changelog entry.
+
+```text
+FAIL changelog contains target version: packages/core/CHANGELOG.md 1.7.1
+Release preflight FAILED
+```
+
+Example failure: dirty worktree.
+
+```text
+FAIL git worktree is clean: M packages/core/package.json
+Release preflight FAILED
+```
+
+Example failure: npm version conflict.
+
+```bash
+pnpm release:preflight --package core --check-npm
+```
+
+```text
+FAIL npm package version is not already published: @oxdeai/core@1.7.0
+Release preflight FAILED
+```
+
+Check existing tags and releases:
+
+```bash
+pnpm tags:audit
+git tag --sort=-creatordate | head -30
+gh release list --limit 30
+```
+
+Check current npm versions:
+
+```bash
+npm view @oxdeai/core version --registry=https://registry.npmjs.org
+npm view @oxdeai/sdk version --registry=https://registry.npmjs.org
+npm view @oxdeai/conformance version --registry=https://registry.npmjs.org
+npm view @oxdeai/guard version --registry=https://registry.npmjs.org
+npm view @oxdeai/cli version --registry=https://registry.npmjs.org
+```
+
+## Single-Package Release Steps
+
+Replace the example package values with the package being released.
+
+Example:
+
+```text
+package: @oxdeai/core
+path: packages/core
+version: 1.7.1
+tag: core-v1.7.1
+```
+
+1. Update the package version.
+
+```bash
+pnpm -C packages/core version 1.7.1 --no-git-tag-version
+pnpm install --no-frozen-lockfile
+```
+
+2. Update the package changelog.
+
+```text
+packages/core/CHANGELOG.md
+```
+
+3. Run validation gates.
+
+```bash
+pnpm install --frozen-lockfile
+pnpm build
+pnpm test
+pnpm -C packages/core api:check
+pnpm -C packages/core api:fingerprint:check
+```
+
+For other packages, use the package-specific gates in `docs/release/RELEASE.md`.
+
+4. Review release diff.
+
+```bash
+git diff --stat
+git diff -- packages/core/package.json packages/core/CHANGELOG.md pnpm-lock.yaml
+```
+
+5. Commit release changes.
+
+```bash
+git add packages/core/package.json packages/core/CHANGELOG.md pnpm-lock.yaml
+git commit -m "chore(release): core v1.7.1"
+```
+
+6. Create the package-scoped tag.
+
+```bash
+git tag -a core-v1.7.1 -m "core v1.7.1"
+```
+
+Use `git tag -s` instead of `-a` when signing is available.
+
+7. Push the commit and tag.
+
+```bash
+git push origin main
+git push origin core-v1.7.1
+```
+
+8. Pack and publish from the tagged commit.
+
+```bash
+git show --no-patch --decorate core-v1.7.1
+pnpm -C packages/core pack --pack-destination /tmp
+pnpm -C packages/core publish --access public --registry=https://registry.npmjs.org
+```
+
+9. Verify npm publication.
+
+```bash
+npm view @oxdeai/core version --registry=https://registry.npmjs.org
+npm view @oxdeai/core@1.7.1 dist.tarball --registry=https://registry.npmjs.org
+```
+
+10. Create the GitHub release.
+
+```bash
+gh release create core-v1.7.1 --title "core v1.7.1" --notes-file /tmp/core-v1.7.1-release-notes.md
+```
+
+The release notes must include package name, version, tag, npm package/version, changelog summary, validation commands run, and security notes if relevant.
+
+## Coordinated Multi-Package Release Steps
+
+Use this when multiple packages should release from the same commit.
+
+1. Choose each package's own next version.
+
+Example:
+
+```text
+@oxdeai/core         1.7.1  core-v1.7.1
+@oxdeai/sdk          1.3.3  sdk-v1.3.3
+@oxdeai/conformance  1.5.1  conformance-v1.5.1
+@oxdeai/guard        1.0.3  guard-v1.0.3
+```
+
+2. Bump each package version without creating tags.
+
+```bash
+pnpm -C packages/core version 1.7.1 --no-git-tag-version
+pnpm -C packages/sdk version 1.3.3 --no-git-tag-version
+pnpm -C packages/conformance version 1.5.1 --no-git-tag-version
+pnpm -C packages/guard version 1.0.3 --no-git-tag-version
+pnpm install --no-frozen-lockfile
+```
+
+3. Update each released package's changelog.
+
+4. Run all required repository-wide and package-specific gates.
+
+```bash
+pnpm install --frozen-lockfile
+pnpm build
+pnpm test
+pnpm -C packages/core api:check
+pnpm -C packages/core api:fingerprint:check
+pnpm -C packages/conformance validate
+pnpm -C packages/guard test
+```
+
+5. Commit once.
+
+```bash
+git add packages/core/package.json packages/sdk/package.json packages/conformance/package.json packages/guard/package.json
+git add packages/core/CHANGELOG.md packages/sdk/CHANGELOG.md packages/conformance/CHANGELOG.md packages/guard/CHANGELOG.md pnpm-lock.yaml
+git commit -m "chore(release): coordinated package release"
+```
+
+6. Create one package-scoped tag per released package on that commit.
+
+```bash
+git tag -a core-v1.7.1 -m "core v1.7.1"
+git tag -a sdk-v1.3.3 -m "sdk v1.3.3"
+git tag -a conformance-v1.5.1 -m "conformance v1.5.1"
+git tag -a guard-v1.0.3 -m "guard v1.0.3"
+```
+
+7. Push the commit and tags.
+
+```bash
+git push origin main
+git push origin core-v1.7.1 sdk-v1.3.3 conformance-v1.5.1 guard-v1.0.3
+```
+
+8. Publish each package from the tagged commit.
+
+```bash
+pnpm -C packages/core publish --access public --registry=https://registry.npmjs.org
+pnpm -C packages/sdk publish --access public --registry=https://registry.npmjs.org
+pnpm -C packages/conformance publish --access public --registry=https://registry.npmjs.org
+pnpm -C packages/guard publish --access public --registry=https://registry.npmjs.org
+```
+
+9. Verify each npm version.
+
+```bash
+npm view @oxdeai/core version --registry=https://registry.npmjs.org
+npm view @oxdeai/sdk version --registry=https://registry.npmjs.org
+npm view @oxdeai/conformance version --registry=https://registry.npmjs.org
+npm view @oxdeai/guard version --registry=https://registry.npmjs.org
+```
+
+10. Create one GitHub release per package tag.
+
+## GitHub Releases
+
+GitHub releases are required for public npm package releases.
+
+Use the package-scoped tag as the release tag and the package name/version as the title.
+
+Example:
+
+```bash
+gh release view core-v1.7.1
+gh release create core-v1.7.1 --title "core v1.7.1" --notes-file /tmp/core-v1.7.1-release-notes.md
+```
+
+## Failure Handling
+
+If npm publish fails before any package is published, fix the release process and retry from the same tagged commit if package contents do not change.
+
+If package contents must change, bump to a new version and create a new tag.
+
+If one package in a coordinated release publishes and another fails, do not rewrite the successful release. Fix the failed package with a new version if contents must change, and document the partial recovery.
+
+Never move a pushed release tag to hide a bad release.

--- a/docs/release/benchmark-announcement.md
+++ b/docs/release/benchmark-announcement.md
@@ -4,6 +4,8 @@
 
 Non-normative (developer documentation)
 
+Announcement draft. This file is not current release policy and must not be used as a release runbook. Current release policy is package-scoped and lives in [`docs/release/RELEASE.md`](./RELEASE.md).
+
 
 
 

--- a/docs/release/release-checklist.md
+++ b/docs/release/release-checklist.md
@@ -1,138 +1,243 @@
-# OxDeAI v1.0.2 Release Checklist
+# OxDeAI Package Release Checklist
 
 ## Status
 
-Non-normative (developer documentation)
+Normative release checklist.
 
+Use this checklist with `docs/release/RELEASE.md` and `docs/release/RELEASING.md`.
 
+OxDeAI uses package-scoped versions and package-scoped tags. Do not create global `vX.Y.Z` tags for normal package releases.
 
+## 1. Identify Release Scope
 
+List every package being released:
 
+```text
+package name:
+package path:
+current package.json version:
+new package.json version:
+release tag:
+changelog path:
+npm package:
+```
 
-Use this checklist for protocol-grade releases in the `1.0.x` line.
+The release tag must be package-scoped:
 
-## 1) API Extractor Baseline Update
+```text
+core-vX.Y.Z
+sdk-vX.Y.Z
+conformance-vX.Y.Z
+guard-vX.Y.Z
+cli-vX.Y.Z
+```
 
-Run:
+For coordinated releases, repeat the mapping for every package. Multiple tags may point to the same commit, but package versions remain independent.
+
+## 2. Preflight
+
+```bash
+git fetch origin --tags --prune
+git status -sb
+pnpm tags:audit
+pnpm release:preflight --package <package-short-name>
+npm whoami
+gh auth status
+```
+
+The working tree must be clean before tagging or publishing.
+
+Run the npm-aware preflight immediately before publication:
+
+```bash
+pnpm release:preflight --package <package-short-name> --check-npm
+```
+
+The preflight fails closed on ambiguous package names, tag mismatches, existing tags, missing changelog entries, dirty worktrees, and npm version conflicts.
+
+Check current npm versions:
+
+```bash
+npm view @oxdeai/core version --registry=https://registry.npmjs.org
+npm view @oxdeai/sdk version --registry=https://registry.npmjs.org
+npm view @oxdeai/conformance version --registry=https://registry.npmjs.org
+npm view @oxdeai/guard version --registry=https://registry.npmjs.org
+npm view @oxdeai/cli version --registry=https://registry.npmjs.org
+```
+
+## 3. Version and Changelog
+
+For each released package:
+
+1. Bump only that package's `package.json` version.
+2. Refresh `pnpm-lock.yaml` if the version bump changes the lockfile.
+3. Update that package's changelog.
+4. Include security, breaking-change, migration, and compatibility notes where applicable.
+
+Do not infer a shared version line from a coordinated release commit.
+
+## 4. Baselines and Vectors
+
+For `@oxdeai/core` API changes:
 
 ```bash
 pnpm -C packages/core api:report
+pnpm -C packages/core api:fingerprint
 pnpm -C packages/core api:check
+pnpm -C packages/core api:fingerprint:check
 ```
 
-If `api:check` reports signature drift and the change is intentional:
+If API drift is intentional, review and update the committed baseline files. Do not commit generated temp output unless the package's API process explicitly requires it.
 
-```bash
-cp packages/core/temp/core.api.md packages/core/etc/core.api.md
-pnpm -C packages/core api:check
-```
-
-Then commit baseline updates with rationale in PR notes.
-
-## 2) Conformance Vector Update Rules
-
-Rules:
-
-- Vectors are frozen per protocol version.
-- Do not regenerate vectors for the same version unless fixing an incorrect vector.
-- Behavior-changing outputs require a new version baseline.
-
-Commands:
+For conformance vector changes:
 
 ```bash
 pnpm -C packages/conformance extract
 pnpm -C packages/conformance validate
 ```
 
-Expected success line:
+Vector changes must be intentional and documented in the relevant changelog or release notes.
 
-```text
-Conformance passed: <N> assertions
-```
+## 5. Required Gates
 
-## 3) Version Bump (Workspace)
-
-For a coordinated patch bump:
-
-1. Update versions in:
-   - `packages/core/package.json`
-   - `packages/sdk/package.json`
-   - `packages/conformance/package.json`
-2. Keep workspace pins for local monorepo development where intended.
-3. Refresh lockfile:
-
-```bash
-pnpm install --no-frozen-lockfile
-```
-
-4. Update changelog entries before tagging.
-
-## 4) Determinism + Invariant Test Gates
-
-Run full quality gates:
+Repository-wide gates:
 
 ```bash
 pnpm install --frozen-lockfile
 pnpm build
 pnpm test
+```
+
+Package-specific gates:
+
+```bash
 pnpm -C packages/core api:check
 pnpm -C packages/core api:fingerprint:check
 pnpm -C packages/conformance validate
+pnpm -C packages/guard test
 ```
 
-All commands MUST pass before release tag/publish.
+Run only the package-specific gates that apply to the packages being released, plus any affected smoke tests.
 
-## 5) End-to-End Envelope Generation + Verification
+All required gates must pass before tag creation and npm publication.
 
-Example using CLI (from repo root):
+## 6. Optional CLI Smoke
+
+Run this when releasing `@oxdeai/cli` or when changes affect envelope generation/verification:
 
 ```bash
-# create a valid initial state file first (example path shown)
 pnpm -C packages/cli start -- init --file /tmp/oxdeai-policy.json --json
 pnpm -C packages/cli start -- launch PROVISION 320 us-east-1 --agent agent-1 --nonce 1 --json
-
-# build artifacts
 pnpm -C packages/cli start -- build --state .oxdeai/state.json --out .oxdeai/snapshot.bin --json
 pnpm -C packages/cli start -- make-envelope --out .oxdeai/envelope.bin --json
-
-# verify snapshot/audit/envelope
 pnpm -C packages/cli start -- verify --kind snapshot --file .oxdeai/snapshot.bin --json
 pnpm -C packages/cli start -- verify --kind audit --file .oxdeai/audit.ndjson --mode strict --json
 pnpm -C packages/cli start -- verify --kind envelope --file .oxdeai/envelope.bin --mode strict --json
 ```
 
-Notes:
+Strict mode may return `inconclusive` without `STATE_CHECKPOINT`; record that result if it occurs.
 
-- Strict mode may return `inconclusive` without `STATE_CHECKPOINT`.
-- Best-effort mode can be used for diagnostics.
+## 7. Commit and Tag
 
-## 6) Security Notes
-
-- v1.0.2 authorization verification in the reference profile uses shared-secret/HMAC.
-- Signing secrets MUST be managed in secure storage (KMS/HSM preferred).
-- Do not commit secrets, OTPs, or private key material.
-- Use environment-specific key isolation and rotation procedures.
-- Follow coordinated disclosure guidance in `SECURITY.md`.
-
-## 7) Tag + Publish Order
-
-After all gates pass:
+Commit release changes first:
 
 ```bash
-git tag vX.Y.Z
-git push origin main --tags
+git diff --stat
+git add <changed package.json files> <changed changelog files> pnpm-lock.yaml
+git commit -m "chore(release): <package> vX.Y.Z"
 ```
 
-Publish in dependency order:
-
-1. `@oxdeai/core`
-2. `@oxdeai/sdk`
-3. `@oxdeai/conformance`
-
-Verify on npm:
+Create package-scoped tags only:
 
 ```bash
-npm view @oxdeai/core version --registry=https://registry.npmjs.org
-npm view @oxdeai/sdk version --registry=https://registry.npmjs.org
-npm view @oxdeai/conformance version --registry=https://registry.npmjs.org
+git tag -a core-vX.Y.Z -m "core vX.Y.Z"
 ```
+
+For coordinated releases:
+
+```bash
+git tag -a core-vX.Y.Z -m "core vX.Y.Z"
+git tag -a sdk-vA.B.C -m "sdk vA.B.C"
+git tag -a conformance-vD.E.F -m "conformance vD.E.F"
+```
+
+Push:
+
+```bash
+git push origin main
+git push origin core-vX.Y.Z
+```
+
+For coordinated releases, push all package tags explicitly.
+
+## 8. Pack and Publish
+
+For each released package:
+
+```bash
+git show --no-patch --decorate <package-tag>
+pnpm -C <package-path> pack --pack-destination /tmp
+pnpm -C <package-path> publish --access public --registry=https://registry.npmjs.org
+```
+
+The npm package version must match the package's `package.json` version and package-scoped Git tag.
+
+## 9. Post-Publish Verification
+
+For each released package:
+
+```bash
+npm view <package-name> version --registry=https://registry.npmjs.org
+npm view <package-name>@<version> dist.tarball --registry=https://registry.npmjs.org
+git show --no-patch --decorate <package-tag>
+```
+
+Create or verify the GitHub release:
+
+```bash
+gh release view <package-tag>
+```
+
+If it does not exist:
+
+```bash
+gh release create <package-tag> --title "<package> vX.Y.Z" --notes-file <notes-file>
+```
+
+## 10. Release Artifact Mapping
+
+Record this mapping in the release notes or release issue:
+
+| Field | Value |
+|---|---|
+| package | |
+| package path | |
+| package.json version | |
+| Git tag | |
+| Git commit | |
+| changelog entry | |
+| npm package/version | |
+| npm tarball URL | |
+| GitHub release URL | |
+| validation commands | |
+
+For coordinated releases, include one row per package.
+
+## 11. Failure Recovery
+
+If tag creation fails, fix locally before pushing.
+
+If a tag was pushed but npm publish failed, do not move the tag. Publish from the tagged commit if package contents are unchanged. If contents must change, create a new package version and tag.
+
+If npm publish succeeded but GitHub release creation failed, create the GitHub release for the already published package tag.
+
+If a bad npm package was published, ship a new corrective version. Do not reuse the original version or move the original tag.
+
+## 12. Security Check
+
+Before publishing, confirm:
+
+- no secrets, OTPs, private keys, or production signing material are committed
+- test keys are clearly test-only
+- security-relevant changes are called out in changelog and GitHub release notes
+- disclosure-sensitive details follow `docs/security/SECURITY.md`

--- a/docs/release/stable-announcement.md
+++ b/docs/release/stable-announcement.md
@@ -1,5 +1,9 @@
 # OxDeAI v1.3 — Stable Execution Authorization Protocol
 
+## Status
+
+Historical announcement draft. This file is not release policy and must not be used as a release runbook.
+
 OxDeAI is now Stable: deterministic execution authorization with cross-language verification. Canonicalization, authorization, PEP, and delegation vectors are published and verified.
 
 ## The Gap

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "tags:audit": "node scripts/audit-tags.mjs",
     "tags:cleanup:dry": "node scripts/cleanup-legacy-tags.mjs",
     "tags:cleanup:local": "node scripts/cleanup-legacy-tags.mjs --apply-local --confirm=DELETE_LEGACY_TAGS",
+    "release:preflight": "node scripts/release-preflight.mjs",
     "regen:vectors": "tsx scripts/generate-canonicalization-vectors.ts",
     "test:vectors": "pnpm test:vectors:ts",
     "test:vectors:ts": "tsx scripts/verify-canonicalization-vectors.ts",
@@ -36,11 +37,11 @@
     "test:vectors:all": "pnpm test:vectors:ts && pnpm test:vectors:auth && pnpm test:vectors:pep && pnpm test:vectors:delegation && pnpm test:vectors:go && pnpm test:vectors:py"
   },
   "devDependencies": {
+    "@oxdeai/core": "workspace:*",
     "@types/node": "^22.19.11",
     "puppeteer": "^24.40.0",
-    "typescript": "^5.6.0",
-    "@oxdeai/core": "workspace:*",
-    "tsx": "^4.21.0"
+    "tsx": "^4.21.0",
+    "typescript": "^5.6.0"
   },
   "pnpm": {
     "overrides": {
@@ -51,5 +52,6 @@
       "basic-ftp": ">=5.3.0"
     }
   },
-  "type": "module"
+  "type": "module",
+  "uuid": "14.0.0"
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,10 +1,9 @@
 # @oxdeai/core
-Execution-time authorization protocol (ETA) — non-bypassable execution boundary.
+Execution-time authorization protocol (ETA) - non-bypassable execution boundary.
 Deterministic decision: (intent, state, policy) → ALLOW | DENY, emits AuthorizationV1 artifacts.
 Fail-closed verification at the PEP; no valid authorization → no execution path.
 
 [![npm version](https://img.shields.io/npm/v/@oxdeai/core.svg)](https://www.npmjs.com/package/@oxdeai/core)
-[![Snyk](https://snyk.io/test/github/AngeYobo/oxdeai-core/badge.svg)](https://snyk.io/test/github/AngeYobo/oxdeai-core)
 [![license](https://img.shields.io/npm/l/@oxdeai/core.svg)](https://github.com/AngeYobo/oxdeai-core/blob/main/packages/core/LICENSE)
 [![build](https://github.com/AngeYobo/oxdeai-core/actions/workflows/ci.yml/badge.svg)](https://github.com/AngeYobo/oxdeai-core/actions/workflows/ci.yml)
 
@@ -85,7 +84,9 @@ if (decision.decision === "ALLOW") {
 
 `@oxdeai/core` is a stable protocol library.
 
-Current protocol stack line: **v1.7.x**.
+Release policy note: OxDeAI uses package-scoped versions and package-scoped tags. `@oxdeai/core` has its own package version line; coordinated release commits do not imply shared package versions across `core`, `sdk`, or `conformance`. See [`docs/release/RELEASE.md`](../../docs/release/RELEASE.md).
+
+Current `@oxdeai/core` package line: **1.7.x**.
 
 v1.7.x adds on top of the preserved v1.6.x verification surface:
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -4,7 +4,9 @@ Builds intents/states and guard boundaries that remain non-bypassable and fail-c
 
 ## Status
 
-Current protocol stack line: `@oxdeai/core@1.6.1`, `@oxdeai/sdk@1.3.2`, `@oxdeai/conformance@1.4.0`.
+Release policy note: OxDeAI uses package-scoped versions and package-scoped tags. `@oxdeai/sdk` has its own package version line; coordinated release commits do not imply shared package versions across `core`, `sdk`, or `conformance`. See [`docs/release/RELEASE.md`](../../docs/release/RELEASE.md).
+
+Current `@oxdeai/sdk` package line: `1.3.x`.
 
 The SDK is an integration surface and does not redefine protocol semantics.
 

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+
+const RELEASE_PACKAGES = {
+  core: {
+    name: "@oxdeai/core",
+    path: "packages/core",
+    tagPrefix: "core",
+    changelog: "packages/core/CHANGELOG.md",
+  },
+  sdk: {
+    name: "@oxdeai/sdk",
+    path: "packages/sdk",
+    tagPrefix: "sdk",
+    changelog: "packages/sdk/CHANGELOG.md",
+  },
+  conformance: {
+    name: "@oxdeai/conformance",
+    path: "packages/conformance",
+    tagPrefix: "conformance",
+    changelog: "packages/conformance/CHANGELOG.md",
+  },
+  guard: {
+    name: "@oxdeai/guard",
+    path: "packages/guard",
+    tagPrefix: "guard",
+    changelog: "packages/guard/CHANGELOG.md",
+  },
+  cli: {
+    name: "@oxdeai/cli",
+    path: "packages/cli",
+    tagPrefix: "cli",
+    changelog: "packages/cli/CHANGELOG.md",
+  },
+};
+
+const VERSION_RE = /^\d+\.\d+\.\d+$/;
+
+function usage(exitCode = 0) {
+  const out = exitCode === 0 ? console.log : console.error;
+  out(`Usage:
+  node scripts/release-preflight.mjs --package <core|sdk|conformance|guard|cli> [options]
+
+Options:
+  --package <name>              Package short name to validate.
+  --tag <tag>                   Planned package-scoped tag. Defaults to <package>-v<package.json version>.
+  --check-npm                   Check npm registry and fail if package@version is already published.
+  --github-release-tag <tag>    Optional planned GitHub release tag; must match the package tag.
+  --github-release-title <text> Optional planned GitHub release title; must include package and version.
+  --help                        Show this help.
+`);
+  process.exit(exitCode);
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") usage(0);
+    if (arg === "--check-npm") {
+      args.checkNpm = true;
+      continue;
+    }
+    if (arg.startsWith("--") && arg.includes("=")) {
+      const [key, ...rest] = arg.slice(2).split("=");
+      args[key] = rest.join("=");
+      continue;
+    }
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+      const value = argv[i + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error(`Missing value for --${key}`);
+      }
+      args[key] = value;
+      i += 1;
+      continue;
+    }
+    throw new Error(`Unexpected argument: ${arg}`);
+  }
+  return args;
+}
+
+function run(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", opts.stderr ?? "pipe"],
+  }).trim();
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function tagExists(tag) {
+  try {
+    run("git", ["rev-parse", "-q", "--verify", `refs/tags/${tag}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function worktreeStatus() {
+  return run("git", ["status", "--porcelain=v1"]);
+}
+
+function npmVersionExists(pkg, version) {
+  try {
+    const found = run(
+      "npm",
+      ["view", `${pkg}@${version}`, "version", "--registry=https://registry.npmjs.org"]
+    );
+    return found === version;
+  } catch (err) {
+    const output = String(err?.stderr ?? err?.stdout ?? err?.message ?? "");
+    if (output.includes("E404") || output.includes("404 Not Found")) {
+      return false;
+    }
+    throw new Error(`Could not determine npm publish state for ${pkg}@${version}`);
+  }
+}
+
+function changelogHasVersion(path, version) {
+  if (!existsSync(path)) return false;
+  const escaped = version.replaceAll(".", "\\.");
+  const re = new RegExp(`^##\\s+\\[?v?${escaped}\\]?\\b`, "m");
+  return re.test(readFileSync(path, "utf8"));
+}
+
+function addCheck(checks, ok, name, detail) {
+  checks.push({ ok, name, detail });
+}
+
+function printChecks(checks) {
+  for (const check of checks) {
+    const marker = check.ok ? "PASS" : "FAIL";
+    console.log(`${marker} ${check.name}${check.detail ? `: ${check.detail}` : ""}`);
+  }
+}
+
+function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(`ERROR ${err.message}`);
+    usage(1);
+  }
+
+  const shortName = args.package;
+  const cfg = RELEASE_PACKAGES[shortName];
+  const checks = [];
+
+  addCheck(
+    checks,
+    Boolean(shortName && cfg),
+    "target package is configured for release",
+    shortName ? shortName : "missing --package"
+  );
+
+  if (!cfg) {
+    printChecks(checks);
+    console.error("\nRelease preflight FAILED");
+    process.exit(1);
+  }
+
+  const packageJsonPath = `${cfg.path}/package.json`;
+  const packageExists = existsSync(packageJsonPath);
+  addCheck(checks, packageExists, "package.json exists", packageJsonPath);
+
+  let pkg = {};
+  if (packageExists) {
+    try {
+      pkg = readJson(packageJsonPath);
+    } catch (err) {
+      addCheck(checks, false, "package.json parses as JSON", err.message);
+    }
+  }
+
+  const version = pkg.version;
+  const expectedTag = `${cfg.tagPrefix}-v${version}`;
+  const plannedTag = args.tag ?? expectedTag;
+
+  addCheck(checks, typeof version === "string" && VERSION_RE.test(version), "package.json version is X.Y.Z", version);
+  addCheck(checks, pkg.name === cfg.name, "package name matches release policy", `${pkg.name ?? "(missing)"} expected ${cfg.name}`);
+  addCheck(checks, pkg.private !== true, "package is publishable", pkg.private === true ? "private=true" : "private flag absent/false");
+
+  const tagPattern = new RegExp(`^${cfg.tagPrefix}-v\\d+\\.\\d+\\.\\d+$`);
+  addCheck(checks, tagPattern.test(plannedTag), "tag uses package-scoped naming", plannedTag);
+  addCheck(checks, plannedTag === expectedTag, "tag version matches package.json version", `${plannedTag} expected ${expectedTag}`);
+  addCheck(checks, !tagExists(plannedTag), "planned tag does not already exist", plannedTag);
+
+  const status = worktreeStatus();
+  addCheck(checks, status.length === 0, "git worktree is clean", status.length === 0 ? "" : status.split("\n").join("; "));
+
+  addCheck(checks, existsSync("pnpm-lock.yaml"), "pnpm lockfile exists", "pnpm-lock.yaml");
+  const lockStatus = status
+    .split("\n")
+    .filter((line) => line.includes("pnpm-lock.yaml"));
+  addCheck(checks, lockStatus.length === 0, "pnpm lockfile has no uncommitted drift", lockStatus.join("; "));
+
+  addCheck(checks, changelogHasVersion(cfg.changelog, version), "changelog contains target version", `${cfg.changelog} ${version}`);
+
+  if (args["github-release-tag"] !== undefined) {
+    addCheck(
+      checks,
+      args["github-release-tag"] === plannedTag,
+      "GitHub release tag metadata matches planned tag",
+      `${args["github-release-tag"]} expected ${plannedTag}`
+    );
+  }
+
+  if (args["github-release-title"] !== undefined) {
+    const title = args["github-release-title"];
+    const hasPackage = title.includes(shortName) || title.includes(cfg.name);
+    const hasVersion = title.includes(version);
+    addCheck(
+      checks,
+      hasPackage && hasVersion,
+      "GitHub release title metadata includes package and version",
+      title
+    );
+  }
+
+  if (args.checkNpm) {
+    const exists = npmVersionExists(cfg.name, version);
+    addCheck(checks, !exists, "npm package version is not already published", `${cfg.name}@${version}`);
+  }
+
+  console.log("OxDeAI release preflight\n========================\n");
+  console.log(`package: ${cfg.name}`);
+  console.log(`path:    ${cfg.path}`);
+  console.log(`version: ${version ?? "(missing)"}`);
+  console.log(`tag:     ${plannedTag}`);
+  console.log("");
+
+  printChecks(checks);
+
+  const failed = checks.filter((check) => !check.ok);
+  if (failed.length > 0) {
+    console.error(`\nRelease preflight FAILED (${failed.length} failure${failed.length === 1 ? "" : "s"})`);
+    process.exit(1);
+  }
+
+  console.log("\nRelease preflight PASSED");
+}
+
+main();


### PR DESCRIPTION
…ignment

- enforce package-scoped release policy across docs
- remove legacy global version/tag guidance
- add release preflight script (fail-closed validation)
- align READMEs with package-scoped versioning
- mark historical release artifacts as non-normative

No runtime changes.