### PR TITLE
docs: update roadmap for interoperability hardening

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-**Last updated:** 2026-04-07
+**Last updated:** 2026-05-17
 
 ---
 
@@ -11,6 +11,22 @@ OxDeAI is an **execution authorization boundary** for autonomous systems.
 Core invariant:
 
 > **No valid authorization → no execution path**
+
+---
+
+## Protocol Maturity
+
+```
+implementation → interoperable protocol → executable interoperability
+```
+
+OxDeAI now specifies:
+
+* accepted wire encodings for external provider interoperability (Encoding A, Encoding B)
+* an interoperability profile (Profile A / B / C) with executable conformance coverage
+* formal threat model, key lifecycle, and replay-store TTL alignment documentation
+
+This reflects maturity at the **interoperable protocol** layer - not standard adoption.
 
 ---
 
@@ -43,7 +59,7 @@ Core invariant:
 
 * build: pass
 * tests: pass
-* conformance: pass (`139 assertions`)
+* conformance: pass (`161 assertions`)
 * adapters: pass (`6/6`)
 * vectors: pass (TS / Go / Python)
 
@@ -182,13 +198,29 @@ Turn OxDeAI into a **deployable infra boundary**, not just a protocol.
 * cross-language determinism
 * non-bypassable execution demo
 
+#### Interoperability Hardening (completed)
+
+* external provider wire encoding specification
+  * Encoding A - Core-native (`"Ed25519"`, `expiry`, domain-prefixed preimage)
+  * Encoding B - external provider-compatible (`"ed25519"`, `expires_at`, base64url signature)
+* durable replay semantics with formal TTL alignment rules (`computeTtl = max(1, expiry − now)`)
+* pluggable `computeStateHash` in `OxDeAIGuard` (fail-closed on exception)
+* external provider interoperability profile
+  * Profile A - Core-native `AuthorizationV1`
+  * Profile B - external provider wire-compatible
+  * Profile C - full semantic state verification
+* Profile C executable conformance vectors (12 assertions; 161 total)
+* external provider threat model (12 threat scenarios, T-1 through T-12)
+* key custody and rotation guide (8 compromise scenarios, KC-1 through KC-8)
+* replay-store TTL alignment guide (10 failure scenarios, RT-1 through RT-10)
+
 ---
 
 ### In Progress
 
-* failure playbooks (real-world scenarios)
 * infra-native enforcement patterns
 * external-builder quickstarts (<10 min)
+* failure playbooks (real-world scenarios)
 * adapter stress testing
 * structured decision events
 
@@ -261,6 +293,10 @@ POST /payments/charge
 * adapters + ecosystem
 * delegated authorization
 * conformance + proof
+* external provider interoperability hardening
+  * wire encoding specification (Encoding A, Encoding B)
+  * interoperability profiles (A / B / C) with executable conformance (161 assertions)
+  * threat model, key lifecycle, replay-store TTL alignment
 
 ## In Progress
 
@@ -273,6 +309,22 @@ POST /payments/charge
 
 * HTTP integrations
 * verifiable execution infrastructure
+
+---
+
+---
+
+# Architecture Documentation
+
+## Specification
+
+* [External Provider Interoperability Profile](docs/spec/interoperability/external-provider-profile.md) - Profile A / B / C, accepted wire encodings, interoperability matrix, fail-closed rules
+
+## Architecture Guides
+
+* [Threat Model: External Authorization Providers](docs/architecture/threat-model-external-providers.md) - trust boundaries, T-1 through T-12 threat scenarios
+* [Key Custody and Rotation](docs/architecture/key-custody-and-rotation.md) - key lifecycle, KC-1 through KC-8 compromise scenarios, operational checklist
+* [Replay-Store TTL Alignment](docs/architecture/replay-store-ttl-alignment.md) - formal TTL rules, RT-1 through RT-10 failure scenarios, store implementation guidance
 
 ---
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,28 @@
+# Architecture
+
+This directory contains architecture guides and decision documents for OxDeAI.
+
+---
+
+## Positioning
+
+- [Why OxDeAI](why-oxdeai.md) — execution authorization boundary vs. guardrails, monitoring, sandboxing
+- [Decision is Not Execution](decision-is-not-execution.md) — separation of authorization from execution
+- [ETA Positioning Note](eta-positioning-note.md) — Execution-Time Authorization scope
+- [System-M Execution Boundary](system-m-execution-boundary.md) — multi-agent execution boundary model
+- [Invariants](invariants.md) — core protocol invariants
+
+---
+
+## Deployment
+
+- [Overview](overview.md) — architectural overview
+- [PEP Production Guide](pep-production-guide.md) — Policy Enforcement Point deployment
+
+---
+
+## Security and Interoperability
+
+- [Threat Model: External Authorization Providers](threat-model-external-providers.md) — trust boundaries, T-1 through T-12 threat scenarios
+- [Key Custody and Rotation](key-custody-and-rotation.md) — key lifecycle, KC-1 through KC-8 compromise scenarios, operational checklist
+- [Replay-Store TTL Alignment](replay-store-ttl-alignment.md) — formal TTL rules, RT-1 through RT-10 failure scenarios, store implementation guidance

--- a/packages/conformance/README.md
+++ b/packages/conformance/README.md
@@ -8,7 +8,7 @@ Ensures implementations reproduce deterministic AuthorizationV1 artifacts and bo
 Passing validation means the implementation reproduces expected deterministic artifacts (hashes, statuses, and verification outputs) from frozen vectors.
 
 ## Version Coupling
-- `@oxdeai/conformance@1.5.0` targets `@oxdeai/core@1.6.1` behavior.
+- `@oxdeai/conformance@1.5.0` targets `@oxdeai/core@1.7.0` behavior.
 - Use matching major/minor protocol versions when validating.
 
 ## Included Vector Sets
@@ -30,7 +30,33 @@ Passing validation means the implementation reproduces expected deterministic ar
 - `delegation-chain-verification.json` - `verifyDelegationChain()` chain checks: hash binding, delegator, parent expiry, expiry ceiling, single-hop, policy binding
 - `delegation-signature-verification.json` - Ed25519 signature path: valid, tampered sig, wrong kid, tampered field, expired
 
-Current validator assertion count: `139`.
+### Profile C - Semantic State Verification (v1.5+)
+
+- `profile-c-state-verification.json` - exercises the full semantic state verification path (Profile C, guard step 10): `computeStateHash(liveState)` compared against the committed `state_hash` in the authorization.
+
+Eight vectors covering:
+
+| Vector | Mode | Expected outcome |
+|--------|------|-----------------|
+| `profile-c-001` | `live-state-match` | `ok` - same state at signing and verification |
+| `profile-c-002` | `live-state-mismatch` | `state-hash-mismatch` - state advanced between signing and execution |
+| `profile-c-003` | `hash-strategy-mismatch` | `state-hash-mismatch` - provider hash committed, Core algorithm at verification |
+| `profile-c-004` | `compute-throws` | `compute-error` - `computeStateHash` throws; execution blocked fail-closed |
+| `profile-c-005` | `toctou-stale-state` | `state-hash-mismatch` - TOCTOU: state advanced since authorization was issued |
+| `profile-c-006` | `encoding-b-live-state-match` | `ok` - Encoding B (Sift-compatible) + matching state |
+| `profile-c-007` | `encoding-b-live-state-mismatch` | `state-hash-mismatch` - Encoding B + stale state |
+| `profile-c-008` | `encoding-b-hash-strategy-mismatch` | `state-hash-mismatch` - Encoding B + strategy mismatch |
+
+Two hash strategies modelled:
+
+| Strategy | Algorithm |
+|----------|-----------|
+| `core` | `sha256HexFromJson` (Core-native) |
+| `provider` | SHA-256 of `"PROVIDER:" + canonicalJson(state)` (simulates external provider hash) |
+
+Encoding B vectors (`profile-c-006` through `profile-c-008`) exercise the Sift-compatible wire format (`alg="ed25519"`, `expires_at`, base64url signature) combined with live-state semantic verification.
+
+Current validator assertion count: `161`.
 
 ### Adapter ops required for DelegationV1
 
@@ -58,6 +84,7 @@ compatibility but not used by the harness runners.
 | `delegation-verification.json` | Field checks, expiry, scope, replay, trust-missing | Yes - no crypto required |
 | `delegation-chain-verification.json` | Chain structural checks (hash binding, delegator, expiry ceiling, policy) | Yes - independently recomputed |
 | `delegation-signature-verification.json` | Ed25519 verification path | Yes - independently verified |
+| `profile-c-state-verification.json` | Semantic state verification: hash comparison, strategy mismatch, compute-throws, TOCTOU, Encoding B | TypeScript only (requires `computeStateHash` integration) |
 | `delegation.property.test.ts` (D-P1–D-P5) | PBT over scope / hash / mutation | TypeScript only |
 | `guard.delegation.property.test.ts` (G-D1–G-D3) | Guard PEP delegation path | TypeScript only |
 | `cross-adapter.test.ts` (CA-1–CA-10) | Cross-adapter equivalence, I6 | TypeScript only |
@@ -73,7 +100,7 @@ pnpm -C packages/conformance validate
 Expected success output includes:
 
 ```text
-Conformance passed: 139 assertions
+Conformance passed: 161 assertions
 ```
 
 ## Adapter Contract
@@ -104,15 +131,32 @@ Vectors are frozen per protocol version.
 - Any behavior-impacting change requires a new protocol/versioned vector release.
 - Regeneration is allowed only when intentionally producing a new version baseline.
 
+## Interoperability Profiles
+
+OxDeAI defines three interoperability profiles. Conformance coverage maps directly to profile requirements:
+
+| Profile | Description | Vector sets required |
+|---------|-------------|----------------------|
+| A | Core-native `AuthorizationV1` | Core protocol + DelegationV1 |
+| B | External provider wire-compatible (Encoding A and Encoding B accepted) | Core + authorization-signature vectors |
+| C | Full semantic state verification via `computeStateHash` | Core + DelegationV1 + Profile C state vectors |
+
+Profile C now has **executable conformance coverage** via `profile-c-state-verification.json` (12 assertions).
+
+See [External Provider Interoperability Profile](../../docs/spec/interoperability/external-provider-profile.md) for the full profile specification, wire encoding reference, and fail-closed rules.
+
 ## Using OxDeAI Conformance from Other Languages
 
 Conformance vectors are the behavioral truth source for protocol compatibility.
 
 Rust, Go, and Python implementations should validate their verifier/engine behavior against these vectors.
-Passing conformance means the implementation is behaviorally aligned with the OxDeAI protocol profile for that version line.
+Passing conformance means the implementation is behaviorally aligned with the OxDeAI protocol profile for that version line, including executable interoperability coverage where applicable.
+
+Profile C vectors (`profile-c-state-verification.json`) require a `computeStateHash` integration point. Cross-language harnesses must supply a compatible hash function to exercise those vectors.
 
 Related implementer docs:
 
 - [`docs/verification/multi-language.md`](../../docs/verification/multi-language.md)
 - [`docs/conformance/conformance-vectors.md`](../../docs/conformance/conformance-vectors.md)
+- [`docs/spec/interoperability/external-provider-profile.md`](../../docs/spec/interoperability/external-provider-profile.md)
 - [`packages/conformance/go-harness`](./go-harness)


### PR DESCRIPTION
## Summary

Closes #90.

Update roadmap and conformance documentation after the external-provider interoperability hardening sequence.

This aligns project status with the current OxDeAI protocol state after Sift interoperability, AuthorizationV1 wire-encoding specification, Profile C executable conformance, and production-readiness documentation work.

## Files changed

* `ROADMAP.md`
* `docs/architecture/README.md`
* `packages/conformance/README.md`

## Roadmap updates

Updated:

* last updated date: 2026-05-17
* conformance count: 161 assertions
* protocol maturity wording

Added a protocol maturity section:

```text
implementation → interoperable protocol → executable interoperability
```

This is explicitly scoped to protocol maturity, not standard adoption.

## v2.5 updates

Added completed interoperability hardening coverage:

* AuthorizationV1 accepted wire encodings
* durable replay semantics
* replay-store TTL alignment guidance
* pluggable `computeStateHash`
* external provider threat model
* key custody and rotation guide
* Profile A / B / C interoperability profiles
* executable Profile C conformance vectors

Failure playbooks remain in progress.

## Architecture documentation index

Added:

* `docs/architecture/README.md`

The index groups architecture docs into:

* Positioning
* Deployment
* Security and Interoperability

## Conformance documentation updates

Updated `packages/conformance/README.md` to reflect:

* `@oxdeai/core@1.7.0`
* 161 assertions
* Profile C state verification vectors
* executable interoperability coverage
* Profile A / B / C references
* updated related docs links

## Validation

* build: pass
* tests: pass
* conformance: 161 assertions, all pass
* security gate: ALLOW

## Result

Project documentation now matches the current post-hardening protocol state.
