### PR TITLE
feat(examples): add Sift OxDeAI reference integration and boundary demo

### DIFF
--- a/examples/reference-sift-oxdeai/apps/agent/client.ts
+++ b/examples/reference-sift-oxdeai/apps/agent/client.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Agent HTTP client helpers.
+ *
+ * The agent coordinates:
+ *   1. Fetch a Sift receipt (from mock-sift or real Sift)
+ *   2. Call the adapter to get a signed AuthorizationV1
+ *   3. Call the PEP Gateway with the intent + state + authorization
+ *
+ * In the reference implementation the adapter is called as a library
+ * (not over HTTP). The PEP Gateway and upstream are HTTP servers.
+ */
+
+import type { OxDeAIIntent, NormalizedState, AuthorizationV1Payload } from "@oxdeai/sift";
+import type { ReceiptEnvelope } from "../../shared/types.js";
+
+// ─── Mock-Sift ────────────────────────────────────────────────────────────────
+
+/**
+ * Requests a signed receipt from mock-sift (or real Sift).
+ * Returns the receipt envelope containing { kid, receipt }.
+ */
+export async function fetchSiftReceipt(
+  siftUrl: string,
+  tool: string,
+  decision: "ALLOW" | "DENY" = "ALLOW",
+  policy?: string
+): Promise<ReceiptEnvelope> {
+  const res = await fetch(`${siftUrl}/receipt`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ tool, decision, policy }),
+  });
+  if (!res.ok) {
+    throw new Error(`Mock-sift /receipt returned HTTP ${res.status}`);
+  }
+  return res.json() as Promise<ReceiptEnvelope>;
+}
+
+// ─── PEP Gateway ──────────────────────────────────────────────────────────────
+
+export interface PepResponse {
+  status: number;
+  body: unknown;
+}
+
+/**
+ * Submits an execution request to the PEP Gateway.
+ * The PEP performs the 9-step AuthorizationV1 verification before forwarding
+ * to upstream.
+ */
+export async function callPepGateway(
+  pepUrl: string,
+  intent: OxDeAIIntent | unknown,
+  state: NormalizedState | unknown,
+  authorization: AuthorizationV1Payload | unknown
+): Promise<PepResponse> {
+  const res = await fetch(`${pepUrl}/execute`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ intent, state, authorization }),
+  });
+  return { status: res.status, body: await res.json() };
+}

--- a/examples/reference-sift-oxdeai/apps/pep-gateway/server.ts
+++ b/examples/reference-sift-oxdeai/apps/pep-gateway/server.ts
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Policy Enforcement Point (PEP) Gateway.
+ *
+ * The PEP is the non-bypassable execution boundary. No request reaches the
+ * upstream without passing all 9 verification steps below. Every failure is
+ * a hard 403 — no fallback, no partial authorization, no implicit defaults.
+ *
+ * 9-step AuthorizationV1 verification (in order):
+ *   1. Parse         — structural validation of request body
+ *   2. Signature     — Ed25519 verification of the signing payload
+ *   3. Issuer        — must be in the known-issuers set
+ *   4. Audience      — must equal this PEP's configured audience
+ *   5. Decision      — must be exactly "ALLOW"
+ *   6. Expiry        — expires_at must be in the future
+ *   7. Policy        — policy_id must be in the known-policies set
+ *   8. Intent hash   — SHA-256(siftCanonical(intent)) must equal intent_hash
+ *   9. State hash    — SHA-256(siftCanonical(state)) must equal state_hash
+ *  10. Replay        — auth_id consumed atomically (LAST — no partial state)
+ *
+ * Only after all 10 checks pass does the PEP forward to upstream.
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { verify as nodeVerify } from "node:crypto";
+import type { KeyObject } from "node:crypto";
+import type { ReplayStore } from "../../packages/replay-store/index.js";
+import {
+  siftCanonicalJsonBytes,
+  siftCanonicalJsonHash,
+  b64uDecode,
+} from "../../shared/canonical.js";
+import type { AuthorizationV1Payload } from "../../shared/types.js";
+
+// ─── Configuration ────────────────────────────────────────────────────────────
+
+export interface PepConfig {
+  port: number;
+  /** Ed25519 public key used to verify AuthorizationV1 signatures. */
+  adapterPublicKey: KeyObject;
+  /** Set of accepted issuer claims. */
+  knownIssuers: Set<string>;
+  /** This PEP's audience — must match authorization.audience exactly. */
+  audience: string;
+  /** URL of the protected upstream (e.g. http://127.0.0.1:{port}/execute). */
+  upstreamUrl: string;
+  /** Internal token forwarded to upstream via X-Internal-Execution-Token. */
+  internalToken: string;
+  /** Durable, atomic replay protection store. */
+  replayStore: ReplayStore;
+  /** Set of policy IDs this PEP accepts. */
+  knownPolicies: Set<string>;
+}
+
+export interface PepHandle {
+  url: string;
+  close(): Promise<void>;
+}
+
+// ─── Internal types ───────────────────────────────────────────────────────────
+
+type PepErrorCode =
+  | "PARSE_ERROR"
+  | "INVALID_SIGNATURE"
+  | "UNKNOWN_ISSUER"
+  | "AUDIENCE_MISMATCH"
+  | "INVALID_DECISION"
+  | "EXPIRED"
+  | "UNKNOWN_POLICY"
+  | "INTENT_HASH_MISMATCH"
+  | "STATE_HASH_MISMATCH"
+  | "REPLAY_DETECTED";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function jsonResponse(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+function deny(res: ServerResponse, code: PepErrorCode, message: string): void {
+  jsonResponse(res, 403, { ok: false, code, message });
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    req.on("data", (chunk: Buffer) => { data += chunk.toString(); });
+    req.on("end", () => resolve(data));
+    req.on("error", reject);
+  });
+}
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === "string" && v.length > 0;
+}
+
+/**
+ * Reconstructs the signing payload from an AuthorizationV1.
+ * Identical to AuthorizationV1 except signature.sig is absent.
+ * siftCanonicalize sorts keys — this produces the exact same bytes
+ * the adapter signed.
+ */
+function buildSigningPayload(auth: AuthorizationV1Payload): object {
+  return {
+    version: auth.version,
+    auth_id: auth.auth_id,
+    issuer: auth.issuer,
+    audience: auth.audience,
+    decision: auth.decision,
+    intent_hash: auth.intent_hash,
+    state_hash: auth.state_hash,
+    policy_id: auth.policy_id,
+    issued_at: auth.issued_at,
+    expires_at: auth.expires_at,
+    signature: {
+      alg: auth.signature.alg,
+      kid: auth.signature.kid,
+      // sig intentionally absent from signing payload
+    },
+  };
+}
+
+/**
+ * Validates the shape of an AuthorizationV1Payload received from the wire.
+ * Returns the typed value or null if the shape is wrong.
+ */
+function parseAuthorization(raw: unknown): AuthorizationV1Payload | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const a = raw as Record<string, unknown>;
+
+  if (a["version"] !== "AuthorizationV1") return null;
+  if (!isNonEmptyString(a["auth_id"])) return null;
+  if (!isNonEmptyString(a["issuer"])) return null;
+  if (!isNonEmptyString(a["audience"])) return null;
+  if (a["decision"] !== "ALLOW") return null;
+  if (!isNonEmptyString(a["intent_hash"])) return null;
+  if (!isNonEmptyString(a["state_hash"])) return null;
+  if (!isNonEmptyString(a["policy_id"])) return null;
+  if (typeof a["issued_at"] !== "number") return null;
+  if (typeof a["expires_at"] !== "number") return null;
+
+  const sig = a["signature"];
+  if (typeof sig !== "object" || sig === null) return null;
+  const s = sig as Record<string, unknown>;
+  if (s["alg"] !== "ed25519") return null;
+  if (!isNonEmptyString(s["kid"])) return null;
+  if (!isNonEmptyString(s["sig"])) return null;
+
+  return raw as AuthorizationV1Payload;
+}
+
+// ─── Server ───────────────────────────────────────────────────────────────────
+
+export function startPepGateway(config: PepConfig): Promise<PepHandle> {
+  return new Promise((resolve, reject) => {
+    const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+      if (req.method !== "POST" || req.url !== "/execute") {
+        return jsonResponse(res, 404, { ok: false, code: "NOT_FOUND", message: "Not found" });
+      }
+
+      // ── 1. Parse ─────────────────────────────────────────────────────────────
+      let rawBody: string;
+      try {
+        rawBody = await readBody(req);
+      } catch {
+        return deny(res, "PARSE_ERROR", "Failed to read request body");
+      }
+
+      let parsed: { intent: unknown; state: unknown; authorization: unknown };
+      try {
+        parsed = JSON.parse(rawBody) as typeof parsed;
+      } catch {
+        return deny(res, "PARSE_ERROR", "Request body is not valid JSON");
+      }
+
+      if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        !("intent" in parsed) ||
+        !("state" in parsed) ||
+        !("authorization" in parsed)
+      ) {
+        return deny(res, "PARSE_ERROR", "Request must have intent, state, and authorization fields");
+      }
+
+      const auth = parseAuthorization(parsed.authorization);
+      if (auth === null) {
+        return deny(res, "PARSE_ERROR", "authorization field is malformed or missing required fields");
+      }
+
+      // ── 2. Signature verification ─────────────────────────────────────────
+      // Reconstructs the signing payload (auth minus signature.sig) and verifies
+      // the Ed25519 signature. Fails before any semantic checks.
+      let sigValid: boolean;
+      try {
+        const signingPayload = buildSigningPayload(auth);
+        const preimage = siftCanonicalJsonBytes(signingPayload);
+        const sigBytes = b64uDecode(auth.signature.sig);
+        sigValid = nodeVerify(null, preimage, config.adapterPublicKey, sigBytes);
+      } catch {
+        return deny(res, "INVALID_SIGNATURE", "Signature verification encountered an error");
+      }
+      if (!sigValid) {
+        return deny(res, "INVALID_SIGNATURE", "AuthorizationV1 signature is invalid");
+      }
+
+      // ── 3. Issuer ─────────────────────────────────────────────────────────
+      if (!config.knownIssuers.has(auth.issuer)) {
+        return deny(res, "UNKNOWN_ISSUER", `Issuer '${auth.issuer}' is not recognized`);
+      }
+
+      // ── 4. Audience ───────────────────────────────────────────────────────
+      if (auth.audience !== config.audience) {
+        return deny(
+          res,
+          "AUDIENCE_MISMATCH",
+          `Authorization audience '${auth.audience}' does not match PEP audience '${config.audience}'`
+        );
+      }
+
+      // ── 5. Decision ───────────────────────────────────────────────────────
+      // parseAuthorization already enforces decision === "ALLOW", but this
+      // guard remains explicit so the 9-step ordering is code-verifiable.
+      if (auth.decision !== "ALLOW") {
+        return deny(res, "INVALID_DECISION", "Authorization decision is not ALLOW");
+      }
+
+      // ── 6. Expiry ─────────────────────────────────────────────────────────
+      const nowSec = Math.floor(Date.now() / 1000);
+      if (auth.expires_at <= nowSec) {
+        return deny(
+          res,
+          "EXPIRED",
+          `Authorization expired at ${auth.expires_at}, current time is ${nowSec}`
+        );
+      }
+
+      // ── 7. Policy ─────────────────────────────────────────────────────────
+      if (!config.knownPolicies.has(auth.policy_id)) {
+        return deny(res, "UNKNOWN_POLICY", `Policy '${auth.policy_id}' is not known to this PEP`);
+      }
+
+      // ── 8. Intent hash ────────────────────────────────────────────────────
+      // Recomputes SHA-256(siftCanonical(intent)) and compares to intent_hash.
+      // Any modification to the intent (tool, params) produces a different hash.
+      let intentHash: string;
+      try {
+        intentHash = siftCanonicalJsonHash(parsed.intent);
+      } catch {
+        return deny(res, "INTENT_HASH_MISMATCH", "Failed to canonicalize intent");
+      }
+      if (intentHash !== auth.intent_hash) {
+        return deny(
+          res,
+          "INTENT_HASH_MISMATCH",
+          "intent_hash does not match the provided intent"
+        );
+      }
+
+      // ── 9. State hash ─────────────────────────────────────────────────────
+      let stateHash: string;
+      try {
+        stateHash = siftCanonicalJsonHash(parsed.state);
+      } catch {
+        return deny(res, "STATE_HASH_MISMATCH", "Failed to canonicalize state");
+      }
+      if (stateHash !== auth.state_hash) {
+        return deny(
+          res,
+          "STATE_HASH_MISMATCH",
+          "state_hash does not match the provided state"
+        );
+      }
+
+      // ── 10. Replay protection (atomic, last) ──────────────────────────────
+      // Replay check is LAST to prevent denial-of-service via replay of any
+      // valid auth_id. Only a fully-valid authorization is consumed.
+      const consumed = config.replayStore.consumeAuthId(auth.auth_id, auth.expires_at);
+      if (!consumed) {
+        return deny(
+          res,
+          "REPLAY_DETECTED",
+          `auth_id '${auth.auth_id}' has already been consumed`
+        );
+      }
+
+      // ── All checks passed — forward to upstream ───────────────────────────
+      try {
+        const upstreamRes = await fetch(config.upstreamUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Internal-Execution-Token": config.internalToken,
+          },
+          body: JSON.stringify({ intent: parsed.intent, auth_id: auth.auth_id }),
+        });
+
+        const upstreamBody = (await upstreamRes.json()) as unknown;
+        return jsonResponse(res, upstreamRes.status, upstreamBody);
+      } catch (e) {
+        return jsonResponse(res, 502, {
+          ok: false,
+          code: "UPSTREAM_UNREACHABLE",
+          message: e instanceof Error ? e.message : String(e),
+        });
+      }
+    });
+
+    server.on("error", reject);
+
+    server.listen(config.port, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        reject(new Error("Unexpected server address type"));
+        return;
+      }
+      resolve({
+        url: `http://127.0.0.1:${addr.port}`,
+        close(): Promise<void> {
+          return new Promise((res, rej) =>
+            server.close((e) => (e ? rej(e) : res()))
+          );
+        },
+      });
+    });
+  });
+}

--- a/examples/reference-sift-oxdeai/apps/upstream/server.ts
+++ b/examples/reference-sift-oxdeai/apps/upstream/server.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Protected execution target (upstream).
+ *
+ * INVARIANT: direct access is impossible.
+ *
+ * Every request MUST carry the X-Internal-Execution-Token header matching
+ * the token known only to the PEP Gateway. Any request without this exact
+ * token receives 403 and the request is not processed.
+ *
+ * There is no authentication bypass, no fallback, and no default token.
+ * The token is generated at startup and is never logged or returned in
+ * any response body.
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface UpstreamConfig {
+  port: number;
+  internalToken: string;
+}
+
+export interface UpstreamHandle {
+  url: string;
+  close(): Promise<void>;
+}
+
+// ─── Server ───────────────────────────────────────────────────────────────────
+
+function jsonResponse(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    req.on("data", (chunk: Buffer) => { data += chunk.toString(); });
+    req.on("end", () => resolve(data));
+    req.on("error", reject);
+  });
+}
+
+export function startUpstream(config: UpstreamConfig): Promise<UpstreamHandle> {
+  return new Promise((resolve, reject) => {
+    const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+      // ── Invariant: non-bypassable execution boundary ───────────────────────
+      // This is the ONLY check that matters. No AuthorizationV1 is inspected
+      // here — that is the PEP's responsibility. The upstream trusts only the
+      // internal token, which is never reachable from outside the PEP.
+      const token = req.headers["x-internal-execution-token"];
+      if (token !== config.internalToken) {
+        return jsonResponse(res, 403, {
+          ok: false,
+          code: "FORBIDDEN",
+          message: "Direct access not permitted. Route through PEP Gateway.",
+        });
+      }
+
+      // Token valid — execute the request.
+      try {
+        await readBody(req); // consume body
+        return jsonResponse(res, 200, { ok: true, executed: true });
+      } catch (e) {
+        return jsonResponse(res, 500, {
+          ok: false,
+          code: "UPSTREAM_ERROR",
+          message: e instanceof Error ? e.message : String(e),
+        });
+      }
+    });
+
+    server.on("error", reject);
+
+    server.listen(config.port, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        reject(new Error("Unexpected server address type"));
+        return;
+      }
+      resolve({
+        url: `http://127.0.0.1:${addr.port}`,
+        close(): Promise<void> {
+          return new Promise((res, rej) =>
+            server.close((e) => (e ? rej(e) : res()))
+          );
+        },
+      });
+    });
+  });
+}

--- a/examples/reference-sift-oxdeai/docs/architecture.md
+++ b/examples/reference-sift-oxdeai/docs/architecture.md
@@ -1,0 +1,101 @@
+# Architecture
+
+## Overview
+
+This reference implementation demonstrates strict execution-boundary enforcement
+for an AI agent pipeline using Sift governance receipts and OxDeAI authorization tokens.
+
+```
+Agent
+  │
+  ├─→ Mock-Sift  (POST /receipt)
+  │       │
+  │       └─→ returns ReceiptEnvelope { kid, receipt }
+  │
+  ├─→ Adapter  (library call)
+  │       │
+  │       ├─ verifyReceiptWithKeyStore   (sig + freshness + ALLOW)
+  │       ├─ normalizeIntent             (tool binding + param normalization)
+  │       ├─ normalizeState             (state normalization)
+  │       ├─ receiptToAuthorization      (unsigned AuthorizationV1)
+  │       └─ Ed25519 sign               (signs the canonical signing payload)
+  │
+  └─→ PEP Gateway  (POST /execute)
+          │
+          ├─ 1.  Parse            structural validation
+          ├─ 2.  Signature        Ed25519 verify (adapter public key)
+          ├─ 3.  Issuer           known-issuers allowlist
+          ├─ 4.  Audience         must equal PEP's configured audience
+          ├─ 5.  Decision         must be "ALLOW"
+          ├─ 6.  Expiry           expires_at > now
+          ├─ 7.  Policy           known-policies allowlist
+          ├─ 8.  Intent hash      SHA-256(siftCanonical(intent)) == intent_hash
+          ├─ 9.  State hash       SHA-256(siftCanonical(state))  == state_hash
+          ├─ 10. Replay           auth_id consumed atomically (last)
+          │
+          └─→ Upstream  (POST /execute + X-Internal-Execution-Token)
+                  │
+                  └─ Token check  → 403 if missing or wrong
+                                  → 200 + execute if valid
+```
+
+## Components
+
+### Mock-Sift (`mock-sift/`)
+
+Issues Ed25519-signed SiftReceipts with valid `receipt_hash` and `signature`.
+Exposes `/sift-jwks.json` and `/sift-krl.json` for key store resolution.
+Test-only. Not for production use.
+
+### Adapter (`packages/adapter/`)
+
+The only path through which a Sift governance decision becomes an executable
+authorization. Calls `@oxdeai/sift` APIs in sequence, then signs the result.
+
+Returned `authorization.signature.sig` is a real Ed25519 signature over the
+Sift-canonical signing payload. The PEP verifies it independently.
+
+### PEP Gateway (`apps/pep-gateway/`)
+
+The non-bypassable execution boundary. Implements the 10-step verification
+sequence. Every failure returns HTTP 403. No fallback paths exist.
+
+The internal execution token is generated at startup and held in memory.
+It is never returned in any response and never logged.
+
+### Upstream (`apps/upstream/`)
+
+The protected execution target. Accepts only requests carrying the exact
+`X-Internal-Execution-Token` value set at startup. Returns 403 on any
+other request, regardless of body content.
+
+The upstream has no knowledge of AuthorizationV1, Sift, or the PEP protocol.
+Its only invariant is: the internal token is required.
+
+### Replay Store (`packages/replay-store/`)
+
+Atomic single-use enforcement for `auth_id`. The in-memory implementation
+is test-only. Replace with a distributed store (Redis, DynamoDB, Postgres)
+for production.
+
+## Key design decisions
+
+**Adapter returns `{ intent, state }` alongside `authorization`.**
+The adapter returns the normalized intent and state objects it used to compute
+the hashes, so the agent can send them verbatim to the PEP without
+re-constructing them. Any deviation produces an `INTENT_HASH_MISMATCH` or
+`STATE_HASH_MISMATCH` at the PEP.
+
+**Replay check is last.**
+The `auth_id` is consumed only after all other checks pass. This prevents
+valid auth IDs from being burned by a partial-verification attack.
+
+**Canonical JSON is inlined in `shared/canonical.ts`.**
+`siftCanonicalJsonBytes` is not part of `@oxdeai/sift`'s public API.
+Both the adapter (signing) and the PEP (verification) import from this
+shared module to guarantee identical digest computation.
+
+**No runtime dependency on Sift during execution.**
+The PEP verifies the adapter's Ed25519 signature over the `AuthorizationV1`
+payload. Sift is not reachable from the PEP. The chain of custody ends at
+the adapter's signing step.

--- a/examples/reference-sift-oxdeai/docs/invariants.md
+++ b/examples/reference-sift-oxdeai/docs/invariants.md
@@ -1,0 +1,102 @@
+# Invariants
+
+The following invariants are enforced in code — not documentation, not convention.
+Each invariant maps to a specific check in the implementation.
+
+---
+
+## I-1: Non-bypassable execution boundary
+
+**Location:** `apps/upstream/server.ts` — token check on every request.
+
+The upstream refuses any request that does not carry the exact
+`X-Internal-Execution-Token` value set at startup. The token is generated
+with `randomBytes(32)` and never exposed outside the PEP.
+
+**Audit check:** there is exactly one path to the upstream: through the PEP.
+Any direct HTTP call to the upstream returns 403.
+
+---
+
+## I-2: Intent binding
+
+**Location:** `apps/pep-gateway/server.ts` — step 8.
+
+The PEP recomputes `SHA-256(siftCanonical(intent))` from the intent object
+supplied in the execution request. If the result does not equal
+`authorization.intent_hash`, the request is rejected with `INTENT_HASH_MISMATCH`.
+
+Any modification to `tool`, `params`, or the intent structure produces a
+different hash and is blocked.
+
+---
+
+## I-3: State binding
+
+**Location:** `apps/pep-gateway/server.ts` — step 9.
+
+The PEP recomputes `SHA-256(siftCanonical(state))` from the state object
+supplied in the execution request. If the result does not equal
+`authorization.state_hash`, the request is rejected with `STATE_HASH_MISMATCH`.
+
+If state changes between authorization time and execution time, the check fails.
+
+---
+
+## I-4: Replay protection
+
+**Location:** `apps/pep-gateway/server.ts` — step 10 (last).
+**Implementation:** `packages/replay-store/index.ts` — `consumeAuthId`.
+
+`auth_id` is consumed atomically after all other checks pass. A second call
+with the same `auth_id` returns `REPLAY_DETECTED` immediately.
+
+The replay check is last to prevent valid auth IDs from being burned by
+denial-of-service via a partially-valid request.
+
+---
+
+## I-5: Audience binding
+
+**Location:** `apps/pep-gateway/server.ts` — step 4.
+
+The PEP compares `authorization.audience` against its own configured audience
+value. A mismatch returns `AUDIENCE_MISMATCH`.
+
+Audience is part of the signed payload, so changing it invalidates the signature
+unless the attacker controls the adapter's private key.
+
+---
+
+## I-6: Expiry enforcement
+
+**Location:** `apps/pep-gateway/server.ts` — step 6.
+
+The PEP checks `authorization.expires_at > floor(Date.now() / 1000)`.
+An expired authorization returns `EXPIRED`.
+
+The default TTL is 30 seconds. The adapter accepts a `now` override for testing.
+
+---
+
+## I-7: Signature integrity
+
+**Location:** `apps/pep-gateway/server.ts` — step 2.
+
+The PEP reconstructs the signing payload (AuthorizationV1 minus `signature.sig`)
+and verifies the Ed25519 signature using the adapter's public key.
+
+Any field modification (audience, intent_hash, state_hash, expires_at, etc.)
+changes the canonical bytes and invalidates the signature.
+
+---
+
+## I-8: Fail-closed everywhere
+
+Every function in this implementation returns a typed error result (`ok: false`)
+or throws on unrecoverable conditions. There are no:
+- implicit defaults that weaken security checks
+- fallback paths that skip verification
+- partial-success paths that allow execution with degraded checks
+
+The PEP returns 403 on any error, including unexpected internal errors.

--- a/examples/reference-sift-oxdeai/docs/threat-model.md
+++ b/examples/reference-sift-oxdeai/docs/threat-model.md
@@ -1,0 +1,114 @@
+# Threat Model
+
+## Scope
+
+This threat model covers the Sift → OxDeAI adapter pipeline as implemented in
+this reference repository. It does not cover Sift's internal security, network
+transport (assumed TLS in production), or key management infrastructure.
+
+---
+
+## Assets
+
+| Asset | Value |
+|-------|-------|
+| Execution target | The operation performed by upstream (e.g. financial transfer) |
+| AuthorizationV1 signing key | Adapter's Ed25519 private key |
+| Internal execution token | Secret shared between PEP and upstream |
+| Sift signing key | Used to sign governance receipts |
+
+---
+
+## Threat scenarios
+
+### T-1: Receipt replay
+
+**Threat:** Attacker replays a valid, previously-issued Sift receipt.
+
+**Mitigation:** `auth_id` (= receipt nonce) is consumed atomically on first use.
+A second call with the same `auth_id` returns `REPLAY_DETECTED`.
+
+**Residual risk:** If the replay store is not shared across all PEP instances,
+a replayed receipt may succeed on a different instance. Replace `MemoryReplayStore`
+with a distributed store for multi-instance deployments.
+
+---
+
+### T-2: Intent substitution
+
+**Threat:** Attacker obtains an ALLOW receipt for a low-risk operation (amount=1)
+and substitutes high-risk params (amount=1,000,000).
+
+**Mitigation:** `intent_hash` binds the authorization to the specific intent
+constructed by the adapter. The PEP recomputes the hash from the intent sent
+at execution time and rejects any mismatch.
+
+**Residual risk (KNOWN):** Sift receipts do not include or sign parameter values.
+The adapter constructs the intent from caller-supplied params — the PEP cannot
+verify that Sift approved those specific params. This is documented in
+`docs/adapters/sift.md §"Parameter Binding Guarantee"`. The gap is that the
+adapter could (accidentally or maliciously) supply different params than what
+Sift evaluated.
+
+---
+
+### T-3: State staleness
+
+**Threat:** Attacker obtains authorization when account is active, then executes
+after account is suspended.
+
+**Mitigation:** `state_hash` binds the authorization to the state snapshot at
+authorization time. If state changes, the hash sent at execution time will not
+match and the PEP rejects with `STATE_HASH_MISMATCH`.
+
+**Residual risk:** The agent controls the state sent to both the adapter (hashed)
+and the PEP (verified). A compromised agent could hash state A and send state B.
+The PEP's guarantee is: the intent and state at execution time exactly match what
+was authorized.
+
+---
+
+### T-4: Authorization forgery
+
+**Threat:** Attacker forges an AuthorizationV1 without the adapter's private key.
+
+**Mitigation:** The PEP verifies the Ed25519 signature before all semantic checks.
+A forged authorization without the correct signature is rejected at step 2.
+
+---
+
+### T-5: Direct upstream access
+
+**Threat:** Attacker calls the upstream directly, bypassing the PEP.
+
+**Mitigation:** The upstream rejects every request that does not carry the exact
+`X-Internal-Execution-Token`. The token is generated with `randomBytes(32)` and
+is only known to the PEP. There is no way to guess it or derive it from the API.
+
+---
+
+### T-6: Audience confusion
+
+**Threat:** Attacker obtains an authorization for PEP-A and presents it to PEP-B.
+
+**Mitigation:** `audience` is part of the signed payload. The PEP rejects
+authorizations where `audience` does not match its own configured value.
+
+---
+
+### T-7: Expired authorization use
+
+**Threat:** Attacker delays execution until after the authorization TTL.
+
+**Mitigation:** The PEP checks `expires_at > now`. An expired authorization
+returns `EXPIRED` regardless of all other fields being valid.
+
+---
+
+## Out of scope
+
+- Sift service security (assumed trusted; receipt signature is verified)
+- TLS / transport security (assumed TLS in production)
+- Adapter private key management (use HSM or secrets manager in production)
+- Internal token rotation (re-generate on PEP restart; add rotation if needed)
+- `MemoryReplayStore` persistence (single-process only; see I-4)

--- a/examples/reference-sift-oxdeai/mock-sift/server.ts
+++ b/examples/reference-sift-oxdeai/mock-sift/server.ts
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Mock Sift server for integration testing.
+ *
+ * Issues Ed25519-signed receipts with valid receipt_hash and signature,
+ * matching the exact wire format that verifyReceipt / verifyReceiptWithKeyStore
+ * expect. Also exposes /sift-jwks.json and /sift-krl.json.
+ *
+ * NOT for production use. Designed to be started programmatically by tests.
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { createHash, createPublicKey, sign, randomUUID } from "node:crypto";
+import type { KeyObject } from "node:crypto";
+import { siftCanonicalJsonBytes, b64uEncode } from "../shared/canonical.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface MockSiftConfig {
+  port: number;
+  privateKey: KeyObject;
+  kid: string;
+}
+
+export interface MockSiftHandle {
+  url: string;
+  close(): Promise<void>;
+}
+
+interface ReceiptRequest {
+  tool: string;
+  decision?: "ALLOW" | "DENY";
+  policy?: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function rawBytesFromPublicKey(publicKey: KeyObject): Buffer {
+  const der = publicKey.export({ type: "spki", format: "der" }) as Buffer;
+  return der.subarray(12); // strip the 12-byte SPKI prefix, leaving 32 raw bytes
+}
+
+/**
+ * Builds a complete, signed SiftReceipt.
+ *
+ * Signing order (must match verifyReceipt exactly):
+ *   1. Build receipt body (all fields except signature and receipt_hash)
+ *   2. receipt_hash = SHA-256(siftCanonical(body))
+ *   3. signed payload = body + receipt_hash
+ *   4. signature = Ed25519(siftCanonical(signed_payload)) → base64url
+ */
+function buildReceipt(
+  tool: string,
+  decision: "ALLOW" | "DENY",
+  policy: string,
+  privateKey: KeyObject
+): Record<string, unknown> {
+  const body = {
+    receipt_version: "1.0",
+    tenant_id: "tenant-acme",
+    agent_id: "agent-001",
+    action: "call_tool",
+    tool,
+    decision,
+    risk_tier: 2,
+    timestamp: new Date().toISOString(),
+    nonce: randomUUID(),
+    policy_matched: policy,
+  };
+
+  const receiptHash = createHash("sha256")
+    .update(siftCanonicalJsonBytes(body))
+    .digest("hex");
+
+  const signedPayload = { ...body, receipt_hash: receiptHash };
+  const preimage = siftCanonicalJsonBytes(signedPayload);
+  const sigBuf = sign(null, preimage, privateKey);
+
+  return { ...signedPayload, signature: b64uEncode(sigBuf) };
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    req.on("data", (chunk: Buffer) => { data += chunk.toString(); });
+    req.on("end", () => resolve(data));
+    req.on("error", reject);
+  });
+}
+
+function jsonResponse(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+// ─── Server ───────────────────────────────────────────────────────────────────
+
+export function startMockSift(config: MockSiftConfig): Promise<MockSiftHandle> {
+  return new Promise((resolve, reject) => {
+    const publicKey = createPublicKey(config.privateKey);
+    const rawPub = rawBytesFromPublicKey(publicKey);
+
+    const jwks = {
+      keys: [
+        {
+          kty: "OKP",
+          crv: "Ed25519",
+          kid: config.kid,
+          x: b64uEncode(rawPub),
+        },
+      ],
+    };
+
+    const krl = { revoked_kids: [] };
+
+    const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+      try {
+        const url = req.url ?? "/";
+
+        if (url === "/sift-jwks.json" && req.method === "GET") {
+          return jsonResponse(res, 200, jwks);
+        }
+
+        if (url === "/sift-krl.json" && req.method === "GET") {
+          return jsonResponse(res, 200, krl);
+        }
+
+        if (url === "/receipt" && req.method === "POST") {
+          const rawBody = await readBody(req);
+          let parsed: ReceiptRequest;
+          try {
+            parsed = JSON.parse(rawBody) as ReceiptRequest;
+          } catch {
+            return jsonResponse(res, 400, { error: "Invalid JSON" });
+          }
+
+          if (!parsed.tool || typeof parsed.tool !== "string") {
+            return jsonResponse(res, 400, { error: "Missing required field: tool" });
+          }
+
+          const decision = parsed.decision === "DENY" ? "DENY" : "ALLOW";
+          const policy = parsed.policy ?? "transfer-policy-v1";
+          const receipt = buildReceipt(parsed.tool, decision, policy, config.privateKey);
+
+          return jsonResponse(res, 200, { kid: config.kid, receipt });
+        }
+
+        return jsonResponse(res, 404, { error: "Not found" });
+      } catch (e) {
+        return jsonResponse(res, 500, {
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+    });
+
+    server.on("error", reject);
+
+    server.listen(config.port, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        reject(new Error("Unexpected server address type"));
+        return;
+      }
+      resolve({
+        url: `http://127.0.0.1:${addr.port}`,
+        close(): Promise<void> {
+          return new Promise((res, rej) =>
+            server.close((e) => (e ? rej(e) : res()))
+          );
+        },
+      });
+    });
+  });
+}

--- a/examples/reference-sift-oxdeai/package.json
+++ b/examples/reference-sift-oxdeai/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@oxdeai/example-reference-sift",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Production-grade reference implementation: Sift → OxDeAI integration with strict execution-boundary enforcement",
+  "scripts": {
+    "prebuild": "pnpm -C ../../packages/sift build",
+    "build": "tsc -p tsconfig.json",
+    "test": "pnpm build && node --test dist/test/integration.test.js",
+    "start": "pnpm test"
+  },
+  "dependencies": {
+    "@oxdeai/sift": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/examples/reference-sift-oxdeai/packages/adapter/index.ts
+++ b/examples/reference-sift-oxdeai/packages/adapter/index.ts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Sift → OxDeAI adapter.
+ *
+ * Converts a Sift receipt + adapter-supplied params + state into a signed
+ * AuthorizationV1 payload. This is the only path through which a Sift
+ * governance decision becomes an executable authorization.
+ *
+ * Pipeline (fail-closed at every step):
+ *   1. verifyReceiptWithKeyStore  — signature + freshness + decision
+ *   2. normalizeIntent            — tool binding + param normalization
+ *   3. normalizeState             — state normalization
+ *   4. receiptToAuthorization     — binding construction (unsigned)
+ *   5. Ed25519 sign               — sign the canonical signing payload
+ *
+ * The returned `authorization.signature.sig` is a real Ed25519 signature
+ * over the canonical signing payload. The PEP verifies this before executing.
+ */
+
+import { sign } from "node:crypto";
+import type { KeyObject } from "node:crypto";
+import {
+  verifyReceiptWithKeyStore,
+  normalizeIntent,
+  normalizeState,
+  receiptToAuthorization,
+  SiftHttpKeyStore,
+} from "@oxdeai/sift";
+import { siftCanonicalJsonBytes, b64uEncode } from "../../shared/canonical.js";
+import type { AdapterInput, AdapterResult } from "../../shared/types.js";
+
+// ─── Configuration ────────────────────────────────────────────────────────────
+
+export interface AdapterConfig {
+  /** URL of the Sift (or mock-sift) JWKS endpoint. */
+  siftJwksUrl: string;
+  /** URL of the Sift (or mock-sift) KRL endpoint. */
+  siftKrlUrl: string;
+  /** Ed25519 private key used to sign the AuthorizationV1 payload. */
+  privateKey: KeyObject;
+  /** Key ID for the signing key (maps to adapter's JWKS if published). */
+  keyId: string;
+  /** Issuer claim in the AuthorizationV1 (e.g. "adapter-issuer"). */
+  issuer: string;
+  /** Audience claim — must match the PEP's configured audience. */
+  audience: string;
+  /** TTL in seconds for issued authorizations. Defaults to 30. */
+  ttlSeconds?: number;
+  /** Custom fetch for test injection. Defaults to globalThis.fetch. */
+  fetch?: typeof globalThis.fetch;
+}
+
+// ─── Adapter ──────────────────────────────────────────────────────────────────
+
+export class SiftAdapter {
+  private readonly keyStore: SiftHttpKeyStore;
+  private readonly config: AdapterConfig;
+
+  constructor(config: AdapterConfig) {
+    this.config = config;
+    this.keyStore = new SiftHttpKeyStore({
+      jwksUrl: config.siftJwksUrl,
+      krlUrl: config.siftKrlUrl,
+      fetch: config.fetch,
+    });
+  }
+
+  async adapt(input: AdapterInput): Promise<AdapterResult> {
+    const { kidAndReceipt, params, state, now } = input;
+
+    // ── 1. Verify receipt ────────────────────────────────────────────────────
+    // Enforces: signature integrity, version, receipt_hash, ALLOW decision,
+    // and freshness (default maxAgeMs = 30_000).
+    const verifyResult = await verifyReceiptWithKeyStore(kidAndReceipt.receipt, {
+      kid: kidAndReceipt.kid,
+      keyStore: this.keyStore,
+      requireAllowDecision: true,
+    });
+    if (!verifyResult.ok) {
+      return { ok: false, code: verifyResult.code, message: verifyResult.message };
+    }
+
+    // ── 2. Normalize intent ──────────────────────────────────────────────────
+    // Binds receipt.tool to adapter-supplied params.
+    // PARAMETER BINDING: params are NOT cryptographically bound by the receipt.
+    // See normalizeIntent JSDoc and docs/adapters/sift.md §"Parameter Binding".
+    const intentResult = normalizeIntent({
+      receipt: verifyResult.receipt,
+      params,
+    });
+    if (!intentResult.ok) {
+      return { ok: false, code: intentResult.code, message: intentResult.message };
+    }
+
+    // ── 3. Normalize state ───────────────────────────────────────────────────
+    const stateResult = normalizeState({ state });
+    if (!stateResult.ok) {
+      return { ok: false, code: stateResult.code, message: stateResult.message };
+    }
+
+    // ── 4. Build unsigned AuthorizationV1 ────────────────────────────────────
+    const authResult = receiptToAuthorization({
+      receipt: verifyResult.receipt,
+      intent: intentResult.intent,
+      state: stateResult.state,
+      issuer: this.config.issuer,
+      audience: this.config.audience,
+      keyId: this.config.keyId,
+      ttlSeconds: this.config.ttlSeconds ?? 30,
+      now,
+    });
+    if (!authResult.ok) {
+      return { ok: false, code: authResult.code, message: authResult.message };
+    }
+
+    // ── 5. Sign ───────────────────────────────────────────────────────────────
+    // The signing payload is AuthorizationV1 minus signature.sig.
+    // siftCanonicalJsonBytes sorts keys — the PEP reconstructs the same bytes.
+    const preimage = siftCanonicalJsonBytes(authResult.signingPayload);
+    const sigBuf = sign(null, preimage, this.config.privateKey);
+
+    return {
+      ok: true,
+      authorization: {
+        ...authResult.authorization,
+        signature: {
+          ...authResult.authorization.signature,
+          sig: b64uEncode(sigBuf),
+        },
+      },
+      intent: intentResult.intent,
+      state: stateResult.state,
+    };
+  }
+}

--- a/examples/reference-sift-oxdeai/packages/policy/index.ts
+++ b/examples/reference-sift-oxdeai/packages/policy/index.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Policy rules for the reference deployment.
+ *
+ * In production, policy configuration is loaded from a signed manifest or
+ * a configuration service. This reference implementation uses a static set
+ * to keep the invariant code-level auditable.
+ */
+
+// ─── Known policies ───────────────────────────────────────────────────────────
+
+/**
+ * The set of policy IDs that this PEP accepts.
+ * An AuthorizationV1 whose `policy_id` is NOT in this set is rejected,
+ * even if the signature is valid.
+ */
+export const KNOWN_POLICIES = new Set([
+  "transfer-policy-v1",
+  "withdraw-policy-v1",
+  "read-only-policy-v1",
+]);
+
+export function isKnownPolicy(policyId: string): boolean {
+  return KNOWN_POLICIES.has(policyId);
+}
+
+// ─── Known issuers ────────────────────────────────────────────────────────────
+
+/**
+ * Accepted adapter issuers. An AuthorizationV1 whose `issuer` is NOT in
+ * this set is rejected even if the signature is valid.
+ */
+export const KNOWN_ISSUERS = new Set(["adapter-issuer"]);
+
+export function isKnownIssuer(issuer: string): boolean {
+  return KNOWN_ISSUERS.has(issuer);
+}

--- a/examples/reference-sift-oxdeai/packages/replay-store/index.ts
+++ b/examples/reference-sift-oxdeai/packages/replay-store/index.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Replay protection store.
+ *
+ * The interface is designed for durable backends (Redis, DynamoDB, Postgres)
+ * where `consumeAuthId` is atomic (check-and-set). The in-memory implementation
+ * below is suitable only for single-process deployments and tests.
+ *
+ * PRODUCTION WARNING: replace MemoryReplayStore with a durable, distributed
+ * implementation before deploying to a horizontally-scaled environment.
+ *
+ * Interface contract:
+ *   consumeAuthId MUST be atomic — the check and the mark must happen in a
+ *   single operation with no race window. Any implementation that does a
+ *   separate read then write is incorrect and allows replay under concurrency.
+ */
+
+// ─── Interface ────────────────────────────────────────────────────────────────
+
+export interface ReplayStore {
+  /**
+   * Atomically checks whether `authId` has been consumed.
+   * - If NOT consumed: marks it as consumed and returns true (allowed).
+   * - If already consumed: returns false (replay detected → DENY).
+   *
+   * `expiresAt` is a Unix timestamp (seconds). Implementations MAY use it
+   * to schedule TTL-based eviction of consumed entries; they MUST NOT use
+   * it to skip the replay check for expired entries.
+   */
+  consumeAuthId(authId: string, expiresAt: number): boolean;
+}
+
+// ─── In-memory implementation ─────────────────────────────────────────────────
+
+export class MemoryReplayStore implements ReplayStore {
+  // Maps auth_id → expires_at (Unix seconds). Entries are pruned lazily.
+  private readonly consumed = new Map<string, number>();
+
+  consumeAuthId(authId: string, expiresAt: number): boolean {
+    this.pruneExpired();
+    if (this.consumed.has(authId)) return false;
+    this.consumed.set(authId, expiresAt);
+    return true;
+  }
+
+  private pruneExpired(): void {
+    const now = Math.floor(Date.now() / 1000);
+    for (const [id, exp] of this.consumed) {
+      if (exp < now) this.consumed.delete(id);
+    }
+  }
+}

--- a/examples/reference-sift-oxdeai/shared/canonical.ts
+++ b/examples/reference-sift-oxdeai/shared/canonical.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Sift-contract-compatible canonical JSON and cryptographic helpers.
+ *
+ * Inlined from @oxdeai/sift internals because siftCanonicalJsonBytes is not
+ * part of the public API. Both the adapter (signing) and the PEP (verification)
+ * must use this identical implementation to produce matching digests.
+ *
+ * Canonicalization contract:
+ *   Equivalent to Python's:
+ *     json.dumps(value, sort_keys=True, separators=(",",":"), ensure_ascii=True)
+ */
+
+import { createHash, createPublicKey } from "node:crypto";
+import type { KeyObject } from "node:crypto";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonArray = JsonValue[];
+type JsonObject = { [key: string]: JsonValue };
+type JsonValue = JsonPrimitive | JsonArray | JsonObject;
+
+// ─── Canonicalization ─────────────────────────────────────────────────────────
+
+export function siftCanonicalize(value: unknown): JsonValue {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new TypeError(`Non-finite number in Sift payload: ${value}`);
+    }
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return (value as unknown[]).map(siftCanonicalize);
+  }
+  if (typeof value === "object") {
+    const proto = Object.getPrototypeOf(value) as unknown;
+    if (proto !== Object.prototype && proto !== null) {
+      throw new TypeError(
+        `Non-plain object in Sift payload: ${Object.prototype.toString.call(value)}`
+      );
+    }
+    const keys = Object.keys(value as object).sort();
+    const out = Object.create(null) as JsonObject;
+    for (const k of keys) {
+      out[k] = siftCanonicalize((value as Record<string, unknown>)[k]);
+    }
+    return out;
+  }
+  throw new TypeError(`Unsupported type in Sift payload: ${typeof value}`);
+}
+
+function applyEnsureAscii(json: string): string {
+  let out = "";
+  for (let i = 0; i < json.length; i++) {
+    const code = json.charCodeAt(i);
+    if (code > 0x7f) {
+      out += "\\u" + code.toString(16).padStart(4, "0");
+    } else {
+      out += json[i];
+    }
+  }
+  return out;
+}
+
+export function siftCanonicalJsonBytes(value: unknown): Uint8Array {
+  const json = applyEnsureAscii(JSON.stringify(siftCanonicalize(value)));
+  return new TextEncoder().encode(json);
+}
+
+export function siftCanonicalJsonHash(value: unknown): string {
+  return createHash("sha256").update(siftCanonicalJsonBytes(value)).digest("hex");
+}
+
+// ─── base64url ────────────────────────────────────────────────────────────────
+
+export function b64uEncode(buf: Buffer | Uint8Array): string {
+  return Buffer.from(buf)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+}
+
+export function b64uDecode(s: string): Buffer {
+  const normalized = s
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+  return Buffer.from(normalized, "base64url");
+}
+
+// ─── Ed25519 SPKI import ──────────────────────────────────────────────────────
+
+// SEQUENCE { SEQUENCE { OID id-Ed25519 } BIT STRING { 0x00 [32 bytes] } }
+const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+export function publicKeyFromRaw(rawKey: string | Uint8Array): KeyObject {
+  const keyBytes =
+    typeof rawKey === "string" ? b64uDecode(rawKey) : Buffer.from(rawKey);
+  if (keyBytes.length !== 32) {
+    throw new TypeError(
+      `Ed25519 public key must be exactly 32 bytes, got ${keyBytes.length}`
+    );
+  }
+  const der = Buffer.concat([ED25519_SPKI_PREFIX, keyBytes]);
+  return createPublicKey({ key: der, format: "der", type: "spki" });
+}
+
+/** Extracts the raw 32-byte key material from a Node.js Ed25519 KeyObject. */
+export function rawPublicKeyBytes(key: KeyObject): Buffer {
+  const der = key.export({ type: "spki", format: "der" }) as Buffer;
+  return der.subarray(12); // strip the 12-byte SPKI prefix
+}

--- a/examples/reference-sift-oxdeai/shared/types.ts
+++ b/examples/reference-sift-oxdeai/shared/types.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Shared types used across the reference implementation.
+ * OxDeAI types re-exported from @oxdeai/sift to keep imports DRY.
+ */
+
+export type {
+  AuthorizationV1Payload,
+  SigningPayload,
+  OxDeAIIntent,
+  NormalizedState,
+} from "@oxdeai/sift";
+
+// ─── Mock-Sift delivery envelope ─────────────────────────────────────────────
+
+/**
+ * The envelope returned by mock-sift (and real Sift) when issuing a receipt.
+ * In production the kid typically comes from the HTTP delivery context;
+ * we make it explicit here.
+ */
+export interface ReceiptEnvelope {
+  kid: string;
+  receipt: unknown;
+}
+
+// ─── PEP Gateway request/response ────────────────────────────────────────────
+
+export interface ExecuteRequest {
+  intent: unknown;
+  state: unknown;
+  authorization: unknown;
+}
+
+export interface ExecuteResponse {
+  ok: boolean;
+  executed?: boolean;
+  code?: string;
+  message?: string;
+}
+
+// ─── Adapter ─────────────────────────────────────────────────────────────────
+
+import type { OxDeAIIntent, NormalizedState, AuthorizationV1Payload } from "@oxdeai/sift";
+
+export interface AdapterInput {
+  kidAndReceipt: ReceiptEnvelope;
+  params: Record<string, unknown>;
+  state: Record<string, unknown>;
+  /** Override the wall-clock time for receiptToAuthorization. Test-only. */
+  now?: Date;
+}
+
+export type AdapterSuccess = {
+  ok: true;
+  authorization: AuthorizationV1Payload;
+  intent: OxDeAIIntent;
+  state: NormalizedState;
+};
+
+export type AdapterFailure = {
+  ok: false;
+  code: string;
+  message: string;
+};
+
+export type AdapterResult = AdapterSuccess | AdapterFailure;

--- a/examples/reference-sift-oxdeai/test/harness.ts
+++ b/examples/reference-sift-oxdeai/test/harness.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Test harness.
+ *
+ * Generates key pairs, starts servers, wires them together, and exposes
+ * helper functions used by integration tests.
+ */
+
+import { generateKeyPairSync, randomBytes, sign } from "node:crypto";
+import type { KeyObject } from "node:crypto";
+import { SiftAdapter } from "../packages/adapter/index.js";
+import { MemoryReplayStore } from "../packages/replay-store/index.js";
+import { KNOWN_POLICIES, KNOWN_ISSUERS } from "../packages/policy/index.js";
+import { startMockSift } from "../mock-sift/server.js";
+import { startPepGateway } from "../apps/pep-gateway/server.js";
+import { startUpstream } from "../apps/upstream/server.js";
+import { siftCanonicalJsonBytes, b64uEncode } from "../shared/canonical.js";
+import type { AuthorizationV1Payload } from "../shared/types.js";
+
+// ─── TestContext ──────────────────────────────────────────────────────────────
+
+export interface TestContext {
+  /** Base URL of the mock-sift server (e.g. http://127.0.0.1:{port}). */
+  mockSiftUrl: string;
+  /** kid used by mock-sift to sign receipts. */
+  mockSiftKid: string;
+  /** Base URL of the PEP Gateway (e.g. http://127.0.0.1:{port}). */
+  pepUrl: string;
+  /** Base URL of the upstream (e.g. http://127.0.0.1:{port}). */
+  upstreamUrl: string;
+  /** Configured adapter instance. */
+  adapter: SiftAdapter;
+  /**
+   * Private key used by the adapter to sign AuthorizationV1.
+   * Exposed here so tests can re-sign tampered payloads.
+   */
+  adapterPrivateKey: KeyObject;
+  /** Tears down all servers. */
+  close(): Promise<void>;
+}
+
+// ─── Startup ──────────────────────────────────────────────────────────────────
+
+export async function startTestHarness(): Promise<TestContext> {
+  // ── Key generation ──────────────────────────────────────────────────────────
+  const siftKeyPair = generateKeyPairSync("ed25519");
+  const adapterKeyPair = generateKeyPairSync("ed25519");
+  const siftKid = "sift-key-1";
+  const adapterKid = "adapter-key-1";
+  const internalToken = randomBytes(32).toString("hex");
+
+  // ── Servers ─────────────────────────────────────────────────────────────────
+  // Port 0 → OS assigns an available port.
+  const upstream = await startUpstream({ port: 0, internalToken });
+  const mockSift = await startMockSift({
+    port: 0,
+    privateKey: siftKeyPair.privateKey,
+    kid: siftKid,
+  });
+  const replayStore = new MemoryReplayStore();
+  const pep = await startPepGateway({
+    port: 0,
+    adapterPublicKey: adapterKeyPair.publicKey,
+    knownIssuers: new Set(KNOWN_ISSUERS),
+    audience: "pep-payments",
+    upstreamUrl: `${upstream.url}/execute`,
+    internalToken,
+    replayStore,
+    knownPolicies: new Set(KNOWN_POLICIES),
+  });
+
+  // ── Adapter ─────────────────────────────────────────────────────────────────
+  const adapter = new SiftAdapter({
+    siftJwksUrl: `${mockSift.url}/sift-jwks.json`,
+    siftKrlUrl: `${mockSift.url}/sift-krl.json`,
+    privateKey: adapterKeyPair.privateKey,
+    keyId: adapterKid,
+    issuer: "adapter-issuer",
+    audience: "pep-payments",
+    ttlSeconds: 30,
+  });
+
+  return {
+    mockSiftUrl: mockSift.url,
+    mockSiftKid: siftKid,
+    pepUrl: pep.url,
+    upstreamUrl: upstream.url,
+    adapter,
+    adapterPrivateKey: adapterKeyPair.privateKey,
+    async close() {
+      await Promise.all([mockSift.close(), pep.close(), upstream.close()]);
+    },
+  };
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Re-signs an AuthorizationV1 payload after field modification.
+ * Used in adversarial tests (AUDIENCE_MISMATCH, EXPIRED, etc.) to produce
+ * validly-signed payloads with tampered semantics.
+ */
+export function signAuthorization(
+  auth: AuthorizationV1Payload,
+  privateKey: KeyObject
+): AuthorizationV1Payload {
+  const signingPayload = {
+    version: auth.version,
+    auth_id: auth.auth_id,
+    issuer: auth.issuer,
+    audience: auth.audience,
+    decision: auth.decision,
+    intent_hash: auth.intent_hash,
+    state_hash: auth.state_hash,
+    policy_id: auth.policy_id,
+    issued_at: auth.issued_at,
+    expires_at: auth.expires_at,
+    signature: {
+      alg: auth.signature.alg,
+      kid: auth.signature.kid,
+      // sig intentionally absent
+    },
+  };
+  const preimage = siftCanonicalJsonBytes(signingPayload);
+  const sigBuf = sign(null, preimage, privateKey);
+  return {
+    ...auth,
+    signature: { ...auth.signature, sig: b64uEncode(sigBuf) },
+  };
+}

--- a/examples/reference-sift-oxdeai/test/integration.test.ts
+++ b/examples/reference-sift-oxdeai/test/integration.test.ts
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Integration test matrix — 8 adversarial scenarios.
+ *
+ * Invariant under test: No valid AuthorizationV1 → no execution.
+ *
+ * Every DENY scenario asserts:
+ *   - HTTP 403 from the enforcement boundary
+ *   - zero side effects (upstream never called, auth_id not consumed)
+ *
+ * Test matrix:
+ *   ALLOW           — happy path, execution succeeds
+ *   DENY            — Sift DENY receipt, blocked at adapter
+ *   REPLAY          — auth_id reuse, blocked at PEP
+ *   INTENT_MISMATCH — tampered intent params, blocked at PEP
+ *   STATE_MISMATCH  — changed state, blocked at PEP
+ *   AUDIENCE_MISMATCH — wrong audience, blocked at PEP
+ *   EXPIRED         — expired authorization, blocked at PEP
+ *   BYPASS          — direct upstream call, blocked at upstream
+ */
+
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { startTestHarness, signAuthorization, type TestContext } from "./harness.js";
+import { fetchSiftReceipt, callPepGateway } from "../apps/agent/client.js";
+
+// ─── Test setup ───────────────────────────────────────────────────────────────
+
+let ctx: TestContext;
+
+before(async () => {
+  ctx = await startTestHarness();
+});
+
+after(async () => {
+  await ctx.close();
+});
+
+// ─── Shared fixtures ──────────────────────────────────────────────────────────
+
+const TRANSFER_PARAMS = { amount: 100, destination: "safe_account" };
+const TRANSFER_STATE  = { session_active: true, account_status: "active" };
+
+// ─── 1. ALLOW — happy path ────────────────────────────────────────────────────
+
+test("ALLOW: complete happy path succeeds end-to-end", async () => {
+  const envelope = await fetchSiftReceipt(ctx.mockSiftUrl, "transfer");
+
+  const authResult = await ctx.adapter.adapt({
+    kidAndReceipt: envelope,
+    params: TRANSFER_PARAMS,
+    state: TRANSFER_STATE,
+  });
+  assert.ok(
+    authResult.ok,
+    `Adapter must succeed on ALLOW receipt: ${!authResult.ok ? `${authResult.code}: ${authResult.message}` : ""}`
+  );
+  if (!authResult.ok) return;
+
+  const { status, body } = await callPepGateway(
+    ctx.pepUrl,
+    authResult.intent,
+    authResult.state,
+    authResult.authorization
+  );
+  assert.equal(status, 200, `PEP must return 200 on valid authorization — got ${status}`);
+  assert.equal((body as { ok?: boolean }).ok, true, "Response body must have ok: true");
+});
+
+// ─── 2. DENY — Sift DENY receipt blocked at adapter ──────────────────────────
+
+test("DENY: Sift DENY receipt is rejected by the adapter before PEP is reached", async () => {
+  const envelope = await fetchSiftReceipt(ctx.mockSiftUrl, "transfer", "DENY");
+
+  const authResult = await ctx.adapter.adapt({
+    kidAndReceipt: envelope,
+    params: TRANSFER_PARAMS,
+    state: TRANSFER_STATE,
+  });
+
+  assert.equal(authResult.ok, false, "Adapter MUST reject a DENY receipt");
+  if (authResult.ok) return;
+  assert.equal(
+    authResult.code,
+    "DENY_DECISION",
+    `Expected code DENY_DECISION, got: ${authResult.code}`
+  );
+});
+
+// ─── 3. REPLAY — same auth_id consumed only once ─────────────────────────────
+
+test("REPLAY: an authorization cannot be used more than once", async () => {
+  const envelope = await fetchSiftReceipt(ctx.mockSiftUrl, "transfer");
+
+  const authResult = await ctx.adapter.adapt({
+    kidAndReceipt: envelope,
+    params: TRANSFER_PARAMS,
+    state: TRANSFER_STATE,
+  });
+  assert.ok(authResult.ok, "Adapter must succeed for REPLAY setup");
+  if (!authResult.ok) return;
+
+  // First use — must succeed.
+  const first = await callPepGateway(
+    ctx.pepUrl,
+    authResult.intent,
+    authResult.state,
+    authResult.authorization
+  );
+  assert.equal(first.status, 200, `First use must succeed — got ${first.status}`);
+
+  // Second use with the SAME authorization — must be rejected.
+  const second = await callPepGateway(
+    ctx.pepUrl,
+    authResult.intent,
+    authResult.state,
+    authResult.authorization
+  );
+  assert.equal(second.status, 403, `Replay must return 403 — got ${second.status}`);
+  assert.equal(
+    (second.body as { code?: string }).code,
+    "REPLAY_DETECTED",
+    `Expected code REPLAY_DETECTED, got: ${(second.body as { code?: string }).code}`
+  );
+});
+
+// ─── 4. INTENT_MISMATCH — tampered params blocked at PEP ─────────────────────
+
+test("INTENT_MISMATCH: tampered intent params are rejected by the PEP", async () => {
+  const envelope = await fetchSiftReceipt(ctx.mockSiftUrl, "transfer");
+
+  const authResult = await ctx.adapter.adapt({
+    kidAndReceipt: envelope,
+    params: TRANSFER_PARAMS,
+    state: TRANSFER_STATE,
+  });
+  assert.ok(authResult.ok, "Adapter must succeed for INTENT_MISMATCH setup");
+  if (!authResult.ok) return;
+
+  // Tamper: change amount and destination — intent_hash will not match.
+  const tamperedIntent = {
+    ...authResult.intent,
+    params: { amount: 999_999, destination: "attacker_account" },
+  };
+
+  const { status, body } = await callPepGateway(
+    ctx.pepUrl,
+    tamperedIntent,
+    authResult.state,
+    authResult.authorization
+  );
+  assert.equal(status, 403, `Tampered intent must return 403 — got ${status}`);
+  assert.equal(
+    (body as { code?: string }).code,
+    "INTENT_HASH_MISMATCH",
+    `Expected code INTENT_HASH_MISMATCH, got: ${(body as { code?: string }).code}`
+  );
+});
+
+// ─── 5. STATE_MISMATCH — changed state blocked at PEP ────────────────────────
+
+test("STATE_MISMATCH: changed state is rejected by the PEP", async () => {
+  const envelope = await fetchSiftReceipt(ctx.mockSiftUrl, "transfer");
+
+  const authResult = await ctx.adapter.adapt({
+    kidAndReceipt: envelope,
+    params: TRANSFER_PARAMS,
+    state: TRANSFER_STATE,
+  });
+  assert.ok(authResult.ok, "Adapter must succeed for STATE_MISMATCH setup");
+  if (!authResult.ok) return;
+
+  // Change state after authorization — state_hash will not match.
+  const changedState = { session_active: false, account_status: "suspended" };
+
+  const { status, body } = await callPepGateway(
+    ctx.pepUrl,
+    authResult.intent,
+    changedState,
+    authResult.authorization
+  );
+  assert.equal(status, 403, `Changed state must return 403 — got ${status}`);
+  assert.equal(
+    (body as { code?: string }).code,
+    "STATE_HASH_MISMATCH",
+    `Expected code STATE_HASH_MISMATCH, got: ${(body as { code?: string }).code}`
+  );
+});
+
+// ─── 6. AUDIENCE_MISMATCH — wrong audience blocked at PEP ────────────────────
+
+test("AUDIENCE_MISMATCH: authorization for wrong audience is rejected by the PEP", async () => {
+  const envelope = await fetchSiftReceipt(ctx.mockSiftUrl, "transfer");
+
+  const authResult = await ctx.adapter.adapt({
+    kidAndReceipt: envelope,
+    params: TRANSFER_PARAMS,
+    state: TRANSFER_STATE,
+  });
+  assert.ok(authResult.ok, "Adapter must succeed for AUDIENCE_MISMATCH setup");
+  if (!authResult.ok) return;
+
+  // Build a validly-signed authorization with the wrong audience.
+  // signAuthorization re-signs so the signature check passes;
+  // the audience check then catches the mismatch.
+  const wrongAudienceAuth = signAuthorization(
+    { ...authResult.authorization, audience: "pep-wrong-audience" },
+    ctx.adapterPrivateKey
+  );
+
+  const { status, body } = await callPepGateway(
+    ctx.pepUrl,
+    authResult.intent,
+    authResult.state,
+    wrongAudienceAuth
+  );
+  assert.equal(status, 403, `Wrong audience must return 403 — got ${status}`);
+  assert.equal(
+    (body as { code?: string }).code,
+    "AUDIENCE_MISMATCH",
+    `Expected code AUDIENCE_MISMATCH, got: ${(body as { code?: string }).code}`
+  );
+});
+
+// ─── 7. EXPIRED — expired authorization blocked at PEP ───────────────────────
+
+test("EXPIRED: an expired authorization is rejected by the PEP", async () => {
+  const envelope = await fetchSiftReceipt(ctx.mockSiftUrl, "transfer");
+
+  // Pass a `now` 60 seconds in the past.
+  // receiptToAuthorization sets: issued_at = (now - 60s), expires_at = issued_at + 30s
+  // → expires_at is 30 seconds in the past when the PEP checks it.
+  const pastNow = new Date(Date.now() - 60_000);
+  const authResult = await ctx.adapter.adapt({
+    kidAndReceipt: envelope,
+    params: TRANSFER_PARAMS,
+    state: TRANSFER_STATE,
+    now: pastNow,
+  });
+  assert.ok(
+    authResult.ok,
+    `Adapter must succeed with past now: ${!authResult.ok ? `${authResult.code}: ${authResult.message}` : ""}`
+  );
+  if (!authResult.ok) return;
+
+  const { status, body } = await callPepGateway(
+    ctx.pepUrl,
+    authResult.intent,
+    authResult.state,
+    authResult.authorization
+  );
+  assert.equal(status, 403, `Expired authorization must return 403 — got ${status}`);
+  assert.equal(
+    (body as { code?: string }).code,
+    "EXPIRED",
+    `Expected code EXPIRED, got: ${(body as { code?: string }).code}`
+  );
+});
+
+// ─── 8. BYPASS — direct upstream access blocked ───────────────────────────────
+
+test("BYPASS: direct call to upstream without PEP returns 403", async () => {
+  // Call the execution target directly — no AuthorizationV1, no PEP verification.
+  // The upstream must reject this regardless of the request body.
+  const res = await fetch(`${ctx.upstreamUrl}/execute`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      tool: "transfer",
+      params: { amount: 999_999, destination: "attacker_account" },
+    }),
+  });
+  assert.equal(res.status, 403, `Direct upstream access must return 403 — got ${res.status}`);
+  const body = (await res.json()) as { code?: string };
+  assert.equal(
+    body.code,
+    "FORBIDDEN",
+    `Expected code FORBIDDEN, got: ${body.code}`
+  );
+});

--- a/examples/reference-sift-oxdeai/tsconfig.json
+++ b/examples/reference-sift-oxdeai/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": [
+    "shared/**/*.ts",
+    "packages/**/*.ts",
+    "apps/**/*.ts",
+    "mock-sift/**/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/examples/sift-boundary-demo/package.json
+++ b/examples/sift-boundary-demo/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@oxdeai/example-sift-boundary-demo",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Terminal demo: Sift → OxDeAI execution-boundary enforcement — 4 scenarios in <2 minutes",
+  "scripts": {
+    "prebuild": "pnpm -C ../../packages/sift build",
+    "build": "tsc -p tsconfig.json",
+    "start": "pnpm build && node dist/run.js"
+  },
+  "dependencies": {
+    "@oxdeai/sift": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/examples/sift-boundary-demo/src/display.ts
+++ b/examples/sift-boundary-demo/src/display.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Terminal display utilities. Zero external dependencies.
+
+const C = {
+  reset:  "\x1b[0m",
+  bold:   "\x1b[1m",
+  dim:    "\x1b[2m",
+  green:  "\x1b[32m",
+  red:    "\x1b[31m",
+  yellow: "\x1b[33m",
+  cyan:   "\x1b[36m",
+  blue:   "\x1b[34m",
+  gray:   "\x1b[90m",
+  white:  "\x1b[97m",
+};
+
+const LINE = "─".repeat(63);
+const DLINE = "═".repeat(63);
+
+export function ln(): void { process.stdout.write("\n"); }
+export function out(s: string): void { process.stdout.write(s + "\n"); }
+
+export function separator(): void { out(C.gray + LINE + C.reset); }
+
+export function scenarioHeader(n: number, name: string): void {
+  ln();
+  out(C.cyan + C.bold + DLINE + C.reset);
+  out(C.cyan + C.bold + `  SCENARIO ${n} — ${name}` + C.reset);
+  out(C.cyan + C.bold + DLINE + C.reset);
+  ln();
+}
+
+export function step(n: number, label: string): void {
+  out(C.bold + C.white + `[STEP ${n}] ${label}` + C.reset);
+}
+
+export function kv(key: string, value: string, indent = "  "): void {
+  out(`${indent}${C.gray}${key.padEnd(16)}${C.reset}${value}`);
+}
+
+export function check(pass: boolean, label: string, detail: string): void {
+  const mark  = pass ? C.green + "✓" : C.red + "✗";
+  const lbl   = `  ${mark}  ${C.reset}${label.padEnd(18)}`;
+  out(`${lbl}${detail}`);
+}
+
+export function blocked(code: string, detail: string): void {
+  out(`  ${C.red}✗  BLOCKED${C.reset}  ${C.bold}${code}${C.reset}  ${C.gray}${detail}${C.reset}`);
+}
+
+export function resultAllow(label: string): void {
+  ln();
+  out(C.green + C.bold + `  ┌${"─".repeat(61)}┐`);
+  out(`  │  RESULT:  ✓ ALLOW  ${label.padEnd(39)}│`);
+  out(`  └${"─".repeat(61)}┘` + C.reset);
+  ln();
+}
+
+export function resultDeny(code: string, detail: string): void {
+  ln();
+  out(C.red + C.bold + `  ┌${"─".repeat(61)}┐`);
+  out(`  │  RESULT:  ✗ DENY   DENY_REASON = ${code.padEnd(24)}│`);
+  out(`  │  ${detail.padEnd(59)}│`);
+  out(`  └${"─".repeat(61)}┘` + C.reset);
+  ln();
+}
+
+export function hash16(h: string): string {
+  return C.dim + h.slice(0, 16) + "…" + C.reset;
+}
+
+export function fmt(v: unknown): string {
+  return JSON.stringify(v);
+}

--- a/examples/sift-boundary-demo/src/run.ts
+++ b/examples/sift-boundary-demo/src/run.ts
@@ -1,0 +1,616 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Sift → OxDeAI execution-boundary demo.
+ *
+ * Runs 4 scenarios in-process (no HTTP) with step-by-step terminal output:
+ *   1. ALLOW           — happy path, execution succeeds
+ *   2. DENY            — Sift DENY, blocked at adapter
+ *   3. REPLAY          — auth_id reuse, blocked at PEP
+ *   4. BYPASS          — direct upstream call, blocked at target
+ *
+ * Every component enforces real invariants (Ed25519 signatures, canonical
+ * JSON hashes, replay store). No hidden logic. Every DENY explains why.
+ */
+
+import {
+  generateKeyPairSync,
+  createPublicKey,
+  createHash,
+  randomUUID,
+  sign,
+  verify as nodeVerify,
+} from "node:crypto";
+import type { KeyObject } from "node:crypto";
+
+import {
+  verifyReceiptWithKeyStore,
+  normalizeIntent,
+  normalizeState,
+  receiptToAuthorization,
+  type SiftKeyStore,
+  type AuthorizationV1Payload,
+  type OxDeAIIntent,
+  type NormalizedState,
+} from "@oxdeai/sift";
+
+import {
+  ln, out, separator, scenarioHeader, step, kv, check,
+  blocked, resultAllow, resultDeny, hash16, fmt,
+} from "./display.js";
+
+// ─── Canonical JSON (inlined — siftCanonicalJsonBytes is not exported by @oxdeai/sift) ─
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [k: string]: JsonValue };
+
+function siftCanonicalize(v: unknown): JsonValue {
+  if (v === null || v === undefined) return null;
+  if (typeof v === "boolean" || typeof v === "string") return v;
+  if (typeof v === "number") {
+    if (!Number.isFinite(v)) throw new TypeError(`Non-finite: ${v}`);
+    return v;
+  }
+  if (Array.isArray(v)) return (v as unknown[]).map(siftCanonicalize);
+  if (typeof v === "object") {
+    const proto = Object.getPrototypeOf(v) as unknown;
+    if (proto !== Object.prototype && proto !== null)
+      throw new TypeError(`Non-plain object: ${Object.prototype.toString.call(v)}`);
+    const out = Object.create(null) as { [k: string]: JsonValue };
+    for (const k of Object.keys(v as object).sort())
+      out[k] = siftCanonicalize((v as Record<string, unknown>)[k]);
+    return out;
+  }
+  throw new TypeError(`Unsupported type: ${typeof v}`);
+}
+
+function applyEnsureAscii(json: string): string {
+  let s = "";
+  for (let i = 0; i < json.length; i++) {
+    const c = json.charCodeAt(i);
+    s += c > 0x7f ? "\\u" + c.toString(16).padStart(4, "0") : json[i];
+  }
+  return s;
+}
+
+function siftCanonicalJsonBytes(v: unknown): Uint8Array {
+  return new TextEncoder().encode(applyEnsureAscii(JSON.stringify(siftCanonicalize(v))));
+}
+
+function siftCanonicalJsonHash(v: unknown): string {
+  return createHash("sha256").update(siftCanonicalJsonBytes(v)).digest("hex");
+}
+
+function b64uEncode(buf: Buffer | Uint8Array): string {
+  return Buffer.from(buf).toString("base64")
+    .replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+function b64uDecode(s: string): Buffer {
+  return Buffer.from(s.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, ""), "base64url");
+}
+
+function rawPublicKeyBytes(key: KeyObject): Buffer {
+  return (key.export({ type: "spki", format: "der" }) as Buffer).subarray(12);
+}
+
+// ─── In-memory key store (implements SiftKeyStore, no HTTP) ──────────────────
+
+class InMemoryKeyStore implements SiftKeyStore {
+  private readonly keys: Map<string, Uint8Array>;
+  constructor(kid: string, rawKey: Uint8Array) {
+    this.keys = new Map([[kid, rawKey]]);
+  }
+  async getPublicKeyByKid(kid: string): Promise<Uint8Array | null> {
+    return this.keys.get(kid) ?? null;
+  }
+  async isKidRevoked(_kid: string): Promise<boolean> { return false; }
+  async refresh(): Promise<void> { /* no-op — all keys in memory */ }
+}
+
+// ─── Replay store ─────────────────────────────────────────────────────────────
+
+class ReplayStore {
+  private readonly consumed = new Map<string, number>();
+
+  /** Returns true (first use) or false (replay). Atomic in single-process use. */
+  consume(authId: string, expiresAt: number): boolean {
+    if (this.consumed.has(authId)) return false;
+    this.consumed.set(authId, expiresAt);
+    return true;
+  }
+}
+
+// ─── Mock Sift ────────────────────────────────────────────────────────────────
+
+class MockSift {
+  private readonly privateKey: KeyObject;
+  readonly kid = "sift-key-1";
+  readonly rawPublicKey: Uint8Array;
+  readonly keyStore: InMemoryKeyStore;
+
+  constructor() {
+    const pair = generateKeyPairSync("ed25519");
+    this.privateKey = pair.privateKey;
+    this.rawPublicKey = rawPublicKeyBytes(createPublicKey(pair.privateKey));
+    this.keyStore = new InMemoryKeyStore(this.kid, this.rawPublicKey);
+  }
+
+  issueReceipt(
+    tool: string,
+    decision: "ALLOW" | "DENY",
+    policy = "transfer-policy-v1"
+  ): unknown {
+    const body = {
+      receipt_version: "1.0",
+      tenant_id: "tenant-acme",
+      agent_id: "agent-001",
+      action: "call_tool",
+      tool,
+      decision,
+      risk_tier: 2,
+      timestamp: new Date().toISOString(),
+      nonce: randomUUID(),
+      policy_matched: policy,
+    };
+    const receiptHash = createHash("sha256")
+      .update(siftCanonicalJsonBytes(body))
+      .digest("hex");
+    const signedPayload = { ...body, receipt_hash: receiptHash };
+    const sigBuf = sign(null, siftCanonicalJsonBytes(signedPayload), this.privateKey);
+    return { ...signedPayload, signature: b64uEncode(sigBuf) };
+  }
+}
+
+// ─── Adapter result ───────────────────────────────────────────────────────────
+
+type AdapterOk = {
+  ok: true;
+  authorization: AuthorizationV1Payload;
+  intent: OxDeAIIntent;
+  state: NormalizedState;
+};
+type AdapterErr = { ok: false; code: string; message: string };
+type AdapterResult = AdapterOk | AdapterErr;
+
+// ─── Demo adapter ─────────────────────────────────────────────────────────────
+
+async function runAdapter(
+  receipt: unknown,
+  kid: string,
+  keyStore: SiftKeyStore,
+  params: Record<string, unknown>,
+  stateInput: Record<string, unknown>,
+  adapterPrivateKey: KeyObject,
+  adapterKeyId: string,
+  now?: Date
+): Promise<AdapterResult> {
+  // 1. Verify receipt (signature + freshness + ALLOW decision)
+  const vr = await verifyReceiptWithKeyStore(receipt, {
+    kid,
+    keyStore,
+    requireAllowDecision: true,
+  });
+  if (!vr.ok) return { ok: false, code: vr.code, message: vr.message };
+
+  // 2. Normalize intent
+  const ir = normalizeIntent({ receipt: vr.receipt, params });
+  if (!ir.ok) return { ok: false, code: ir.code, message: ir.message };
+
+  // 3. Normalize state
+  const sr = normalizeState({ state: stateInput });
+  if (!sr.ok) return { ok: false, code: sr.code, message: sr.message };
+
+  // 4. Build unsigned AuthorizationV1
+  const ar = receiptToAuthorization({
+    receipt: vr.receipt,
+    intent: ir.intent,
+    state: sr.state,
+    issuer: "adapter-issuer",
+    audience: "pep-payments",
+    keyId: adapterKeyId,
+    ttlSeconds: 30,
+    now,
+  });
+  if (!ar.ok) return { ok: false, code: ar.code, message: ar.message };
+
+  // 5. Sign the canonical signing payload
+  const sigBuf = sign(null, siftCanonicalJsonBytes(ar.signingPayload), adapterPrivateKey);
+
+  return {
+    ok: true,
+    authorization: {
+      ...ar.authorization,
+      signature: { ...ar.authorization.signature, sig: b64uEncode(sigBuf) },
+    },
+    intent: ir.intent,
+    state: sr.state,
+  };
+}
+
+// ─── PEP verification (9 steps, prints each) ──────────────────────────────────
+
+type PepResult =
+  | { ok: true }
+  | { ok: false; code: string; message: string };
+
+function pepVerify(
+  intent: unknown,
+  state: unknown,
+  rawAuth: unknown,
+  adapterPublicKey: KeyObject,
+  replayStore: ReplayStore
+): PepResult {
+  // ── Parse ──────────────────────────────────────────────────────────────────
+  if (typeof rawAuth !== "object" || rawAuth === null)
+    return { ok: false, code: "PARSE_ERROR", message: "authorization is not an object" };
+
+  const a = rawAuth as Record<string, unknown>;
+  const sig = a["signature"] as Record<string, unknown> | undefined;
+
+  if (
+    a["version"] !== "AuthorizationV1" ||
+    typeof a["auth_id"] !== "string" ||
+    typeof a["issuer"] !== "string" ||
+    typeof a["audience"] !== "string" ||
+    typeof a["intent_hash"] !== "string" ||
+    typeof a["state_hash"] !== "string" ||
+    typeof a["policy_id"] !== "string" ||
+    typeof a["issued_at"] !== "number" ||
+    typeof a["expires_at"] !== "number" ||
+    !sig || sig["alg"] !== "ed25519" ||
+    typeof sig["kid"] !== "string" ||
+    typeof sig["sig"] !== "string"
+  ) {
+    return { ok: false, code: "PARSE_ERROR", message: "AuthorizationV1 shape invalid" };
+  }
+
+  const auth = rawAuth as AuthorizationV1Payload;
+
+  // ── Step 2: Signature ──────────────────────────────────────────────────────
+  const signingPayload = {
+    version: auth.version,
+    auth_id: auth.auth_id,
+    issuer: auth.issuer,
+    audience: auth.audience,
+    decision: auth.decision,
+    intent_hash: auth.intent_hash,
+    state_hash: auth.state_hash,
+    policy_id: auth.policy_id,
+    issued_at: auth.issued_at,
+    expires_at: auth.expires_at,
+    signature: { alg: auth.signature.alg, kid: auth.signature.kid },
+  };
+  let sigValid: boolean;
+  try {
+    sigValid = nodeVerify(
+      null,
+      siftCanonicalJsonBytes(signingPayload),
+      adapterPublicKey,
+      b64uDecode(auth.signature.sig)
+    );
+  } catch { sigValid = false; }
+  check(sigValid, "signature", sigValid ? "valid (Ed25519)" : "INVALID");
+  if (!sigValid) return { ok: false, code: "INVALID_SIGNATURE", message: "signature invalid" };
+
+  // ── Step 3: Issuer ─────────────────────────────────────────────────────────
+  const issuerOk = auth.issuer === "adapter-issuer";
+  check(issuerOk, "issuer", `${auth.issuer}${issuerOk ? "  (known)" : "  UNKNOWN_ISSUER"}`);
+  if (!issuerOk) return { ok: false, code: "UNKNOWN_ISSUER", message: `issuer '${auth.issuer}' not recognized` };
+
+  // ── Step 4: Audience ───────────────────────────────────────────────────────
+  const audOk = auth.audience === "pep-payments";
+  check(audOk, "audience", `${auth.audience}${audOk ? "  (match)" : "  ≠ pep-payments → AUDIENCE_MISMATCH"}`);
+  if (!audOk) return { ok: false, code: "AUDIENCE_MISMATCH", message: `audience mismatch: '${auth.audience}'` };
+
+  // ── Step 5: Decision ───────────────────────────────────────────────────────
+  check(true, "decision", "ALLOW");
+
+  // ── Step 6: Expiry ─────────────────────────────────────────────────────────
+  const nowSec = Math.floor(Date.now() / 1000);
+  const remaining = auth.expires_at - nowSec;
+  const notExpired = remaining > 0;
+  check(notExpired, "expiry", notExpired ? `${remaining}s remaining` : `EXPIRED (${-remaining}s ago)`);
+  if (!notExpired) return { ok: false, code: "EXPIRED", message: `expired ${-remaining}s ago` };
+
+  // ── Step 7: Policy ─────────────────────────────────────────────────────────
+  const policyOk = ["transfer-policy-v1", "withdraw-policy-v1", "read-only-policy-v1"].includes(auth.policy_id);
+  check(policyOk, "policy", `${auth.policy_id}${policyOk ? "  (known)" : "  UNKNOWN_POLICY"}`);
+  if (!policyOk) return { ok: false, code: "UNKNOWN_POLICY", message: `policy '${auth.policy_id}' not known` };
+
+  // ── Step 8: Intent hash ────────────────────────────────────────────────────
+  const computedIntent = siftCanonicalJsonHash(intent);
+  const intentOk = computedIntent === auth.intent_hash;
+  check(intentOk, "intent hash", intentOk
+    ? `${hash16(computedIntent)} matched`
+    : `${hash16(computedIntent)} ≠ ${hash16(auth.intent_hash)}  INTENT_HASH_MISMATCH`
+  );
+  if (!intentOk) return { ok: false, code: "INTENT_HASH_MISMATCH", message: "intent_hash mismatch" };
+
+  // ── Step 9: State hash ─────────────────────────────────────────────────────
+  const computedState = siftCanonicalJsonHash(state);
+  const stateOk = computedState === auth.state_hash;
+  check(stateOk, "state hash", stateOk
+    ? `${hash16(computedState)} matched`
+    : `${hash16(computedState)} ≠ ${hash16(auth.state_hash)}  STATE_HASH_MISMATCH`
+  );
+  if (!stateOk) return { ok: false, code: "STATE_HASH_MISMATCH", message: "state_hash mismatch" };
+
+  // ── Step 10: Replay (atomic, last) ─────────────────────────────────────────
+  const notReplayed = replayStore.consume(auth.auth_id, auth.expires_at);
+  check(notReplayed, "replay", notReplayed
+    ? "first use — auth_id consumed"
+    : "REPLAY_DETECTED — auth_id already consumed"
+  );
+  if (!notReplayed) return { ok: false, code: "REPLAY_DETECTED", message: "auth_id already consumed" };
+
+  return { ok: true };
+}
+
+// ─── Upstream ─────────────────────────────────────────────────────────────────
+
+class DemoUpstream {
+  private readonly internalToken: string;
+  executed = 0; // counter — asserts zero side effects on DENY
+
+  constructor(token: string) { this.internalToken = token; }
+
+  execute(token: string | undefined, intent: unknown): { ok: boolean; code?: string } {
+    if (token !== this.internalToken) {
+      return { ok: false, code: "FORBIDDEN" };
+    }
+    this.executed++;
+    return { ok: true };
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  SCENARIOS
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function scenario1Allow(
+  sift: MockSift,
+  adapterPrivKey: KeyObject,
+  adapterPubKey: KeyObject,
+  adapterKid: string,
+  replay: ReplayStore,
+  upstream: DemoUpstream,
+  internalToken: string
+): Promise<void> {
+  scenarioHeader(1, "ALLOW");
+
+  const params = { amount: 100, destination: "safe_account" };
+  const stateInput = { session_active: true, account_status: "active" };
+
+  // ── Step 1 ────────────────────────────────────────────────────────────────
+  step(1, "Agent request");
+  kv("tool", "transfer");
+  kv("params", fmt(params));
+  kv("state", fmt(stateInput));
+  ln();
+
+  // ── Step 2 ────────────────────────────────────────────────────────────────
+  step(2, "Sift decision");
+  const receipt = sift.issueReceipt("transfer", "ALLOW");
+  // Verify inline to show the check
+  const vr = await verifyReceiptWithKeyStore(receipt, {
+    kid: sift.kid,
+    keyStore: sift.keyStore,
+    requireAllowDecision: false,
+  });
+  check(vr.ok, "receipt signature", vr.ok ? "valid (Ed25519)" : "INVALID");
+  if (!vr.ok) { resultDeny("VERIFY_FAILED", vr.message); return; }
+  const decisionOk = vr.receipt.decision === "ALLOW";
+  check(decisionOk, "decision", vr.receipt.decision);
+  kv("policy", vr.receipt.policy_matched, "           ");
+  kv("nonce", vr.receipt.nonce.slice(0, 18) + "…", "           ");
+  ln();
+
+  // ── Step 3 ────────────────────────────────────────────────────────────────
+  step(3, "Adapter output");
+  const ar = await runAdapter(
+    receipt, sift.kid, sift.keyStore,
+    params, stateInput,
+    adapterPrivKey, adapterKid
+  );
+  if (!ar.ok) { blocked(ar.code, ar.message); resultDeny(ar.code, "No AuthorizationV1 issued."); return; }
+  const auth = ar.authorization;
+  check(true, "intent_hash", `${hash16(auth.intent_hash)}  (SHA-256 of canonical intent)`);
+  check(true, "state_hash", `${hash16(auth.state_hash)}  (SHA-256 of canonical state)`);
+  kv("auth_id", auth.auth_id.slice(0, 18) + "…  (= receipt.nonce)", "           ");
+  kv("expires_at", new Date(auth.expires_at * 1000).toISOString() + "  (+30s)", "           ");
+  ln();
+
+  // ── Step 4 ────────────────────────────────────────────────────────────────
+  step(4, "PEP verification");
+  const pep = pepVerify(ar.intent, ar.state, auth, adapterPubKey, replay);
+  ln();
+
+  if (!pep.ok) {
+    resultDeny(pep.code, "Execution blocked.");
+    return;
+  }
+
+  // Forward to upstream with internal token
+  const exec = upstream.execute(internalToken, ar.intent);
+  resultAllow(`execution succeeded  (upstream.executed = ${upstream.executed})`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function scenario2Deny(
+  sift: MockSift,
+  adapterPrivKey: KeyObject,
+  adapterKid: string,
+  replay: ReplayStore,
+  adapterPubKey: KeyObject,
+  upstream: DemoUpstream
+): Promise<void> {
+  scenarioHeader(2, "DENY");
+
+  const params = { amount: 100, destination: "safe_account" };
+  const stateInput = { session_active: true, account_status: "active" };
+  const execBefore = upstream.executed;
+
+  step(1, "Agent request");
+  kv("tool", "transfer");
+  kv("params", fmt(params));
+  ln();
+
+  step(2, "Sift decision");
+  const receipt = sift.issueReceipt("transfer", "DENY");
+  const vr = await verifyReceiptWithKeyStore(receipt, {
+    kid: sift.kid,
+    keyStore: sift.keyStore,
+    requireAllowDecision: false,
+  });
+  check(vr.ok, "receipt signature", vr.ok ? "valid (Ed25519)" : "INVALID");
+  if (!vr.ok) { resultDeny("VERIFY_FAILED", vr.message); return; }
+  check(false, "decision", "DENY");
+  ln();
+
+  step(3, "Adapter output");
+  // adapter enforces requireAllowDecision: true — will reject DENY
+  const ar = await runAdapter(
+    receipt, sift.kid, sift.keyStore,
+    params, stateInput,
+    adapterPrivKey, adapterKid
+  );
+  blocked(ar.ok ? "???" : ar.code, "No AuthorizationV1 issued.  Execution never reached.");
+  out(`             upstream.executed = ${upstream.executed}  (unchanged — zero side effects)`);
+  ln();
+
+  resultDeny(
+    ar.ok ? "???" : ar.code,
+    `upstream.executed = ${upstream.executed} (was ${execBefore}) — no side effects`
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function scenario3Replay(
+  sift: MockSift,
+  adapterPrivKey: KeyObject,
+  adapterPubKey: KeyObject,
+  adapterKid: string,
+  replay: ReplayStore,
+  upstream: DemoUpstream,
+  internalToken: string
+): Promise<void> {
+  scenarioHeader(3, "REPLAY");
+
+  const params = { amount: 100, destination: "safe_account" };
+  const stateInput = { session_active: true, account_status: "active" };
+
+  out(`  First use — obtain and consume the authorization:`);
+  ln();
+
+  const receipt = sift.issueReceipt("transfer", "ALLOW");
+  const ar = await runAdapter(
+    receipt, sift.kid, sift.keyStore,
+    params, stateInput,
+    adapterPrivKey, adapterKid
+  );
+  if (!ar.ok) { resultDeny(ar.code, ar.message); return; }
+
+  step(4, "PEP verification (first use)");
+  const first = pepVerify(ar.intent, ar.state, ar.authorization, adapterPubKey, replay);
+  ln();
+  if (!first.ok) { resultDeny(first.code, "unexpected failure"); return; }
+  upstream.execute(internalToken, ar.intent);
+  out(`  ✓  First use succeeded.  upstream.executed = ${upstream.executed}`);
+
+  separator();
+  ln();
+  out(`  Second use — SAME AuthorizationV1, same auth_id:`);
+  ln();
+
+  step(4, "PEP verification (second use)");
+  const second = pepVerify(ar.intent, ar.state, ar.authorization, adapterPubKey, replay);
+  ln();
+
+  const execAfterReplay = upstream.executed;
+  resultDeny(
+    second.ok ? "???" : second.code,
+    `upstream.executed = ${execAfterReplay} (unchanged — execution blocked)`
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+function scenario4Bypass(upstream: DemoUpstream): void {
+  scenarioHeader(4, "BYPASS");
+
+  out(`  Attacker calls execution target directly.`);
+  out(`  No Sift receipt.  No AuthorizationV1.  No PEP.`);
+  ln();
+
+  step(1, "Attacker → Upstream.execute()");
+  kv("token", "(none — no X-Internal-Execution-Token)");
+  kv("intent", fmt({ tool: "transfer", params: { amount: 999_999 } }));
+  ln();
+
+  step(2, "Upstream: token check");
+  const result = upstream.execute(undefined, { tool: "transfer", params: { amount: 999_999 } });
+  check(false, "token", "MISSING → FORBIDDEN");
+  out(`             upstream.executed = ${upstream.executed}  (unchanged — execution never reached)`);
+  ln();
+
+  resultDeny(
+    result.code ?? "FORBIDDEN",
+    `Execution blocked at target.  Valid AuthorizationV1 verified by the PEP is the only execution gate.`
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  MAIN
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  out("\x1b[1m\x1b[97m  Sift → OxDeAI  Execution Boundary Demo\x1b[0m");
+  out("\x1b[90m  Invariant: No valid AuthorizationV1 → no execution\x1b[0m");
+  out("\x1b[90m  All cryptographic operations are real (Ed25519 + SHA-256).\x1b[0m");
+
+  // Generate fresh key pairs for this demo run.
+  const siftMock = new MockSift();
+  const adapterPair = generateKeyPairSync("ed25519");
+  const adapterKid = "adapter-key-1";
+  const internalToken = "demo-internal-token-" + Math.random().toString(36).slice(2);
+
+  // Shared replay store — carries state across scenarios so REPLAY works.
+  const replay = new ReplayStore();
+  const upstream = new DemoUpstream(internalToken);
+
+  // Run all 4 scenarios sequentially.
+  await scenario1Allow(
+    siftMock,
+    adapterPair.privateKey, adapterPair.publicKey, adapterKid,
+    replay, upstream, internalToken
+  );
+  separator(); ln();
+
+  await scenario2Deny(
+    siftMock,
+    adapterPair.privateKey, adapterKid,
+    replay, adapterPair.publicKey, upstream
+  );
+  separator(); ln();
+
+  await scenario3Replay(
+    siftMock,
+    adapterPair.privateKey, adapterPair.publicKey, adapterKid,
+    replay, upstream, internalToken
+  );
+  separator(); ln();
+
+  scenario4Bypass(upstream);
+  separator(); ln();
+
+  out(`\x1b[1m  Summary\x1b[0m`);
+  out(`  upstream.executed = ${upstream.executed}  (scenario 1 + scenario 3 first-use — 2 total)`);
+  out(`  All DENY scenarios produced zero side effects.`);
+  ln();
+}
+
+main().catch((e) => {
+  process.stderr.write(`Fatal: ${e instanceof Error ? e.stack : String(e)}\n`);
+  process.exit(1);
+});

--- a/examples/sift-boundary-demo/tsconfig.json
+++ b/examples/sift-boundary-demo/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,7 +196,33 @@ importers:
         specifier: ^5.0.0
         version: 5.9.3
 
+  examples/reference-sift-oxdeai:
+    dependencies:
+      '@oxdeai/sift':
+        specifier: workspace:*
+        version: link:../../packages/sift
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.13
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+
   examples/sift:
+    dependencies:
+      '@oxdeai/sift':
+        specifier: workspace:*
+        version: link:../../packages/sift
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.13
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+
+  examples/sift-boundary-demo:
     dependencies:
       '@oxdeai/sift':
         specifier: workspace:*


### PR DESCRIPTION
Adds two isolated examples for the Sift → OxDeAI integration:

- examples/reference-sift-oxdeai: auditable reference implementation
- examples/sift-boundary-demo: terminal demo showing ALLOW / DENY / REPLAY / BYPASS

The reference implementation validates execution-boundary invariants:

- non-bypassable PEP boundary
- deterministic intent binding
- deterministic state binding
- audience binding
- expiry enforcement
- replay protection
- upstream direct-call rejection

The demo makes the invariant visible:

No valid AuthorizationV1 verified by the PEP → no execution path.

All DENY paths preserve zero side effects.