### PR TITLE
test(conformance): add Profile B trust separation vector

### DIFF
--- a/docs/audits/protocol-audit-post-interoperability.md
+++ b/docs/audits/protocol-audit-post-interoperability.md
@@ -151,7 +151,7 @@
 | Area | Status | Notes |
 |------|--------|-------|
 | Profile A (Core-native) | `DONE` | Defined, implemented, conformance covered by existing auth-sig and auth-verify vectors. |
-| Profile B (External wire-compatible) | `PARTIAL` | Defined. Encoding B accepted in verifyAuthorization. Conformance vector `authorization-sig-010`. **No vector for Profile B trust separation** (Sift receipt trust root ≠ AuthorizationV1 signing key). |
+| Profile B (External wire-compatible) | `DONE` | Defined. Encoding B accepted in verifyAuthorization. Conformance vector `authorization-sig-010`. Trust separation proven: `pb-trust-oxdeai-key-allow` (OxDeAI key in trustedKeySets → ALLOW) and `pb-trust-provider-key-rejected` (provider receipt key absent from trustedKeySets → DENY/UNKNOWN_KID). Resolved in #108. |
 | Profile C (Full semantic state verification) | `DONE` | Defined. Implemented via pluggable `computeStateHash`. 12 executable conformance assertions across 8 vectors. Encoding B path tested. |
 | Profile C cross-language | `MISSING` | No Go/Python harness integration for Profile C vectors. |
 | Interoperability matrix | `DOCUMENTED ONLY` | Matrix in `external-provider-profile.md`. Not backed by conformance automation. |
@@ -256,7 +256,7 @@ The following areas still have **no portable conformance vector**:
 | `decision != "ALLOW"` portable vector | **Medium** | Only checked structurally; no dedicated cross-language vector. |
 | Both `expiry` and `expires_at` present simultaneously | ~~**Medium**~~ | ✓ Resolved: vector `auth-expiry-wins-over-expires-at` locks the precedence rule — `expiry` expired + `expires_at` valid → DENY/EXPIRED. Resolved in #106. |
 | Intent hash mismatch → DENY (cross-language) | ~~**Medium**~~ | ✓ Resolved: `authorization-v1.json` now includes `proposed_action` field enabling independent hash derivation. Portable ALLOW case `auth-intent-action-match-1` and `portable-key-1` fixture key added. Go/Python authorization harness integration remains a future item. Resolved in #105. |
-| Profile B trust separation vector | **Medium** | No vector where Sift receipt key ≠ AuthorizationV1 signing key for same `kid`. |
+| Profile B trust separation vector | ~~**Medium**~~ | ✓ Resolved: `pb-trust-oxdeai-key-allow` proves OxDeAI key (in trustedKeySets) verifies correctly; `pb-trust-provider-key-rejected` proves provider receipt key absent from trustedKeySets returns DENY/UNKNOWN_KID. Resolved in #108. |
 | Profile C cross-language vectors | **Medium** | Profile C vectors are TypeScript-only. `computeStateHash` requires adapter integration. |
 | Replay TTL failure scenarios | **Low** | RT-1–RT-10 documented; none executable as portable conformance vectors. |
 | Malformed canonicalization (float, duplicate key) cross-language | **Low** | TypeScript unit tests exist. No cross-language conformance vectors for error cases. |
@@ -372,7 +372,7 @@ New deployments start with an empty replay store. Authorization artifacts issued
 **Status: READY (Profile A/B), PARTIAL (Profile C)**
 
 - Profile A: fully specified, conformance covered.
-- Profile B: specified, Encoding B conformance covered. Profile B trust separation not explicitly vectorized.
+- Profile B: specified, Encoding B conformance covered, trust separation vectorized (`pb-trust-oxdeai-key-allow`, `pb-trust-provider-key-rejected`). Resolved in #108.
 - Profile C: specified, 12 executable assertions. Cross-language portability requires additional harness work.
 
 ### 7.5 Security Review Readiness
@@ -458,9 +458,8 @@ Resolution: `authorization-v1.json` now includes `proposed_action` on the existi
 **P1-2: Add `expiry`/`expires_at` simultaneous presence precedence vector** ✓ RESOLVED
 Resolution: `authorization-v1.json` vector `auth-expiry-wins-over-expires-at` added: both `expiry` (expired: 1712447100) and `expires_at` (valid: 9999999999) present; expected DENY/EXPIRED. An implementer that incorrectly prefers `expires_at` would return ALLOW, failing the test. Authorization vector count: 9 → 10. Resolved in #106.
 
-**P1-3: Add Profile B trust separation conformance vector**  
-Reason: Profile B correctness depends on the trust bridge between Sift receipt key and OxDeAI signing key. No vector exercises the separate trust root for Profile B.  
-Scope: New vector in `authorization-signature-verification.json` with distinct adapter-issued key.
+**P1-3: Add Profile B trust separation conformance vector** ✓ RESOLVED
+Resolution: Two vectors added to `authorization-v1.json`: `pb-trust-oxdeai-key-allow` (artifact signed by `portable-key-1`, an OxDeAI key present in the runner's `keys` array → ALLOW) and `pb-trust-provider-key-rejected` (identical artifact with `signature.kid = "provider-receipt-key-1"`, a provider receipt key absent from the `keys` array → DENY/UNKNOWN_KID). Proves that the PEP must verify AuthorizationV1 artifacts against OxDeAI trustedKeySets, not the provider's receipt-signing key. Authorization vector count: 10 → 12. Resolved in #108.
 
 **P1-4: Resolve or formally mitigate KRL transport integrity risk**  
 Reason: Sift KRL payload is not signature-verified. A compromised network path can suppress revocations. Either require a signed KRL contract from Sift, or formally document this as an accepted operational risk with compensating controls.  
@@ -501,16 +500,16 @@ Scope: `pep-gateway-v1.md` §7 or a new `state-provider-requirements.md`.
 
 | Status | Count |
 |--------|-------|
-| `DONE` | 55 |
-| `PARTIAL` | 17 |
+| `DONE` | 56 |
+| `PARTIAL` | 16 |
 | `SPECIFIED ONLY` | 5 |
 | `DOCUMENTED ONLY` | 6 |
 | `MISSING` | 6 |
 | `RISK` | 4 |
 
-**Conformance:** 191 assertions across 15 vector files + 10 portable `authorization-v1.json` vectors. Remaining gaps reduced (P0-1, P0-2, P0-3, P0-4, P1-1, P1-2, P1-5 resolved).
+**Conformance:** 191 assertions across 15 vector files + 12 portable `authorization-v1.json` vectors. Remaining gaps reduced (P0-1, P0-2, P0-3, P0-4, P1-1, P1-2, P1-3, P1-5 resolved).
 
-**Follow-up issue counts:** P0: 0 open (P0-1, P0-2, P0-3, P0-4 resolved) · P1: 3 · P2: 4 · Total: 7 open
+**Follow-up issue counts:** P0: 0 open (P0-1, P0-2, P0-3, P0-4 resolved) · P1: 2 · P2: 4 · Total: 6 open
 
 **Critical path to external adoption:**
 

--- a/docs/spec/test-vectors/authorization-v1.json
+++ b/docs/spec/test-vectors/authorization-v1.json
@@ -164,6 +164,60 @@
       }
     },
     {
+      "id": "pb-trust-oxdeai-key-allow",
+      "description": "Profile B trust separation: artifact signed by OxDeAI key (portable-key-1, present in trustedKeySets) MUST verify and ALLOW",
+      "artifact": {
+        "version": "AuthorizationV1",
+        "auth_id": "pb-trust-allow-1",
+        "issuer": "issuer-1",
+        "audience": "pep-gateway.local",
+        "decision": "ALLOW",
+        "intent_hash": "8fbb30c8419a1c88a7799b39d77c77ef19dbdcdf82476bfb6c3d08b644683fa7",
+        "state_hash": "89d739f4d161ed9c8de4319bd2ab140d4d2f7de0d0ae172133cb79cd70187823",
+        "policy_id": "policy-1",
+        "issued_at": 1712448000,
+        "expiry": 1712448600,
+        "alg": "Ed25519",
+        "kid": "portable-key-1",
+        "signature": {
+          "alg": "Ed25519",
+          "kid": "portable-key-1",
+          "sig": "IFUjndKq1bMwNRZordKUPZpfdKenul9XkrgLq5xQXQabTxudV11nrSdWBWi07cA+GChfwzkuokpVawbKJoo2AA=="
+        }
+      },
+      "expected": {
+        "decision": "ALLOW",
+        "error": null
+      }
+    },
+    {
+      "id": "pb-trust-provider-key-rejected",
+      "description": "Profile B trust separation: artifact claiming signature by provider receipt key (provider-receipt-key-1, NOT in OxDeAI trustedKeySets) MUST be rejected with UNKNOWN_KID",
+      "artifact": {
+        "version": "AuthorizationV1",
+        "auth_id": "pb-trust-allow-1",
+        "issuer": "issuer-1",
+        "audience": "pep-gateway.local",
+        "decision": "ALLOW",
+        "intent_hash": "8fbb30c8419a1c88a7799b39d77c77ef19dbdcdf82476bfb6c3d08b644683fa7",
+        "state_hash": "89d739f4d161ed9c8de4319bd2ab140d4d2f7de0d0ae172133cb79cd70187823",
+        "policy_id": "policy-1",
+        "issued_at": 1712448000,
+        "expiry": 1712448600,
+        "alg": "Ed25519",
+        "kid": "provider-receipt-key-1",
+        "signature": {
+          "alg": "Ed25519",
+          "kid": "provider-receipt-key-1",
+          "sig": "IFUjndKq1bMwNRZordKUPZpfdKenul9XkrgLq5xQXQabTxudV11nrSdWBWi07cA+GChfwzkuokpVawbKJoo2AA=="
+        }
+      },
+      "expected": {
+        "decision": "DENY",
+        "error": "UNKNOWN_KID"
+      }
+    },
+    {
       "id": "auth-invalid-signature",
       "description": "tampered payload invalidates signature",
       "artifact": {


### PR DESCRIPTION
## Summary

Closes #111.

Adds portable conformance coverage for Profile B trust separation.

Profile B relies on a strict trust-boundary invariant:

```text
external provider receipt key
≠
OxDeAI AuthorizationV1 signing key
````

The external provider receipt key authenticates the upstream provider decision.
The OxDeAI AuthorizationV1 signing key authorizes execution in the OxDeAI trust domain.

The PEP must verify the AuthorizationV1 key, not the external provider receipt key.

## What changed

Added two AuthorizationV1 vectors:

* `pb-trust-oxdeai-key-allow`

  * verifies successfully with the OxDeAI AuthorizationV1 key
  * proves the expected Profile B ALLOW path

* `pb-trust-provider-key-rejected`

  * uses the provider receipt key id instead of the OxDeAI AuthorizationV1 signing key
  * expects deterministic DENY with `UNKNOWN_KID`
  * proves provider receipt keys are not accepted as AuthorizationV1 signing keys

Updated the protocol audit to mark P1-3 as resolved.

## Why

Profile B correctness depends on preserving separate trust roots:

```text
Provider receipt signature
→ verifies provider decision authenticity

OxDeAI AuthorizationV1 signature
→ verifies execution authorization
```

Without this vector, an implementation could accidentally collapse both trust domains and still pass basic Encoding B tests.

## Validation

* `pnpm test:vectors:auth`: 12/12 passing
* `pnpm test:vectors:all`: passing
* `pnpm typecheck`: passing
* `pnpm test`: passing
* `git diff --check`: clean

## Notes

This PR does not change AuthorizationV1 semantics, Encoding A behavior, Encoding B / Sift signing behavior, DelegationV1, KRL handling, or verification policy.

It only adds conformance coverage for Profile B trust separation and updates the audit.