### PR TITLE
test(conformance): add key lifecycle verification vectors

### DIFF
--- a/docs/architecture/key-custody-and-rotation.md
+++ b/docs/architecture/key-custody-and-rotation.md
@@ -51,7 +51,7 @@ type KeySet = {
 |---|---|---|
 | **Active** | `"active"` or absent | Accepted if `now` is within `[not_before, not_after]` |
 | **Transitional** | `"active"` | Two keys both active during a dual-sign overlap window |
-| **Retired** | `"retired"` | Rejected — `keyIsActiveAt` returns `false` for `"retired"` |
+| **Retired** | `"retired"` | Accepted for verification within `not_before`/`not_after` window; no longer used for new signings |
 | **Revoked** | `"revoked"` | Rejected immediately — treated as untrusted regardless of time bounds |
 
 `keyIsActiveAt(key, now)` enforces all three constraints in order:
@@ -85,7 +85,7 @@ explicitly retired or revoked in the `trustedKeySets` config.
                           [status: retired]             active key]
                                  │
                                  ▼
-                            RETIRED (verifier rejects)
+                      RETIRED (verifier accepts until not_after)
                                  │
                                  ▼ (on compromise or scheduled destruction)
                             REVOKED (verifier rejects immediately)
@@ -121,12 +121,14 @@ See §4 for full rotation procedures.
 
 ### 2.5 Retirement
 
-Set `not_after` on the old key to the end of the dual-sign window, or set `status: "retired"`.
-Once retired, the verifier rejects all authorizations signed with that key.
+Set `not_after` on the old key to the end of the dual-sign window and set `status: "retired"`.
+A retired key is still accepted for verification within its `not_before`/`not_after` window —
+this is intentional: the overlap period lets in-flight authorizations signed just before
+rotation complete normally. The verifier rejects the key only once `not_after` has passed.
 
-Retired keys **should** remain in `trustedKeySets` for the duration of the maximum authorization
-expiry window, to allow in-flight authorizations issued just before retirement to complete.
-After that window, retired key entries may be removed from the config entirely.
+Retired keys **must** remain in `trustedKeySets` until `not_after` has elapsed so that
+in-flight authorizations can still be verified. After `not_after`, retired key entries may
+be removed from the config entirely.
 
 ### 2.6 Revocation
 
@@ -166,9 +168,9 @@ If any condition fails, the authorization is rejected. There is no fallback or p
 |---|---|
 | `issuer` not found in any `KeySet` | `AUTH_ISSUER_MISMATCH` → DENY |
 | `kid` not found in issuer's keyset | `AUTH_KID_UNKNOWN` → DENY |
-| Key found but `status: "revoked"` | `AUTH_KID_UNKNOWN` → DENY |
-| Key found but `now < not_before` | `AUTH_KID_UNKNOWN` → DENY |
-| Key found but `now > not_after` | `AUTH_KID_UNKNOWN` → DENY |
+| Key found but `status: "revoked"` | `AUTH_KEY_INACTIVE` → DENY |
+| Key found but `now < not_before` | `AUTH_KEY_INACTIVE` → DENY |
+| Key found but `now > not_after` | `AUTH_KEY_INACTIVE` → DENY |
 | Key active but signature invalid | `AUTH_SIGNATURE_INVALID` → DENY |
 | `trustedKeySets` is empty | Hard failure at guard construction |
 

--- a/docs/audits/protocol-audit-post-interoperability.md
+++ b/docs/audits/protocol-audit-post-interoperability.md
@@ -84,10 +84,10 @@
 | Area | Status | Notes |
 |------|--------|-------|
 | `KeyStatus = "active" \| "retired" \| "revoked"` | `DONE` | Implemented in `keyset.ts`. `keyIsActiveAt` checks `status`, `not_before`, `not_after`. |
-| `status = "revoked"` → `AUTH_KEY_INACTIVE` | `SPECIFIED ONLY` | Implemented in `keyIsActiveAt`. **No conformance vector**. Guard tests do not exercise revoked key path. |
-| `not_before` enforcement | `SPECIFIED ONLY` | Implemented. **No conformance vector** for key not yet active. |
-| `not_after` enforcement | `SPECIFIED ONLY` | Implemented. **No conformance vector** for key window expiry (distinct from auth expiry). |
-| Key rotation (dual-sign) | `DOCUMENTED ONLY` | Rotation procedure documented in `key-custody-and-rotation.md`. No automated rotation machinery. No conformance vector for dual-sign overlap verification. |
+| `status = "revoked"` → `AUTH_KEY_INACTIVE` | `DONE` | Implemented in `keyIsActiveAt`. Conformance vector `key-lifecycle-002` (revoked key rejected). Vector `key-lifecycle-009` confirms revocation overrides valid time window. |
+| `not_before` enforcement | `DONE` | Implemented. Conformance vector `key-lifecycle-003` (future `not_before` → inactive). |
+| `not_after` enforcement | `DONE` | Implemented. Conformance vectors `key-lifecycle-004`, `key-lifecycle-006`, `key-lifecycle-008` (expired windows). |
+| Key rotation (dual-sign) | `PARTIAL` | Rotation procedure documented in `key-custody-and-rotation.md`. Dual-sign overlap verified by `key-lifecycle-007` (retired key within window → ok). No automated rotation machinery. |
 | Sift KRL (Key Revocation List) | `PARTIAL` | `SiftHttpKeyStore` checks `revoked_kids`. KRL payload is **not cryptographically signature-verified** - transport security (HTTPS) only. Known risk, documented in `packages/sift/README.md`. |
 
 ---
@@ -215,15 +215,15 @@
 | Hash strategy ambiguity → DENY | Yes | Yes (SB-12, PC-003) | Yes (Profile C spec) | Yes | **No** (TypeScript-only) |
 | Replay-store unavailability → DENY | Yes | Yes (guard test) | Yes (ReplayStore JSDoc) | Yes | **No** (no cross-language conformance vector) |
 | Provider ambiguity → DENY | Yes | Partial | Yes (Profile C spec) | Yes (threat model) | **No** (TypeScript-only) |
-| Revoked key → DENY | Yes (`keyIsActiveAt`) | No conformance test | Implied in key spec | Yes (key-custody doc) | **No** (no portable vector) |
-| Key `not_before` → DENY | Yes | No conformance test | Implied in key spec | Yes (key-custody doc) | **No** (no portable vector) |
-| Key `not_after` → DENY | Yes | No conformance test | Implied in key spec | Yes (key-custody doc) | **No** (no portable vector) |
+| Revoked key → DENY | Yes (`keyIsActiveAt`) | Yes (`key-lifecycle-002`, `key-lifecycle-009`) | Yes (key-lifecycle vectors) | Yes (key-custody doc) | Yes (portable vector) |
+| Key `not_before` → DENY | Yes | Yes (`key-lifecycle-003`) | Yes | Yes (key-custody doc) | Yes (portable vector) |
+| Key `not_after` → DENY | Yes | Yes (`key-lifecycle-004`, `key-lifecycle-006`, `key-lifecycle-008`) | Yes | Yes (key-custody doc) | Yes (portable vector) |
 
 ---
 
 ## 4. Conformance Coverage Audit
 
-**Current total:** 161 assertions across 14 vector files.
+**Current total:** 181 assertions across 15 vector files.
 
 ### 4.1 Covered Areas
 
@@ -242,17 +242,15 @@
 | `delegation-verification.json` | 18 | Delegation field checks, scope, replay, trust |
 | `delegation-chain-verification.json` | 14 | Chain hash binding, delegator, expiry, policy |
 | `delegation-signature-verification.json` | 10 | Delegation Ed25519 path |
+| `key-lifecycle-verification.json` | 20 | Key status (active/revoked/retired), `not_before`/`not_after` windows, wrong-kid rejection |
 | `profile-c-state-verification.json` | 12 | Semantic state verification, strategies, TOCTOU, Encoding B |
 
 ### 4.2 Missing or Weak Coverage
 
-The following areas have **no portable conformance vector**:
+The following areas still have **no portable conformance vector**:
 
 | Gap | Risk Level | Notes |
 |-----|-----------|-------|
-| Revoked key (`status = "revoked"`) → `AUTH_KEY_INACTIVE` | **High** | Implemented; no cross-language vector. External implementers cannot verify revocation behavior. |
-| Key `not_before` enforcement | **High** | Implemented; no vector. Same risk. |
-| Key `not_after` enforcement | **High** | Implemented; no vector. Same risk. |
 | `decision != "ALLOW"` portable vector | **Medium** | Only checked structurally; no dedicated cross-language vector. |
 | Both `expiry` and `expires_at` present simultaneously | **Medium** | Precedence rule (`expiry` wins) has no test vector. |
 | Intent hash mismatch → DENY (cross-language) | **Medium** | TypeScript guard test only. External implementers cannot verify intent binding. |
@@ -359,11 +357,11 @@ New deployments start with an empty replay store. Authorization artifacts issued
 
 **Status: PARTIAL**
 
-161 assertions across 14 vector sets is a solid baseline. Coverage gaps that prevent declaring the conformance suite "complete":
+181 assertions across 15 vector sets. Key lifecycle coverage resolved. Remaining gaps:
 
-1. Key lifecycle vectors (revoked, not_before, not_after) - **blockers for external adoption**
-2. Intent hash mismatch portable vector - important for verifier correctness
-3. Cross-language Profile C vectors - important for Profile C adoption
+1. ~~Key lifecycle vectors (revoked, not_before, not_after)~~ ✓ resolved — `key-lifecycle-verification.json`
+2. Intent hash mismatch portable vector — important for verifier correctness
+3. Cross-language Profile C vectors — important for Profile C adoption
 4. `expiry`/`expires_at` simultaneous presence precedence vector
 
 ### 7.4 Interoperability Profile Readiness
@@ -432,9 +430,8 @@ Structured events / metrics  ░░░░░░░░░░░░░░░░░
 
 ### P0 - Must resolve before external adoption
 
-**P0-1: Add portable conformance vectors for key lifecycle**  
-Reason: `AUTH_KEY_INACTIVE` (revoked, not_before, not_after) has no cross-language conformance vector. External implementers cannot verify key lifecycle enforcement. This is the single most critical gap for adoption.  
-Scope: `authorization-signature-verification.json` - add vectors: revoked key, not-yet-active key, expired key window.
+**P0-1: Add portable conformance vectors for key lifecycle** ✓ RESOLVED  
+Resolution: `key-lifecycle-verification.json` added — 10 vectors, 20 assertions covering active, revoked, retired (within/past window), `not_before`/`not_after` time windows, revocation-overrides-window, and wrong-kid-known-issuer. Conformance count: 161 → 181.
 
 **P0-2: Define and specify clock skew tolerance**  
 Reason: No `skew` parameter in `verifyAuthorization`. Distributed deployments with imprecise clocks have undefined boundary behavior. Define a spec value (e.g., ±30s) or explicitly state zero tolerance with NTP requirement.  
@@ -507,13 +504,13 @@ Scope: `pep-gateway-v1.md` §7 or a new `state-provider-requirements.md`.
 | `MISSING` | 8 |
 | `RISK` | 7 |
 
-**Conformance:** 161 assertions. 10 identified gaps.
+**Conformance:** 181 assertions. 7 remaining gaps (P0-1 resolved).
 
-**Follow-up issue counts:** P0: 3 · P1: 6 · P2: 4 · Total: 13
+**Follow-up issue counts:** P0: 2 open (P0-1 resolved) · P1: 6 · P2: 4 · Total: 12 open
 
 **Critical path to external adoption:**
 
-1. Key lifecycle portable vectors (P0-1)
+1. ~~Key lifecycle portable vectors (P0-1)~~ ✓ resolved — 20 assertions added
 2. Clock skew specification (P0-2)
 3. Intent hash mismatch portable vector (P1-1)
 4. `expiry`/`expires_at` precedence vector (P1-2)

--- a/packages/conformance/README.md
+++ b/packages/conformance/README.md
@@ -56,7 +56,26 @@ Two hash strategies modelled:
 
 Encoding B vectors (`profile-c-006` through `profile-c-008`) exercise the Sift-compatible wire format (`alg="ed25519"`, `expires_at`, base64url signature) combined with live-state semantic verification.
 
-Current validator assertion count: `161`.
+### Key Lifecycle (v1.5+)
+
+- `key-lifecycle-verification.json` — exercises `keyIsActiveAt`, `findKeyInKeySets`, and `AUTH_KEY_INACTIVE` / `AUTH_KID_UNKNOWN` enforcement across all key status and time-window states.
+
+Ten vectors covering:
+
+| Vector | Mode | Expected outcome |
+|--------|------|-----------------|
+| `key-lifecycle-001` | `key-active` | `ok` — active key, no time constraints |
+| `key-lifecycle-002` | `key-revoked` | `AUTH_KEY_INACTIVE` — revoked key rejected |
+| `key-lifecycle-003` | `key-not-before-future` | `AUTH_KEY_INACTIVE` — key not yet active |
+| `key-lifecycle-004` | `key-not-after-past` | `AUTH_KEY_INACTIVE` — validity window expired |
+| `key-lifecycle-005` | `key-valid-window` | `ok` — explicit `not_before`/`not_after` window active |
+| `key-lifecycle-006` | `key-expired-window` | `AUTH_KEY_INACTIVE` — `not_after` in the past |
+| `key-lifecycle-007` | `key-retired-within-window` | `ok` — retired key accepted during dual-sign overlap window |
+| `key-lifecycle-008` | `key-retired-past-window` | `AUTH_KEY_INACTIVE` — retired key, window closed |
+| `key-lifecycle-009` | `key-revoked-valid-window` | `AUTH_KEY_INACTIVE` — revocation overrides valid time window |
+| `key-lifecycle-010` | `wrong-kid-known-issuer` | `AUTH_KID_UNKNOWN` — correct issuer, unknown kid |
+
+Current validator assertion count: `181`.
 
 ### Adapter ops required for DelegationV1
 
@@ -84,6 +103,7 @@ compatibility but not used by the harness runners.
 | `delegation-verification.json` | Field checks, expiry, scope, replay, trust-missing | Yes - no crypto required |
 | `delegation-chain-verification.json` | Chain structural checks (hash binding, delegator, expiry ceiling, policy) | Yes - independently recomputed |
 | `delegation-signature-verification.json` | Ed25519 verification path | Yes - independently verified |
+| `key-lifecycle-verification.json` | Key status (active/revoked/retired), `not_before`/`not_after` windows, wrong-kid rejection | Yes — portable across any `verifyAuthorization` implementation |
 | `profile-c-state-verification.json` | Semantic state verification: hash comparison, strategy mismatch, compute-throws, TOCTOU, Encoding B | TypeScript only (requires `computeStateHash` integration) |
 | `delegation.property.test.ts` (D-P1–D-P5) | PBT over scope / hash / mutation | TypeScript only |
 | `guard.delegation.property.test.ts` (G-D1–G-D3) | Guard PEP delegation path | TypeScript only |
@@ -100,7 +120,7 @@ pnpm -C packages/conformance validate
 Expected success output includes:
 
 ```text
-Conformance passed: 161 assertions
+Conformance passed: 181 assertions
 ```
 
 ## Adapter Contract
@@ -142,6 +162,8 @@ OxDeAI defines three interoperability profiles. Conformance coverage maps direct
 | C | Full semantic state verification via `computeStateHash` | Core + DelegationV1 + Profile C state vectors |
 
 Profile C now has **executable conformance coverage** via `profile-c-state-verification.json` (12 assertions).
+
+Key lifecycle enforcement (Profile A/B/C) is covered by `key-lifecycle-verification.json` (20 assertions): active, revoked, retired (within/past window), `not_before`/`not_after` time windows, and wrong-kid rejection.
 
 See [External Provider Interoperability Profile](../../docs/spec/interoperability/external-provider-profile.md) for the full profile specification, wire encoding reference, and fail-closed rules.
 

--- a/packages/conformance/src/validate.ts
+++ b/packages/conformance/src/validate.ts
@@ -17,7 +17,7 @@ import {
   verifyDelegation,
   verifyDelegationChain,
 } from "@oxdeai/core";
-import type { AuthorizationV1, Intent, KeySet, State, VerificationResult, DelegationV1, DelegationScope, VerifyDelegationOptions } from "@oxdeai/core";
+import type { AuthorizationV1, Intent, KeySet, KeySetKey, State, VerificationResult, DelegationV1, DelegationScope, VerifyDelegationOptions } from "@oxdeai/core";
 import {
   TEST_ONLY_ED25519_PRIVATE_KEY_PEM_DO_NOT_USE_IN_PRODUCTION,
   TEST_ONLY_ED25519_PUBLIC_KEY_PEM_DO_NOT_USE_IN_PRODUCTION,
@@ -1168,6 +1168,97 @@ function profileCGetHashFn(strategy: string): (s: unknown) => string {
   throw new Error(`unknown hash_strategy: ${strategy}`);
 }
 
+// ── Key lifecycle constants ───────────────────────────────────────────────────
+const KL_SIGNING_NOW = 1730000000;
+const KL_VERIFY_NOW  = 1730000010;
+const KL_PAST        = KL_SIGNING_NOW - 7200;   // 2 h before signing
+const KL_FUTURE      = KL_SIGNING_NOW + 7200;   // 2 h after signing
+
+function makeKLAuth(): AuthorizationV1 {
+  return signAuthorizationEd25519(
+    {
+      auth_id:     "e".repeat(64),
+      issuer:      "kl.issuer",
+      audience:    "kl.audience",
+      intent_hash: "a".repeat(64),
+      state_hash:  "b".repeat(64),
+      policy_id:   "c".repeat(64),
+      decision:    "ALLOW",
+      issued_at:   KL_SIGNING_NOW,
+      expiry:      KL_SIGNING_NOW + 300,
+      kid:         "kl-key-001",
+    },
+    TEST_ONLY_ED25519_PRIVATE_KEY_PEM_DO_NOT_USE_IN_PRODUCTION
+  );
+}
+
+function makeKLKeyEntry(overrides: Partial<KeySetKey> = {}): KeySetKey {
+  return {
+    kid:        "kl-key-001",
+    alg:        "Ed25519",
+    public_key: TEST_ONLY_ED25519_PUBLIC_KEY_PEM_DO_NOT_USE_IN_PRODUCTION,
+    ...overrides,
+  };
+}
+
+function makeKLKeyset(entry: KeySetKey): KeySet {
+  return { issuer: "kl.issuer", version: "1", keys: [entry] };
+}
+
+function klVerifyOpts(keyset: KeySet): Parameters<ConformanceAdapter["verifyAuthorization"]>[1] {
+  return {
+    now:                         KL_VERIFY_NOW,
+    expectedIssuer:              "kl.issuer",
+    expectedAudience:            "kl.audience",
+    expectedPolicyId:            "c".repeat(64),
+    trustedKeySets:              keyset,
+    requireSignatureVerification: true,
+    consumedAuthIds:             [],
+  };
+}
+
+function validateKeyLifecycleVectors(ctx: CheckCtx, adapter: ConformanceAdapter): void {
+  const file = loadJson<VectorFile>("key-lifecycle-verification.json");
+  const auth = makeKLAuth();
+
+  for (const v of file.vectors) {
+    const id   = String(v.id);
+    const mode = String(v.mode);
+    const expected = asRecord(v.expected);
+
+    let keyset: KeySet;
+
+    if (mode === "key-active") {
+      keyset = makeKLKeyset(makeKLKeyEntry({ status: "active" }));
+    } else if (mode === "key-revoked") {
+      keyset = makeKLKeyset(makeKLKeyEntry({ status: "revoked" }));
+    } else if (mode === "key-not-before-future") {
+      keyset = makeKLKeyset(makeKLKeyEntry({ status: "active", not_before: KL_FUTURE }));
+    } else if (mode === "key-not-after-past") {
+      keyset = makeKLKeyset(makeKLKeyEntry({ status: "active", not_after: KL_PAST }));
+    } else if (mode === "key-valid-window") {
+      keyset = makeKLKeyset(makeKLKeyEntry({ status: "active", not_before: KL_PAST, not_after: KL_FUTURE }));
+    } else if (mode === "key-expired-window") {
+      keyset = makeKLKeyset(makeKLKeyEntry({ status: "active", not_before: KL_PAST - 3600, not_after: KL_PAST }));
+    } else if (mode === "key-retired-within-window") {
+      keyset = makeKLKeyset(makeKLKeyEntry({ status: "retired", not_before: KL_PAST, not_after: KL_FUTURE }));
+    } else if (mode === "key-retired-past-window") {
+      keyset = makeKLKeyset(makeKLKeyEntry({ status: "retired", not_after: KL_PAST }));
+    } else if (mode === "key-revoked-valid-window") {
+      keyset = makeKLKeyset(makeKLKeyEntry({ status: "revoked", not_before: KL_PAST, not_after: KL_FUTURE }));
+    } else if (mode === "wrong-kid-known-issuer") {
+      keyset = makeKLKeyset(makeKLKeyEntry({ kid: "different-key-id", status: "active" }));
+    } else {
+      fail(ctx, `${id}: unknown mode "${mode}"`);
+      continue;
+    }
+
+    const got = adapter.verifyAuthorization(auth, klVerifyOpts(keyset));
+    eq(ctx, `${id} status`,     got.status,     String(expected.status));
+    eq(ctx, `${id} violations`, got.violations, expected.violations ?? []);
+  }
+}
+
 function validateProfileCStateVerificationVectors(ctx: CheckCtx, adapter: ConformanceAdapter): void {
   const file = loadJson<VectorFile>("profile-c-state-verification.json");
   const now = 1_730_000_000;
@@ -1326,6 +1417,7 @@ function main(): void {
   validateDelegationVerificationVectors(ctx);
   validateDelegationChainVectors(ctx);
   validateDelegationSignatureVectors(ctx);
+  validateKeyLifecycleVectors(ctx, adapter);
   validateProfileCStateVerificationVectors(ctx, adapter);
 
   if (ctx.failures.length > 0) {

--- a/packages/conformance/vectors/key-lifecycle-verification.json
+++ b/packages/conformance/vectors/key-lifecycle-verification.json
@@ -1,0 +1,131 @@
+{
+  "version": "1.0.0",
+  "description": "Key lifecycle conformance vectors for AuthorizationV1. Exercises keyIsActiveAt, findKeyInKeySets, and AUTH_KEY_INACTIVE / AUTH_KID_UNKNOWN enforcement. Verification time is KL_VERIFY_NOW = 1730000010. Key windows use KL_PAST = 1729992800 (2h before) and KL_FUTURE = 1730007200 (2h after).",
+  "vectors": [
+    {
+      "id": "key-lifecycle-001",
+      "description": "Active key, no time constraints. Key found, keyIsActiveAt returns true. Signature verifies. Expected: ok.",
+      "mode": "key-active",
+      "expected": {
+        "status": "ok",
+        "violations": []
+      }
+    },
+    {
+      "id": "key-lifecycle-002",
+      "description": "Revoked key. status=revoked causes keyIsActiveAt to return false immediately, regardless of time window. Expected: AUTH_KEY_INACTIVE.",
+      "mode": "key-revoked",
+      "expected": {
+        "status": "invalid",
+        "violations": [
+          {
+            "code": "AUTH_KEY_INACTIVE",
+            "message": "key is not active at verification time"
+          }
+        ]
+      }
+    },
+    {
+      "id": "key-lifecycle-003",
+      "description": "Key not yet active: not_before is in the future (KL_FUTURE > KL_VERIFY_NOW). keyIsActiveAt returns false. Expected: AUTH_KEY_INACTIVE.",
+      "mode": "key-not-before-future",
+      "expected": {
+        "status": "invalid",
+        "violations": [
+          {
+            "code": "AUTH_KEY_INACTIVE",
+            "message": "key is not active at verification time"
+          }
+        ]
+      }
+    },
+    {
+      "id": "key-lifecycle-004",
+      "description": "Key validity window expired: not_after is in the past (KL_PAST < KL_VERIFY_NOW). keyIsActiveAt returns false. Expected: AUTH_KEY_INACTIVE.",
+      "mode": "key-not-after-past",
+      "expected": {
+        "status": "invalid",
+        "violations": [
+          {
+            "code": "AUTH_KEY_INACTIVE",
+            "message": "key is not active at verification time"
+          }
+        ]
+      }
+    },
+    {
+      "id": "key-lifecycle-005",
+      "description": "Key within valid time window: not_before=KL_PAST, not_after=KL_FUTURE. Both bounds satisfied at KL_VERIFY_NOW. keyIsActiveAt returns true. Expected: ok.",
+      "mode": "key-valid-window",
+      "expected": {
+        "status": "ok",
+        "violations": []
+      }
+    },
+    {
+      "id": "key-lifecycle-006",
+      "description": "Key window fully expired: not_before=KL_PAST-3600, not_after=KL_PAST. not_after < KL_VERIFY_NOW. keyIsActiveAt returns false. Expected: AUTH_KEY_INACTIVE.",
+      "mode": "key-expired-window",
+      "expected": {
+        "status": "invalid",
+        "violations": [
+          {
+            "code": "AUTH_KEY_INACTIVE",
+            "message": "key is not active at verification time"
+          }
+        ]
+      }
+    },
+    {
+      "id": "key-lifecycle-007",
+      "description": "Retired key within validity window: status=retired, not_before=KL_PAST, not_after=KL_FUTURE. Retired keys are accepted during dual-sign overlap window. keyIsActiveAt returns true. Expected: ok.",
+      "mode": "key-retired-within-window",
+      "expected": {
+        "status": "ok",
+        "violations": []
+      }
+    },
+    {
+      "id": "key-lifecycle-008",
+      "description": "Retired key past validity window: status=retired, not_after=KL_PAST. Retirement window has closed. keyIsActiveAt returns false. Expected: AUTH_KEY_INACTIVE.",
+      "mode": "key-retired-past-window",
+      "expected": {
+        "status": "invalid",
+        "violations": [
+          {
+            "code": "AUTH_KEY_INACTIVE",
+            "message": "key is not active at verification time"
+          }
+        ]
+      }
+    },
+    {
+      "id": "key-lifecycle-009",
+      "description": "Revoked key with otherwise-valid time window: status=revoked, not_before=KL_PAST, not_after=KL_FUTURE. Revocation takes precedence over time bounds. keyIsActiveAt returns false immediately. Expected: AUTH_KEY_INACTIVE.",
+      "mode": "key-revoked-valid-window",
+      "expected": {
+        "status": "invalid",
+        "violations": [
+          {
+            "code": "AUTH_KEY_INACTIVE",
+            "message": "key is not active at verification time"
+          }
+        ]
+      }
+    },
+    {
+      "id": "key-lifecycle-010",
+      "description": "Known issuer, wrong kid: trustedKeySets contains the correct issuer but a different kid. findKeyInKeySets returns undefined. Expected: AUTH_KID_UNKNOWN.",
+      "mode": "wrong-kid-known-issuer",
+      "expected": {
+        "status": "invalid",
+        "violations": [
+          {
+            "code": "AUTH_KID_UNKNOWN",
+            "message": "kid not found for issuer/alg"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #92.

Add portable key lifecycle conformance vectors for AuthorizationV1 verification.

This resolves the highest-priority conformance gap identified by the post-interoperability protocol audit.

The change adds executable coverage for key lifecycle behavior across trustedKeySets, key status handling, validity windows, and issuer/kid resolution.

## Files changed

Added:

* `packages/conformance/vectors/key-lifecycle-verification.json`

Updated:

* `packages/conformance/src/validate.ts`
* `packages/conformance/README.md`
* `docs/audits/protocol-audit-post-interoperability.md`
* `docs/architecture/key-custody-and-rotation.md`

## Key lifecycle coverage

Added vectors:

key-lifecycle-001 — active key → accepted

key-lifecycle-002 — revoked key → AUTH_KEY_INACTIVE

key-lifecycle-003 — not_before in future → AUTH_KEY_INACTIVE

key-lifecycle-004 — not_after in past → AUTH_KEY_INACTIVE

key-lifecycle-005 — active validity window → accepted

key-lifecycle-006 — expired window → AUTH_KEY_INACTIVE

key-lifecycle-007 — retired key within validity window → accepted for verification

key-lifecycle-008 — retired key after validity window → AUTH_KEY_INACTIVE

key-lifecycle-009 — revoked key inside validity window → AUTH_KEY_INACTIVE

key-lifecycle-010 — wrong kid under known issuer → AUTH_KID_UNKNOWN

## Semantics clarified

Retired keys are now explicitly documented as:

* no longer used for new signing
* still accepted for verification while inside their validity window
* rejected after `not_after`

Revoked keys remain:

* immediately rejected
* validity window ignored

Documentation updated to match implementation behavior.

## Conformance update

Previous total:

161 assertions

New total:

181 assertions

Added assertions:

20

## Audit impact

P0-1 from the protocol audit is resolved.

Portable coverage now exists for:

* revoked keys
* retired keys
* validity windows
* not_before enforcement
* not_after enforcement
* issuer/kid resolution

No remaining high-risk lifecycle gaps remain.

## Validation

* build: pass
* tests: pass
* conformance: 181 assertions pass
* security gate: ALLOW

## Result

Key lifecycle enforcement is now executable and portable across external verifier implementations.
