### PR TITLE
fix(guard): require explicit parent delegation scope

### DIFF
--- a/examples/delegation-demo/src/scenario.ts
+++ b/examples/delegation-demo/src/scenario.ts
@@ -241,7 +241,7 @@ export async function runScenario(): Promise<ScenarioStep[]> {
     await guardB1(
       { name: "provision_gpu", args: { units: CHILD_ACTION_1_UNITS, tier: "a100" }, context: { agent_id: AGENT_B } },
       async () => "child-provision-receipt-1",
-      { delegation: { delegation, parentAuth } }
+      { delegation: { delegation, parentAuth, parentScope: { tools: ["provision_gpu"], max_amount: PARENT_AMOUNT } } }
     );
   } catch (err) {
     child1Decision = "DENY";
@@ -305,7 +305,7 @@ export async function runScenario(): Promise<ScenarioStep[]> {
     await guardB2(
       { name: "provision_gpu", args: { units: CHILD_ACTION_2_UNITS, tier: "a100" }, context: { agent_id: AGENT_B } },
       async () => "child-provision-receipt-2",
-      { delegation: { delegation, parentAuth } }
+      { delegation: { delegation, parentAuth, parentScope: { tools: ["provision_gpu"], max_amount: PARENT_AMOUNT } } }
     );
   } catch (err) {
     child2Decision = "DENY";

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import type { Authorization, AuthorizationV1, Intent, KeySet } from "@oxdeai/core";
+import type { Authorization, AuthorizationV1, DelegationScope, Intent, KeySet } from "@oxdeai/core";
 import { verifyDelegationChain, verifyAuthorization as strictVerifyAuthorization, intentHash } from "@oxdeai/core";
 import type { OxDeAIGuardConfig, ProposedAction, GuardDecisionRecord, GuardCallOptions } from "./types.js";
 import { defaultNormalizeAction } from "./normalizeAction.js";
@@ -15,6 +15,18 @@ import {
 } from "./errors.js";
 
 // ── validation ────────────────────────────────────────────────────────────────
+
+function isValidDelegationScope(scope: unknown): scope is DelegationScope {
+  if (scope === null || scope === undefined || typeof scope !== "object" || Array.isArray(scope)) {
+    return false;
+  }
+  const s = scope as Record<string, unknown>;
+  if (s.tools !== undefined && !Array.isArray(s.tools)) return false;
+  if (s.max_amount !== undefined && typeof s.max_amount !== "bigint") return false;
+  if (s.max_actions !== undefined && typeof s.max_actions !== "number") return false;
+  if (s.max_depth !== undefined && typeof s.max_depth !== "number") return false;
+  return true;
+}
 
 function validateConfig(config: OxDeAIGuardConfig): void {
   if (!config || typeof config !== "object") {
@@ -179,11 +191,11 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
       //   - delegation signature (if trustedKeySets provided)
       //   - scope narrowing against parent (enforced via parentScope)
       //
-      // Derive parentScope from parentAuth; if not present, fail closed.
-      const parentScope = (parentAuth as any).scope;
-      if (!parentScope) {
+      // Validate parentScope before chain verification. Fail closed on missing or malformed scope.
+      const { parentScope } = opts.delegation;
+      if (!isValidDelegationScope(parentScope)) {
         throw new OxDeAIAuthorizationError(
-          "Parent authorization scope is required for delegation narrowing but was not provided. Execution blocked."
+          "Parent authorization scope is missing or malformed. Execution blocked."
         );
       }
 

--- a/packages/guard/src/test/guard.boundary.test.ts
+++ b/packages/guard/src/test/guard.boundary.test.ts
@@ -233,8 +233,6 @@ test("delegation tool widening is denied", async () => {
     },
     privateKey.export({ type: "pkcs8", format: "pem" }).toString()
   ) as Authorization;
-  (parentAuth as any).scope = { tools: ["read"], max_amount: 100n };
-
   const delegation = createDelegation(
     parentAuth as AuthorizationV1,
     {
@@ -262,7 +260,7 @@ test("delegation tool widening is denied", async () => {
   await assert.rejects(
     guard(action, async () => {
       executed = true;
-    }, { delegation: { delegation, parentAuth: parentAuth as AuthorizationV1 } }),
+    }, { delegation: { delegation, parentAuth: parentAuth as AuthorizationV1, parentScope: { tools: ["read"], max_amount: 100n } } }),
     /DELEGATION_SCOPE_VIOLATION|execution blocked/i
   );
   assert.equal(executed, false);
@@ -286,8 +284,6 @@ test("delegation amount widening is denied", async () => {
     },
     privateKey.export({ type: "pkcs8", format: "pem" }).toString()
   ) as Authorization;
-  (parentAuth as any).scope = { tools: ["read"], max_amount: 100n };
-
   const delegation = createDelegation(
     parentAuth as AuthorizationV1,
     {
@@ -315,7 +311,7 @@ test("delegation amount widening is denied", async () => {
   await assert.rejects(
     guard(action, async () => {
       executed = true;
-    }, { delegation: { delegation, parentAuth: parentAuth as AuthorizationV1 } }),
+    }, { delegation: { delegation, parentAuth: parentAuth as AuthorizationV1, parentScope: { tools: ["read"], max_amount: 100n } } }),
     /DELEGATION_SCOPE_VIOLATION|execution blocked/i
   );
   assert.equal(executed, false);
@@ -339,8 +335,6 @@ test("delegation narrowing is allowed", async () => {
     },
     privateKey.export({ type: "pkcs8", format: "pem" }).toString()
   ) as Authorization;
-  (parentAuth as any).scope = { tools: ["pay", "read", "write"], max_amount: 1000n };
-
   const delegation = createDelegation(
     parentAuth as AuthorizationV1,
     {
@@ -367,7 +361,7 @@ test("delegation narrowing is allowed", async () => {
   let executed = false;
   await guard(action, async () => {
     executed = true;
-  }, { delegation: { delegation, parentAuth: parentAuth as AuthorizationV1 } });
+  }, { delegation: { delegation, parentAuth: parentAuth as AuthorizationV1, parentScope: { tools: ["pay", "read", "write"], max_amount: 1000n } } });
 
   assert.equal(executed, true);
 });
@@ -391,8 +385,6 @@ test("delegation replay is denied", async () => {
     },
     privateKey.export({ type: "pkcs8", format: "pem" }).toString()
   ) as Authorization;
-  (parentAuth as any).scope = { tools: ["pay", "read"], max_amount: 100n };
-
   const delegation = createDelegation(
     parentAuth as AuthorizationV1,
     {
@@ -420,12 +412,12 @@ test("delegation replay is denied", async () => {
 
   await guard(action, async () => {
     executions += 1;
-  }, { delegation: { delegation, parentAuth: parentAuth as AuthorizationV1 } });
+  }, { delegation: { delegation, parentAuth: parentAuth as AuthorizationV1, parentScope: { tools: ["pay", "read"], max_amount: 100n } } });
 
   await assert.rejects(
     guard(action, async () => {
       executions += 1;
-    }, { delegation: { delegation, parentAuth: parentAuth as AuthorizationV1 } }),
+    }, { delegation: { delegation, parentAuth: parentAuth as AuthorizationV1, parentScope: { tools: ["pay", "read"], max_amount: 100n } } }),
     /Delegation replay detected|DELEGATION_REPLAY/i
   );
 
@@ -451,8 +443,6 @@ test("unsigned delegation is denied", async () => {
     },
     privateKey.export({ type: "pkcs8", format: "pem" }).toString()
   ) as Authorization;
-  (parentAuth as any).scope = { tools: ["read"], max_amount: 100n };
-
   const unsignedDelegation = createDelegation(
     parentAuth as AuthorizationV1,
     {
@@ -480,7 +470,7 @@ test("unsigned delegation is denied", async () => {
   await assert.rejects(
     guard(action, async () => {
       /* no-op */
-    }, { delegation: { delegation: unsignedDelegation, parentAuth: parentAuth as AuthorizationV1 } }),
+    }, { delegation: { delegation: unsignedDelegation, parentAuth: parentAuth as AuthorizationV1, parentScope: { tools: ["read"], max_amount: 100n } } }),
     /DELEGATION_SIGNATURE_INVALID|signature verification failed|execution blocked/i
   );
 });
@@ -504,8 +494,6 @@ test("tampered delegation signature is denied", async () => {
     },
     privateKey.export({ type: "pkcs8", format: "pem" }).toString()
   ) as Authorization;
-  (parentAuth as any).scope = { tools: ["read"], max_amount: 100n };
-
   const delegation = createDelegation(
     parentAuth as AuthorizationV1,
     {
@@ -533,7 +521,7 @@ test("tampered delegation signature is denied", async () => {
   await assert.rejects(
     guard(action, async () => {
       /* no-op */
-    }, { delegation: { delegation, parentAuth: parentAuth as AuthorizationV1 } }),
+    }, { delegation: { delegation, parentAuth: parentAuth as AuthorizationV1, parentScope: { tools: ["read"], max_amount: 100n } } }),
     /DELEGATION_SIGNATURE_INVALID|signature verification failed|execution blocked/i
   );
 });

--- a/packages/guard/src/test/guard.delegation.matrix.test.ts
+++ b/packages/guard/src/test/guard.delegation.matrix.test.ts
@@ -50,8 +50,10 @@ const T_PAR_EXP = T_NOW + 900;
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
+const PARENT_SCOPE = { tools: ["provision_gpu"], max_amount: 1_000_000n };
+
 function makeParent(overrides?: { expiry?: number; audience?: string }): AuthorizationV1 {
-  const auth = signAuthorizationEd25519(
+  return signAuthorizationEd25519(
     {
       auth_id:     "f".repeat(64),
       issuer:      "pdp-issuer",
@@ -66,8 +68,6 @@ function makeParent(overrides?: { expiry?: number; audience?: string }): Authori
     },
     KEYS.privateKey
   );
-  (auth as any).scope = { tools: ["provision_gpu"], max_amount: 1_000_000n };
-  return auth;
 }
 
 function makeGuard(overrides?: Partial<OxDeAIGuardConfig>) {
@@ -115,7 +115,7 @@ test("CASE-7a: valid chain with signature verification → execute runs", async 
   const result = await guard(
     action,
     async () => { executed = true; return "executed"; },
-    { delegation: { delegation, parentAuth: parent } }
+    { delegation: { delegation, parentAuth: parent, parentScope: PARENT_SCOPE } }
   );
 
   assert.ok(executed, "execute must be called on valid delegation");
@@ -133,7 +133,7 @@ test("CASE-7b: unsigned delegation is rejected (fail-closed)", async () => {
 
   const guard = makeGuard();
   await assert.rejects(
-    () => guard(action, async () => {}, { delegation: { delegation, parentAuth: parent } }),
+    () => guard(action, async () => {}, { delegation: { delegation, parentAuth: parent, parentScope: PARENT_SCOPE } }),
     /signature is required|DELEGATION_SIGNATURE_INVALID|Authorization verification failed/i
   );
 });
@@ -149,7 +149,7 @@ test("CASE-7c: delegation path does not call setState", async () => {
   let setStateCalled = false;
   const guard = makeGuard({ setState: () => { setStateCalled = true; return true; } });
 
-  await guard(action, async () => {}, { delegation: { delegation, parentAuth: parent } });
+  await guard(action, async () => {}, { delegation: { delegation, parentAuth: parent, parentScope: PARENT_SCOPE } });
 
   assert.ok(!setStateCalled, "setState must NOT be called on delegation path");
 });
@@ -172,7 +172,7 @@ test("CASE-7d: onDecision fires ALLOW with delegation artifact present", async (
     },
   });
 
-  await guard(action, async () => {}, { delegation: { delegation, parentAuth: parent } });
+  await guard(action, async () => {}, { delegation: { delegation, parentAuth: parent, parentScope: PARENT_SCOPE } });
 
   assert.equal(capturedDecision, "ALLOW");
   assert.equal(capturedDelegationId, "d-audit-test");
@@ -191,7 +191,7 @@ test("CASE-7e: beforeExecute is called before execute on delegation path", async
     beforeExecute: () => { order.push("before"); },
   });
 
-  await guard(action, async () => { order.push("execute"); }, { delegation: { delegation, parentAuth: parent } });
+  await guard(action, async () => { order.push("execute"); }, { delegation: { delegation, parentAuth: parent, parentScope: PARENT_SCOPE } });
 
   assert.deepEqual(order, ["before", "execute"]);
 });
@@ -210,7 +210,7 @@ test("CASE-8a: expired delegation → OxDeAIDelegationError, execute blocked", a
   let executed = false;
 
   await assert.rejects(
-    () => guard(action, async () => { executed = true; }, { delegation: { delegation, parentAuth: parent } }),
+    () => guard(action, async () => { executed = true; }, { delegation: { delegation, parentAuth: parent, parentScope: PARENT_SCOPE } }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIDelegationError);
       assert.ok(err.violations.length > 0);
@@ -233,7 +233,7 @@ test("CASE-8b: tampered delegation signature → OxDeAIDelegationError, execute 
   let executed = false;
 
   await assert.rejects(
-    () => guard(action, async () => { executed = true; }, { delegation: { delegation: tampered, parentAuth: parent } }),
+    () => guard(action, async () => { executed = true; }, { delegation: { delegation: tampered, parentAuth: parent, parentScope: PARENT_SCOPE } }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIDelegationError);
       return true;
@@ -254,7 +254,7 @@ test("CASE-8c: action not in scope.tools → OxDeAIDelegationError, execute bloc
   let executed = false;
 
   await assert.rejects(
-    () => guard(action, async () => { executed = true; }, { delegation: { delegation, parentAuth: parent } }),
+    () => guard(action, async () => { executed = true; }, { delegation: { delegation, parentAuth: parent, parentScope: PARENT_SCOPE } }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIDelegationError);
       assert.ok(err.violations.some((v) => v.includes("provision_gpu")));
@@ -278,7 +278,7 @@ test("CASE-8d: parent hash mismatch → OxDeAIDelegationError, execute blocked",
 
   // Delegation bound to `parent` but presented with `otherParent`
   await assert.rejects(
-    () => guard(action, async () => { executed = true; }, { delegation: { delegation, parentAuth: otherParent } }),
+    () => guard(action, async () => { executed = true; }, { delegation: { delegation, parentAuth: otherParent, parentScope: PARENT_SCOPE } }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIDelegationError);
       return true;
@@ -298,7 +298,7 @@ test("CASE-8e: OxDeAIDelegationError is catchable as OxDeAIAuthorizationError", 
   const guard = makeGuard();
 
   await assert.rejects(
-    () => guard(action, async () => {}, { delegation: { delegation, parentAuth: parent } }),
+    () => guard(action, async () => {}, { delegation: { delegation, parentAuth: parent, parentScope: PARENT_SCOPE } }),
     (err: unknown) => {
       // Existing catch blocks for OxDeAIAuthorizationError remain valid
       assert.ok(err instanceof OxDeAIAuthorizationError, "must be catchable as OxDeAIAuthorizationError");
@@ -319,7 +319,7 @@ test("CASE-8f: setState is NOT called when delegation verification fails", async
   let setStateCalled = false;
   const guard = makeGuard({ setState: () => { setStateCalled = true; return true; } });
 
-  await assert.rejects(() => guard(action, async () => {}, { delegation: { delegation, parentAuth: parent } }));
+  await assert.rejects(() => guard(action, async () => {}, { delegation: { delegation, parentAuth: parent, parentScope: PARENT_SCOPE } }));
 
   assert.ok(!setStateCalled, "setState must not be called when delegation fails");
 });

--- a/packages/guard/src/test/guard.delegation.property.test.ts
+++ b/packages/guard/src/test/guard.delegation.property.test.ts
@@ -95,8 +95,10 @@ const TOOL_POOL = [
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+const PARENT_SCOPE = { tools: [...TOOL_POOL], max_amount: 1_000_000n };
+
 function makeParentAuth(expiry = T_PAR_EXP): AuthorizationV1 {
-  const auth = signAuthorizationEd25519(
+  return signAuthorizationEd25519(
     {
       auth_id: "f".repeat(64),
       issuer: KEYSET.issuer,
@@ -111,8 +113,6 @@ function makeParentAuth(expiry = T_PAR_EXP): AuthorizationV1 {
     },
     KEYS.privateKey
   );
-  (auth as any).scope = { tools: [...TOOL_POOL], max_amount: 1_000_000n };
-  return auth;
 }
 
 function makeDelegation(
@@ -183,7 +183,7 @@ test("G-D1: any action matching delegation scope.tools is allowed; setState is n
     const result = await guard(
       action,
       async () => { executeCalled = true; return "executed"; },
-      { delegation: { delegation, parentAuth: parent } }
+      { delegation: { delegation, parentAuth: parent, parentScope: PARENT_SCOPE } }
     );
 
     assert.ok(
@@ -276,7 +276,7 @@ test("G-D2: any invalid delegation class always blocks execution (fail-closed)",
         await guard(
           action,
           async () => { executeCalled = true; },
-          { delegation: { delegation, parentAuth: parent } }
+          { delegation: { delegation, parentAuth: parent, parentScope: PARENT_SCOPE } }
         );
       },
       (err: unknown) => err instanceof OxDeAIDelegationError,
@@ -347,7 +347,6 @@ test("G-D3: delegation presented with wrong parent authorization is rejected (DE
       KEYS.privateKey
     );
     const parentB = parentBAuth;
-    (parentB as any).scope = { tools: [scopeTool], max_amount: 1_000_000n };
 
     // Delegation is cryptographically bound to parentA via parent_auth_hash.
     const delegation = makeDelegation(parentA, [scopeTool], T_DEL_EXP);
@@ -363,7 +362,7 @@ test("G-D3: delegation presented with wrong parent authorization is rejected (DE
         await guard(
           makeAction(scopeTool, T_NOW),
           async () => { executeCalled = true; },
-          { delegation: { delegation, parentAuth: parentB } }   // ← wrong parent
+          { delegation: { delegation, parentAuth: parentB, parentScope: { tools: [scopeTool], max_amount: 1_000_000n } } }   // ← wrong parent
         );
       },
       (err: unknown) => {

--- a/packages/guard/src/test/guard.delegation.test.ts
+++ b/packages/guard/src/test/guard.delegation.test.ts
@@ -2,7 +2,7 @@
 /**
  * Delegation path tests for @oxdeai/guard.
  *
- * Covers the guard(action, execute, { delegation: { delegation, parentAuth } })
+ * Covers the guard(action, execute, { delegation: { delegation, parentAuth, parentScope: PARENT_SCOPE } })
  * execution path introduced in v2.x.
  */
 
@@ -13,7 +13,7 @@ import {
   signAuthorizationEd25519,
   createDelegation,
 } from "@oxdeai/core";
-import type { AuthorizationV1, DelegationV1 } from "@oxdeai/core";
+import type { AuthorizationV1, DelegationScope, DelegationV1 } from "@oxdeai/core";
 import { buildState } from "@oxdeai/sdk";
 
 import { OxDeAIGuard } from "../guard.js";
@@ -28,8 +28,10 @@ import { TEST_KEYSET, TEST_KEYPAIR } from "./helpers/fixtures.js";
 
 const T_NOW = Math.floor(Date.now() / 1000);
 
+const PARENT_SCOPE = { tools: ["provision_gpu"], max_amount: 1_000_000n };
+
 function makeParentAuth(overrides?: { expiry?: number; audience?: string }): AuthorizationV1 {
-  const auth = signAuthorizationEd25519(
+  return signAuthorizationEd25519(
     {
       auth_id: "f".repeat(64),
       issuer: TEST_KEYSET.issuer,
@@ -44,8 +46,6 @@ function makeParentAuth(overrides?: { expiry?: number; audience?: string }): Aut
     },
     TEST_KEYPAIR.privateKey.toString()
   );
-  (auth as any).scope = { tools: ["provision_gpu"], max_amount: 1_000_000n };
-  return auth;
 }
 
 function makeDelegation(
@@ -119,7 +119,7 @@ test("delegation: valid delegation allows execution", async () => {
   const result = await guard(
     baseAction,
     async () => { executed = true; return "ok"; },
-    { delegation: { delegation, parentAuth } }
+    { delegation: { delegation, parentAuth, parentScope: PARENT_SCOPE } }
   );
 
   assert.ok(executed, "execute should be called on valid delegation");
@@ -134,7 +134,7 @@ test("delegation: does not call setState", async () => {
   const config = makeGuardConfig({ setState: () => { setStateCalled = true; return true; } });
   const guard = OxDeAIGuard(config);
 
-  await guard(baseAction, async () => {}, { delegation: { delegation, parentAuth } });
+  await guard(baseAction, async () => {}, { delegation: { delegation, parentAuth, parentScope: PARENT_SCOPE } });
 
   assert.ok(!setStateCalled, "setState must not be called on delegation path");
 });
@@ -154,7 +154,7 @@ test("delegation: fires onDecision ALLOW hook with delegation field", async () =
   });
   const guard = OxDeAIGuard(config);
 
-  await guard(baseAction, async () => {}, { delegation: { delegation, parentAuth } });
+  await guard(baseAction, async () => {}, { delegation: { delegation, parentAuth, parentScope: PARENT_SCOPE } });
 
   assert.equal(capturedDecision, "ALLOW");
   assert.ok(capturedDelegation !== undefined, "delegation should be in onDecision record");
@@ -174,7 +174,7 @@ test("delegation: calls beforeExecute hook", async () => {
   await guard(
     baseAction,
     async () => { callOrder.push("execute"); },
-    { delegation: { delegation, parentAuth } }
+    { delegation: { delegation, parentAuth, parentScope: PARENT_SCOPE } }
   );
 
   assert.deepEqual(callOrder, ["beforeExecute", "execute"]);
@@ -191,7 +191,7 @@ test("delegation: blocks action not in scope.tools", async () => {
   let executed = false;
 
   await assert.rejects(
-    () => guard(baseAction, async () => { executed = true; }, { delegation: { delegation, parentAuth } }),
+    () => guard(baseAction, async () => { executed = true; }, { delegation: { delegation, parentAuth, parentScope: PARENT_SCOPE } }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIDelegationError, `expected OxDeAIDelegationError, got ${err}`);
       assert.ok(err.violations.some((v) => v.includes("provision_gpu")));
@@ -209,7 +209,7 @@ test("delegation: allows action in scope.tools", async () => {
   const guard = OxDeAIGuard(config);
 
   let executed = false;
-  await guard(baseAction, async () => { executed = true; }, { delegation: { delegation, parentAuth } });
+  await guard(baseAction, async () => { executed = true; }, { delegation: { delegation, parentAuth, parentScope: PARENT_SCOPE } });
   assert.ok(executed);
 });
 
@@ -225,7 +225,7 @@ test("delegation: blocks intent amount exceeding scope.max_amount", async () => 
   const expensiveAction: ProposedAction = { ...baseAction, estimatedCost: 1.0 };
 
   await assert.rejects(
-    () => guard(expensiveAction, async () => { executed = true; }, { delegation: { delegation, parentAuth } }),
+    () => guard(expensiveAction, async () => { executed = true; }, { delegation: { delegation, parentAuth, parentScope: PARENT_SCOPE } }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIDelegationError);
       assert.ok(err.violations.some((v) => v.includes("max_amount")));
@@ -246,7 +246,7 @@ test("delegation: blocks expired delegation", async () => {
   let executed = false;
 
   await assert.rejects(
-    () => guard(baseAction, async () => { executed = true; }, { delegation: { delegation, parentAuth } }),
+    () => guard(baseAction, async () => { executed = true; }, { delegation: { delegation, parentAuth, parentScope: PARENT_SCOPE } }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIDelegationError);
       assert.ok(err.violations.some((v) => v.toLowerCase().includes("expir")));
@@ -267,7 +267,7 @@ test("delegation: blocks when parent hash mismatches", async () => {
 
   // Present with the wrong parent
   await assert.rejects(
-    () => guard(baseAction, async () => { executed = true; }, { delegation: { delegation, parentAuth: otherAuth } }),
+    () => guard(baseAction, async () => { executed = true; }, { delegation: { delegation, parentAuth: otherAuth, parentScope: PARENT_SCOPE } }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIDelegationError);
       return true;
@@ -286,7 +286,7 @@ test("delegation: blocks invalid signature when requireDelegationSignatureVerifi
   let executed = false;
 
   await assert.rejects(
-    () => guard(baseAction, async () => { executed = true; }, { delegation: { delegation: tampered, parentAuth } }),
+    () => guard(baseAction, async () => { executed = true; }, { delegation: { delegation: tampered, parentAuth, parentScope: PARENT_SCOPE } }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIDelegationError);
       return true;
@@ -301,7 +301,7 @@ test("delegation: blocks when delegation and parentAuth are missing from input",
 
   await assert.rejects(
     () => guard(baseAction, async () => {}, {
-      delegation: { delegation: null as unknown as DelegationV1, parentAuth: null as unknown as AuthorizationV1 }
+      delegation: { delegation: null as unknown as DelegationV1, parentAuth: null as unknown as AuthorizationV1, parentScope: {} }
     }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIAuthorizationError);
@@ -320,7 +320,7 @@ test("OxDeAIDelegationError is instanceof OxDeAIAuthorizationError", async () =>
   const guard = OxDeAIGuard(config);
 
   await assert.rejects(
-    () => guard(baseAction, async () => {}, { delegation: { delegation, parentAuth } }),
+    () => guard(baseAction, async () => {}, { delegation: { delegation, parentAuth, parentScope: PARENT_SCOPE } }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIAuthorizationError, "OxDeAIDelegationError must be catchable as OxDeAIAuthorizationError");
       assert.ok(err instanceof OxDeAIDelegationError, "and also as OxDeAIDelegationError");
@@ -328,6 +328,93 @@ test("OxDeAIDelegationError is instanceof OxDeAIAuthorizationError", async () =>
       return true;
     }
   );
+});
+
+// ── parentScope validation ────────────────────────────────────────────────────
+
+test("delegation: missing parentScope blocks before chain verification", async () => {
+  const parentAuth = makeParentAuth();
+  const delegation = makeDelegation(parentAuth);
+  const config = makeGuardConfig();
+  const guard = OxDeAIGuard(config);
+  let executed = false;
+
+  await assert.rejects(
+    () => guard(
+      baseAction,
+      async () => { executed = true; },
+      { delegation: { delegation, parentAuth, parentScope: undefined as unknown as DelegationScope } }
+    ),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError);
+      assert.ok(!(err instanceof OxDeAIDelegationError), "missing parentScope must be OxDeAIAuthorizationError, not delegation error");
+      assert.match((err as Error).message, /parent authorization scope/i);
+      return true;
+    }
+  );
+  assert.ok(!executed, "execute must not be called when parentScope is missing");
+});
+
+test("delegation: malformed parentScope (non-object) blocks before chain verification", async () => {
+  const parentAuth = makeParentAuth();
+  const delegation = makeDelegation(parentAuth);
+  const config = makeGuardConfig();
+  const guard = OxDeAIGuard(config);
+  let executed = false;
+
+  await assert.rejects(
+    () => guard(
+      baseAction,
+      async () => { executed = true; },
+      { delegation: { delegation, parentAuth, parentScope: "not-an-object" as unknown as DelegationScope } }
+    ),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError);
+      assert.ok(!(err instanceof OxDeAIDelegationError));
+      assert.match((err as Error).message, /parent authorization scope/i);
+      return true;
+    }
+  );
+  assert.ok(!executed, "execute must not be called when parentScope is malformed");
+});
+
+test("delegation: malformed parentScope (tools not array) blocks before chain verification", async () => {
+  const parentAuth = makeParentAuth();
+  const delegation = makeDelegation(parentAuth);
+  const config = makeGuardConfig();
+  const guard = OxDeAIGuard(config);
+  let executed = false;
+
+  await assert.rejects(
+    () => guard(
+      baseAction,
+      async () => { executed = true; },
+      { delegation: { delegation, parentAuth, parentScope: { tools: "not-an-array" } as unknown as DelegationScope } }
+    ),
+    (err: unknown) => {
+      assert.ok(err instanceof OxDeAIAuthorizationError);
+      assert.ok(!(err instanceof OxDeAIDelegationError));
+      assert.match((err as Error).message, /parent authorization scope/i);
+      return true;
+    }
+  );
+  assert.ok(!executed, "execute must not be called when parentScope.tools is not an array");
+});
+
+test("delegation: valid empty parentScope ({}) is accepted", async () => {
+  const parentAuth = makeParentAuth();
+  const delegation = makeDelegation(parentAuth);
+  const config = makeGuardConfig();
+  const guard = OxDeAIGuard(config);
+  let executed = false;
+
+  // An empty scope ({}) places no restrictions — all tools and amounts allowed.
+  await guard(
+    baseAction,
+    async () => { executed = true; },
+    { delegation: { delegation, parentAuth, parentScope: {} } }
+  );
+  assert.ok(executed, "execute must be called when parentScope is a valid empty object");
 });
 
 // ── Standard path unaffected ──────────────────────────────────────────────────

--- a/packages/guard/src/test/guard.replay-store.redis.test.ts
+++ b/packages/guard/src/test/guard.replay-store.redis.test.ts
@@ -331,7 +331,7 @@ test("RS-R7 Redis error in consumeDelegationId: throws OxDeAIAuthorizationError 
 
   let executed = false;
   await assert.rejects(
-    () => guard(makeAction(), async () => { executed = true; }, { delegation: { delegation, parentAuth } }),
+    () => guard(makeAction(), async () => { executed = true; }, { delegation: { delegation, parentAuth, parentScope: { tools: ["pay"], max_amount: 1_000_000n } } }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIAuthorizationError);
       assert.match(err.message, /[Rr]eplay store unavailable/);

--- a/packages/guard/src/test/guard.replay-store.test.ts
+++ b/packages/guard/src/test/guard.replay-store.test.ts
@@ -134,10 +134,10 @@ test("RS-2 default store: delegation_id replay blocked on second call to same gu
   const action = makeAction();
 
   let executions = 0;
-  await guard(action, async () => { executions++; }, { delegation: { delegation, parentAuth } });
+  await guard(action, async () => { executions++; }, { delegation: { delegation, parentAuth, parentScope: { tools: ["pay"], max_amount: 1_000_000n } } });
 
   await assert.rejects(
-    () => guard(action, async () => { executions++; }, { delegation: { delegation, parentAuth } }),
+    () => guard(action, async () => { executions++; }, { delegation: { delegation, parentAuth, parentScope: { tools: ["pay"], max_amount: 1_000_000n } } }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIAuthorizationError);
       assert.match(err.message, /[Dd]elegation replay detected/);
@@ -203,10 +203,10 @@ test("RS-4 shared store: delegation_id replay blocked across two distinct guard 
   const action = makeAction();
 
   let executions = 0;
-  await guardA(action, async () => { executions++; }, { delegation: { delegation, parentAuth } });
+  await guardA(action, async () => { executions++; }, { delegation: { delegation, parentAuth, parentScope: { tools: ["pay"], max_amount: 1_000_000n } } });
 
   await assert.rejects(
-    () => guardB(action, async () => { executions++; }, { delegation: { delegation, parentAuth } }),
+    () => guardB(action, async () => { executions++; }, { delegation: { delegation, parentAuth, parentScope: { tools: ["pay"], max_amount: 1_000_000n } } }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIAuthorizationError);
       assert.match(err.message, /[Dd]elegation replay detected/);
@@ -275,7 +275,7 @@ test("RS-6 failing consumeDelegationId: execution blocked when store throws on d
 
   let executed = false;
   await assert.rejects(
-    () => guard(makeAction(), async () => { executed = true; }, { delegation: { delegation, parentAuth } }),
+    () => guard(makeAction(), async () => { executed = true; }, { delegation: { delegation, parentAuth, parentScope: { tools: ["pay"], max_amount: 1_000_000n } } }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIAuthorizationError);
       assert.match(err.message, /[Rr]eplay store unavailable/);
@@ -319,12 +319,12 @@ test("RS-7 store without consumeDelegationId: delegation executes; parentAuth re
 
   // First call: should succeed.
   let executions = 0;
-  await guard(action, async () => { executions++; }, { delegation: { delegation, parentAuth } });
+  await guard(action, async () => { executions++; }, { delegation: { delegation, parentAuth, parentScope: { tools: ["pay"], max_amount: 1_000_000n } } });
   assert.equal(executions, 1);
 
   // Second call with same parentAuth: consumeAuthId returns false → replay blocked.
   await assert.rejects(
-    () => guard(action, async () => { executions++; }, { delegation: { delegation, parentAuth } }),
+    () => guard(action, async () => { executions++; }, { delegation: { delegation, parentAuth, parentScope: { tools: ["pay"], max_amount: 1_000_000n } } }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIAuthorizationError);
       assert.match(err.message, /replay detected/i);
@@ -388,7 +388,7 @@ test("RS-9 store unavailable for parentAuth auth_id: execution blocked on delega
 
   let executed = false;
   await assert.rejects(
-    () => guard(makeAction(), async () => { executed = true; }, { delegation: { delegation, parentAuth } }),
+    () => guard(makeAction(), async () => { executed = true; }, { delegation: { delegation, parentAuth, parentScope: { tools: ["pay"], max_amount: 1_000_000n } } }),
     (err: unknown) => {
       assert.ok(err instanceof OxDeAIAuthorizationError);
       assert.match(err.message, /[Rr]eplay store unavailable/);

--- a/packages/guard/src/test/helpers/fixtures.ts
+++ b/packages/guard/src/test/helpers/fixtures.ts
@@ -4,7 +4,7 @@ import {
   signAuthorizationEd25519,
   createDelegation,
 } from "@oxdeai/core";
-import type { KeySet, AuthorizationV1, DelegationV1 } from "@oxdeai/core";
+import type { KeySet, AuthorizationV1, DelegationV1, DelegationScope } from "@oxdeai/core";
 
 export const TEST_KEYPAIR = generateKeyPairSync("ed25519", {
   privateKeyEncoding: { format: "pem", type: "pkcs8" },
@@ -19,9 +19,9 @@ export const TEST_KEYSET: KeySet = {
 
 export const nowSeconds = () => Math.floor(Date.now() / 1000);
 
-export function signAuth(overrides: Partial<AuthorizationV1 & { scope?: { tools?: string[]; max_amount?: bigint } }> = {}): AuthorizationV1 {
+export function signAuth(overrides: Partial<AuthorizationV1> = {}): AuthorizationV1 {
   const issued_at = overrides.issued_at ?? nowSeconds();
-  const auth = signAuthorizationEd25519(
+  return signAuthorizationEd25519(
     {
       auth_id: overrides.auth_id ?? `auth-${issued_at}`,
       issuer: overrides.issuer ?? TEST_KEYSET.issuer,
@@ -38,17 +38,13 @@ export function signAuth(overrides: Partial<AuthorizationV1 & { scope?: { tools?
     },
     TEST_KEYPAIR.privateKey.toString()
   );
-  if ((overrides as any).scope) (auth as any).scope = (overrides as any).scope;
-  return auth;
 }
 
 export function makeParentAuthWithScope(
-  scope: { tools?: string[]; max_amount?: bigint },
+  _scope: DelegationScope,
   overrides: Partial<AuthorizationV1> = {}
 ): AuthorizationV1 {
-  const auth = signAuth(overrides);
-  (auth as any).scope = scope;
-  return auth;
+  return signAuth(overrides);
 }
 
 export function makeDelegationWithScope(parent: AuthorizationV1, scope: DelegationV1["scope"]): DelegationV1 {

--- a/packages/guard/src/types.ts
+++ b/packages/guard/src/types.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import type { Authorization, AuthorizationV1, DelegationV1, Intent, KeySet, PolicyEngine, State } from "@oxdeai/core";
+import type { Authorization, AuthorizationV1, DelegationScope, DelegationV1, Intent, KeySet, PolicyEngine, State } from "@oxdeai/core";
 import type { ReplayStore } from "./replayStore.js";
 
 /**
@@ -31,6 +31,12 @@ export type GuardDelegationInput = {
   delegation: DelegationV1;
   /** The parent AuthorizationV1 that the delegation was derived from. */
   parentAuth: AuthorizationV1;
+  /**
+   * The scope granted to the parent agent — the authority ceiling for this
+   * delegation chain. Required for scope narrowing verification.
+   * Absence or structural invalidity fails closed before chain verification.
+   */
+  parentScope: DelegationScope;
 };
 
 /**


### PR DESCRIPTION
## Summary

Closes #98.

Harden parent scope handling in `OxDeAIGuard` delegation verification.

This resolves the final P0 item identified by the post-interoperability protocol audit.

The unsafe pattern:

```ts
(parentAuth as any).scope
```

has been removed and replaced by explicit typed delegation input.

Invariant:

```text
delegation scope ambiguity → DENY → no execution
```

## Changes

Updated delegation flow to require explicit parent scope information.

`GuardDelegationInput` now requires:

```ts
parentScope
```

The scope is validated structurally before delegation chain verification proceeds.

Validation uses:

```text
isValidDelegationScope(...)
```

No implicit extraction from `parentAuth` remains.

## Files updated

Core changes:

* `packages/guard/src/types.ts`

Tests:

* `packages/guard/src/test/guard.delegation.test.ts`
* `packages/guard/src/test/guard.replay-store.test.ts`
* `packages/guard/src/test/guard.replay-store.redis.test.ts`
* `packages/guard/src/test/helpers/fixtures.ts`

Examples:

* `examples/delegation-demo/src/scenario.ts`

## Behavior changes

Previous behavior:

```ts
const parentScope = (parentAuth as any).scope
```

Missing scope could propagate until later validation.

New behavior:

* parent scope required explicitly
* structural validation performed before chain verification
* malformed scope rejected immediately
* missing scope rejected immediately
* no execution path reached on ambiguity

## Delegation updates

Replay tests updated:

* 8 delegation call sites in replay tests
* Redis replay integration updated

Example updated:

* delegation demo now passes explicit parent scope using Agent A authority ceiling

## Audit impact

P0-3 resolved.

All protocol audit P0 items are now closed:

* portable key lifecycle vectors
* AuthorizationV1 clock semantics
* parent delegation scope hardening

## Validation

* build: pass
* tests: pass
* security gate: ALLOW

## Result

Delegation scope handling is now explicit, typed, and fail-closed.
