### PR TITLE
fix(sift): harden staging keystore and document production limits

### DIFF
--- a/docs/adapters/sift.md
+++ b/docs/adapters/sift.md
@@ -221,6 +221,20 @@ The `alg: "EdDSA"` field is JWKS metadata for key-discovery tooling. It is disti
 - no fallback guessing
 - deterministic key selection
 
+**KRL payload integrity limitation.**
+
+`SiftHttpKeyStore` checks whether a `kid` appears in the fetched KRL, but does NOT verify a cryptographic signature over the KRL payload itself.
+
+KRL payload integrity therefore depends on transport security (HTTPS to a trusted endpoint). A compromised intermediary — a CDN edge, a stale unsigned cache, or a man-in-the-middle — could return a modified KRL that omits specific revoked kids, allowing a revoked Sift signing key to pass the revocation check.
+
+Unknown and revoked kids still fail closed:
+- `kid` in `revoked_kids` → `REVOKED_KID` immediately
+- `kid` not found after one refresh attempt → `UNKNOWN_KID` (no guessing)
+
+Production deployments that require cryptographic revocation integrity MUST wait for the Sift protocol to define and publish a KRL signing contract. Until that contract exists, revocation guarantees depend on the trustworthiness of the transport and the hosting endpoint.
+
+**Do not assert that KRL revocation is cryptographically enforced end-to-end without a signed KRL contract from Sift.**
+
 ---
 
 ## Intent Normalization (Normative)

--- a/examples/reference-sift-oxdeai/docs/architecture.md
+++ b/examples/reference-sift-oxdeai/docs/architecture.md
@@ -99,3 +99,29 @@ shared module to guarantee identical digest computation.
 The PEP verifies the adapter's Ed25519 signature over the `AuthorizationV1`
 payload. Sift is not reachable from the PEP. The chain of custody ends at
 the adapter's signing step.
+
+## Production deployment notes
+
+**`apps/pep-gateway/` is a pedagogical PEP implementation.**
+
+The PEP gateway in this reference example implements the 10-step
+`AuthorizationV1` verification sequence inline to make the ordering readable
+and independently testable.  It is not the production PEP implementation.
+
+For production deployments, use `packages/guard` (the hardened PEP library)
+or an equivalent implementation with equivalent test coverage.  `packages/guard`
+provides the same verification sequence with additional hardening:
+- strict mode requiring non-empty trusted key sets
+- pluggable replay store with Redis support
+- CAS-based state versioning for TOCTOU prevention
+- 136 conformance tests
+
+**Replay store.**
+
+`packages/replay-store` (in-memory `MemoryReplayStore`) is suitable for
+single-process tests only.  It is not restart-durable and does not
+coordinate across multiple processes or instances.
+
+Production deployments MUST replace it with a durable, distributed store
+that provides atomic consume semantics (check-and-set in a single operation).
+`packages/guard` includes `createRedisReplayStore` for this purpose.

--- a/packages/sift/README.md
+++ b/packages/sift/README.md
@@ -303,6 +303,8 @@ Minimum requirements:
 - no fallback guessing
 - deterministic key selection
 
+**KRL payload integrity limitation.** `SiftHttpKeyStore` checks whether a `kid` appears in the fetched KRL but does NOT verify a cryptographic signature over the KRL payload itself. KRL payload integrity depends on transport security (HTTPS to a trusted endpoint). A compromised intermediary could return a modified KRL that omits specific revoked kids. Unknown and revoked kids still fail closed. Production deployments requiring cryptographic revocation integrity must wait for a signed KRL contract from Sift.
+
 ### Prototype safety
 
 All user-controlled normalized objects are created with `Object.create(null)`.
@@ -399,18 +401,25 @@ latency requirements - not just on startup.
 ```ts
 import { SiftHttpKeyStore, createStagingKeyStore, type SiftKeyStore } from "@oxdeai/sift";
 
-// Staging (Sift-hosted JWKS + KRL endpoints):
+// Staging (development / testing only — NOT for production):
 const store = createStagingKeyStore();
 await store.refresh();
+// Note: createStagingKeyStore() throws if NODE_ENV === "production".
+// Use new SiftHttpKeyStore({ jwksUrl, krlUrl }) with your production endpoints.
 
-// Custom endpoints:
-const custom = new SiftHttpKeyStore({ jwksUrl: "...", krlUrl: "..." });
+// Production:
+const prodStore = new SiftHttpKeyStore({
+  jwksUrl: "https://your-production-sift-host/sift-jwks.json",
+  krlUrl:  "https://your-production-sift-host/sift-krl.json",
+});
 
 // Inject a mock fetch for tests:
 const testStore = new SiftHttpKeyStore({ jwksUrl, krlUrl, fetch: mockFetch });
 ```
 
 `SiftKeyStore` is the interface.  `SiftHttpKeyStore` is the HTTP-backed implementation.  Both `getPublicKeyByKid` and `isKidRevoked` operate on the in-memory cache; only `refresh()` makes network calls.
+
+`createStagingKeyStore()` is for development and testing only.  It throws if `NODE_ENV === "production"` unless `{ _allowInProduction: true }` is passed explicitly.  Do not call it in production processes.
 
 Staging endpoints:
 

--- a/packages/sift/src/index.ts
+++ b/packages/sift/src/index.ts
@@ -46,6 +46,7 @@ export type {
   SiftKeyStore,
   SiftHttpKeyStoreOptions,
   KeyStoreErrorCode,
+  CreateStagingKeyStoreOptions,
 } from "./siftKeyStore.js";
 export {
   KeyStoreError,

--- a/packages/sift/src/siftKeyStore.ts
+++ b/packages/sift/src/siftKeyStore.ts
@@ -130,9 +130,23 @@ function parseJwks(body: unknown): Map<string, Uint8Array> {
  * key).  Throws `KeyStoreError("KRL_FETCH_FAILED", ...)` if the top-level
  * shape is not a valid KRL object.
  *
- * KRL signature verification is intentionally not implemented here.
- * The structure is designed so that a verifier can be added later without
- * refactoring: parse first, verify the parsed payload second.
+ * ── KRL payload integrity limitation ─────────────────────────────────────────
+ * `SiftHttpKeyStore` checks whether a `kid` appears in the fetched KRL, but
+ * does NOT verify a cryptographic signature over the KRL payload itself.
+ *
+ * KRL payload integrity therefore depends on transport security (HTTPS to a
+ * trusted endpoint).  A compromised intermediary (e.g. a CDN edge, a man-in-
+ * the-middle, or a stale unsigned cache entry) could return a modified KRL
+ * that omits specific revoked kids — allowing a revoked key to pass the
+ * revocation check.
+ *
+ * Unknown/revoked kids still fail closed:
+ *   - kid in revoked_kids   → REVOKED_KID immediately
+ *   - kid not found after refresh → UNKNOWN_KID (no guessing)
+ *
+ * Production deployments that require cryptographic revocation integrity MUST
+ * wait for the Sift protocol to define a KRL signing contract.  This code is
+ * structured to accept a verify-after-parse step without further refactoring.
  */
 function parseKrl(body: unknown): Set<string> {
   if (typeof body !== "object" || body === null) {
@@ -251,16 +265,52 @@ export class SiftHttpKeyStore implements SiftKeyStore {
 const STAGING_JWKS_URL = "https://sift-staging.walkosystems.com/sift-jwks.json";
 const STAGING_KRL_URL  = "https://sift-staging.walkosystems.com/sift-krl.json";
 
+export interface CreateStagingKeyStoreOptions {
+  /**
+   * Set to `true` to suppress the production-environment guard.
+   *
+   * This escape hatch exists for non-production integration tests that
+   * intentionally run in an environment where NODE_ENV is set to "production".
+   * It MUST NOT be used in real production deployments.
+   */
+  _allowInProduction?: boolean;
+}
+
 /**
- * Returns a new `SiftHttpKeyStore` pre-configured for the Sift staging
+ * Returns a new `SiftHttpKeyStore` pre-configured for the Sift **staging**
  * endpoints.  No network calls are made at construction time.
  *
- * Usage:
- *   const keyStore = createStagingKeyStore();
- *   await keyStore.refresh();           // or let verifyReceiptWithKeyStore do it
- *   const result = await verifyReceiptWithKeyStore(receipt, { kid, keyStore });
+ * @internal
+ *
+ * **NOT FOR PRODUCTION USE.**
+ *
+ * The Sift staging JWKS and KRL endpoints (`sift-staging.walkosystems.com`)
+ * are for development and testing only.  Calling this function in a production
+ * process trusts staging keys for production receipts and exposes internal
+ * staging state to production traffic.
+ *
+ * For production, construct a `SiftHttpKeyStore` directly with your production
+ * JWKS and KRL endpoint URLs:
+ *
+ * ```ts
+ * const keyStore = new SiftHttpKeyStore({
+ *   jwksUrl: "https://your-production-sift-host/sift-jwks.json",
+ *   krlUrl:  "https://your-production-sift-host/sift-krl.json",
+ * });
+ * ```
+ *
+ * This function throws if `NODE_ENV === "production"` unless
+ * `_allowInProduction: true` is explicitly passed.
  */
-export function createStagingKeyStore(): SiftHttpKeyStore {
+export function createStagingKeyStore(opts?: CreateStagingKeyStoreOptions): SiftHttpKeyStore {
+  if (process.env["NODE_ENV"] === "production" && opts?._allowInProduction !== true) {
+    throw new Error(
+      "[createStagingKeyStore] MUST NOT be called in production (NODE_ENV=production). " +
+      "Staging JWKS/KRL endpoints are not suitable for production deployments. " +
+      "Use new SiftHttpKeyStore({ jwksUrl, krlUrl }) with your production endpoints instead. " +
+      "To suppress this guard in a controlled non-production context, pass { _allowInProduction: true }."
+    );
+  }
   return new SiftHttpKeyStore({
     jwksUrl: STAGING_JWKS_URL,
     krlUrl: STAGING_KRL_URL,

--- a/packages/sift/test/siftKeyStore.test.ts
+++ b/packages/sift/test/siftKeyStore.test.ts
@@ -12,6 +12,7 @@ import assert from "node:assert/strict";
 import {
   SiftHttpKeyStore,
   KeyStoreError,
+  createStagingKeyStore,
 } from "../src/siftKeyStore.js";
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
@@ -405,4 +406,63 @@ test("siftKeyStore: failed refresh does not corrupt existing cache", async () =>
 
   const keyAfter = await store.getPublicKeyByKid(RFC8037_KID);
   assert.ok(keyAfter !== null, "key must survive a failed second refresh on the same instance");
+});
+
+// ─── Tests: createStagingKeyStore production guard ────────────────────────────
+
+test("createStagingKeyStore: throws when NODE_ENV is 'production' without override", () => {
+  const orig = process.env["NODE_ENV"];
+  try {
+    process.env["NODE_ENV"] = "production";
+    assert.throws(
+      () => createStagingKeyStore(),
+      (err: unknown) => {
+        assert.ok(err instanceof Error, "must throw an Error");
+        assert.ok(
+          err.message.includes("MUST NOT be called in production"),
+          `unexpected message: ${err.message}`
+        );
+        return true;
+      }
+    );
+  } finally {
+    if (orig === undefined) delete process.env["NODE_ENV"];
+    else process.env["NODE_ENV"] = orig;
+  }
+});
+
+test("createStagingKeyStore: succeeds when NODE_ENV is 'production' and _allowInProduction is true", () => {
+  const orig = process.env["NODE_ENV"];
+  try {
+    process.env["NODE_ENV"] = "production";
+    const store = createStagingKeyStore({ _allowInProduction: true });
+    assert.ok(store instanceof SiftHttpKeyStore, "must return a SiftHttpKeyStore");
+  } finally {
+    if (orig === undefined) delete process.env["NODE_ENV"];
+    else process.env["NODE_ENV"] = orig;
+  }
+});
+
+test("createStagingKeyStore: succeeds when NODE_ENV is 'test'", () => {
+  const orig = process.env["NODE_ENV"];
+  try {
+    process.env["NODE_ENV"] = "test";
+    const store = createStagingKeyStore();
+    assert.ok(store instanceof SiftHttpKeyStore, "must return a SiftHttpKeyStore");
+  } finally {
+    if (orig === undefined) delete process.env["NODE_ENV"];
+    else process.env["NODE_ENV"] = orig;
+  }
+});
+
+test("createStagingKeyStore: succeeds when NODE_ENV is undefined", () => {
+  const orig = process.env["NODE_ENV"];
+  try {
+    delete process.env["NODE_ENV"];
+    const store = createStagingKeyStore();
+    assert.ok(store instanceof SiftHttpKeyStore, "must return a SiftHttpKeyStore");
+  } finally {
+    if (orig === undefined) delete process.env["NODE_ENV"];
+    else process.env["NODE_ENV"] = orig;
+  }
 });


### PR DESCRIPTION
Adds a production guard to createStagingKeyStore so staging JWKS/KRL endpoints cannot be used accidentally in NODE_ENV=production.

Documents the current KRL payload integrity limitation: SiftHttpKeyStore enforces kid revocation from the fetched KRL, but does not cryptographically verify the KRL payload itself.

Clarifies that the reference PEP gateway is pedagogical and that production deployments should use packages/guard or an equivalent hardened PEP with durable atomic replay consumption.

No receipt verification semantics, canonicalization behavior, or AuthorizationV1 shape changed.

Validation:
- packages/sift: 119/119 passing
- packages/sift typecheck: clean
- examples/reference-sift-oxdeai: 8/8 passing
- examples/sift-boundary-demo build: clean