### PR TITLE
feat(reference-sift): add durable replay store path

### DIFF
--- a/examples/reference-sift-oxdeai/apps/pep-gateway/server.ts
+++ b/examples/reference-sift-oxdeai/apps/pep-gateway/server.ts
@@ -69,7 +69,8 @@ type PepErrorCode =
   | "UNKNOWN_POLICY"
   | "INTENT_HASH_MISMATCH"
   | "STATE_HASH_MISMATCH"
-  | "REPLAY_DETECTED";
+  | "REPLAY_DETECTED"
+  | "REPLAY_STORE_ERROR";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -280,7 +281,17 @@ export function startPepGateway(config: PepConfig): Promise<PepHandle> {
       // ── 10. Replay protection (atomic, last) ──────────────────────────────
       // Replay check is LAST to prevent denial-of-service via replay of any
       // valid auth_id. Only a fully-valid authorization is consumed.
-      const consumed = config.replayStore.consumeAuthId(auth.auth_id, auth.expires_at);
+      // Store errors are fatal — fail-closed, never fall through to execution.
+      let consumed: boolean;
+      try {
+        consumed = await config.replayStore.consumeAuthId(auth.auth_id, auth.expires_at);
+      } catch (e) {
+        return jsonResponse(res, 500, {
+          ok: false,
+          code: "REPLAY_STORE_ERROR",
+          message: e instanceof Error ? e.message : String(e),
+        });
+      }
       if (!consumed) {
         return deny(
           res,

--- a/examples/reference-sift-oxdeai/package.json
+++ b/examples/reference-sift-oxdeai/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "prebuild": "pnpm -C ../../packages/sift build",
     "build": "tsc -p tsconfig.json",
-    "test": "pnpm build && node --test dist/test/integration.test.js",
+    "test": "pnpm build && node --test dist/test/integration.test.js dist/test/replay-store.test.js",
     "start": "pnpm test"
   },
   "dependencies": {

--- a/examples/reference-sift-oxdeai/packages/replay-store/index.ts
+++ b/examples/reference-sift-oxdeai/packages/replay-store/index.ts
@@ -26,8 +26,11 @@ export interface ReplayStore {
    * `expiresAt` is a Unix timestamp (seconds). Implementations MAY use it
    * to schedule TTL-based eviction of consumed entries; they MUST NOT use
    * it to skip the replay check for expired entries.
+   *
+   * Implementations MUST throw on store errors. The PEP treats any thrown
+   * error as a hard failure (REPLAY_STORE_ERROR, HTTP 500) — fail-closed.
    */
-  consumeAuthId(authId: string, expiresAt: number): boolean;
+  consumeAuthId(authId: string, expiresAt: number): Promise<boolean>;
 }
 
 // ─── In-memory implementation ─────────────────────────────────────────────────
@@ -36,7 +39,7 @@ export class MemoryReplayStore implements ReplayStore {
   // Maps auth_id → expires_at (Unix seconds). Entries are pruned lazily.
   private readonly consumed = new Map<string, number>();
 
-  consumeAuthId(authId: string, expiresAt: number): boolean {
+  async consumeAuthId(authId: string, expiresAt: number): Promise<boolean> {
     this.pruneExpired();
     if (this.consumed.has(authId)) return false;
     this.consumed.set(authId, expiresAt);
@@ -48,5 +51,31 @@ export class MemoryReplayStore implements ReplayStore {
     for (const [id, exp] of this.consumed) {
       if (exp < now) this.consumed.delete(id);
     }
+  }
+}
+
+// ─── Map-backed implementation (durable across restarts when map is shared) ───
+
+/**
+ * A `ReplayStore` backed by an external `Map<string, number>`.
+ *
+ * Passing the same `Map` instance to multiple `MapBackedReplayStore` instances
+ * (e.g. after a simulated process restart) provides durability within a single
+ * process — any auth_id consumed by the first instance is visible to the second.
+ *
+ * This implementation is a stand-in for a Redis `SET NX EX` backend:
+ * - First call for an auth_id: writes the entry and returns `true`.
+ * - Subsequent calls for the same auth_id: returns `false` (replay detected).
+ *
+ * PRODUCTION NOTE: Replace this with a Redis-backed implementation that uses
+ * `SET key 1 NX EX <ttl>` for true distributed atomicity across processes/hosts.
+ */
+export class MapBackedReplayStore implements ReplayStore {
+  constructor(private readonly store: Map<string, number>) {}
+
+  async consumeAuthId(authId: string, expiresAt: number): Promise<boolean> {
+    if (this.store.has(authId)) return false;
+    this.store.set(authId, expiresAt);
+    return true;
   }
 }

--- a/examples/reference-sift-oxdeai/test/harness.ts
+++ b/examples/reference-sift-oxdeai/test/harness.ts
@@ -9,7 +9,7 @@
 import { generateKeyPairSync, randomBytes, sign } from "node:crypto";
 import type { KeyObject } from "node:crypto";
 import { SiftAdapter } from "../packages/adapter/index.js";
-import { MemoryReplayStore } from "../packages/replay-store/index.js";
+import { MemoryReplayStore, type ReplayStore } from "../packages/replay-store/index.js";
 import { KNOWN_POLICIES, KNOWN_ISSUERS } from "../packages/policy/index.js";
 import { startMockSift } from "../mock-sift/server.js";
 import { startPepGateway } from "../apps/pep-gateway/server.js";
@@ -41,7 +41,7 @@ export interface TestContext {
 
 // ─── Startup ──────────────────────────────────────────────────────────────────
 
-export async function startTestHarness(): Promise<TestContext> {
+export async function startTestHarness(options?: { replayStore?: ReplayStore }): Promise<TestContext> {
   // ── Key generation ──────────────────────────────────────────────────────────
   const siftKeyPair = generateKeyPairSync("ed25519");
   const adapterKeyPair = generateKeyPairSync("ed25519");
@@ -57,7 +57,7 @@ export async function startTestHarness(): Promise<TestContext> {
     privateKey: siftKeyPair.privateKey,
     kid: siftKid,
   });
-  const replayStore = new MemoryReplayStore();
+  const replayStore = options?.replayStore ?? new MemoryReplayStore();
   const pep = await startPepGateway({
     port: 0,
     adapterPublicKey: adapterKeyPair.publicKey,

--- a/examples/reference-sift-oxdeai/test/replay-store.test.ts
+++ b/examples/reference-sift-oxdeai/test/replay-store.test.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Replay store tests.
+ *
+ * Unit: MapBackedReplayStore semantics (NX, durability via shared Map).
+ * Integration: PEP fail-closed on replay store error (REPLAY_STORE_ERROR, HTTP 500).
+ */
+
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { MapBackedReplayStore, type ReplayStore } from "../packages/replay-store/index.js";
+import { startTestHarness, type TestContext } from "./harness.js";
+import { fetchSiftReceipt, callPepGateway } from "../apps/agent/client.js";
+
+// ─── Unit: MapBackedReplayStore ───────────────────────────────────────────────
+
+const FUTURE = Math.floor(Date.now() / 1000) + 3600;
+
+test("MapBackedReplayStore: first consume returns true", async () => {
+  const store = new MapBackedReplayStore(new Map());
+  const result = await store.consumeAuthId("auth-001", FUTURE);
+  assert.equal(result, true, "First consume must return true");
+});
+
+test("MapBackedReplayStore: second consume with same auth_id returns false", async () => {
+  const store = new MapBackedReplayStore(new Map());
+  await store.consumeAuthId("auth-002", FUTURE);
+  const second = await store.consumeAuthId("auth-002", FUTURE);
+  assert.equal(second, false, "Replay must return false");
+});
+
+test("MapBackedReplayStore: new instance with shared Map still denies (durability)", async () => {
+  const sharedMap = new Map<string, number>();
+  const first = new MapBackedReplayStore(sharedMap);
+  await first.consumeAuthId("auth-003", FUTURE);
+
+  // Simulate restart: new instance, same backing Map.
+  const second = new MapBackedReplayStore(sharedMap);
+  const result = await second.consumeAuthId("auth-003", FUTURE);
+  assert.equal(result, false, "Replay must be denied even after simulated restart");
+});
+
+test("MapBackedReplayStore: different auth_ids are independent", async () => {
+  const store = new MapBackedReplayStore(new Map());
+  const a = await store.consumeAuthId("auth-a", FUTURE);
+  const b = await store.consumeAuthId("auth-b", FUTURE);
+  assert.equal(a, true, "First auth_id must be allowed");
+  assert.equal(b, true, "Second distinct auth_id must be allowed");
+});
+
+// ─── Integration: PEP fail-closed on replay store error ──────────────────────
+
+class FaultyReplayStore implements ReplayStore {
+  async consumeAuthId(_authId: string, _expiresAt: number): Promise<boolean> {
+    throw new Error("simulated store failure");
+  }
+}
+
+let ctx: TestContext;
+
+before(async () => {
+  ctx = await startTestHarness({ replayStore: new FaultyReplayStore() });
+});
+
+after(async () => {
+  await ctx.close();
+});
+
+test("REPLAY_STORE_ERROR: store failure causes PEP to return 500 (fail-closed)", async () => {
+  const envelope = await fetchSiftReceipt(ctx.mockSiftUrl, "transfer");
+
+  const authResult = await ctx.adapter.adapt({
+    kidAndReceipt: envelope,
+    params: { amount: 100, destination: "safe_account" },
+    state: { session_active: true, account_status: "active" },
+  });
+  assert.ok(authResult.ok, "Adapter must succeed for REPLAY_STORE_ERROR setup");
+  if (!authResult.ok) return;
+
+  const { status, body } = await callPepGateway(
+    ctx.pepUrl,
+    authResult.intent,
+    authResult.state,
+    authResult.authorization
+  );
+  assert.equal(status, 500, `Store error must return 500 — got ${status}`);
+  assert.equal(
+    (body as { code?: string }).code,
+    "REPLAY_STORE_ERROR",
+    `Expected code REPLAY_STORE_ERROR, got: ${(body as { code?: string }).code}`
+  );
+});


### PR DESCRIPTION
Implements issue #71 by adding a durable replay-store path for the Sift reference integration while preserving the existing in-memory replay flow for demo/reference readability.

This change strengthens replay enforcement semantics for production-oriented deployments by introducing an async ReplayStore contract and support for externally backed replay persistence.

What changed

* ReplayStore.consumeAuthId now returns Promise<boolean>
* MemoryReplayStore behavior remains unchanged
* Added MapBackedReplayStore with shared backing-store semantics
* PEP gateway now awaits replay consumption and fails closed on replay-store errors
* Added replay-store override support in the test harness
* Added replay-store tests:

  * first consume succeeds
  * replay consume denied
  * shared-store durability across instances
  * independent auth_id behavior
  * fail-closed replay-store error handling

Security properties

* replay-store ambiguity → execution blocked
* replay-store failure → fail-closed (`REPLAY_STORE_ERROR`)
* replay enforcement remains atomic at the store boundary
* no best-effort or fallback replay path introduced

No protocol changes

* no AuthorizationV1 shape changes
* no canonicalization changes
* no receipt verification changes
* no signing behavior changes

Validation

* examples/reference-sift-oxdeai: 13/13 tests passing
* security gate: ALLOW
