### PR TITLE
feat(guard): support pluggable state hash strategy

### DIFF
--- a/examples/reference-sift-oxdeai/test/guard-integration.test.ts
+++ b/examples/reference-sift-oxdeai/test/guard-integration.test.ts
@@ -52,8 +52,10 @@ import {
   createInMemoryReplayStore,
 } from "@oxdeai/guard";
 import type { AuthorizationV1, KeySet } from "@oxdeai/core";
+import { sha256HexFromJson } from "@oxdeai/core";
 import { startTestHarness, type TestContext } from "./harness.js";
 import { fetchSiftReceipt } from "../apps/agent/client.js";
+import { siftCanonicalJsonHash } from "../shared/canonical.js";
 
 // ─── Test setup ───────────────────────────────────────────────────────────────
 
@@ -103,7 +105,7 @@ after(async () => {
 
 // ─── Helper: run the adapter and return raw Sift auth ────────────────────────
 
-async function adaptAllow(): Promise<{ rawAuth: AuthorizationV1; intent: unknown }> {
+async function adaptAllow(): Promise<{ rawAuth: AuthorizationV1; intent: unknown; state: unknown }> {
   const envelope = await fetchSiftReceipt(ctx.mockSiftUrl, "transfer");
   const result = await ctx.adapter.adapt({
     kidAndReceipt: envelope,
@@ -117,7 +119,7 @@ async function adaptAllow(): Promise<{ rawAuth: AuthorizationV1; intent: unknown
   // Core's verifyAuthorization accepts the Sift wire format natively:
   //   alg="ed25519" (lowercase), expires_at, base64url signature.
   const rawAuth = result.authorization as unknown as AuthorizationV1;
-  return { rawAuth, intent: result.intent };
+  return { rawAuth, intent: result.intent, state: result.state };
 }
 
 // ─── 1. ALLOW — raw Sift auth passes guard without any bridge ─────────────────
@@ -246,4 +248,79 @@ test("GUARD/BAD_ALG: unsupported alg 'EdDSA' is rejected (AUTH_ALG_UNSUPPORTED)"
     `Expected AUTH_ALG_UNSUPPORTED, got: ${result.body.reason}`
   );
   assert.equal(result.upstreamCalled, false, "Upstream must not be called on unsupported alg");
+});
+
+// ─── 7. STATE_HASH — documents the Sift adapter's state hash strategy ─────────
+//
+// The authorization artifact cryptographically binds state_hash via the Ed25519
+// signature (signature integrity — tested in GUARD/STATE_TAMPER above).
+//
+// In addition, the state_hash value is computed by a specific algorithm:
+//   Sift adapter: state_hash = siftCanonicalJsonHash(normalizedState)
+//
+// This section proves the algorithm contract and documents the requirement
+// for OxDeAIGuard integration: configure computeStateHash: siftCanonicalJsonHash
+// so that live-state semantic verification uses the same algorithm as the adapter.
+
+test("GUARD/STATE_HASH/CONTRACT: adapter computes state_hash using siftCanonicalJsonHash", async () => {
+  const { rawAuth, state } = await adaptAllow();
+
+  // The adapter commits state_hash = siftCanonicalJsonHash(normalizedState).
+  // Verify this is the exact algorithm.
+  const expected = siftCanonicalJsonHash(state);
+  assert.equal(
+    rawAuth.state_hash,
+    expected,
+    "adapter must use siftCanonicalJsonHash for state_hash binding"
+  );
+});
+
+test("GUARD/STATE_HASH/DETERMINISM: same state always produces the same state_hash", async () => {
+  const { rawAuth: auth1, state: state1 } = await adaptAllow();
+  const { rawAuth: auth2, state: state2 } = await adaptAllow();
+
+  // Both calls use the same TRANSFER_STATE → same normalized state → same hash.
+  assert.equal(
+    auth1.state_hash,
+    auth2.state_hash,
+    "state_hash must be deterministic for the same input state"
+  );
+  assert.equal(
+    siftCanonicalJsonHash(state1),
+    siftCanonicalJsonHash(state2),
+    "siftCanonicalJsonHash must be stable across calls with the same state"
+  );
+});
+
+test("GUARD/STATE_HASH/STRATEGY: correct strategy (siftCanonicalJsonHash) produces hash matching the auth commitment", async () => {
+  const { rawAuth, state } = await adaptAllow();
+
+  // Demonstrates that configuring computeStateHash: siftCanonicalJsonHash in
+  // OxDeAIGuard would produce the correct hash for state_hash verification.
+  const computedWithCorrectStrategy = siftCanonicalJsonHash(state);
+  assert.equal(
+    computedWithCorrectStrategy,
+    rawAuth.state_hash,
+    "computeStateHash: siftCanonicalJsonHash produces the hash that matches the authorization's state_hash"
+  );
+});
+
+test("GUARD/STATE_HASH/SIGNATURE_ONLY: createPepGatewayExecutor relies on signature integrity, not live-state re-verification", async () => {
+  // createPepGatewayExecutor verifies state_hash integrity via Ed25519 signature:
+  // tampering state_hash without re-signing produces AUTH_SIGNATURE_INVALID (proven in GUARD/STATE_TAMPER).
+  // It does NOT re-verify state_hash against live state (no state accessor at the gateway layer).
+  //
+  // For live-state semantic verification (re-computing hash against current state):
+  // use OxDeAIGuard with computeStateHash: siftCanonicalJsonHash configured.
+  // Without this option, OxDeAIGuard would use engine.computeStateHash (Core algorithm),
+  // which produces a different value than siftCanonicalJsonHash — execution would be blocked.
+  //
+  // This test documents the boundary: signature integrity ≠ live-state semantic verification.
+  const { rawAuth, intent } = await adaptAllow();
+  const result = await executeThroughPep({ action: intent, authorization: rawAuth });
+
+  assert.equal(result.status, 200,
+    "createPepGatewayExecutor accepts Sift auth when signature is valid — state_hash integrity is signature-protected"
+  );
+  assert.ok(result.upstreamCalled, "upstream must be called when auth passes all gateway checks");
 });

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -376,15 +376,22 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
     // The authorization artifact commits to the execution-time state snapshot
     // that the policy engine evaluated. Verify the current state matches.
     // Fail closed on mismatch, missing hash, or canonicalization failure.
+    //
+    // Hash strategy: config.computeStateHash takes precedence over
+    // config.engine.computeStateHash. Use config.computeStateHash when the
+    // authorization was produced by a provider with a different state
+    // canonicalization algorithm (e.g., Sift adapter: siftCanonicalJsonHash).
+    // Using the wrong strategy produces a deterministic mismatch — fail-closed.
     const expectedStateHash = (authorization as AuthorizationV1).state_hash;
     if (!expectedStateHash) {
       throw new OxDeAIAuthorizationError(
         "Authorization is missing state_hash. Execution blocked."
       );
     }
+    const computeHash = config.computeStateHash ?? ((s) => config.engine.computeStateHash(s));
     let actualStateHash: string;
     try {
-      actualStateHash = config.engine.computeStateHash(state);
+      actualStateHash = computeHash(state);
     } catch (err) {
       throw new OxDeAIAuthorizationError(
         `State canonicalization failed: ${err instanceof Error ? err.message : String(err)}. Execution blocked.`

--- a/packages/guard/src/test/guard.state-binding.test.ts
+++ b/packages/guard/src/test/guard.state-binding.test.ts
@@ -5,20 +5,26 @@
  * Verifies that OxDeAIGuard enforces state_hash binding at the PEP boundary:
  * the authorization's state_hash must equal stateSnapshotHash(executionState).
  *
- * Test IDs: SB-1 through SB-8.
+ * Test IDs: SB-1 through SB-13.
  *
- *   SB-1  Matching state_hash         → execute runs, result returned
- *   SB-2  Mismatched state_hash       → OxDeAIAuthorizationError, execute blocked
- *   SB-3  Empty/missing state_hash    → OxDeAIAuthorizationError, execute blocked
- *   SB-4  Uncanonicalizeable state    → OxDeAIAuthorizationError, execute blocked
- *   SB-5  Determinism                 → same state always produces the same hash
- *   SB-6  TOCTOU state mutation       → state mutated after auth issued → execute blocked
- *   SB-7  Null execution state        → computeStateHash throws → execute blocked
- *   SB-8  Boundary integrity          → mismatch blocks beforeExecute, execute, and setState
+ *   SB-1   Matching state_hash         → execute runs, result returned
+ *   SB-2   Mismatched state_hash       → OxDeAIAuthorizationError, execute blocked
+ *   SB-3   Empty/missing state_hash    → OxDeAIAuthorizationError, execute blocked
+ *   SB-4   Uncanonicalizeable state    → OxDeAIAuthorizationError, execute blocked
+ *   SB-5   Determinism                 → same state always produces the same hash
+ *   SB-6   TOCTOU state mutation       → state mutated after auth issued → execute blocked
+ *   SB-7   Null execution state        → computeStateHash throws → execute blocked
+ *   SB-8   Boundary integrity          → mismatch blocks beforeExecute, execute, and setState
+ *   SB-9   Pluggable computeStateHash  → matching custom strategy → execute runs
+ *   SB-10  Pluggable computeStateHash  → hash mismatch → execute blocked
+ *   SB-11  Compatible hash strategy    → provider hash committed + verified consistently → execute runs
+ *   SB-12  Incompatible hash strategy  → ambiguous config → execute blocked (fail-closed)
+ *   SB-13  computeStateHash throws     → OxDeAIAuthorizationError, execute blocked (fail-closed)
  */
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 
 import type { Authorization, Intent, State } from "@oxdeai/core";
 import { stateSnapshotHash, intentHash } from "@oxdeai/core";
@@ -383,4 +389,196 @@ test("SB-8 boundary integrity: state_hash mismatch blocks beforeExecute, execute
   assert.ok(!beforeExecuteCalled, "beforeExecute must not be called when state_hash mismatches");
   assert.ok(!executeCalled, "execute must not be called when state_hash mismatches");
   assert.ok(!setStateCalled, "setState must not be called when state_hash mismatches");
+});
+
+// ── SB-9 through SB-12: Pluggable computeStateHash strategy ───────────────────
+//
+// These tests verify the config.computeStateHash option, which allows
+// injecting a custom state hash function when authorizations are produced by
+// an external provider with a different state canonicalization algorithm
+// (e.g., Sift adapter: siftCanonicalJsonHash vs Core: stateSnapshotHash).
+
+// Simulates a provider-specific state hash algorithm (e.g., siftCanonicalJsonHash).
+// Deterministic, but distinct from stateSnapshotHash for any state.
+function providerSpecificHash(_state: unknown): string {
+  return createHash("sha256").update("provider-specific-state-repr").digest("hex");
+}
+
+// ── SB-9: Pluggable computeStateHash with matching commitment → execute runs ───
+
+test("SB-9 pluggable computeStateHash: matching hash commitment with custom strategy → execute runs", async () => {
+  const state = makeBaseState();
+  // Auth committed with provider-specific hash (not stateSnapshotHash).
+  const auth = signAuth({
+    auth_id: "sb9-auth",
+    audience: "aud-test",
+    state_hash: providerSpecificHash(state),
+    intent_hash: FIXED_INTENT_HASH,
+  });
+
+  // Guard configured with the matching custom computeStateHash.
+  const guard = OxDeAIGuard(makeGuardConfig(auth, state, {
+    computeStateHash: providerSpecificHash,
+  }));
+  let executed = false;
+  const result = await guard(ACTION, async () => { executed = true; return "sb9-ok"; });
+
+  assert.ok(executed, "execute must be called when computeStateHash matches the commitment");
+  assert.equal(result, "sb9-ok");
+});
+
+// ── SB-10: Pluggable computeStateHash with mismatched hash → execute blocked ───
+
+test("SB-10 pluggable computeStateHash: hash mismatch blocks execution", async () => {
+  const state = makeBaseState();
+  // Auth committed with provider-specific hash.
+  const auth = signAuth({
+    auth_id: "sb10-auth",
+    audience: "aud-test",
+    state_hash: providerSpecificHash(state),
+    intent_hash: FIXED_INTENT_HASH,
+  });
+
+  // Guard configured with a DIFFERENT strategy than was used at signing time.
+  // This simulates using the wrong computeStateHash — incompatible config.
+  const guard = OxDeAIGuard(makeGuardConfig(auth, state, {
+    computeStateHash: (s) => stateSnapshotHash(s),
+  }));
+  let executed = false;
+
+  await assert.rejects(
+    () => guard(ACTION, async () => { executed = true; }),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError,
+        `expected OxDeAIAuthorizationError, got: ${Object.prototype.toString.call(err)}`);
+      assert.ok(
+        err.message.includes("state_hash"),
+        `error must mention state_hash, got: ${err.message}`
+      );
+      return true;
+    }
+  );
+  assert.ok(!executed, "execute must not be called when hash strategies are incompatible");
+});
+
+// ── SB-11: Provider-specific strategy used consistently → execute runs ─────────
+
+test("SB-11 compatible hash strategy: provider-specific hash committed and verified with same strategy → execute runs", async () => {
+  const state = makeBaseState();
+
+  // Precondition: provider hash differs from Core default to ensure the
+  // test is meaningful (not accidentally testing the same algorithm).
+  assert.notEqual(
+    providerSpecificHash(state),
+    stateSnapshotHash(state),
+    "precondition: provider hash must differ from Core stateSnapshotHash"
+  );
+
+  // Auth committed with provider-specific hash.
+  const auth = signAuth({
+    auth_id: "sb11-auth",
+    audience: "aud-test",
+    state_hash: providerSpecificHash(state),
+    intent_hash: FIXED_INTENT_HASH,
+  });
+
+  // Guard correctly configured with the matching provider strategy.
+  const guard = OxDeAIGuard(makeGuardConfig(auth, state, {
+    computeStateHash: providerSpecificHash,
+  }));
+  let executed = false;
+  const result = await guard(ACTION, async () => { executed = true; return "sb11-ok"; });
+
+  assert.ok(executed, "execute must be called when provider strategy is configured correctly");
+  assert.equal(result, "sb11-ok");
+});
+
+// ── SB-12: Incompatible/unconfigured strategy → execute blocked ────────────────
+//
+// Documents the correct integration requirement: when using an external
+// authorization provider with a non-Core state hash algorithm, omitting
+// config.computeStateHash causes a deterministic state_hash mismatch.
+// This is the "ambiguous config" case — fail-closed.
+
+test("SB-12 incompatible hash strategy (ambiguous config): provider hash committed, Core engine default at verification → blocked", async () => {
+  const state = makeBaseState();
+
+  // Auth committed with provider-specific hash (simulates Sift adapter output).
+  const auth = signAuth({
+    auth_id: "sb12-auth",
+    audience: "aud-test",
+    state_hash: providerSpecificHash(state),
+    intent_hash: FIXED_INTENT_HASH,
+  });
+
+  // Precondition: the two hash functions produce different values for this state.
+  assert.notEqual(
+    stateSnapshotHash(state),
+    providerSpecificHash(state),
+    "precondition: Core and provider hashes must differ for this test to be meaningful"
+  );
+
+  // Guard NOT configured with computeStateHash → uses engine.computeStateHash
+  // (which is stateSnapshotHash). This will not match the committed provider hash.
+  const guard = OxDeAIGuard(makeGuardConfig(auth, state));
+  let executed = false;
+
+  await assert.rejects(
+    () => guard(ACTION, async () => { executed = true; }),
+    (err: unknown) => {
+      assert.ok(
+        err instanceof OxDeAIAuthorizationError,
+        `expected OxDeAIAuthorizationError, got: ${Object.prototype.toString.call(err)}`
+      );
+      assert.ok(
+        err.message.includes("state_hash"),
+        `error message should mention state_hash, got: ${err.message}`
+      );
+      return true;
+    }
+  );
+  assert.ok(
+    !executed,
+    "execute must not be called when computeStateHash is not configured for a non-Core provider"
+  );
+});
+
+// ── SB-13: computeStateHash throws → OxDeAIAuthorizationError, execute blocked ──
+//
+// When config.computeStateHash throws for any reason, the guard must wrap the
+// exception in OxDeAIAuthorizationError and block execution — fail-closed.
+// The error message must clearly indicate that state hash computation failed.
+
+test("SB-13 custom computeStateHash throws: execution is blocked fail-closed (OxDeAIAuthorizationError)", async () => {
+  const state = makeBaseState();
+  const auth = signAuth({
+    auth_id: "sb13-auth",
+    audience: "aud-test",
+    state_hash: stateSnapshotHash(state),
+    intent_hash: FIXED_INTENT_HASH,
+  });
+
+  // computeStateHash always throws — simulates a broken or unavailable hash implementation.
+  const guard = OxDeAIGuard(makeGuardConfig(auth, state, {
+    computeStateHash: (_s) => {
+      throw new Error("hash backend unavailable");
+    },
+  }));
+  let executed = false;
+
+  await assert.rejects(
+    () => guard(ACTION, async () => { executed = true; }),
+    (err: unknown) => {
+      assert.ok(
+        err instanceof OxDeAIAuthorizationError,
+        `expected OxDeAIAuthorizationError, got: ${Object.prototype.toString.call(err)}`
+      );
+      assert.ok(
+        err.message.includes("canonicalization") || err.message.includes("State"),
+        `error message must indicate state hash computation failed, got: ${err.message}`
+      );
+      return true;
+    }
+  );
+  assert.ok(!executed, "execute must not be called when computeStateHash throws");
 });

--- a/packages/guard/src/types.ts
+++ b/packages/guard/src/types.ts
@@ -148,4 +148,26 @@ export type OxDeAIGuardConfig = {
    * result when unavailable. The guard treats any thrown error as DENY.
    */
   replayStore?: ReplayStore;
+
+  /**
+   * Optional custom function for computing the live-state hash used in
+   * state_hash binding verification (guard step 6c).
+   *
+   * When provided, this function is called instead of
+   * `config.engine.computeStateHash(state)` to produce the hash that is
+   * compared against `authorization.state_hash`.
+   *
+   * Required when authorizations are produced by an external provider that
+   * uses a different state canonicalization algorithm. For example:
+   *   - Sift adapter: uses siftCanonicalJsonHash(state)
+   *   - Core PolicyEngine: uses engine.computeStateHash(state) (default)
+   *
+   * Using the wrong function for the authorization's committed hash algorithm
+   * produces a deterministic state_hash mismatch — execution is blocked,
+   * fail-closed. There is no fallback or partial acceptance.
+   *
+   * Fail-closed: any exception thrown by this function blocks execution
+   * with OxDeAIAuthorizationError.
+   */
+  computeStateHash?: (state: State) => string;
 };


### PR DESCRIPTION
## Summary

Closes #78.

Add a pluggable state hash strategy to `OxDeAIGuard` to support interoperable execution-boundary verification across external authorization providers with different canonicalization or hashing semantics.

This merge formalizes the distinction between:

* signature-protected `state_hash` integrity
* semantic live-state verification at execution time

while preserving deterministic fail-closed enforcement semantics.

## Problem

Prior to this merge, `OxDeAIGuard` always verified execution-time state using:

```ts
config.engine.computeStateHash(state)
```

This assumed all authorization providers used the same canonicalization and hashing strategy as the local PolicyEngine.

That assumption does not hold for external providers such as the Sift adapter path, which computes:

```text
state_hash = SHA-256(siftCanonical(state))
```

As a result:

* signature verification succeeded
* but semantic live-state verification could fail deterministically due to incompatible hash strategies

even when the state itself was unchanged.

## Solution

Add optional:

```ts
computeStateHash?: (state: State) => string
```

to `OxDeAIGuardConfig`.

Verification now resolves:

```ts
config.computeStateHash
  ?? config.engine.computeStateHash
```

This preserves backward compatibility while allowing deployments to explicitly configure the hash strategy used by the authorization issuer.

Example:

```ts
computeStateHash: siftCanonicalJsonHash
```

## Security semantics

This merge does NOT:

* weaken signature verification
* alter AuthorizationV1
* change canonicalization-v1
* introduce fallback verification
* silently normalize mismatched hash strategies

Wrong hash strategy configuration still fails closed:

```text
state_hash mismatch → OxDeAIAuthorizationError → no execution
```

## Fail-closed behavior

`computeStateHash` execution is wrapped in explicit fail-closed handling.

If the custom hash strategy throws:

* execution is blocked
* `OxDeAIAuthorizationError` is raised
* `execute()` is never called

This covers canonicalization failures and provider-specific hash computation failures.

## Tests added

### Guard state-binding tests

Added:

* SB-9
* SB-10
* SB-11
* SB-12
* SB-13

Coverage includes:

* matching custom hash strategy
* mismatched custom strategy
* provider-style strategy compatibility
* incompatible strategy rejection
* thrown hash-computation failure

### Reference Sift integration tests

Added:

* GUARD/STATE_HASH/CONTRACT
* GUARD/STATE_HASH/DETERMINISM
* GUARD/STATE_HASH/STRATEGY
* GUARD/STATE_HASH/SIGNATURE_ONLY

Coverage includes:

* adapter state_hash contract
* deterministic hashing
* strategy compatibility expectations
* gateway signature-only semantics

## Important architectural clarification

`createPepGatewayExecutor` verifies:

* signature integrity
* replay
* intent binding
* authorization validity

It does NOT perform semantic live-state re-verification because it has no trusted execution-time state source.

Semantic execution-time state verification belongs to `OxDeAIGuard`, which requires:

* trusted `getState()`
* correct `computeStateHash`

This separation is now explicit and documented.

## Validation

All checks pass:

* examples/reference-sift-oxdeai: 23/23
* @oxdeai/guard: 141/141
* security gate: ALLOW

## Result

OxDeAI Guard now supports deterministic, fail-closed state verification across heterogeneous authorization providers without weakening the execution-boundary model.
