### PR TITLE
ix(sift): correct AuthorizationV1 signing vector + formalize parameter-binding boundary

### DIFF
--- a/docs/adapters/sift.md
+++ b/docs/adapters/sift.md
@@ -249,6 +249,79 @@ Example canonical intent shape:
 
 ---
 
+## Parameter Binding Guarantee
+
+### What Sift signs
+
+A Sift receipt is an Ed25519-signed attestation that a specific **tool** (identified by `receipt.tool`) matched a specific **policy** (identified by `receipt.policy_matched`) for a specific **action** (identified by `receipt.action`) at a given point in time.
+
+**Sift receipts do NOT include parameter values. Sift's signature does NOT cover the specific parameters submitted for evaluation.**
+
+### What `intent_hash` commits to
+
+`AuthorizationV1.intent_hash` is the SHA-256 of the Sift-canonical JSON of the intent object supplied by the adapter. That intent object contains `type`, `tool`, and `params`.
+
+The `params` are **supplied by the adapter from the execution context** — they are NOT extracted from the Sift receipt.
+
+Therefore:
+
+```text
+intent_hash commits to:  adapter-supplied params
+                         (what the adapter says will be executed)
+
+NOT to:                  params that Sift evaluated
+                         (what Sift was actually asked about)
+```
+
+### Security boundary
+
+A mismatch between the parameters Sift evaluated and the parameters the adapter supplies is **NOT detectable from the receipt alone**. The PEP detects a mismatch only if it independently recomputes `intent_hash` from the actual execution call at the moment of execution and finds a hash collision — which it will, if params differ between authorization issuance and execution. But the PEP cannot determine what Sift originally approved.
+
+This means:
+
+- Sift provides **action-level authorization**: it approves `tool X` under `policy Y`.
+- Sift does NOT provide **parameter-level cryptographic binding**: it does not prove that specific parameter values were approved.
+
+### Invariant
+
+> **Parameter mismatch between Sift evaluation and execution is NOT detectable from the receipt alone.**
+
+The adapter is responsible for ensuring that the params it injects into the intent faithfully represent the params it intends to execute. There is no protocol-level mechanism to verify this at the Sift receipt boundary.
+
+### Security warning
+
+If parameter-level guarantees are required by the deployment's threat model, Sift MUST be extended to include a `params_hash` field (SHA-256 of Sift-canonical params) in the signed receipt payload. The adapter MUST then verify:
+
+```text
+params_hash == SHA-256(sift_canonical(adapter_params))
+```
+
+before calling `normalizeIntent`. Without this, parameter-level enforcement relies entirely on the adapter's own integrity.
+
+**Do not treat `AuthorizationV1.intent_hash` as evidence that Sift evaluated the specific parameter values bound by that hash.**
+
+### Future extension path (DO NOT IMPLEMENT until Sift protocol adds support)
+
+When Sift adds `params_hash` to the signed receipt:
+
+```json
+{
+  "params_hash": "<sha256-hex of sift_canonical(params)>",
+  ...
+}
+```
+
+The adapter MUST add a verification step between `verifyReceipt` and `normalizeIntent`:
+
+```text
+recompute = sha256(sift_canonical(adapter_params))
+assert recompute == receipt.params_hash  → DENY if mismatch
+```
+
+Until that field exists in the Sift receipt contract, this check cannot be performed and the parameter binding gap remains.
+
+---
+
 ## State Binding (Normative)
 
 - The adapter MUST produce a deterministic state snapshot for `AuthorizationV1.state_hash`.
@@ -427,13 +500,14 @@ No implicit trust is allowed.
 
 Sift receipts do not provide the following. The adapter MUST compensate for each.
 
-| Gap                       | Risk without compensation                                           | Adapter requirement                                                    |
-|---------------------------|----------------------------------------------------------------------|-------------------------------------------------------------------------|
-| No audience binding       | Receipt replayed against unintended service                         | Inject audience from trusted adapter configuration                      |
-| No state binding          | Receipt replayed after state change (budget consumed, permission revoked) | Derive, canonicalize, and hash execution-relevant state                |
-| No canonical intent form  | Intent ambiguity; `intent_hash` inconsistency across implementations | Normalize Sift fields to canonical OxDeAI intent under canonicalization-v1 |
-| No OxDeAI replay contract | Sift nonce deduplication ≠ OxDeAI `auth_id` single-use enforcement  | Explicitly map nonce to `auth_id`; enforce consumption at PEP           |
-| No bounded expiry contract | Stale receipt converted to long-lived `AuthorizationV1`             | Define and enforce adapter-side bounded freshness window                |
+| Gap                           | Risk without compensation                                                                           | Adapter requirement                                                                                      |
+|-------------------------------|------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
+| No audience binding           | Receipt replayed against unintended service                                                         | Inject audience from trusted adapter configuration                                                       |
+| No state binding              | Receipt replayed after state change (budget consumed, permission revoked)                           | Derive, canonicalize, and hash execution-relevant state                                                  |
+| **No parameter binding**      | **Adapter can inject params different from what Sift evaluated; `intent_hash` binds adapter params, NOT Sift-evaluated params** | **Adapter MUST ensure injected params match intended execution; see §"Parameter Binding Guarantee"** |
+| No canonical intent form      | Intent ambiguity; `intent_hash` inconsistency across implementations                               | Normalize Sift fields to canonical OxDeAI intent under canonicalization-v1                               |
+| No OxDeAI replay contract     | Sift nonce deduplication ≠ OxDeAI `auth_id` single-use enforcement                                 | Explicitly map nonce to `auth_id`; enforce consumption at PEP                                            |
+| No bounded expiry contract    | Stale receipt converted to long-lived `AuthorizationV1`                                             | Define and enforce adapter-side bounded freshness window                                                 |
 
 ---
 

--- a/packages/sift/README.md
+++ b/packages/sift/README.md
@@ -16,7 +16,8 @@ It does **not** execute actions and it does **not** treat a Sift receipt as exec
 
 ## Purpose
 
-Sift is an upstream **decision / governance layer**.
+Sift is an upstream **decision / governance layer** providing signed receipt-level decisions.
+With the current receipt shape, it does not provide cryptographic proof of parameter-level approval.
 
 OxDeAI is the **execution-time authorization and enforcement layer**.
 
@@ -59,7 +60,7 @@ Responsibilities:
 * receipt version validation
 * receipt hash integrity validation (Sift-canonical JSON, ensure_ascii=True)
 * Ed25519 signature verification (raw 32-byte key; base64url-decoded signature)
-* `ALLOW` / `DENY` decision enforcement
+* `ALLOW` / `DENY` decision validation
 * bounded freshness validation (`maxAgeMs` - configurable per deployment; treat as a security parameter)
 
 Verification order (integrity before semantics):
@@ -97,6 +98,7 @@ Properties:
 * safe integers only
 * rejects non-deterministic runtime objects
 * prototype-safe object construction
+* parameters are supplied by the caller and are not cryptographically bound to the receipt
 
 ### `normalizeState`
 
@@ -169,6 +171,36 @@ A Sift receipt is a **governance decision artifact**.
 It is **not** an OxDeAI authorization artifact.
 
 Execution must remain gated by valid `AuthorizationV1` verified at the PEP boundary.
+
+### Parameter binding limitation
+
+Sift receipts do **not** cryptographically bind execution parameter values.
+
+A Sift receipt proves that a governance decision was issued for the signed fields
+(e.g. `action`, `tool`, `decision`, `nonce`, `timestamp`).
+
+It does **not** prove that the `params` later supplied to `normalizeIntent`
+are the same parameters evaluated by Sift.
+
+Therefore:
+
+- `AuthorizationV1.intent_hash` commits to **adapter-supplied params**
+- it does **not** prove parameter-level approval by Sift
+- parameter mismatch between Sift evaluation and execution is **not detectable**
+  from the receipt alone
+
+A receipt alone MUST NEVER be treated as sufficient to construct an executable intent.
+
+This limitation does **not weaken the execution boundary**:
+
+- execution remains strictly gated by `AuthorizationV1`
+- the PEP Gateway enforces exact `intent_hash` and `state_hash` matching
+- any mismatch at execution time still results in **DENY → no execution**
+
+If parameter-level guarantees are required, the Sift receipt format MUST include:
+
+- canonical `params`, or
+- `params_hash = sha256(sift_canonical(params))`
 
 ### Fail-closed behavior
 
@@ -276,6 +308,26 @@ Minimum requirements:
 All user-controlled normalized objects are created with `Object.create(null)`.
 
 This prevents `__proto__` setter side effects and silent key loss during normalization.
+
+### Responsibility split
+
+Sift provides:
+
+- signed governance decisions (`ALLOW` / `DENY`)
+- receipt integrity and authenticity
+
+OxDeAI provides:
+
+- deterministic intent binding (including params)
+- deterministic state binding
+- audience binding
+- replay protection
+- non-bypassable execution enforcement at the PEP
+
+These guarantees are intentionally separated.
+
+A Sift receipt alone cannot authorize execution.
+Only a valid `AuthorizationV1` verified at the PEP Gateway can.
 
 ## Package structure
 

--- a/packages/sift/src/normalizeIntent.ts
+++ b/packages/sift/src/normalizeIntent.ts
@@ -147,6 +147,21 @@ function normalizeValue(value: unknown, path: string): NormalizeOk | NormalizeEr
  * explicit params — a receipt alone is never sufficient to construct an
  * executable intent.
  *
+ * PARAMETER BINDING GUARANTEE (read before use):
+ *   Sift receipts do NOT include or cryptographically bind parameter values.
+ *   The `intent_hash` computed downstream (in receiptToAuthorization) commits
+ *   to the params supplied HERE by the caller — NOT to the params that Sift
+ *   evaluated when it issued the receipt.
+ *
+ *   Therefore: Sift provides action-level authorization (tool identity +
+ *   policy match), NOT parameter-level cryptographic binding.  A mismatch
+ *   between the params Sift evaluated and the params the adapter supplies is
+ *   NOT detectable from the receipt alone.
+ *
+ *   If parameter-level guarantees are required, Sift MUST include a
+ *   params_hash (SHA-256 of canonical params) in the signed receipt payload,
+ *   and the adapter MUST verify it before calling this function.
+ *
  * Only `type`, `tool`, and normalized `params` appear in the intent.
  * All receipt governance fields (timestamp, nonce, receipt_hash, signature,
  * tenant_id, agent_id, policy_matched, risk_tier, action) are intentionally

--- a/packages/sift/src/receiptToAuthorization.ts
+++ b/packages/sift/src/receiptToAuthorization.ts
@@ -177,6 +177,10 @@ export function receiptToAuthorization(
     // ── 7. Intent hash ───────────────────────────────────────────────────────
     // Computed with Sift-canonical JSON (ensure_ascii=True) so that the PEP
     // can independently recompute the hash from the same intent object.
+    //
+    // PARAMETER BINDING: intent_hash commits to the adapter-supplied params
+    // (carried in `intent`), NOT to the params that Sift evaluated.  Sift
+    // receipts do not include parameter values.  See normalizeIntent JSDoc.
     let intentHash: string;
     try {
       intentHash = siftCanonicalJsonHash(intent);

--- a/packages/sift/test/contract-vector.test.ts
+++ b/packages/sift/test/contract-vector.test.ts
@@ -38,10 +38,28 @@ const RFC8037_D    = "nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A";
 const RFC8037_X    = "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo";
 const RFC8037_KID  = "key-rfc8037";
 
+// ─── alg literal disambiguation ───────────────────────────────────────────────
+//
+// TWO DISTINCT SURFACES — MUST NOT BE CONFLATED:
+//
+//   "EdDSA"   — JWKS metadata label (RFC 8037 §2, OKP key-discovery tooling).
+//               Appears in the JWKS entry: { "kty": "OKP", "alg": "EdDSA", ... }
+//               It is NEVER included in an AuthorizationV1 signed payload.
+//
+//   "ed25519" — Runtime literal included in the AuthorizationV1 signing payload.
+//               Defined in AuthorizationV1Payload.signature.alg as the literal
+//               type "ed25519" (lowercase). MUST appear verbatim in the preimage.
+//
+// Consequence: changing "ed25519" to "EdDSA" in the signing payload produces
+// different canonical bytes → a different signature → PEP verification fails.
+// There is no normalization or case-folding of the alg field.
+// See regression tests C-A and C-B at the bottom of this file.
+
 // ─── Worked example: AuthorizationV1 signing payload ─────────────────────────
 //
 // This is the exact object that would be handed to the signer.
 // signature.sig is absent — that absence is the signing preimage contract.
+// signature.alg MUST be "ed25519" (the runtime literal, lowercase).
 // All string values are ASCII so the ensure_ascii pass is a no-op here;
 // the ensure_ascii tests below use separate non-ASCII payloads.
 
@@ -57,7 +75,7 @@ const EXAMPLE_SIGNING_PAYLOAD = {
   issued_at:   1700000000,
   expires_at:  1700000030,
   signature: {
-    alg: "EdDSA",
+    alg: "ed25519",   // runtime literal (lowercase) — NOT the JWKS "EdDSA" label
     kid: RFC8037_KID,
   },
 } as const;
@@ -85,7 +103,7 @@ const EXPECTED_CANONICAL_JSON =
   '"issued_at":1700000000,' +
   '"issuer":"sift.example.local",' +
   '"policy_id":"policy-v1",' +
-  '"signature":{"alg":"EdDSA","kid":"key-rfc8037"},' +
+  '"signature":{"alg":"ed25519","kid":"key-rfc8037"},' +
   '"state_hash":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",' +
   '"version":"1"}';
 
@@ -302,5 +320,85 @@ test("contract-vector: correct preimage fails with wrong public key", () => {
     nodeVerify(null, preimage, wrongPub, sig),
     false,
     "Verification should fail with an unrelated public key"
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// C-A / C-B  alg-literal regression — ed25519 vs EdDSA
+//
+// These tests lock in the invariant that the alg field is included verbatim in
+// the canonical bytes and that its exact casing determines the signature.
+//
+// C-A (must pass): alg="ed25519" (production literal) → sign → verify → OK
+// C-B (must fail): sign over alg="EdDSA" bytes, verify against alg="ed25519"
+//                  bytes → FAIL because the preimages are different byte strings
+//
+// "EdDSA" is the JWKS metadata label (RFC 8037 OKP key-discovery).
+// "ed25519" is the runtime literal in AuthorizationV1.signature.alg.
+// They MUST NOT be conflated. There is no normalization or case-folding.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test("C-A [regression]: alg=\"ed25519\" in signing payload produces a verifiable signature", () => {
+  // EXAMPLE_SIGNING_PAYLOAD.signature.alg === "ed25519" (the production runtime literal).
+  // This is the correct canonical preimage for AuthorizationV1.
+  const privKey  = privateKeyFromB64U(RFC8037_D);
+  const pubKey   = publicKeyFromB64U(RFC8037_X);
+  const preimage = toUtf8(canonicalJsonEnsureAscii(EXAMPLE_SIGNING_PAYLOAD));
+  const sig      = nodeSign(null, preimage, privKey);
+
+  assert.ok(
+    nodeVerify(null, preimage, pubKey, sig),
+    'alg="ed25519" (runtime literal) MUST produce a verifiable signature'
+  );
+
+  // Confirm the alg field appears verbatim as "ed25519" in the canonical bytes.
+  const canonicalStr = canonicalJsonEnsureAscii(EXAMPLE_SIGNING_PAYLOAD);
+  assert.ok(
+    canonicalStr.includes('"alg":"ed25519"'),
+    `Canonical preimage MUST contain "alg":"ed25519" verbatim. Got: ${canonicalStr}`
+  );
+  assert.ok(
+    !canonicalStr.includes('"alg":"EdDSA"'),
+    `Canonical preimage MUST NOT contain "alg":"EdDSA" in any form`
+  );
+});
+
+test("C-B [regression]: signature over alg=\"EdDSA\" preimage MUST NOT verify against alg=\"ed25519\" preimage", () => {
+  // Construct the WRONG payload that a misimplemented language adapter would produce:
+  // using the JWKS metadata label "EdDSA" instead of the runtime literal "ed25519".
+  // Spreading EXAMPLE_SIGNING_PAYLOAD and overriding signature.alg is the safest
+  // way to produce the wrong variant without modifying the shared constant.
+  const wrongPayload = {
+    ...EXAMPLE_SIGNING_PAYLOAD,
+    signature: {
+      alg: "EdDSA",       // WRONG — JWKS label, not the runtime literal
+      kid: RFC8037_KID,
+    },
+  };
+
+  const privKey         = privateKeyFromB64U(RFC8037_D);
+  const pubKey          = publicKeyFromB64U(RFC8037_X);
+
+  // Sign over the WRONG preimage (EdDSA bytes).
+  const wrongPreimage   = toUtf8(canonicalJsonEnsureAscii(wrongPayload));
+  const sigOverWrong    = nodeSign(null, wrongPreimage, privKey);
+
+  // The CORRECT production preimage uses the "ed25519" literal.
+  const correctPreimage = toUtf8(canonicalJsonEnsureAscii(EXAMPLE_SIGNING_PAYLOAD));
+
+  // The two preimages MUST be byte-distinct — "EdDSA" ≠ "ed25519".
+  assert.notDeepStrictEqual(
+    wrongPreimage,
+    correctPreimage,
+    'Preimage with alg="EdDSA" and preimage with alg="ed25519" MUST differ'
+  );
+
+  // A signature computed over the EdDSA preimage MUST NOT verify against the
+  // ed25519 preimage.  This is the cross-language breakage that would occur if
+  // an adapter used the wrong literal.
+  assert.strictEqual(
+    nodeVerify(null, correctPreimage, pubKey, sigOverWrong),
+    false,
+    'Signature over alg="EdDSA" preimage MUST NOT verify against alg="ed25519" preimage'
   );
 });

--- a/packages/sift/test/parameter-binding.test.ts
+++ b/packages/sift/test/parameter-binding.test.ts
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Parameter binding documentation tests.
+ *
+ * These tests demonstrate — NOT fix — the architectural property that Sift
+ * receipts do not cryptographically bind parameter values.
+ *
+ * PURPOSE:
+ *   Lock in and document the known security boundary so that future maintainers,
+ *   cross-language adapter authors, and auditors have an executable specification
+ *   of the limitation.
+ *
+ * PROPERTY UNDER TEST:
+ *   A Sift receipt that approved tool T under policy P will be accepted by
+ *   normalizeIntent and receiptToAuthorization regardless of the specific
+ *   parameter values the adapter supplies.  The resulting AuthorizationV1.intent_hash
+ *   commits to the ADAPTER-SUPPLIED params, not to the params Sift evaluated.
+ *
+ * THIS IS NOT A BUG.  The PEP still enforces intent binding at execution time:
+ *   if the adapter issues AuthorizationV1 with params P2 but execution uses P1,
+ *   the PEP will recompute intent_hash from P1 and find a mismatch → DENY.
+ *   The gap is that the PEP cannot verify that Sift approved P2 specifically.
+ *
+ * See: docs/adapters/sift.md §"Parameter Binding Guarantee"
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+
+import { normalizeIntent }         from "../src/normalizeIntent.js";
+import { receiptToAuthorization }  from "../src/receiptToAuthorization.js";
+import { siftCanonicalJsonBytes }  from "../src/siftCanonical.js";
+import type { SiftReceipt }        from "../src/verifyReceipt.js";
+import type { NormalizedState }    from "../src/state.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Returns a pre-verified SiftReceipt for the "transfer" tool.
+ *
+ * The receipt represents Sift's decision to ALLOW the "transfer" tool under
+ * "transfer-policy-v1".  The receipt does NOT include parameter values —
+ * the params Sift evaluated (e.g. amount=1) are NOT present anywhere in the
+ * receipt payload and NOT covered by the receipt's Ed25519 signature.
+ */
+function makeTransferReceipt(): SiftReceipt {
+  return {
+    receipt_version: "1.0",
+    tenant_id:       "tenant-acme",
+    agent_id:        "agent-001",
+    action:          "call_tool",
+    tool:            "transfer",
+    decision:        "ALLOW",
+    risk_tier:       2,
+    timestamp:       "2026-04-14T12:00:00.000Z",
+    nonce:           "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    policy_matched:  "transfer-policy-v1",
+    // receipt_hash and signature are placeholders.
+    // normalizeIntent and receiptToAuthorization operate on a pre-verified
+    // SiftReceipt; they do not re-run verifyReceipt.
+    receipt_hash:    "a".repeat(64),
+    signature:       "placeholder",
+  };
+}
+
+function makeBaseState(): NormalizedState {
+  return { session_active: true, account_status: "active" } as NormalizedState;
+}
+
+function sha256hex(value: unknown): string {
+  return createHash("sha256").update(siftCanonicalJsonBytes(value)).digest("hex");
+}
+
+// Fixed wall-clock for all time-sensitive assertions.
+const FIXED_NOW = new Date(1_700_000_000_000);
+
+// ─── PB-1: normalizeIntent accepts params that differ from what Sift evaluated ──
+
+test("PB-1: normalizeIntent succeeds with adapter-supplied params regardless of what Sift evaluated", () => {
+  const receipt = makeTransferReceipt();
+
+  // The adapter supplies amount=100_000.
+  // Sift was hypothetically asked about amount=1 — but that is NOT in the receipt
+  // and NOT verifiable from the receipt alone.
+  const adapterParams = { amount: 100_000, destination: "attacker_account" };
+
+  const result = normalizeIntent({ receipt, params: adapterParams });
+
+  // normalizeIntent MUST succeed — params are not bound by the receipt.
+  assert.ok(
+    result.ok,
+    `normalizeIntent MUST succeed for structurally valid params: ${
+      !result.ok ? result.code + ": " + result.message : ""
+    }`
+  );
+  if (!result.ok) return;
+
+  // The intent reflects the adapter-supplied values, not anything Sift signed.
+  assert.equal(result.intent.type, "EXECUTE");
+  assert.equal(result.intent.tool, "transfer");
+  // normalizeIntent returns Object.create(null) params; use JSON round-trip to
+  // compare values without requiring identical prototype chains.
+  assert.deepStrictEqual(
+    JSON.parse(JSON.stringify(result.intent.params)),
+    adapterParams,
+    "intent.params MUST equal the adapter-supplied params"
+  );
+});
+
+// ─── PB-2: intent_hash commits to adapter-supplied params, NOT Sift-evaluated ──
+
+test("PB-2: intent_hash in AuthorizationV1 equals SHA-256 of adapter-supplied params — not Sift-evaluated params", () => {
+  const receipt      = makeTransferReceipt();
+  const adapterParams = { amount: 100_000, destination: "attacker_account" };
+
+  const intentResult = normalizeIntent({ receipt, params: adapterParams });
+  assert.ok(intentResult.ok);
+
+  const authResult = receiptToAuthorization({
+    receipt,
+    intent:     intentResult.intent,
+    state:      makeBaseState(),
+    issuer:     "adapter-issuer",
+    audience:   "pep-payments",
+    keyId:      "adapter-key-1",
+    ttlSeconds: 30,
+    now:        FIXED_NOW,
+  });
+  assert.ok(
+    authResult.ok,
+    `receiptToAuthorization MUST succeed: ${!authResult.ok ? authResult.code : ""}`
+  );
+  if (!authResult.ok) return;
+
+  // The expected hash is over the adapter-supplied intent — not Sift's evaluation.
+  const expectedHash = sha256hex(intentResult.intent);
+
+  assert.equal(
+    authResult.authorization.intent_hash,
+    expectedHash,
+    "intent_hash MUST equal SHA-256(sift_canonical(adapter-supplied intent))"
+  );
+
+  // Sanity-check the negative: the hash is NOT over what Sift (hypothetically) evaluated.
+  const siftEvaluatedIntent = {
+    type:   "EXECUTE",
+    tool:   "transfer",
+    params: { amount: 1, destination: "safe_account" }, // what Sift was asked
+  };
+  assert.notEqual(
+    authResult.authorization.intent_hash,
+    sha256hex(siftEvaluatedIntent),
+    "intent_hash MUST NOT equal the hash of the params Sift (hypothetically) evaluated"
+  );
+});
+
+// ─── PB-3: same receipt, different params → same auth_id, different intent_hash ─
+
+test("PB-3: using the same receipt with different params produces the same auth_id but different intent_hash values", () => {
+  const receipt = makeTransferReceipt();
+
+  const paramsSmall  = { amount: 1,       destination: "safe_account"     };
+  const paramsLarge  = { amount: 100_000, destination: "attacker_account" };
+
+  const intentSmall  = normalizeIntent({ receipt, params: paramsSmall });
+  const intentLarge  = normalizeIntent({ receipt, params: paramsLarge });
+  assert.ok(intentSmall.ok);
+  assert.ok(intentLarge.ok);
+  if (!intentSmall.ok || !intentLarge.ok) return;
+
+  const base = {
+    receipt,
+    state:      makeBaseState(),
+    issuer:     "adapter-issuer",
+    audience:   "pep-payments",
+    keyId:      "adapter-key-1",
+    ttlSeconds: 30,
+    now:        FIXED_NOW,
+  };
+
+  const authSmall = receiptToAuthorization({ ...base, intent: intentSmall.intent });
+  const authLarge = receiptToAuthorization({ ...base, intent: intentLarge.intent });
+  assert.ok(authSmall.ok);
+  assert.ok(authLarge.ok);
+  if (!authSmall.ok || !authLarge.ok) return;
+
+  // auth_id is receipt.nonce — always the same for the same receipt.
+  assert.equal(
+    authSmall.authorization.auth_id,
+    authLarge.authorization.auth_id,
+    "auth_id MUST equal receipt.nonce regardless of params"
+  );
+  assert.equal(
+    authSmall.authorization.auth_id,
+    receipt.nonce,
+    "auth_id MUST be exactly receipt.nonce"
+  );
+
+  // intent_hash MUST differ because params differ.
+  assert.notEqual(
+    authSmall.authorization.intent_hash,
+    authLarge.authorization.intent_hash,
+    "intent_hash MUST differ when adapter-supplied params differ"
+  );
+
+  // Each intent_hash must equal the locally-computed hash for its own params.
+  assert.equal(authSmall.authorization.intent_hash, sha256hex(intentSmall.intent));
+  assert.equal(authLarge.authorization.intent_hash, sha256hex(intentLarge.intent));
+});
+
+// ─── PB-4: receipt contains no params field — the absence is structural ─────────
+
+test("PB-4: the SiftReceipt type has no params field — absence is structural, not a parsing artefact", () => {
+  const receipt = makeTransferReceipt();
+
+  // Verify that the receipt object genuinely does not carry params.
+  assert.ok(
+    !Object.prototype.hasOwnProperty.call(receipt, "params"),
+    "SiftReceipt MUST NOT have a 'params' field — Sift does not include params in the receipt"
+  );
+  assert.ok(
+    !Object.prototype.hasOwnProperty.call(receipt, "params_hash"),
+    "SiftReceipt MUST NOT have a 'params_hash' field — Sift does not sign params"
+  );
+
+  // The tool field IS present and IS covered by the receipt signature.
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(receipt, "tool"),
+    "SiftReceipt MUST have a 'tool' field — tool identity is signed"
+  );
+});


### PR DESCRIPTION
## 1. FIX: AuthorizationV1 signing vector (CRITICAL)

Corrects contract test vector:

- signature.alg: "EdDSA" → "ed25519"

Rationale:

- "EdDSA" is JWKS metadata (RFC 8037)
- "ed25519" is the runtime literal included in the signed payload

Impact:

- canonical signing payload is now byte-identical to production AuthorizationV1
- prevents cross-language signature divergence (TS / Go / Python)
- ensures PEP verification compatibility

Added regression tests:

- valid preimage (alg="ed25519") → signature verifies
- mismatched preimage ("EdDSA" vs "ed25519") → verification fails
- asserts byte-level distinction of canonical payload

Invariant enforced:

Signature preimage MUST match AuthorizationV1 canonical payload exactly → any deviation results in DENY

---

## 2. SPEC: Parameter binding boundary (ARCHITECTURAL)

Formalizes a previously implicit constraint:

Sift receipts do NOT cryptographically bind execution parameters.

Clarifications added to:

- docs/adapters/sift.md
- packages/sift/README.md
- normalizeIntent.ts (JSDoc)
- receiptToAuthorization.ts (intent_hash annotation)

Defined invariant:

- intent_hash commits to adapter-supplied params
- NOT to parameters evaluated by Sift

Explicitly stated:

Parameter mismatch between Sift evaluation and execution → NOT detectable from receipt alone

This is a governance-layer limitation, not an execution-boundary failure.

---

## 3. TESTS: Parameter binding behavior (DOCUMENTED, NOT ENFORCED)

Added parameter-binding test suite:

packages/sift/test/parameter-binding.test.ts

Covers:

- receipt reused with different params → allowed
- intent_hash derived from supplied params
- same receipt → same auth_id, different intent_hash
- absence of params in Sift receipt structure

Purpose:

- document behavior explicitly
- prevent incorrect assumptions by integrators

---

## 4. DOC: Responsibility split (Sift vs OxDeAI)

Adds explicit boundary definition in README:

Sift:
- governance decision (ALLOW / DENY)
- receipt integrity

OxDeAI:
- intent binding
- state binding
- audience binding
- replay protection
- PEP enforcement

Invariant clarified:

Sift receipt ≠ execution authorization
AuthorizationV1 verified at PEP is the only execution gate

---

## 5. NO BEHAVIORAL DRIFT

- no changes to verification logic
- no changes to canonicalization
- no changes to AuthorizationV1 structure
- no changes to enforcement semantics

All existing tests pass + new tests added

---

## RESULT

System is now:

- cryptographically correct (signing preimage)
- explicit at the protocol boundary
- auditable by construction
- aligned with OxDeAI invariant:

  No valid AuthorizationV1 → no execution