### PR TITLE
fix(core): separate public AuthorizationV1 artifact boundary

### DIFF
--- a/examples/agentgram-demo/src/agentgram.test.ts
+++ b/examples/agentgram-demo/src/agentgram.test.ts
@@ -2,6 +2,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
+import type { Authorization } from "@oxdeai/core";
 import { InMemoryAuditAdapter, InMemoryStateAdapter, buildIntent } from "@oxdeai/sdk";
 
 import { createAgentgramGuard, toTarget, toIntentInput } from "./adapter.js";
@@ -329,9 +330,11 @@ test("decision can be verified independently", async () => {
   assert.ok(result.authorization, "expected authorization on ALLOW");
   assert.ok(result.nextState, "expected nextState on ALLOW");
 
+  // Cast as Authorization: runtime object retains internal engine fields even
+  // though the TypeScript type was narrowed to AuthorizationV1 at evaluatePure boundary.
   const verification = engine.verifyAuthorization(
     intent,
-    result.authorization!,
+    result.authorization! as Authorization,
     result.nextState!,
     intent.timestamp
   );
@@ -371,9 +374,10 @@ test("tampered intent fails verification", async () => {
     target: "agentgram:/posts/evil/like"
   };
 
+  // Cast as Authorization: same rationale as above — internal HMAC verification.
   const verification = engine.verifyAuthorization(
     tamperedIntent,
-    result.authorization!,
+    result.authorization! as Authorization,
     result.nextState!,
     intent.timestamp
   );

--- a/examples/autogen/src/pep.ts
+++ b/examples/autogen/src/pep.ts
@@ -6,7 +6,7 @@
  * universal guard. No evaluatePure / verifyAuthorization calls here.
  */
 
-import type { Authorization, State } from "@oxdeai/core";
+import type { AuthorizationV1, State } from "@oxdeai/core";
 import { createAutoGenGuard, OxDeAIDenyError } from "@oxdeai/autogen";
 import type { AutoGenToolCall } from "@oxdeai/autogen";
 import { buildProvisionIntent, engine, gpuCost, AGENT_ID } from "./policy.js";
@@ -41,7 +41,7 @@ function provision_gpu(asset: string, region: string): string {
 }
 
 export type GuardedResult =
-  | { allowed: true; instanceId: string; authorization: Authorization; nextState: State }
+  | { allowed: true; instanceId: string; authorization: AuthorizationV1; nextState: State }
   | { allowed: false; reasons: string[] };
 
 export async function guardedProvision(
@@ -62,7 +62,7 @@ export async function guardedProvision(
   log(`${c(C.dim, "│")}  cost=${c(C.yellow, String(cost))} minor units  nonce=${intent.nonce}  intent_id=${intent.intent_id}`);
 
   let nextState = state;
-  let capturedAuth: Authorization | undefined;
+  let capturedAuth: AuthorizationV1 | undefined;
 
   const toolCall: AutoGenToolCall = {
     name: "provision_gpu",
@@ -78,10 +78,10 @@ export async function guardedProvision(
     trustedKeySets: [DEMO_KEYSET],
     // Return the pre-built intent so nonce/intent_id are stable.
     mapActionToIntent: () => intent,
-    beforeExecute(_action: unknown, authorization: Authorization) {
+    beforeExecute(_action: unknown, authorization: AuthorizationV1) {
       capturedAuth = authorization;
-      log(`${c(C.dim, "│")}  ${c(C.bGreen, "ALLOW")}  auth_id=${c(C.blue, authorization.authorization_id.slice(0, 16) + "...")}`);
-      log(`${c(C.dim, "│")}         expires=${authorization.expires_at}  state_hash=${c(C.cyan, authorization.state_snapshot_hash.slice(0, 16) + "...")}`);
+      log(`${c(C.dim, "│")}  ${c(C.bGreen, "ALLOW")}  auth_id=${c(C.blue, authorization.auth_id.slice(0, 16) + "...")}`);
+      log(`${c(C.dim, "│")}         expires=${authorization.expiry}  state_hash=${c(C.cyan, authorization.state_hash.slice(0, 16) + "...")}`);
     },
   });
 

--- a/examples/crewai/src/pep.ts
+++ b/examples/crewai/src/pep.ts
@@ -6,7 +6,7 @@
  * universal guard. No evaluatePure / verifyAuthorization calls here.
  */
 
-import type { Authorization, State } from "@oxdeai/core";
+import type { AuthorizationV1, State } from "@oxdeai/core";
 import { createCrewAIGuard, OxDeAIDenyError } from "@oxdeai/crewai";
 import type { CrewAIToolCall } from "@oxdeai/crewai";
 import { buildProvisionIntent, engine, gpuCost, AGENT_ID } from "./policy.js";
@@ -41,7 +41,7 @@ function provision_gpu(asset: string, region: string): string {
 }
 
 export type GuardedResult =
-  | { allowed: true; instanceId: string; authorization: Authorization; nextState: State }
+  | { allowed: true; instanceId: string; authorization: AuthorizationV1; nextState: State }
   | { allowed: false; reasons: string[] };
 
 export async function guardedProvision(
@@ -62,7 +62,7 @@ export async function guardedProvision(
   log(`${c(C.dim, "│")}  cost=${c(C.yellow, String(cost))} minor units  nonce=${intent.nonce}  intent_id=${intent.intent_id}`);
 
   let nextState = state;
-  let capturedAuth: Authorization | undefined;
+  let capturedAuth: AuthorizationV1 | undefined;
 
   const toolCall: CrewAIToolCall = {
     name: "provision_gpu",
@@ -78,10 +78,10 @@ export async function guardedProvision(
     trustedKeySets: [DEMO_KEYSET],
     // Return the pre-built intent so nonce/intent_id are stable.
     mapActionToIntent: () => intent,
-    beforeExecute(_action: unknown, authorization: Authorization) {
+    beforeExecute(_action: unknown, authorization: AuthorizationV1) {
       capturedAuth = authorization;
-      log(`${c(C.dim, "│")}  ${c(C.bGreen, "ALLOW")}  auth_id=${c(C.blue, authorization.authorization_id.slice(0, 16) + "...")}`);
-      log(`${c(C.dim, "│")}         expires=${authorization.expires_at}  state_hash=${c(C.cyan, authorization.state_snapshot_hash.slice(0, 16) + "...")}`);
+      log(`${c(C.dim, "│")}  ${c(C.bGreen, "ALLOW")}  auth_id=${c(C.blue, authorization.auth_id.slice(0, 16) + "...")}`);
+      log(`${c(C.dim, "│")}         expires=${authorization.expiry}  state_hash=${c(C.cyan, authorization.state_hash.slice(0, 16) + "...")}`);
     },
   });
 

--- a/examples/delegation-demo/src/scenario.ts
+++ b/examples/delegation-demo/src/scenario.ts
@@ -121,9 +121,8 @@ export async function runScenario(): Promise<ScenarioStep[]> {
     beforeExecute(_action, authorization) {
       parentDecision = "ALLOW";
       parentReason = "within budget · tool allowed · state consistent";
-      parentAuthId = authorization.authorization_id;
-      // Cast Authorization → AuthorizationV1 (Authorization is a superset)
-      parentAuth = authorization as unknown as AuthorizationV1;
+      parentAuthId = authorization.auth_id;
+      parentAuth = authorization;
     },
   });
 

--- a/examples/execution-boundary-demo/src/scenario.ts
+++ b/examples/execution-boundary-demo/src/scenario.ts
@@ -21,7 +21,7 @@
  * No mocked decisions. Real policy evaluation on every call.
  */
 
-import type { Authorization, State } from "@oxdeai/core";
+import type { AuthorizationV1, State } from "@oxdeai/core";
 import { OxDeAIGuard, OxDeAIDenyError } from "@oxdeai/guard";
 import { engine, makeState, buildChargeIntent, AGENT_ID, WALLET_START } from "./policy.js";
 
@@ -92,8 +92,8 @@ export async function runScenario(): Promise<ScenarioStep[]> {
     expectedAudience: AGENT_ID,
     // chargeIntent is identical for both calls — only state differs
     mapActionToIntent: () => chargeIntent,
-    beforeExecute(_action: unknown, authorization: Authorization) {
-      firstAuthId = authorization.authorization_id;
+    beforeExecute(_action: unknown, authorization: AuthorizationV1) {
+      firstAuthId = authorization.auth_id;
       firstDecision = "ALLOW";
       firstReason = "state consistent · no prior side effect recorded for this intent";
     },

--- a/examples/langgraph/src/pep.ts
+++ b/examples/langgraph/src/pep.ts
@@ -6,7 +6,7 @@
  * universal guard. No evaluatePure / verifyAuthorization calls here.
  */
 
-import type { Authorization, State } from "@oxdeai/core";
+import type { AuthorizationV1, State } from "@oxdeai/core";
 import { createLangGraphGuard, OxDeAIDenyError } from "@oxdeai/langgraph";
 import type { LangGraphToolCall } from "@oxdeai/langgraph";
 import { buildProvisionIntent, engine, gpuCost, AGENT_ID } from "./policy.js";
@@ -41,7 +41,7 @@ function provision_gpu(asset: string, region: string): string {
 }
 
 export type GuardedResult =
-  | { allowed: true; instanceId: string; authorization: Authorization; nextState: State }
+  | { allowed: true; instanceId: string; authorization: AuthorizationV1; nextState: State }
   | { allowed: false; reasons: string[] };
 
 export async function guardedProvision(
@@ -62,7 +62,7 @@ export async function guardedProvision(
   log(`${c(C.dim, "│")}  cost=${c(C.yellow, String(cost))} minor units  nonce=${intent.nonce}  intent_id=${intent.intent_id}`);
 
   let nextState = state;
-  let capturedAuth: Authorization | undefined;
+  let capturedAuth: AuthorizationV1 | undefined;
 
   const toolCall: LangGraphToolCall = {
     name: "provision_gpu",
@@ -78,10 +78,10 @@ export async function guardedProvision(
     trustedKeySets: [DEMO_KEYSET],
     // Return the pre-built intent so nonce/intent_id are stable.
     mapActionToIntent: () => intent,
-    beforeExecute(_action: unknown, authorization: Authorization) {
+    beforeExecute(_action: unknown, authorization: AuthorizationV1) {
       capturedAuth = authorization;
-      log(`${c(C.dim, "│")}  ${c(C.bGreen, "ALLOW")}  auth_id=${c(C.blue, authorization.authorization_id.slice(0, 16) + "...")}`);
-      log(`${c(C.dim, "│")}         expires=${authorization.expires_at}  state_hash=${c(C.cyan, authorization.state_snapshot_hash.slice(0, 16) + "...")}`);
+      log(`${c(C.dim, "│")}  ${c(C.bGreen, "ALLOW")}  auth_id=${c(C.blue, authorization.auth_id.slice(0, 16) + "...")}`);
+      log(`${c(C.dim, "│")}         expires=${authorization.expiry}  state_hash=${c(C.cyan, authorization.state_hash.slice(0, 16) + "...")}`);
     },
   });
 

--- a/examples/openai-agents-sdk/src/pep.ts
+++ b/examples/openai-agents-sdk/src/pep.ts
@@ -6,7 +6,7 @@
  * universal guard. No evaluatePure / verifyAuthorization calls here.
  */
 
-import type { Authorization, State } from "@oxdeai/core";
+import type { AuthorizationV1, State } from "@oxdeai/core";
 import { createOpenAIAgentsGuard, OxDeAIDenyError } from "@oxdeai/openai-agents";
 import type { OpenAIAgentsToolCall } from "@oxdeai/openai-agents";
 import { buildProvisionIntent, engine, gpuCost, AGENT_ID } from "./policy.js";
@@ -41,7 +41,7 @@ function provision_gpu(asset: string, region: string): string {
 }
 
 export type GuardedResult =
-  | { allowed: true; instanceId: string; authorization: Authorization; nextState: State }
+  | { allowed: true; instanceId: string; authorization: AuthorizationV1; nextState: State }
   | { allowed: false; reasons: string[] };
 
 export async function guardedProvision(
@@ -62,7 +62,7 @@ export async function guardedProvision(
   log(`${c(C.dim, "│")}  cost=${c(C.yellow, String(cost))} minor units  nonce=${intent.nonce}  intent_id=${intent.intent_id}`);
 
   let nextState = state;
-  let capturedAuth: Authorization | undefined;
+  let capturedAuth: AuthorizationV1 | undefined;
 
   const toolCall: OpenAIAgentsToolCall = {
     name: "provision_gpu",
@@ -78,10 +78,10 @@ export async function guardedProvision(
     trustedKeySets: [DEMO_KEYSET],
     // Return the pre-built intent so nonce/intent_id are stable.
     mapActionToIntent: () => intent,
-    beforeExecute(_action: unknown, authorization: Authorization) {
+    beforeExecute(_action: unknown, authorization: AuthorizationV1) {
       capturedAuth = authorization;
-      log(`${c(C.dim, "│")}  ${c(C.bGreen, "ALLOW")}  auth_id=${c(C.blue, authorization.authorization_id.slice(0, 16) + "...")}`);
-      log(`${c(C.dim, "│")}         expires=${authorization.expires_at}  state_hash=${c(C.cyan, authorization.state_snapshot_hash.slice(0, 16) + "...")}`);
+      log(`${c(C.dim, "│")}  ${c(C.bGreen, "ALLOW")}  auth_id=${c(C.blue, authorization.auth_id.slice(0, 16) + "...")}`);
+      log(`${c(C.dim, "│")}         expires=${authorization.expiry}  state_hash=${c(C.cyan, authorization.state_hash.slice(0, 16) + "...")}`);
     },
   });
 

--- a/examples/openai-tools/src/pep.ts
+++ b/examples/openai-tools/src/pep.ts
@@ -15,7 +15,7 @@
  * The PEP is deliberately thin. It enforces, never decides.
  */
 
-import type { Authorization, State } from "@oxdeai/core";
+import type { AuthorizationV1, State } from "@oxdeai/core";
 import { engine, buildProvisionIntent, gpuCost } from "./policy.js";
 
 // ── Mocked tool ───────────────────────────────────────────────────────────────
@@ -32,7 +32,7 @@ function provision_gpu(asset: string, region: string): string {
 // ── Result types ──────────────────────────────────────────────────────────────
 
 export type GuardedResult =
-  | { allowed: true;  instanceId: string; authorization: Authorization; nextState: State }
+  | { allowed: true;  instanceId: string; authorization: AuthorizationV1; nextState: State }
   | { allowed: false; reasons: string[] };
 
 // ── PEP: guarded tool call ────────────────────────────────────────────────────
@@ -72,7 +72,7 @@ export function guardedProvision(
 
   // ── Step 4: Execute tool (only after Authorization confirmed) ────────────
   const instanceId = provision_gpu(asset, region);
-  log(`   provision_gpu(${asset}, ${region})  cost=${cost}  nonce=${intent.nonce}  → ALLOW  auth=${authorization.authorization_id.slice(0, 12)}...  instance=${instanceId}`);
+  log(`   provision_gpu(${asset}, ${region})  cost=${cost}  nonce=${intent.nonce}  → ALLOW  auth=${authorization.auth_id.slice(0, 12)}...  instance=${instanceId}`);
 
   // nextState from PDP must be used for the next evaluation.
   // Never mutate state directly - always use result.nextState.

--- a/examples/openai-tools/src/run-openai.ts
+++ b/examples/openai-tools/src/run-openai.ts
@@ -182,7 +182,7 @@ export async function runOpenAIDemo(
         toolContent = JSON.stringify({
           status: "provisioned",
           instance_id: result.instanceId,
-          authorization_id: result.authorization.authorization_id.slice(0, 16),
+          authorization_id: result.authorization.auth_id.slice(0, 16),
         });
         log(`      ${c(C.bgGreen, " ALLOW ")}  ${c(C.dim, "instance =")} ${c(C.green, result.instanceId)}`);
         log(`               ${c(C.dim, "budget  =")} ${c(C.yellow, `${spent} / ${limit}`)} minor units`);

--- a/examples/openclaw/src/pep.ts
+++ b/examples/openclaw/src/pep.ts
@@ -6,7 +6,7 @@
  * universal guard. No evaluatePure / verifyAuthorization calls here.
  */
 
-import type { Authorization, State } from "@oxdeai/core";
+import type { AuthorizationV1, State } from "@oxdeai/core";
 import { createOpenClawGuard, OxDeAIDenyError } from "@oxdeai/openclaw";
 import type { OpenClawAction } from "@oxdeai/openclaw";
 import { buildProvisionIntent, engine, gpuCost, AGENT_ID } from "./policy.js";
@@ -37,7 +37,7 @@ function provision_gpu(asset: string, region: string): string {
 }
 
 export type GuardedResult =
-  | { allowed: true; instanceId: string; authorization: Authorization; nextState: State }
+  | { allowed: true; instanceId: string; authorization: AuthorizationV1; nextState: State }
   | { allowed: false; reasons: string[] };
 
 export async function guardedProvision(
@@ -59,7 +59,7 @@ export async function guardedProvision(
   log(`${c(C.dim, "│")}  ${c(C.dim, `cost=${c(C.yellow, String(cost))} minor units  nonce=${intent.nonce}  intent_id=${intent.intent_id}`)}`);
 
   let nextState = state;
-  let capturedAuth: Authorization | undefined;
+  let capturedAuth: AuthorizationV1 | undefined;
 
   const action: OpenClawAction = {
     name: "provision_gpu",
@@ -76,10 +76,10 @@ export async function guardedProvision(
     trustedKeySets: [DEMO_KEYSET],
     // Return the pre-built intent so nonce/intent_id are stable.
     mapActionToIntent: () => intent,
-    beforeExecute(_action: unknown, authorization: Authorization) {
+    beforeExecute(_action: unknown, authorization: AuthorizationV1) {
       capturedAuth = authorization;
-      log(`${c(C.dim, "│")}  ${c(C.bGreen, "ALLOW")}  ${c(C.dim, "auth_id=")}${c(C.blue, authorization.authorization_id.slice(0, 16) + "...")}`);
-      log(`${c(C.dim, "│")}         ${c(C.dim, "expires=")}${authorization.expires_at}  ${c(C.dim, "state_hash=")}${c(C.blue, authorization.state_snapshot_hash.slice(0, 16) + "...")}`);
+      log(`${c(C.dim, "│")}  ${c(C.bGreen, "ALLOW")}  ${c(C.dim, "auth_id=")}${c(C.blue, authorization.auth_id.slice(0, 16) + "...")}`);
+      log(`${c(C.dim, "│")}         ${c(C.dim, "expires=")}${authorization.expiry}  ${c(C.dim, "state_hash=")}${c(C.blue, authorization.state_hash.slice(0, 16) + "...")}`);
     },
   });
 

--- a/package.json
+++ b/package.json
@@ -48,11 +48,12 @@
       "langsmith": "0.7.1",
       "minimatch": ">=10.2.3",
       "lodash": ">=4.18.0",
-      "brace-expansion": ">=5.0.5",
+      "brace-expansion": ">=5.0.6",
+      "ws": ">=8.20.1",
+      "uuid": "14.0.0",
       "basic-ftp": ">=5.3.0",
       "fast-uri": "3.1.2"
     }
   },
-  "type": "module",
-  "uuid": "14.0.0"
+  "type": "module"
 }

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -890,8 +890,8 @@ export async function runCli(argv: string[], io?: Partial<Io>): Promise<number> 
       }
       await mkdir(dirname(flags.out), { recursive: true });
       await writeFile(flags.out, `${toJson(outEval.authorization)}\n`, "utf8");
-      const payload = { ok: true, out: flags.out, authorization_id: outEval.authorization.authorization_id };
-      writePayload(out, flags, payload, `ALLOW: ${outEval.authorization.authorization_id}\nout: ${flags.out}`);
+      const payload = { ok: true, out: flags.out, authorization_id: outEval.authorization.auth_id };
+      writePayload(out, flags, payload, `ALLOW: ${outEval.authorization.auth_id}\nout: ${flags.out}`);
       return EXIT_CODE_OK;
     }
 
@@ -1018,7 +1018,7 @@ export async function runCli(argv: string[], io?: Partial<Io>): Promise<number> 
           await appendAuditEvents(auditPath, emitted);
           await writeStateFile(statePath, outEval.nextState);
         }
-        const payload = { decision: "ALLOW" as const, authorization_id: outEval.authorization.authorization_id, reasons: [] as string[], dryRun };
+        const payload = { decision: "ALLOW" as const, authorization_id: outEval.authorization.auth_id, reasons: [] as string[], dryRun };
         writePayload(out, flags, payload, `ALLOW: ${payload.authorization_id}`);
         return EXIT_CODE_OK;
       }

--- a/packages/conformance/scripts/extract-vectors.ts
+++ b/packages/conformance/scripts/extract-vectors.ts
@@ -212,9 +212,13 @@ async function extractAuthorizationPayload(): Promise<void> {
 
   const r1 = engine.evaluatePure(makeIntent(100n, 1730000000), state);
   if (r1.decision !== "ALLOW") throw new Error("expected ALLOW for auth vector 1");
+  // Cast to Authorization to access engine-internal fields needed for vector extraction.
+  // The runtime object still carries these fields; only the TypeScript type was narrowed.
+  const r1auth = r1.authorization as Authorization;
 
   const r2 = engine.evaluatePure(makeIntent(101n, 0), makeState());
   if (r2.decision !== "ALLOW") throw new Error("expected ALLOW for auth vector 2");
+  const r2auth = r2.authorization as Authorization;
 
   writeVector("authorization-payload.json", {
     version: "1.0.0",
@@ -225,23 +229,23 @@ async function extractAuthorizationPayload(): Promise<void> {
         id: "auth-payload-001",
         input: makeIntent(100n, 1730000000),
         expected: {
-          intent_hash: r1.authorization.intent_hash,
+          intent_hash: r1auth.intent_hash,
           policy_id: policyId,
-          state_hash: r1.authorization.state_snapshot_hash,
-          expires_at: r1.authorization.expires_at,
-          canonical_signing_payload: canonicalJson(authSigningPayload(r1.authorization, policyId)),
-          signature: r1.authorization.engine_signature
+          state_hash: r1auth.state_snapshot_hash,
+          expires_at: r1auth.expires_at,
+          canonical_signing_payload: canonicalJson(authSigningPayload(r1auth, policyId)),
+          signature: r1auth.engine_signature
         }
       },
       {
         id: "auth-payload-002",
         input: makeIntent(101n, 0),
         expected: {
-          intent_hash: r2.authorization.intent_hash,
-          expires_at: r2.authorization.expires_at,
+          intent_hash: r2auth.intent_hash,
+          expires_at: r2auth.expires_at,
           expires_at_derivation: "intent.timestamp(0) + ttl_seconds(60) = 60",
-          canonical_signing_payload: canonicalJson(authSigningPayload(r2.authorization, policyId)),
-          signature: r2.authorization.engine_signature
+          canonical_signing_payload: canonicalJson(authSigningPayload(r2auth, policyId)),
+          signature: r2auth.engine_signature
         }
       }
     ]

--- a/packages/conformance/src/validate.ts
+++ b/packages/conformance/src/validate.ts
@@ -307,7 +307,10 @@ const coreAdapter: ConformanceAdapter = {
     if (out.decision !== "ALLOW") {
       throw new Error(`expected ALLOW, got DENY: ${out.reasons.join(",")}`);
     }
-    return { authorization: out.authorization, policyId: engine.computePolicyId() };
+    // Cast to AuthorizationLike: runtime object retains internal engine fields
+    // (state_snapshot_hash, expires_at, engine_signature) even though the
+    // TypeScript type was narrowed to AuthorizationV1 at the evaluatePure boundary.
+    return { authorization: out.authorization as unknown as AuthorizationLike, policyId: engine.computePolicyId() };
   },
   encodeSnapshot(state: State) {
     const engine = makeEngine();

--- a/packages/core/src/dev/decision-subprocess.ts
+++ b/packages/core/src/dev/decision-subprocess.ts
@@ -123,7 +123,7 @@ async function main(): Promise<void> {
       state = out.nextState;
       if (actual.type !== "RELEASE") {
         const queue = authQueue[actual.agent_id] ?? [];
-        queue.push(out.authorization.authorization_id);
+        queue.push(out.authorization.auth_id);
         authQueue[actual.agent_id] = queue;
       }
     } else {

--- a/packages/core/src/dev/smoke.ts
+++ b/packages/core/src/dev/smoke.ts
@@ -186,7 +186,7 @@ async function main() {
 
     // RELEASE with real auth -> ALLOW (free one slot)
     const rel = engine.evaluatePure(
-      intentBase({ nonce: 204n, type: "RELEASE", authorization_id: r2.authorization.authorization_id }),
+      intentBase({ nonce: 204n, type: "RELEASE", authorization_id: r2.authorization.auth_id }),
       r2.nextState,
       { mode: "fail-fast" }
     );

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,7 +25,7 @@ export { encodeEnvelope, decodeEnvelope, signEnvelopeEd25519, envelopeSigningPay
 export { verifySnapshot } from "./verification/verifySnapshot.js";
 export { verifyAuditEvents } from "./verification/verifyAuditEvents.js";
 export { verifyEnvelope } from "./verification/verifyEnvelope.js";
-export { verifyAuthorization, signAuthorizationEd25519, authorizationSigningPayload } from "./verification/verifyAuthorization.js";
+export { verifyAuthorization, signAuthorizationEd25519, authorizationSigningPayload, toPublicAuthorizationV1 } from "./verification/verifyAuthorization.js";
 export { createVerifier } from "./verification/createVerifier.js";
 export type { VerifierConfig, BoundVerifier } from "./verification/createVerifier.js";
 export {

--- a/packages/core/src/policy/PolicyEngine.ts
+++ b/packages/core/src/policy/PolicyEngine.ts
@@ -2,7 +2,7 @@
 import { createHash } from "node:crypto";
 import type { Intent } from "../types/intent.js";
 import type { State, CanonicalState } from "../types/state.js";
-import type { Authorization } from "../types/authorization.js";
+import type { Authorization, AuthorizationV1 } from "../types/authorization.js";
 import type { ReasonCode, PolicyModule } from "../types/policy.js";
 
 import { canonicalJson, intentHash, sha256HexFromJson } from "../crypto/hashes.js";
@@ -35,12 +35,12 @@ export type EngineEvalOptions = {
 
 /** @public */
 export type EvaluateOutput =
-  | { decision: "ALLOW"; reasons: []; authorization: Authorization }
+  | { decision: "ALLOW"; reasons: []; authorization: AuthorizationV1 }
   | { decision: "DENY"; reasons: ReasonCode[] };
 
 /** @public */
 export type EvaluatePureOutput =
-  | { decision: "ALLOW"; reasons: []; authorization: Authorization; nextState: State }
+  | { decision: "ALLOW"; reasons: []; authorization: AuthorizationV1; nextState: State }
   | { decision: "DENY"; reasons: ReasonCode[] };
 
 /** @public */
@@ -497,7 +497,7 @@ export class PolicyEngine {
               ...working.concurrency.active_auths,
               [agent]: {
                 ...current,
-                [authorization.authorization_id]: { expires_at: authorization.expires_at }
+                [authorization.auth_id]: { expires_at: authorization.expiry }
               }
             }
           }

--- a/packages/core/src/test/property.decision.test.ts
+++ b/packages/core/src/test/property.decision.test.ts
@@ -23,6 +23,7 @@ import assert from "node:assert/strict";
 import { PolicyEngine } from "../policy/PolicyEngine.js";
 import type { Intent, ActionType } from "../types/intent.js";
 import type { State, ToolLimitsState } from "../types/state.js";
+import type { Authorization } from "../types/authorization.js";
 
 const DEFAULT_CASES = Number(process.env["PBT_CASES"] ?? "50");
 const BASE_SEED = Number(process.env["PBT_SEED"] ?? "20260303");
@@ -376,7 +377,7 @@ function runIntentOps(
       state = out.nextState;
       if (intent.type !== "RELEASE") {
         const queue = authsByAgent[intent.agent_id] ?? [];
-        queue.push(out.authorization.authorization_id);
+        queue.push(out.authorization.auth_id);
         authsByAgent[intent.agent_id] = queue;
       }
     }
@@ -534,15 +535,17 @@ test("D-6 strict mode: verifyAuthorization requires explicit now", () => {
     // Without `now` in strict mode: the implementation's inner strictDeterminism
     // throw is caught by the outer try/catch in verifyAuthorization and converted
     // to { valid: false, reason: "INTERNAL_ERROR" }.  The result must not be valid.
-    const noNowResult = engine.verifyAuthorization(intent, authorization, state);
+    // Cast as Authorization: runtime object has all legacy fields even though
+    // the TypeScript type was narrowed to AuthorizationV1 at the evaluatePure boundary.
+    const noNowResult = engine.verifyAuthorization(intent, authorization as Authorization, state);
     assert.ok(!noNowResult.valid,
       `seed=${seed} expected invalid result when now is omitted in strict mode`);
     assert.equal(noNowResult.reason, "INTERNAL_ERROR",
       `seed=${seed} expected INTERNAL_ERROR when now is omitted in strict mode`);
 
     // With explicit `now`: must succeed and be stable across repeated calls.
-    const r1 = engine.verifyAuthorization(intent, authorization, state, explicitNow);
-    const r2 = engine.verifyAuthorization(intent, authorization, state, explicitNow);
+    const r1 = engine.verifyAuthorization(intent, authorization as Authorization, state, explicitNow);
+    const r2 = engine.verifyAuthorization(intent, authorization as Authorization, state, explicitNow);
     assert.deepEqual(r1, r2,
       `seed=${seed} verifyAuthorization not stable with the same explicit now`);
     assert.ok(r1.valid,

--- a/packages/core/src/test/property.test.ts
+++ b/packages/core/src/test/property.test.ts
@@ -345,7 +345,7 @@ function runIntentOps(engine: PolicyEngine, initial: State, ops: IntentOp[], see
       state = out.nextState;
       if (intent.type !== "RELEASE") {
         const queue = authsByAgent[intent.agent_id] ?? [];
-        queue.push(out.authorization.authorization_id);
+        queue.push(out.authorization.auth_id);
         authsByAgent[intent.agent_id] = queue;
       }
     }

--- a/packages/core/src/test/public-artifact-boundary.test.ts
+++ b/packages/core/src/test/public-artifact-boundary.test.ts
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Public AuthorizationV1 artifact boundary tests.
+ *
+ * Acceptance criteria (P0 hardening):
+ *   1. toPublicAuthorizationV1 strips legacy/internal engine fields.
+ *   2. authorizationSigningPayload excludes legacy fields from Encoding B.
+ *   3. delegationParentHash does NOT change when legacy engine fields are present.
+ *   4. DelegationV1 parent hash verification does not depend on TypeScript-specific
+ *      legacy fields — an independent implementation reproducing only normative
+ *      AuthorizationV1 fields arrives at the same parent hash.
+ *
+ * These tests prove the public protocol surface is stable: any conforming
+ * implementation that knows only the normative AuthorizationV1 shape can
+ * reproduce all public hashes without access to internal engine state.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync, createHash } from "node:crypto";
+import {
+  toPublicAuthorizationV1,
+  authorizationSigningPayload,
+  delegationParentHash,
+  signAuthorizationEd25519,
+  canonicalJson,
+} from "@oxdeai/core";
+import type { Authorization, AuthorizationV1 } from "@oxdeai/core";
+
+// ─── Test fixtures ─────────────────────────────────────────────────────────────
+
+const RUNTIME_KEYPAIR = generateKeyPairSync("ed25519", {
+  privateKeyEncoding: { format: "pem", type: "pkcs8" },
+  publicKeyEncoding: { format: "pem", type: "spki" },
+});
+
+/** A clean, normative AuthorizationV1 (no legacy fields). */
+function makeCleanAuth(): AuthorizationV1 {
+  return signAuthorizationEd25519(
+    {
+      auth_id: "a".repeat(64),
+      issuer: "issuer-A",
+      audience: "rp-A",
+      intent_hash: "b".repeat(64),
+      state_hash: "c".repeat(64),
+      policy_id: "d".repeat(64),
+      decision: "ALLOW",
+      issued_at: 1_000_000,
+      expiry: 1_000_060,
+      kid: "k1",
+    },
+    RUNTIME_KEYPAIR.privateKey
+  );
+}
+
+/**
+ * Attach legacy/internal engine fields to an existing AuthorizationV1.
+ * This simulates what PolicyEngine.evaluatePure() returns at runtime:
+ * the Authorization type that carries internal fields alongside the public ones.
+ */
+function attachLegacyFields(auth: AuthorizationV1): Authorization {
+  return {
+    ...auth,
+    // Legacy aliases — same values as the public fields but different names
+    authorization_id: auth.auth_id,
+    expires_at: auth.expiry,
+    // Engine-internal fields — never part of the public protocol
+    engine_signature: "hmac-sig-would-go-here",
+    state_snapshot_hash: "e".repeat(64),
+    policy_version: "0.1.0",
+  } as Authorization;
+}
+
+// ─── 1. toPublicAuthorizationV1 strips legacy fields ──────────────────────────
+
+test("toPublicAuthorizationV1: strips legacy engine fields", () => {
+  const clean = makeCleanAuth();
+  const withLegacy = attachLegacyFields(clean);
+
+  const pub = toPublicAuthorizationV1(withLegacy as unknown as AuthorizationV1);
+  const pubRecord = pub as Record<string, unknown>;
+
+  // Legacy fields must not appear in the public artifact
+  assert.equal(pubRecord["authorization_id"], undefined, "authorization_id must be stripped");
+  assert.equal(pubRecord["engine_signature"], undefined, "engine_signature must be stripped");
+  assert.equal(pubRecord["state_snapshot_hash"], undefined, "state_snapshot_hash must be stripped");
+  assert.equal(pubRecord["policy_version"], undefined, "policy_version must be stripped");
+  assert.equal(pubRecord["expires_at"], undefined, "expires_at alias must be stripped");
+
+  // Normative fields must be preserved
+  assert.equal(pub.auth_id, clean.auth_id);
+  assert.equal(pub.issuer, clean.issuer);
+  assert.equal(pub.audience, clean.audience);
+  assert.equal(pub.decision, clean.decision);
+  assert.equal(pub.intent_hash, clean.intent_hash);
+  assert.equal(pub.state_hash, clean.state_hash);
+  assert.equal(pub.policy_id, clean.policy_id);
+  assert.equal(pub.issued_at, clean.issued_at);
+  assert.equal(pub.expiry, clean.expiry);
+  assert.equal(pub.alg, clean.alg);
+  assert.equal(pub.kid, clean.kid);
+  assert.deepEqual(pub.signature, clean.signature);
+});
+
+// ─── 2. toPublicAuthorizationV1 is idempotent ─────────────────────────────────
+
+test("toPublicAuthorizationV1: calling it twice produces the same object shape", () => {
+  const clean = makeCleanAuth();
+  const pub1 = toPublicAuthorizationV1(clean);
+  const pub2 = toPublicAuthorizationV1(pub1);
+
+  assert.equal(
+    canonicalJson(pub1 as unknown as Record<string, unknown>),
+    canonicalJson(pub2 as unknown as Record<string, unknown>),
+    "toPublicAuthorizationV1 must be idempotent"
+  );
+});
+
+// ─── 3. Legacy fields do NOT change the public canonical hash ─────────────────
+
+test("adding legacy fields does NOT change the toPublicAuthorizationV1 canonical hash", () => {
+  const clean = makeCleanAuth();
+  const withLegacy = attachLegacyFields(clean);
+
+  const hashClean = canonicalJson(
+    toPublicAuthorizationV1(clean) as unknown as Record<string, unknown>
+  );
+  const hashWithLegacy = canonicalJson(
+    toPublicAuthorizationV1(withLegacy as unknown as AuthorizationV1) as unknown as Record<string, unknown>
+  );
+
+  assert.equal(
+    hashClean,
+    hashWithLegacy,
+    "canonical hash of toPublicAuthorizationV1 must not change when legacy fields are present"
+  );
+});
+
+// ─── 4. Encoding B signing payload excludes legacy fields ─────────────────────
+
+test("authorizationSigningPayload (Encoding A): excludes legacy fields", () => {
+  const clean = makeCleanAuth();
+  const withLegacy = attachLegacyFields(clean);
+
+  const payloadClean = authorizationSigningPayload(clean);
+  const payloadWithLegacy = authorizationSigningPayload(withLegacy as unknown as AuthorizationV1);
+
+  const recordClean = payloadClean as Record<string, unknown>;
+  const recordWithLegacy = payloadWithLegacy as Record<string, unknown>;
+
+  // Legacy fields must never appear in the signing payload
+  assert.equal(recordClean["authorization_id"], undefined, "authorization_id must not be in signing payload");
+  assert.equal(recordClean["engine_signature"], undefined, "engine_signature must not be in signing payload");
+  assert.equal(recordClean["state_snapshot_hash"], undefined, "state_snapshot_hash must not be in signing payload");
+  assert.equal(recordClean["policy_version"], undefined, "policy_version must not be in signing payload");
+
+  assert.equal(recordWithLegacy["authorization_id"], undefined, "authorization_id must not be in signing payload with legacy fields");
+  assert.equal(recordWithLegacy["engine_signature"], undefined, "engine_signature must not be in signing payload with legacy fields");
+  assert.equal(recordWithLegacy["state_snapshot_hash"], undefined, "state_snapshot_hash must not be in signing payload with legacy fields");
+  assert.equal(recordWithLegacy["policy_version"], undefined, "policy_version must not be in signing payload with legacy fields");
+
+  // The signing payload must be identical whether or not legacy fields are present
+  assert.equal(
+    canonicalJson(payloadClean as Record<string, unknown>),
+    canonicalJson(payloadWithLegacy as Record<string, unknown>),
+    "signing payload canonical JSON must be identical with or without legacy fields"
+  );
+});
+
+// ─── 5. delegationParentHash: legacy fields do NOT change the hash ─────────────
+
+test("delegationParentHash: adding legacy fields does NOT change the parent hash", () => {
+  const clean = makeCleanAuth();
+  const withLegacy = attachLegacyFields(clean);
+
+  const hashClean   = delegationParentHash(clean);
+  const hashLegacy  = delegationParentHash(withLegacy as unknown as AuthorizationV1);
+
+  assert.equal(
+    hashClean,
+    hashLegacy,
+    "delegationParentHash must be identical for clean vs. legacy-annotated authorization"
+  );
+});
+
+// ─── 6. Independent implementation can reproduce delegationParentHash ──────────
+
+test("delegationParentHash: independent implementation (normative fields only) produces same hash", () => {
+  const clean = makeCleanAuth();
+
+  // Simulate an independent implementation that only knows the normative fields.
+  // It reconstructs the public artifact manually — no access to Authorization internals.
+  const independentPublicArtifact: Record<string, unknown> = {
+    auth_id:      clean.auth_id,
+    issuer:       clean.issuer,
+    audience:     clean.audience,
+    intent_hash:  clean.intent_hash,
+    state_hash:   clean.state_hash,
+    policy_id:    clean.policy_id,
+    decision:     clean.decision,
+    issued_at:    clean.issued_at,
+    expiry:       clean.expiry,
+    alg:          clean.alg,
+    kid:          clean.kid,
+    signature:    clean.signature,
+  };
+
+  const independentHash = createHash("sha256")
+    .update(canonicalJson(independentPublicArtifact), "utf8")
+    .digest("hex");
+
+  const sdkHash = delegationParentHash(clean);
+
+  assert.equal(
+    independentHash,
+    sdkHash,
+    "independent implementation using only normative fields must produce the same delegationParentHash"
+  );
+});
+
+// ─── 7. delegationParentHash is stable (same input → same output) ─────────────
+
+test("delegationParentHash: deterministic for the same input", () => {
+  const clean = makeCleanAuth();
+
+  const h1 = delegationParentHash(clean);
+  const h2 = delegationParentHash(clean);
+
+  assert.equal(h1, h2, "delegationParentHash must be deterministic");
+  assert.match(h1, /^[0-9a-f]{64}$/, "hash must be a lowercase 64-char hex string");
+});

--- a/packages/core/src/test/toctou.test.ts
+++ b/packages/core/src/test/toctou.test.ts
@@ -25,6 +25,7 @@ import { createDelegation } from "../delegation/createDelegation.js";
 import { verifyDelegation, verifyDelegationChain } from "../verification/verifyDelegation.js";
 import type { State } from "../types/state.js";
 import type { Intent } from "../types/intent.js";
+import type { Authorization } from "../types/authorization.js";
 import type { KeySet } from "../types/keyset.js";
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -102,7 +103,9 @@ test("T-1 state_snapshot_hash tamper → AUTH_SIGNATURE_INVALID", () => {
   const { authorization } = issueAuth(engine, state, intent);
 
   // Mutate the embedded state snapshot hash — the HMAC must no longer verify.
-  const tampered = { ...authorization, state_snapshot_hash: "f".repeat(64) };
+  // Cast as Authorization: runtime object has all legacy fields even though the
+  // TypeScript type was narrowed to AuthorizationV1 at the evaluatePure boundary.
+  const tampered = { ...authorization, state_snapshot_hash: "f".repeat(64) } as Authorization;
 
   const result = engine.verifyAuthorization(intent, tampered, state, T0);
   assert.equal(result.valid, false, "tampered state_snapshot_hash must fail verification");
@@ -122,7 +125,7 @@ test("T-2 policy_version mismatch → POLICY_VERSION_MISMATCH", () => {
   // Present the auth against a state whose policy_version is different.
   const altState: State = { ...state, policy_version: "v-other" };
 
-  const result = engine.verifyAuthorization(intent, authorization, altState, T0);
+  const result = engine.verifyAuthorization(intent, authorization as Authorization, altState, T0);
   assert.equal(result.valid, false, "policy_version mismatch must fail verification");
   assert.equal(result.reason, "POLICY_VERSION_MISMATCH",
     `expected POLICY_VERSION_MISMATCH, got ${result.reason}`);
@@ -139,7 +142,7 @@ test("T-3 explicit now past expiry → AUTH_EXPIRED", () => {
   // authorization.expiry = T0 + 60
 
   // Verify one second after expiry.
-  const result = engine.verifyAuthorization(intent, authorization, state, T0 + TTL + 1);
+  const result = engine.verifyAuthorization(intent, authorization as Authorization, state, T0 + TTL + 1);
   assert.equal(result.valid, false, "expired authorization must be rejected");
   assert.equal(result.reason, "AUTH_EXPIRED",
     `expected AUTH_EXPIRED, got ${result.reason}`);
@@ -157,7 +160,7 @@ test("T-4 intent field mutation → AUTH_INTENT_MISMATCH", () => {
   // Alter a binding field — a different amount changes the intent hash.
   const mutated = { ...intent, amount: 999n };
 
-  const result = engine.verifyAuthorization(mutated, authorization, state, T0);
+  const result = engine.verifyAuthorization(mutated, authorization as Authorization, state, T0);
   assert.equal(result.valid, false, "mutated intent must not verify against issued auth");
   assert.equal(result.reason, "AUTH_INTENT_MISMATCH",
     `expected AUTH_INTENT_MISMATCH, got ${result.reason}`);
@@ -232,11 +235,11 @@ test("T-6 RELEASE with unknown authorization_id → CONCURRENCY_RELEASE_INVALID"
   const engine = makeEngine();
   const state  = makeState();
 
-  // Step 1: EXECUTE → ALLOW → record the authorization_id and advance state.
+  // Step 1: EXECUTE → ALLOW → record the auth_id and advance state.
   const execIntent = makeIntent({ nonce: 6n, type: "EXECUTE" });
   const execOut    = engine.evaluatePure(execIntent, state);
   assert.equal(execOut.decision, "ALLOW", "EXECUTE precondition: must ALLOW");
-  const { authorization_id } = execOut.authorization;
+  const authorization_id = execOut.authorization.auth_id;
   const stateAfterExec = execOut.nextState;
 
   // The slot is recorded in active_auths.
@@ -300,7 +303,7 @@ test("T-7 cross-engine artifact: wrong engine secret → AUTH_SIGNATURE_INVALID"
   assert.equal(out.decision, "ALLOW", "engine A precondition");
 
   // Verified by engine B (different secret) → HMAC mismatch.
-  const result = engineB.verifyAuthorization(intent, out.authorization, state, T0);
+  const result = engineB.verifyAuthorization(intent, out.authorization as Authorization, state, T0);
   assert.equal(result.valid, false,
     "auth issued by engine A must not verify against engine B");
   assert.equal(result.reason, "AUTH_SIGNATURE_INVALID",

--- a/packages/core/src/verification/verifyAuthorization.ts
+++ b/packages/core/src/verification/verifyAuthorization.ts
@@ -83,18 +83,70 @@ function nowOrThrow(now: number | undefined): number {
   return Math.floor(Date.now() / 1000);
 }
 
+/**
+ * Strip an authorization object down to only the normative `AuthorizationV1`
+ * fields, excluding internal engine fields (`authorization_id`,
+ * `policy_version`, `state_snapshot_hash`, `engine_signature`, `expires_at`).
+ *
+ * Use this before computing `delegationParentHash` or any public signing
+ * payload so that independent implementations can reproduce the same hash
+ * without access to internal engine state.
+ *
+ * @public
+ */
+export function toPublicAuthorizationV1(auth: AuthorizationV1): AuthorizationV1 {
+  const out: AuthorizationV1 = {
+    auth_id:      auth.auth_id,
+    issuer:       auth.issuer,
+    audience:     auth.audience,
+    intent_hash:  auth.intent_hash,
+    state_hash:   auth.state_hash,
+    policy_id:    auth.policy_id,
+    decision:     auth.decision,
+    issued_at:    auth.issued_at,
+    expiry:       auth.expiry,
+    alg:          auth.alg,
+    kid:          auth.kid,
+    signature:    auth.signature,
+  };
+  if (auth.version    !== undefined) out.version    = auth.version;
+  if (auth.nonce      !== undefined) out.nonce      = auth.nonce;
+  if (auth.capability !== undefined) out.capability = auth.capability;
+  return out;
+}
+
 /** @public */
 export function authorizationSigningPayload(auth: AuthorizationV1): Omit<AuthorizationV1, "signature"> | Record<string, unknown> {
   const sig = signatureParts(auth);
   const hasFlatAlgKid = hasText(auth.alg) && hasText(auth.kid);
 
   if (sig.nested) {
+    // Use only normative AuthorizationV1 fields so legacy engine-internal fields
+    // (engine_signature, state_snapshot_hash, etc.) are never included in the
+    // Encoding B signing payload — independent implementations must be able to
+    // reproduce this payload without access to engine-internal state.
+    //
+    // canonicalJson throws on undefined values; only include fields that are
+    // actually present. Sift wire format omits `expiry` and uses `expires_at`
+    // instead — both are normalised here so either wire format verifies correctly.
+    const pub = toPublicAuthorizationV1(auth);
     const payload: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(auth as Record<string, unknown>)) {
-      if (value === undefined) continue;
-      if (key === "signature") continue;
-      payload[key] = value;
-    }
+    payload.auth_id     = pub.auth_id;
+    payload.issuer      = pub.issuer;
+    payload.audience    = pub.audience;
+    payload.intent_hash = pub.intent_hash;
+    payload.state_hash  = pub.state_hash;
+    payload.policy_id   = pub.policy_id;
+    payload.decision    = pub.decision;
+    payload.issued_at   = pub.issued_at;
+    if (pub.expiry      !== undefined) payload.expiry      = pub.expiry;
+    if (pub.version     !== undefined) payload.version     = pub.version;
+    if (pub.nonce       !== undefined) payload.nonce       = pub.nonce;
+    if (pub.capability  !== undefined) payload.capability  = pub.capability;
+    // Sift wire format uses expires_at instead of expiry; preserve it when present
+    // so Sift-issued tokens remain verifiable without re-signing.
+    const raw = auth as Record<string, unknown>;
+    if (typeof raw["expires_at"] === "number") payload["expires_at"] = raw["expires_at"];
     if (!hasFlatAlgKid) {
       payload.signature = { alg: sig.alg, kid: sig.kid };
     }

--- a/packages/core/src/verification/verifyDelegation.ts
+++ b/packages/core/src/verification/verifyDelegation.ts
@@ -11,6 +11,7 @@ import {
   verifyEd25519,
 } from "../crypto/signatures.js";
 import { canonicalJson } from "../crypto/hashes.js";
+import { toPublicAuthorizationV1 } from "./verifyAuthorization.js";
 
 // ── Options ───────────────────────────────────────────────────────────────────
 
@@ -54,9 +55,18 @@ function sortViolations(violations: VerificationViolation[]): VerificationViolat
   });
 }
 
-/** @public */
+/**
+ * Compute the canonical hash of a parent `AuthorizationV1` for use in
+ * `DelegationV1.parent_auth_hash`.
+ *
+ * Only normative `AuthorizationV1` fields are included in the hash so
+ * independent implementations can reproduce the same value without access
+ * to engine-internal state (e.g. `engine_signature`, `state_snapshot_hash`).
+ *
+ * @public
+ */
 export function delegationParentHash(parent: AuthorizationV1): string {
-  return createHash("sha256").update(canonicalJson(parent), "utf8").digest("hex");
+  return createHash("sha256").update(canonicalJson(toPublicAuthorizationV1(parent)), "utf8").digest("hex");
 }
 
 /** @public */

--- a/packages/guard/src/test/guard.boundary.test.ts
+++ b/packages/guard/src/test/guard.boundary.test.ts
@@ -126,7 +126,9 @@ test("audience tampering is denied by strict verifier", async () => {
   engine.evaluatePure = ((intent: Intent, st: State) => {
     const out = originalEval(intent, st);
     if (out.decision === "ALLOW") {
-      const tampered: Authorization = { ...out.authorization, audience: "attacker" };
+      // Cast as Authorization: spread of AuthorizationV1 + tampered field; internal
+      // engine fields are present at runtime even though TypeScript type was narrowed.
+      const tampered = { ...out.authorization, audience: "attacker" } as Authorization;
       return { ...out, authorization: tampered };
     }
     return out;

--- a/packages/guard/src/test/guard.test.ts
+++ b/packages/guard/src/test/guard.test.ts
@@ -2,7 +2,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { PolicyEngine } from "@oxdeai/core";
-import type { Authorization, State } from "@oxdeai/core";
+import type { Authorization, AuthorizationV1, State } from "@oxdeai/core";
 import { buildState } from "@oxdeai/sdk";
 import { TEST_KEYSET, TEST_KEYPAIR, signAuth } from "./helpers/fixtures.js";
 
@@ -309,7 +309,7 @@ test("guard: ALLOW executes and returns the result", async () => {
 
 test("guard: ALLOW fires onDecision hook with ALLOW decision", async () => {
   let capturedDecision: string | undefined;
-  let capturedAuth: Authorization | undefined;
+  let capturedAuth: AuthorizationV1 | undefined;
 
   const config = makeGuardConfig({
     onDecision({ decision, authorization }) {

--- a/packages/guard/src/types.ts
+++ b/packages/guard/src/types.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import type { Authorization, AuthorizationV1, DelegationScope, DelegationV1, Intent, KeySet, PolicyEngine, State } from "@oxdeai/core";
+import type { AuthorizationV1, DelegationScope, DelegationV1, Intent, KeySet, PolicyEngine, State } from "@oxdeai/core";
 import type { ReplayStore } from "./replayStore.js";
 
 /**
@@ -57,7 +57,7 @@ export type GuardCallOptions = {
 export type GuardDecisionRecord = {
   action: ProposedAction;
   decision: "ALLOW" | "DENY";
-  authorization?: Authorization;
+  authorization?: AuthorizationV1;
   /** Present when the decision was made via the delegation verification path. */
   delegation?: DelegationV1;
   reasons?: string[];
@@ -111,7 +111,7 @@ export type OxDeAIGuardConfig = {
    */
   beforeExecute?: (
     action: ProposedAction,
-    authorization: Authorization
+    authorization: AuthorizationV1
   ) => void | Promise<void>;
 
   /**

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -7,7 +7,7 @@ import {
   verifyEnvelope,
   verifySnapshot
 } from "@oxdeai/core";
-import type { Authorization, Intent } from "@oxdeai/core";
+import type { Authorization, AuthorizationV1, Intent } from "@oxdeai/core";
 
 import type {
   AuditAdapter,
@@ -80,9 +80,12 @@ export class OxDeAIClient {
     return { output, state, auditEvents: emitted.events };
   }
 
-  async verifyAuthorization(intent: Intent, authorization: Authorization): Promise<{ valid: boolean; reason?: string }> {
+  async verifyAuthorization(intent: Intent, authorization: AuthorizationV1): Promise<{ valid: boolean; reason?: string }> {
     const state = await this.stateAdapter.load();
-    const result = this.engine.verifyAuthorization(intent, authorization, state, intent.timestamp);
+    // Cast as Authorization: internal engine.verifyAuthorization() uses legacy fields
+    // (engine_signature, state_snapshot_hash) for HMAC binding verification.
+    // Authorization objects returned by evaluatePure() retain these at runtime.
+    const result = this.engine.verifyAuthorization(intent, authorization as Authorization, state, intent.timestamp);
     return result.valid ? { valid: true } : { valid: false, reason: result.reason };
   }
 

--- a/packages/sdk/src/guard.ts
+++ b/packages/sdk/src/guard.ts
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-import type { Intent, PolicyEngine, State, Authorization } from "@oxdeai/core";
+import type { Intent, PolicyEngine, State, Authorization, AuthorizationV1 } from "@oxdeai/core";
 import type { AuditAdapter, ClockAdapter, MaybePromise, StateAdapter, IntentBuilderInput } from "./types.js";
 import { buildIntent } from "./builders.js";
 
 export type GuardDecision =
-  | { decision: "ALLOW"; reasons: []; authorization: Authorization }
+  | { decision: "ALLOW"; reasons: []; authorization: AuthorizationV1 }
   | { decision: "DENY"; reasons: string[] };
 
 export type GuardAllowResult<T> = {
-  output: GuardDecision & { decision: "ALLOW"; reasons: []; authorization: Authorization };
+  output: GuardDecision & { decision: "ALLOW"; reasons: []; authorization: AuthorizationV1 };
   intent: Intent;
   state: State;
   auditEvents: unknown[];
@@ -45,7 +45,7 @@ export type GuardOptions = {
 
 type GuardExecuteContext = {
   intent: Intent;
-  authorization: Authorization;
+  authorization: AuthorizationV1;
   state: State;
 };
 
@@ -122,7 +122,9 @@ export function createGuard(opts: GuardOptions): GuardFn {
     }
 
     if (opts.verifyAuthorization !== false) {
-      const authCheck = opts.engine.verifyAuthorization(intent, out.authorization, out.nextState, intent.timestamp);
+      // Cast as Authorization: runtime object retains internal engine fields even
+      // though the TypeScript type was narrowed to AuthorizationV1 at the evaluatePure boundary.
+      const authCheck = opts.engine.verifyAuthorization(intent, out.authorization as Authorization, out.nextState, intent.timestamp);
       if (!authCheck.valid) {
         return {
           output: { decision: "DENY", reasons: [`AUTH_INVALID:${authCheck.reason ?? "unknown"}`] },

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
-import type { Authorization, Intent, State, VerificationResult } from "@oxdeai/core";
+import type { AuthorizationV1, Intent, State, VerificationResult } from "@oxdeai/core";
 
 export type MaybePromise<T> = T | Promise<T>;
 
 export type EvaluateDecision =
-  | { decision: "ALLOW"; reasons: []; authorization: Authorization }
+  | { decision: "ALLOW"; reasons: []; authorization: AuthorizationV1 }
   | { decision: "DENY"; reasons: string[] };
 
 export type EvaluateAndCommitResult = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,9 @@ overrides:
   langsmith: 0.7.1
   minimatch: '>=10.2.3'
   lodash: '>=4.18.0'
-  brace-expansion: '>=5.0.5'
+  brace-expansion: '>=5.0.6'
+  ws: '>=8.20.1'
+  uuid: 14.0.0
   basic-ftp: '>=5.3.0'
   fast-uri: 3.1.2
 
@@ -147,10 +149,10 @@ importers:
     dependencies:
       '@langchain/core':
         specifier: ^1.1.46
-        version: 1.1.46(openai@6.36.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+        version: 1.1.46(openai@6.36.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: ^1.2.9
-        version: 1.3.0(@langchain/core@1.1.46(openai@6.36.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.36.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
+        version: 1.3.0(@langchain/core@1.1.46(openai@6.36.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(openai@6.36.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
       '@oxdeai/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -159,7 +161,7 @@ importers:
         version: link:../../packages/langgraph
       langsmith:
         specifier: 0.7.1
-        version: 0.7.1(openai@6.36.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+        version: 0.7.1(openai@6.36.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
@@ -205,7 +207,7 @@ importers:
         version: link:../../packages/core
       openai:
         specifier: ^4.0.0
-        version: 4.104.0(ws@8.20.0)(zod@3.25.76)
+        version: 4.104.0(ws@8.21.0)(zod@3.25.76)
     devDependencies:
       typescript:
         specifier: ^5.0.0
@@ -874,8 +876,8 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   buffer-crc32@0.2.13:
@@ -1233,7 +1235,7 @@ packages:
       '@opentelemetry/exporter-trace-otlp-proto': '*'
       '@opentelemetry/sdk-trace-base': '*'
       openai: '*'
-      ws: '>=7'
+      ws: '>=8.20.1'
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
@@ -1327,7 +1329,7 @@ packages:
     resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
     hasBin: true
     peerDependencies:
-      ws: ^8.18.0
+      ws: '>=8.20.1'
       zod: ^3.23.8
     peerDependenciesMeta:
       ws:
@@ -1339,7 +1341,7 @@ packages:
     resolution: {integrity: sha512-Has2YbIusMq9wQEierFsgf9c783dy1y9arX459LmphNacEkkM5yxi2RIyXP0LmkOroQyW19iTwALHL8Yf26UKA==}
     hasBin: true
     peerDependencies:
-      ws: ^8.18.0
+      ws: '>=8.20.1'
       zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       ws:
@@ -1590,13 +1592,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@13.0.2:
-    resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -1622,8 +1619,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -1769,12 +1766,12 @@ snapshots:
 
   '@kurkle/color@0.3.4': {}
 
-  '@langchain/core@1.1.46(openai@6.36.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)':
+  '@langchain/core@1.1.46(openai@6.36.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
       js-tiktoken: 1.0.21
-      langsmith: 0.7.1(openai@6.36.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      langsmith: 0.7.1(openai@6.36.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       mustache: 4.2.0
       p-queue: 6.6.2
       zod: 4.4.3
@@ -1785,19 +1782,19 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph-checkpoint@1.0.2(@langchain/core@1.1.46(openai@6.36.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
+  '@langchain/langgraph-checkpoint@1.0.2(@langchain/core@1.1.46(openai@6.36.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))':
     dependencies:
-      '@langchain/core': 1.1.46(openai@6.36.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      uuid: 10.0.0
+      '@langchain/core': 1.1.46(openai@6.36.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
+      uuid: 14.0.0
 
-  '@langchain/langgraph-sdk@1.9.1(openai@6.36.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)':
+  '@langchain/langgraph-sdk@1.9.1(openai@6.36.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)':
     dependencies:
-      '@langchain/core': 1.1.46(openai@6.36.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/core': 1.1.46(openai@6.36.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       '@langchain/protocol': 0.0.15
       '@types/json-schema': 7.0.15
       p-queue: 9.2.0
       p-retry: 7.1.1
-      uuid: 13.0.2
+      uuid: 14.0.0
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -1805,14 +1802,14 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph@1.3.0(@langchain/core@1.1.46(openai@6.36.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.36.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)':
+  '@langchain/langgraph@1.3.0(@langchain/core@1.1.46(openai@6.36.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(openai@6.36.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@langchain/core': 1.1.46(openai@6.36.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.46(openai@6.36.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
-      '@langchain/langgraph-sdk': 1.9.1(openai@6.36.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/core': 1.1.46(openai@6.36.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
+      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.46(openai@6.36.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))
+      '@langchain/langgraph-sdk': 1.9.1(openai@6.36.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       '@langchain/protocol': 0.0.15
       '@standard-schema/spec': 1.1.0
-      uuid: 10.0.0
+      uuid: 14.0.0
       zod: 4.4.3
     optionalDependencies:
       zod-to-json-schema: 3.25.2(zod@4.4.3)
@@ -2055,7 +2052,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2414,12 +2411,12 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  langsmith@0.7.1(openai@6.36.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0):
+  langsmith@0.7.1(openai@6.36.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0):
     dependencies:
       p-queue: 6.6.2
     optionalDependencies:
-      openai: 6.36.0(ws@8.20.0)(zod@4.4.3)
-      ws: 8.20.0
+      openai: 6.36.0(ws@8.21.0)(zod@4.4.3)
+      ws: 8.21.0
 
   lines-and-columns@1.2.4: {}
 
@@ -2439,7 +2436,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 
@@ -2471,7 +2468,7 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  openai@4.104.0(ws@8.20.0)(zod@3.25.76):
+  openai@4.104.0(ws@8.21.0)(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -2481,14 +2478,14 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0
     optionalDependencies:
-      ws: 8.20.0
+      ws: 8.21.0
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
 
-  openai@6.36.0(ws@8.20.0)(zod@4.4.3):
+  openai@6.36.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
-      ws: 8.20.0
+      ws: 8.21.0
       zod: 4.4.3
     optional: true
 
@@ -2594,7 +2591,7 @@ snapshots:
       devtools-protocol: 0.0.1608973
       typed-query-selector: 2.12.2
       webdriver-bidi-protocol: 0.4.1
-      ws: 8.20.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -2811,9 +2808,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@10.0.0: {}
-
-  uuid@13.0.2: {}
+  uuid@14.0.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 
@@ -2836,7 +2831,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   y18n@5.0.8: {}
 

--- a/security/vuln-policy.json
+++ b/security/vuln-policy.json
@@ -7,12 +7,12 @@
   },
   "exceptions": [
     {
-      "id": 1116970,
+      "id": 1119441,
       "package": "uuid",
       "severity": "moderate",
       "scope": "examples/langgraph",
-      "reason": "Transitive via langsmith/langgraph; no effective upstream fix available in current dependency graph",
-      "expires_on": "2026-06-01"
+      "reason": "Resolved via pnpm.overrides uuid@14.0.0; exception retained as guard against lockfile drift re-introducing uuid@10.x via @langchain/langgraph-checkpoint@^1.0.2",
+      "expires_on": "2026-09-01"
     }
   ]
 }

--- a/tests/src/unit/authorization.test.ts
+++ b/tests/src/unit/authorization.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { PolicyEngine } from "@oxdeai/core";
+import type { Authorization } from "@oxdeai/core";
 import { makeIntent } from "../helpers/intent.js";
 import { makeState } from "../helpers/state.js";
 
@@ -32,6 +33,6 @@ test("authorization signature verifies", () => {
 
   if (out.decision !== "ALLOW") throw new Error("expected ALLOW");
 
-  const v = engine.verifyAuthorization(intent, out.authorization, out.nextState, 1000);
+  const v = engine.verifyAuthorization(intent, out.authorization as Authorization, out.nextState, 1000);
   assert.equal(v.valid, true);
 });

--- a/tests/src/unit/authorization/authorizationV1.test.ts
+++ b/tests/src/unit/authorization/authorizationV1.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { generateKeyPairSync } from "node:crypto";
 import { PolicyEngine, signAuthorizationEd25519, verifyAuthorization } from "@oxdeai/core";
-import type { KeySet } from "@oxdeai/core";
+import type { Authorization, KeySet } from "@oxdeai/core";
 import { makeIntent } from "../../helpers/intent.js";
 import { makeState } from "../../helpers/state.js";
 
@@ -54,10 +54,13 @@ function allowOutput() {
 test("creation emits AuthorizationV1 fields on ALLOW", () => {
   const { out, state, engine } = allowOutput();
   const auth = out.authorization;
+  // Cast to Authorization to access internal engine fields in this compatibility test.
+  // The runtime object still carries them; only the TypeScript type was narrowed.
+  const authInternal = out.authorization as Authorization;
 
   assert.equal(auth.decision, "ALLOW");
   assert.ok(typeof auth.auth_id === "string" && auth.auth_id.length > 0);
-  assert.equal(auth.auth_id, auth.authorization_id);
+  assert.equal(auth.auth_id, authInternal.authorization_id);
   assert.equal(auth.issuer, "issuer-A");
   assert.equal(auth.audience, "rp-A");
   // state_hash commits to the pre-evaluation input state (PEP boundary binding).
@@ -65,10 +68,10 @@ test("creation emits AuthorizationV1 fields on ALLOW", () => {
   // They must differ because evaluation changes the state (nonces, budget, etc.).
   assert.equal(auth.state_hash, engine.computeStateHash(state),
     "state_hash must equal the canonical hash of the pre-evaluation input state");
-  assert.notEqual(auth.state_hash, auth.state_snapshot_hash,
+  assert.notEqual(auth.state_hash, authInternal.state_snapshot_hash,
     "state_hash and state_snapshot_hash must differ: evaluation changes state");
   assert.equal(auth.policy_id, "a".repeat(64));
-  assert.equal(auth.expiry, auth.expires_at);
+  assert.equal(auth.expiry, authInternal.expires_at);
   assert.equal(auth.issued_at, 1000);
   assert.ok(auth.alg === "Ed25519" || auth.alg === "HMAC-SHA256");
   assert.ok(typeof auth.kid === "string" && auth.kid.length > 0);


### PR DESCRIPTION
## Summary

Closes #102.

This PR separates the public `AuthorizationV1` protocol artifact boundary from the internal legacy authorization shape used by the reference engine.

Public signing, hashing, and `DelegationV1.parent_auth_hash` now depend only on normative `AuthorizationV1` fields, not internal legacy fields such as:

- `authorization_id`
- `engine_signature`
- `state_snapshot_hash`
- `policy_version`
- `expires_at`

## Why

OxDeAI’s protocol claim depends on independently reproducible authorization artifacts.

A third-party implementation must be able to reproduce:

- the public `AuthorizationV1` canonical surface
- the signing payload
- the `DelegationV1` parent authorization hash
- the verification result

without knowing TypeScript engine internals.

## What changed

- Narrowed public engine authorization output to `AuthorizationV1`
- Added `toPublicAuthorizationV1()` as the explicit public projection boundary
- Updated `delegationParentHash()` to hash only the clean public artifact
- Preserved Encoding B / Sift compatibility with explicit field selection
- Updated downstream examples, SDK, CLI, conformance helpers, and tests
- Added `public-artifact-boundary.test.ts`
- Added Agentgram typecheck follow-up for the internal `engine.verifyAuthorization()` test path

## Validation

- `git diff --check`: clean
- `pnpm build`: passing
- `pnpm --filter @oxdeai/core test`: 177/177 passing
- `pnpm --filter @oxdeai/guard test`: 145/145 passing
- `pnpm test:vectors:auth`: 8/8 passing
- `pnpm test:vectors:all`: 11/11 passing
- `pnpm typecheck`: passing
- `pnpm test`: workspace green, including Sift and compat

## Notes

This PR intentionally does not solve Encoding A / Encoding B verification-path disambiguation. That should remain a separate follow-up issue.

The scope here is strictly the public `AuthorizationV1` artifact boundary.