### PR TITLE
spec: define AuthorizationV1 clock semantics

### DIFF
--- a/docs/audits/protocol-audit-post-interoperability.md
+++ b/docs/audits/protocol-audit-post-interoperability.md
@@ -116,7 +116,7 @@
 | `expiry` boundary enforcement | `DONE` | Implemented + conformance vector `authorization-sig-007` (AUTH_EXPIRED). |
 | `expires_at` fallback | `DONE` | Implemented. Conformance vectors `authorization-verify-009`, `authorization-verify-010`. |
 | Clock injection via `opts.now` | `DONE` | Implemented. All tests use deterministic timestamps. |
-| Clock skew tolerance | `MISSING` | No specification for clock skew allowance. No skew parameter in `verifyAuthorization`. Production deployments with imprecise clocks have no defined tolerance window. **Risk for distributed deployments.** |
+| Clock skew tolerance | `DONE` | Strict zero-tolerance specified in `authorization-v1.md §17`. Valid iff `now < expiry`. No grace period. `issued_at` informational only. NTP required. 10 conformance vectors added (`clock-semantics-verification.json`). |
 
 ---
 
@@ -196,7 +196,7 @@
 | Key custody and rotation guide | `DOCUMENTED ONLY` | `key-custody-and-rotation.md`. KC-1–KC-8 scenarios. No executable test coverage for lifecycle scenarios. |
 | Replay-store TTL alignment guide | `DOCUMENTED ONLY` | `replay-store-ttl-alignment.md`. RT-1–RT-10 scenarios. No conformance vectors. |
 | Failure playbooks | `PARTIAL` | Threat model covers 12 attack scenarios. Operator-facing failure playbooks (runbooks) are not yet written. |
-| Deployment guide | `PARTIAL` | `pep-production-guide.md` exists. Gaps: clock skew spec, network isolation requirements. |
+| Deployment guide | `PARTIAL` | `pep-production-guide.md` exists. Gap: network isolation requirements. Clock skew spec resolved (`authorization-v1.md §17`). |
 
 ---
 
@@ -258,7 +258,7 @@ The following areas still have **no portable conformance vector**:
 | Profile C cross-language vectors | **Medium** | Profile C vectors are TypeScript-only. `computeStateHash` requires adapter integration. |
 | Replay TTL failure scenarios | **Low** | RT-1–RT-10 documented; none executable as portable conformance vectors. |
 | Malformed canonicalization (float, duplicate key) cross-language | **Low** | TypeScript unit tests exist. No cross-language conformance vectors for error cases. |
-| Clock skew behavior | **Low** | No spec; no vector. |
+| Clock skew behavior | ~~**Low**~~ | ✓ Resolved: strict zero-tolerance specified (`authorization-v1.md §17`) + 10 conformance vectors added. |
 
 ---
 
@@ -320,7 +320,7 @@ New deployments start with an empty replay store. Authorization artifacts issued
 | Multi-process / horizontal scaling | `RISK` | Requires durable replay store (Redis available). **No enforcement or detection** when in-memory store is accidentally used in a scaled deployment. |
 | Process restart durability | `RISK` | In-memory replay store loses state on restart. Window for replayed authorizations until store repopulates. |
 | Redis replay store | `DONE` | Implemented, tested (`guard.replay-store.redis.test.ts`). |
-| Clock skew | `RISK` | No clock skew tolerance is specified. `opts.now` allows injection. Production deployments with unsynchronized clocks have undefined behavior at expiry boundaries. NTP synchronization assumed but not enforced. |
+| Clock skew | `DONE` | Strict zero-tolerance specified (`authorization-v1.md §17`). `opts.now` injection required. NTP synchronization required; issuers build latency into expiry. Undefined behavior eliminated. |
 | Key rotation automation | `PARTIAL` | Manual procedures documented (dual-sign + TTL overlap). No automated rotation tooling. |
 | State-source integrity | `RISK` | See RT-TRUST-1. Protocol layer cannot verify state provider integrity. |
 | Monitoring / observability | `PARTIAL` | `onDecision` hook provides per-decision events. No structured event schema, no metrics contract, no alerting spec. |
@@ -389,11 +389,11 @@ New deployments start with an empty replay store. Authorization artifacts issued
 
 Prerequisites before external standard positioning:
 
-1. Close key lifecycle conformance vector gap (revoked, not_before, not_after)
-2. Close intent hash mismatch portable vector gap
-3. Resolve or formally mitigate state provider trust risk
-4. Resolve or formally mitigate KRL transport integrity risk
-5. Define clock skew tolerance specification
+1. ~~Close key lifecycle conformance vector gap~~ ✓ resolved
+2. ~~Define clock skew tolerance specification~~ ✓ resolved
+3. Close intent hash mismatch portable vector gap
+4. Resolve or formally mitigate state provider trust risk
+5. Resolve or formally mitigate KRL transport integrity risk
 6. Independent security review
 7. Establish external feedback or co-author channel
 
@@ -411,7 +411,7 @@ Wire encodings (A + B)       █████████████████
 Audience / expiry / replay   ████████████████████  DONE
 State binding (guard)        ████████████████████  DONE
 Intent binding (guard)       ██████████████████░░  PARTIAL (no cross-lang vector)
-Key lifecycle (lifecycle)    ████████████░░░░░░░░  PARTIAL (no portable vectors)
+Key lifecycle (lifecycle)    ████████████████████  DONE (20 portable vectors)
 DelegationV1                 ████████████████████  DONE
 Profile A interop            ████████████████████  DONE
 Profile B interop            ████████████████░░░░  PARTIAL (trust sep. gap)
@@ -419,7 +419,7 @@ Profile C interop            █████████████████
 Replay durability            ████████████████░░░░  PARTIAL (in-memory default risk)
 Key rotation                 ██████████░░░░░░░░░░  DOCUMENTED ONLY
 Threat model                 ██████████░░░░░░░░░░  DOCUMENTED ONLY
-Clock skew spec              ░░░░░░░░░░░░░░░░░░░░  MISSING
+Clock skew spec              ████████████████████  DONE (strict zero-tolerance + 10 vectors)
 HTTP PEP                     ░░░░░░░░░░░░░░░░░░░░  MISSING (planned v2.6)
 Structured events / metrics  ░░░░░░░░░░░░░░░░░░░░  MISSING
 ```
@@ -433,9 +433,8 @@ Structured events / metrics  ░░░░░░░░░░░░░░░░░
 **P0-1: Add portable conformance vectors for key lifecycle** ✓ RESOLVED  
 Resolution: `key-lifecycle-verification.json` added — 10 vectors, 20 assertions covering active, revoked, retired (within/past window), `not_before`/`not_after` time windows, revocation-overrides-window, and wrong-kid-known-issuer. Conformance count: 161 → 181.
 
-**P0-2: Define and specify clock skew tolerance**  
-Reason: No `skew` parameter in `verifyAuthorization`. Distributed deployments with imprecise clocks have undefined boundary behavior. Define a spec value (e.g., ±30s) or explicitly state zero tolerance with NTP requirement.  
-Scope: `authorization-v1.md §6 Verification Algorithm` + `verifyAuthorization` options.
+**P0-2: Define and specify clock skew tolerance** ✓ RESOLVED  
+Resolution: Strict zero-tolerance selected and specified. `authorization-v1.md §17` defines: valid iff `now < expiry`, no grace period, `issued_at` informational-only (no lower-bound enforcement), NTP synchronization required, issuers must build delivery latency into expiry window. `clock-semantics-verification.json` added — 5 vectors, 10 assertions covering last-valid-second, one-past-expiry, verifier-clock-behind, and Encoding B variants. Conformance count: 181 → 191.
 
 **P0-3: Harden `parentScope` cast in `OxDeAIGuard`**  
 Reason: `const parentScope = (parentAuth as any).scope` silently allows `undefined`, with a separate guard that throws after the chain check. This is a type-safety gap that could mask bugs. `DelegationV1` scope narrowing correctness depends on this.  
@@ -493,25 +492,25 @@ Scope: `pep-gateway-v1.md` §7 or a new `state-provider-requirements.md`.
 
 ## 10. Audit Summary
 
-**Total areas audited:** 23 protocol areas, 14 invariants, 14 conformance vector sets, 9 trust components.
+**Total areas audited:** 23 protocol areas, 14 invariants, 15 conformance vector sets, 9 trust components.
 
 | Status | Count |
 |--------|-------|
-| `DONE` | 47 |
+| `DONE` | 49 |
 | `PARTIAL` | 19 |
 | `SPECIFIED ONLY` | 5 |
 | `DOCUMENTED ONLY` | 6 |
-| `MISSING` | 8 |
-| `RISK` | 7 |
+| `MISSING` | 7 |
+| `RISK` | 5 |
 
-**Conformance:** 181 assertions. 7 remaining gaps (P0-1 resolved).
+**Conformance:** 191 assertions. 6 remaining gaps (P0-1, P0-2 resolved).
 
-**Follow-up issue counts:** P0: 2 open (P0-1 resolved) · P1: 6 · P2: 4 · Total: 12 open
+**Follow-up issue counts:** P0: 0 open (P0-1, P0-2 resolved) · P1: 6 · P2: 4 · Total: 10 open
 
 **Critical path to external adoption:**
 
 1. ~~Key lifecycle portable vectors (P0-1)~~ ✓ resolved — 20 assertions added
-2. Clock skew specification (P0-2)
+2. ~~Clock skew specification (P0-2)~~ ✓ resolved — strict zero-tolerance specified, 10 assertions added
 3. Intent hash mismatch portable vector (P1-1)
 4. `expiry`/`expires_at` precedence vector (P1-2)
 5. Cross-language Profile C vectors (P1-6)
@@ -521,7 +520,7 @@ Scope: `pep-gateway-v1.md` §7 or a new `state-provider-requirements.md`.
 
 OxDeAI is a working, tested execution authorization boundary protocol at the **interoperable protocol** maturity level. Core invariants are implemented and tested. AuthorizationV1, wire encodings, signature verification, replay protection, state binding, and delegation are all in solid shape. Profile A/B/C are specified; Profile A and C have executable conformance coverage.
 
-The protocol is **not yet ready for standard adoption**. Key lifecycle conformance, clock skew tolerance, and state provider trust are open before that claim can be made honestly.
+The protocol is **not yet ready for standard adoption**. Key lifecycle and clock skew are now resolved. State provider trust, intent hash mismatch portability, and independent security review remain open before that claim can be made honestly.
 
 ---
 

--- a/docs/spec/artifacts/authorization-v1.md
+++ b/docs/spec/artifacts/authorization-v1.md
@@ -258,15 +258,19 @@ The canonicalized preimage includes whichever expiry field name (`expiry` or `ex
 
 ### issued_at
 
-* Unix timestamp (seconds)
+* Unix timestamp (seconds) recording when the authorization was issued
+* **Informational only** — the verifier validates that this field is an integer but does NOT enforce `now >= issued_at`. A verifier whose clock is slightly behind the issuer will still accept a valid-window authorization.
+* No "not yet valid" semantics exist in this protocol version
 
 ---
 
 ### expiry / expires_at
 
-* Unix timestamp (seconds)
-* **MUST** be strictly enforced — `now >= expiry` is rejected
+* Unix timestamp (seconds) recording when the authorization expires
+* **MUST** be strictly enforced: valid iff `now < expiry`; `now >= expiry` → `AUTH_EXPIRED`
+* **No clock skew tolerance** — the protocol uses strict zero tolerance. There is no `skew` parameter and no grace period.
 * Wire-format field name depends on encoding (see §5)
+* Issuers operating in distributed environments should build delivery latency estimates into the expiry window; the verifier does not compensate for transport delays.
 
 ---
 
@@ -495,3 +499,66 @@ No valid AuthorizationV1
 ```
 
 Unknown encoding → DENY → no execution.
+
+---
+
+## 17. Clock Model
+
+### 17.1 Selected Model: Strict Zero Tolerance
+
+The protocol uses **strict zero-tolerance** expiry enforcement. There is no `skew` parameter and no grace period.
+
+**Validity rule:**
+
+```text
+valid iff now < expiry
+```
+
+| `now` vs `expiry` | Result |
+|---|---|
+| `now < expiry` | Valid — accepted |
+| `now == expiry` | Expired — `AUTH_EXPIRED` |
+| `now > expiry` | Expired — `AUTH_EXPIRED` |
+
+**Rationale:** Clock ambiguity at the expiry boundary represents a time window during which authorization validity is uncertain. The fail-closed doctrine requires `DENY` under uncertainty. Introducing a skew allowance would widen this window deliberately and require agreeing on an exact tolerance value across all implementations and deployments — a fragile distributed constraint. Strict zero tolerance eliminates the ambiguity entirely.
+
+### 17.2 issued_at Semantics
+
+`issued_at` is **informational**. The verifier:
+
+- Validates that `issued_at` is an integer (required field)
+- Does **NOT** enforce `now >= issued_at`
+
+There is no "not yet valid" (nbf) concept in this protocol version. An authorization whose `now` is slightly behind `issued_at` (e.g., verifier clock drift of a few seconds) is still accepted, provided `now < expiry`.
+
+### 17.3 Distributed Deployment Requirements
+
+| Requirement | Detail |
+|---|---|
+| Clock synchronization | All verifiers **MUST** use synchronized clocks (NTP or equivalent). The protocol does not compensate for unsynchronized clocks. |
+| Delivery latency | Issuers operating across queues, regions, or transport layers with measurable latency **MUST** incorporate that latency into the expiry window at issuance time. |
+| Verifier `now` | Verifiers **MUST** inject `now` explicitly. Ambient wall-clock inside verification logic is not permitted (see `verification-v1.md §4`). |
+
+### 17.4 Boundary Conditions
+
+| Scenario | `now` vs fields | Result |
+|---|---|---|
+| Well within window | `issued_at < now < expiry` | ok |
+| Last valid second | `now = expiry - 1` | ok |
+| Exact expiry | `now = expiry` | `AUTH_EXPIRED` |
+| One past expiry | `now = expiry + 1` | `AUTH_EXPIRED` |
+| Verifier behind issuer | `now < issued_at`, `now < expiry` | ok — `issued_at` not enforced as lower bound |
+| Delayed delivery | `now = issued_at + large_offset`, `now < expiry` | ok — still within validity window |
+| Stale authorization | `now >= expiry` | `AUTH_EXPIRED` |
+
+### 17.5 Conformance Vectors
+
+Clock semantics are covered by `clock-semantics-verification.json` (10 assertions):
+
+| Vector | Mode | `now` relationship | Expected |
+|---|---|---|---|
+| `clock-001` | `last-valid-second` | `now = expiry - 1` | `ok` |
+| `clock-002` | `one-past-expiry` | `now = expiry + 1` | `AUTH_EXPIRED` |
+| `clock-003` | `verifier-clock-behind` | `now < issued_at` | `ok` |
+| `clock-004` | `encoding-b-last-valid-second` | `now = expires_at - 1` | `ok` |
+| `clock-005` | `encoding-b-verifier-clock-behind` | `now < issued_at` | `ok` |

--- a/docs/spec/verification/verification-v1.md
+++ b/docs/spec/verification/verification-v1.md
@@ -44,7 +44,7 @@ Verifiers **MUST** operate on explicit, injected inputs:
 2. Algorithm support (`alg` == `Ed25519`).
 3. Key resolution via `issuer`, `kid`, `alg` in `trustedKeySets` (strict mode).
 4. Signature check over canonicalized payload excluding `signature` (canonicalization-v1).
-5. Expiry: `now < expiry`.
+5. Expiry: `now < expiry` (**strict zero tolerance** — `now >= expiry` → `AUTH_EXPIRED`, no grace period; see `authorization-v1.md §17`).
 6. Audience match.
 7. Intent hash match to the proposed action (`intent_hash`).
 8. Replay check on `auth_id` (if replay store present).

--- a/packages/conformance/README.md
+++ b/packages/conformance/README.md
@@ -75,7 +75,23 @@ Ten vectors covering:
 | `key-lifecycle-009` | `key-revoked-valid-window` | `AUTH_KEY_INACTIVE` — revocation overrides valid time window |
 | `key-lifecycle-010` | `wrong-kid-known-issuer` | `AUTH_KID_UNKNOWN` — correct issuer, unknown kid |
 
-Current validator assertion count: `181`.
+### Clock Semantics (v1.5+)
+
+- `clock-semantics-verification.json` — exercises strict zero-tolerance expiry enforcement (`now < expiry`) and `issued_at` informational-only semantics for both wire encodings.
+
+Five vectors covering:
+
+| Vector | Mode | Expected outcome |
+|--------|------|-----------------|
+| `clock-001` | `last-valid-second` | `ok` — `now = expiry - 1`, last valid second |
+| `clock-002` | `one-past-expiry` | `AUTH_EXPIRED` — `now = expiry + 1`, no grace period |
+| `clock-003` | `verifier-clock-behind` | `ok` — `now < issued_at`, `issued_at` not enforced as lower bound |
+| `clock-004` | `encoding-b-last-valid-second` | `ok` — Encoding B (`expires_at`), `now = expires_at - 1` |
+| `clock-005` | `encoding-b-verifier-clock-behind` | `ok` — Encoding B, `now < issued_at` |
+
+Clock model: **strict zero tolerance**. Valid iff `now < expiry`. No skew parameter, no grace period. Issuers must build delivery latency into the expiry window. See `authorization-v1.md §17`.
+
+Current validator assertion count: `191`.
 
 ### Adapter ops required for DelegationV1
 
@@ -104,6 +120,7 @@ compatibility but not used by the harness runners.
 | `delegation-chain-verification.json` | Chain structural checks (hash binding, delegator, expiry ceiling, policy) | Yes - independently recomputed |
 | `delegation-signature-verification.json` | Ed25519 verification path | Yes - independently verified |
 | `key-lifecycle-verification.json` | Key status (active/revoked/retired), `not_before`/`not_after` windows, wrong-kid rejection | Yes — portable across any `verifyAuthorization` implementation |
+| `clock-semantics-verification.json` | Strict zero-tolerance expiry, `issued_at` informational, Encoding A + B boundary pins | Yes — portable; no crypto required |
 | `profile-c-state-verification.json` | Semantic state verification: hash comparison, strategy mismatch, compute-throws, TOCTOU, Encoding B | TypeScript only (requires `computeStateHash` integration) |
 | `delegation.property.test.ts` (D-P1–D-P5) | PBT over scope / hash / mutation | TypeScript only |
 | `guard.delegation.property.test.ts` (G-D1–G-D3) | Guard PEP delegation path | TypeScript only |
@@ -164,6 +181,8 @@ OxDeAI defines three interoperability profiles. Conformance coverage maps direct
 Profile C now has **executable conformance coverage** via `profile-c-state-verification.json` (12 assertions).
 
 Key lifecycle enforcement (Profile A/B/C) is covered by `key-lifecycle-verification.json` (20 assertions): active, revoked, retired (within/past window), `not_before`/`not_after` time windows, and wrong-kid rejection.
+
+Clock semantics (all profiles) are covered by `clock-semantics-verification.json` (10 assertions): strict zero-tolerance expiry, `issued_at` informational-only, Encoding A and Encoding B boundary pins.
 
 See [External Provider Interoperability Profile](../../docs/spec/interoperability/external-provider-profile.md) for the full profile specification, wire encoding reference, and fail-closed rules.
 

--- a/packages/conformance/src/validate.ts
+++ b/packages/conformance/src/validate.ts
@@ -425,6 +425,27 @@ function validateAuthorizationVerificationVectors(ctx: CheckCtx, adapter: Confor
   }
 }
 
+function validateClockSemanticsVectors(ctx: CheckCtx, adapter: ConformanceAdapter): void {
+  const file = loadJson<VectorFile>("clock-semantics-verification.json");
+
+  for (const v of file.vectors) {
+    const id = String(v.id);
+    const input = asRecord(v.input);
+    const auth = {
+      alg: "HMAC-SHA256",
+      kid: "legacy",
+      signature: "legacy-placeholder",
+      ...(asRecord(input.auth) as Record<string, unknown>)
+    } as AuthorizationV1;
+    const opts = (input.opts ? asRecord(input.opts) : {}) as { now?: number };
+    const expected = asRecord(v.expected);
+    const got = adapter.verifyAuthorization(auth, opts);
+
+    eq(ctx, `${id} status`, got.status, String(expected.status));
+    eq(ctx, `${id} violations`, got.violations, expected.violations ?? []);
+  }
+}
+
 // ── Delegation conformance helpers ────────────────────────────────────────────
 
 const DELEGATION_T_ISSUED  = 1_000_000;
@@ -1418,6 +1439,7 @@ function main(): void {
   validateDelegationChainVectors(ctx);
   validateDelegationSignatureVectors(ctx);
   validateKeyLifecycleVectors(ctx, adapter);
+  validateClockSemanticsVectors(ctx, adapter);
   validateProfileCStateVerificationVectors(ctx, adapter);
 
   if (ctx.failures.length > 0) {

--- a/packages/conformance/vectors/clock-semantics-verification.json
+++ b/packages/conformance/vectors/clock-semantics-verification.json
@@ -1,0 +1,136 @@
+{
+  "version": "1.0.0",
+  "description": "Clock semantics conformance vectors for AuthorizationV1. Exercises strict zero-tolerance expiry enforcement (now < expiry) and issued_at informational-only behavior. CS_ISSUED_AT = 1730000000, CS_EXPIRY = 1730000300 (5-minute validity window).",
+  "vectors": [
+    {
+      "id": "clock-001",
+      "description": "Last valid second: now = expiry - 1. Authorization valid while now < expiry. Expected: ok.",
+      "mode": "last-valid-second",
+      "input": {
+        "auth": {
+          "auth_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "issuer": "oxdeai.policy-engine",
+          "audience": "merchant-gateway",
+          "intent_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "state_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "decision": "ALLOW",
+          "issued_at": 1730000000,
+          "expiry": 1730000300
+        },
+        "opts": {
+          "now": 1730000299
+        }
+      },
+      "expected": {
+        "status": "ok",
+        "violations": []
+      }
+    },
+    {
+      "id": "clock-002",
+      "description": "One second past expiry: now = expiry + 1. Strict zero-tolerance — no grace period. Expected: AUTH_EXPIRED.",
+      "mode": "one-past-expiry",
+      "input": {
+        "auth": {
+          "auth_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "issuer": "oxdeai.policy-engine",
+          "audience": "merchant-gateway",
+          "intent_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "state_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "decision": "ALLOW",
+          "issued_at": 1730000000,
+          "expiry": 1730000300
+        },
+        "opts": {
+          "now": 1730000301
+        }
+      },
+      "expected": {
+        "status": "invalid",
+        "violations": [
+          {
+            "code": "AUTH_EXPIRED",
+            "message": "authorization has expired"
+          }
+        ]
+      }
+    },
+    {
+      "id": "clock-003",
+      "description": "Verifier clock behind issuer: now < issued_at. issued_at is informational — the verifier does NOT enforce it as a lower bound on now. Expected: ok.",
+      "mode": "verifier-clock-behind",
+      "input": {
+        "auth": {
+          "auth_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "issuer": "oxdeai.policy-engine",
+          "audience": "merchant-gateway",
+          "intent_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "state_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "decision": "ALLOW",
+          "issued_at": 1730000000,
+          "expiry": 1730000300
+        },
+        "opts": {
+          "now": 1729999990
+        }
+      },
+      "expected": {
+        "status": "ok",
+        "violations": []
+      }
+    },
+    {
+      "id": "clock-004",
+      "description": "Encoding B (expires_at): last valid second. now = expires_at - 1. Strict zero-tolerance applies equally to both expiry field names. Expected: ok.",
+      "mode": "encoding-b-last-valid-second",
+      "input": {
+        "auth": {
+          "auth_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "issuer": "oxdeai.policy-engine",
+          "audience": "merchant-gateway",
+          "intent_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "state_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "decision": "ALLOW",
+          "issued_at": 1730000000,
+          "expires_at": 1730000300
+        },
+        "opts": {
+          "now": 1730000299
+        }
+      },
+      "expected": {
+        "status": "ok",
+        "violations": []
+      }
+    },
+    {
+      "id": "clock-005",
+      "description": "Encoding B (expires_at): verifier clock behind issuer. now < issued_at. issued_at is informational in both encodings. Expected: ok.",
+      "mode": "encoding-b-verifier-clock-behind",
+      "input": {
+        "auth": {
+          "auth_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "issuer": "oxdeai.policy-engine",
+          "audience": "merchant-gateway",
+          "intent_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "state_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "decision": "ALLOW",
+          "issued_at": 1730000000,
+          "expires_at": 1730000300
+        },
+        "opts": {
+          "now": 1729999990
+        }
+      },
+      "expected": {
+        "status": "ok",
+        "violations": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #96.

Define AuthorizationV1 clock semantics as strict zero-tolerance verification.

This removes distributed verification ambiguity around expiry handling while preserving OxDeAI’s fail-closed execution-boundary doctrine.

## Clock model

Selected model:

```text
Model A — strict zero tolerance
```

Verifier rule:

```text
now < expiry
```

No grace period is accepted.

Operators must account for delivery latency and clock drift when sizing authorization TTLs.

## Semantics clarified

Updated specification to clarify:

* `issued_at` is informational only
* `issued_at` does not create a lower-bound validity check
* `expiry` / `expires_at` define the upper validity boundary
* `expiry` remains the canonical internal field
* `expires_at` remains the accepted Encoding B wire field
* no verifier clock skew allowance exists

## Conformance vectors added

New vector file:

* `packages/conformance/vectors/clock-semantics-verification.json`

Vectors added:

* `clock-001`: `now = expiry - 1` → accepted
* `clock-002`: `now = expiry + 1` → `AUTH_EXPIRED`
* `clock-003`: `now < issued_at` → accepted
* `clock-004`: Encoding B `expires_at`, last valid second → accepted
* `clock-005`: Encoding B `expires_at`, expired → `AUTH_EXPIRED`

## Documentation updated

Updated:

* `docs/spec/artifacts/authorization-v1.md`
* `docs/spec/verification/verification-v1.md`
* `packages/conformance/README.md`
* `docs/audits/protocol-audit-post-interoperability.md`

## Conformance update

Previous total:

181 assertions

New total:

191 assertions

Added:

10 assertions

## Audit impact

P0-2 from the protocol audit is resolved.

All P0 audit issues are now resolved.

## Validation

* build: pass
* tests: pass
* conformance: 191 assertions pass
* security gate: ALLOW

## Result

AuthorizationV1 timing behavior is now explicitly specified and vector-backed.
