### PR TITLE
feat(sift): integrate SignedKRLV1 integrity modes

### DIFF
--- a/docs/audits/protocol-audit-post-interoperability.md
+++ b/docs/audits/protocol-audit-post-interoperability.md
@@ -89,8 +89,8 @@
 | `not_before` enforcement | `DONE` | Implemented. Conformance vector `key-lifecycle-003` (future `not_before` → inactive). |
 | `not_after` enforcement | `DONE` | Implemented. Conformance vectors `key-lifecycle-004`, `key-lifecycle-006`, `key-lifecycle-008` (expired windows). |
 | Key rotation (dual-sign) | `PARTIAL` | Rotation procedure documented in `key-custody-and-rotation.md`. Dual-sign overlap verified by `key-lifecycle-007` (retired key within window → ok). No automated rotation machinery. |
-| Sift KRL (Key Revocation List) | `PARTIAL` | `SiftHttpKeyStore` checks `revoked_kids`. KRL payload is **not cryptographically signature-verified** - transport security (HTTPS) only. Known risk, documented in `packages/sift/README.md`. |
-| `SignedKRLV1` artifact | `PARTIAL` | Defined in `docs/spec/artifacts/signed-krl-v1.md`. Pure `verifySignedKrl` verifier implemented in `@oxdeai/core` with 9 conformance vectors. **Not yet integrated into `SiftHttpKeyStore`** — `SiftHttpKeyStore` still uses unsigned KRL. Patch A establishes the cryptographic contract; Patch B wires it into the runtime. |
+| Sift KRL (Key Revocation List) | `DONE` | `SiftHttpKeyStore` now supports three KRL integrity modes: `signed_required` (closes transport gap), `signed_preferred` (default, signed when present), `unsigned_legacy` (deprecated). `verifyKrl` callback injection preserves `@oxdeai/sift` zero-dependency boundary. 29 new tests. See `packages/sift/README.md`. |
+| `SignedKRLV1` artifact | `DONE` | Defined in `docs/spec/artifacts/signed-krl-v1.md`. `verifySignedKrl` verifier in `@oxdeai/core` with 9 conformance vectors. Integrated into `SiftHttpKeyStore` via `verifyKrl` callback (`signed_required` mode closes the transport-integrity gap). Residual: persistent high-watermark storage and cross-language vectors deferred to future patches. |
 
 ---
 
@@ -307,8 +307,8 @@ The following areas still have **no portable conformance vector**:
 **RT-TRUST-1: State provider integrity**
 The state provider is unconditionally trusted. A compromised `getState()` implementation can return a state that produces a matching `state_hash` for an authorization, bypassing the semantic check. **No mitigation exists at the protocol layer.** Documented in `threat-model-external-providers.md` (T-8).
 
-**RT-TRUST-2: KRL transport integrity**
-Sift KRL is not cryptographically signed. MITM can suppress revocations. Documented as known limitation in `packages/sift/README.md`. **Patch A progress:** `SignedKRLV1` artifact defined and `verifySignedKrl` pure verifier implemented in `@oxdeai/core`. The cryptographic contract exists. **Patch B required** to integrate `signed_required` / `signed_preferred` modes into `SiftHttpKeyStore`. Transport integrity risk is not eliminated until Patch B is deployed with `signed_required` mode.
+**RT-TRUST-2: KRL transport integrity** *(mitigated by `signed_required` mode; residual in default mode)*
+`SiftHttpKeyStore` now supports three KRL integrity modes. `signed_required` mode (via `verifyKrl` callback + `verifySignedKrl` from `@oxdeai/core`) closes the transport-integrity gap for deployments that configure it. The default `signed_preferred` mode accepts unsigned KRLs as a fallback. **Residual risk:** the gap is only eliminated when `signed_required` is actively deployed. `unsigned_legacy` and unsigned fallback in `signed_preferred` remain transport-trust-only. See deprecation trajectory in `packages/sift/README.md`.
 
 **RT-TRUST-3: Replay store bootstrapping**
 New deployments start with an empty replay store. Authorization artifacts issued before the store was populated can replay within their validity window. No mitigation; documented in `replay-store-ttl-alignment.md` (RT-3: clock-skew edge) and adjacent scenarios.
@@ -427,7 +427,7 @@ Key rotation                 ██████████░░░░░░░
 Threat model                 ██████████░░░░░░░░░░  DOCUMENTED ONLY
 Clock skew spec              ████████████████████  DONE (strict zero-tolerance + 10 vectors)
 Public artifact boundary     ████████████████████  DONE (#103: toPublicAuthorizationV1, delegationParentHash)
-SignedKRLV1 artifact         ██████████████░░░░░░  PARTIAL (verifier + 9 vectors; Sift integration Patch B pending)
+SignedKRLV1 artifact         ████████████████████  DONE (verifier + 9 vectors; signed_required mode closes transport gap)
 HTTP PEP                     ░░░░░░░░░░░░░░░░░░░░  MISSING (planned v2.6)
 Structured events / metrics  ░░░░░░░░░░░░░░░░░░░░  MISSING
 ```
@@ -463,11 +463,14 @@ Resolution: `authorization-v1.json` vector `auth-expiry-wins-over-expires-at` ad
 **P1-3: Add Profile B trust separation conformance vector** ✓ RESOLVED
 Resolution: Two vectors added to `authorization-v1.json`: `pb-trust-oxdeai-key-allow` (artifact signed by `portable-key-1`, an OxDeAI key present in the runner's `keys` array → ALLOW) and `pb-trust-provider-key-rejected` (identical artifact with `signature.kid = "provider-receipt-key-1"`, a provider receipt key absent from the `keys` array → DENY/UNKNOWN_KID). Proves that the PEP must verify AuthorizationV1 artifacts against OxDeAI trustedKeySets, not the provider's receipt-signing key. Authorization vector count: 10 → 12. Resolved in #108.
 
-**P1-4: Resolve KRL transport integrity risk** *(Patch A complete; Patch B required to close)*
-Reason: Sift KRL payload is not signature-verified. A compromised network path can suppress revocations.
-**Patch A (complete):** `SignedKRLV1` artifact defined (`docs/spec/artifacts/signed-krl-v1.md`). Pure `verifySignedKrl` verifier implemented in `packages/core` with 7 deterministic reason codes and 9 conformance vectors (`packages/conformance/vectors/signed-krl-verification.json`). KRL signing domain `OXDEAI_KRL_V1` established. KRL fixture key separate from AuthorizationV1 signing key — trust domain separation is testable.
-**Patch B (pending):** Integrate `verifySignedKrl` into `SiftHttpKeyStore` with `krl_mode` configuration (`signed_required` / `signed_preferred` / `unsigned_legacy`). The transport integrity risk is not closed until `SiftHttpKeyStore` enforces signed KRLs in production.
-Scope remaining: `packages/sift/src/siftKeyStore.ts` + `packages/sift/README.md` + `docs/architecture/threat-model-external-providers.md`.
+**P1-4: Resolve KRL transport integrity risk** ✓ RESOLVED for `signed_required`; residual risk in default mode
+Resolution: `SiftHttpKeyStore` now supports three KRL integrity modes via `verifyKrl` callback injection (Patch A + Patch B):
+- `signed_required` — closes the transport-integrity gap. Every KRL must be a signed `SignedKRLV1` verified by `verifySignedKrl` from `@oxdeai/core`. Unsigned KRLs rejected before `verifyKrl` is consulted. Constructor fails fast without `verifyKrl`.
+- `signed_preferred` (default) — signed KRLs verified when present; unsigned fallback for unsigned KRLs. Signed KRL with missing `verifyKrl` fails closed.
+- `unsigned_legacy` — deprecated; transport-trust-only; warns at construction.
+`@oxdeai/sift` zero-dependency boundary preserved via callback injection. `krl_version` per-issuer watermark tracked in memory. `getKrlStatus()` status surface added. 29 new mode tests in `siftKeyStore.krl-modes.test.ts`.
+Caveats: transport-integrity gap is only fully closed when callers deploy `signed_required`. `signed_preferred` unsigned fallback and `unsigned_legacy` retain transport-trust-only semantics. Persistent high-watermark storage and cross-language KRL vectors remain future work. Non-string `revoked_kids` skipping is legacy-path-only behavior, not `SignedKRLV1` semantics.
+**KRL reason-code ownership:** Four codes are Sift-local (produced by mode logic, NOT from `@oxdeai/core`): `KRL_UNSIGNED_IN_SIGNED_REQUIRED`, `KRL_MISSING_VERIFY_CALLBACK`, `KRL_VERIFY_CALLBACK_ERROR`, `KRL_VERIFY_RESULT_INCOMPLETE`. Seven core codes are passed through as opaque strings from the `verifyKrl` callback: `KRL_MALFORMED`, `KRL_SIG_INVALID`, `KRL_EXPIRED`, `KRL_UNSUPPORTED_ALG`, `KRL_UNKNOWN_SIGNING_KID`, `KRL_SIGNING_KEY_INACTIVE`, `KRL_VERSION_REGRESSION`.
 
 **P1-5: Mark HMAC-SHA256 as deprecated** ✓ RESOLVED
 Resolution: `authorization-v1.md §5` now carries an explicit "Deprecated legacy algorithm" section: HMAC-SHA256 is not standard, is symmetric/non-portable, and its migration path is documented. `legacyHmacSecret` in `VerifyAuthorizationOptions` carries a `@deprecated` JSDoc with removal notice. `authorization_signing_alg: "HMAC-SHA256"` default in `EngineOptions` carries a `@deprecated` JSDoc directing new users to Ed25519. Two explicit legacy-path tests document backward-compat guarantee and the fail-closed behavior when `legacyHmacSecret` is absent. Resolved in #107.
@@ -504,16 +507,16 @@ Scope: `pep-gateway-v1.md` §7 or a new `state-provider-requirements.md`.
 
 | Status | Count |
 |--------|-------|
-| `DONE` | 56 |
-| `PARTIAL` | 17 |
+| `DONE` | 58 |
+| `PARTIAL` | 15 |
 | `SPECIFIED ONLY` | 5 |
 | `DOCUMENTED ONLY` | 6 |
 | `MISSING` | 6 |
 | `RISK` | 4 |
 
-**Conformance:** 209 assertions across 16 vector files + 12 portable `authorization-v1.json` vectors. Remaining gaps reduced (P0-1, P0-2, P0-3, P0-4, P1-1, P1-2, P1-3, P1-5 resolved; P1-4 Patch A complete).
+**Conformance:** 209 assertions across 16 vector files + 12 portable `authorization-v1.json` vectors. Remaining gaps reduced (P0-1, P0-2, P0-3, P0-4, P1-1, P1-2, P1-3, P1-4, P1-5 resolved with caveats).
 
-**Follow-up issue counts:** P0: 0 open · P1: 2 open (P1-4 Patch B pending, P1-6 open) · P2: 4 · Total: 6 open
+**Follow-up issue counts:** P0: 0 open · P1: 1 open (P1-6) · P2: 4 · Total: 5 open
 
 **Critical path to external adoption:**
 
@@ -530,7 +533,7 @@ Scope: `pep-gateway-v1.md` §7 or a new `state-provider-requirements.md`.
 
 OxDeAI is a working, tested execution authorization boundary protocol at the **interoperable protocol** maturity level. Core invariants are implemented and tested. AuthorizationV1, wire encodings, signature verification, replay protection, state binding, and delegation are all in solid shape. Profile A/B/C are specified; Profile A and C have executable conformance coverage.
 
-The protocol is **not yet ready for standard adoption**. Key lifecycle, clock skew, parentScope type safety, public artifact boundary separation, intent hash mismatch portability, expiry precedence, and HMAC-SHA256 deprecation are now resolved. The spec/implementation mismatch is closed. State provider trust, KRL transport integrity, Profile C cross-language coverage, and independent security review remain open before that claim can be made honestly.
+The protocol is **not yet ready for standard adoption**. Key lifecycle, clock skew, parentScope type safety, public artifact boundary separation, intent hash mismatch portability, expiry precedence, HMAC-SHA256 deprecation, and KRL transport integrity (for `signed_required` mode deployments) are now resolved. State provider trust, Profile C cross-language coverage, and independent security review remain open before that claim can be made honestly.
 
 ---
 

--- a/docs/spec/interoperability/external-provider-profile.md
+++ b/docs/spec/interoperability/external-provider-profile.md
@@ -178,6 +178,65 @@ Same as Profile A: `state_hash` is protected by signature integrity. The adapter
 `state_hash` using its own canonicalization function. The verifier does not re-compute
 `state_hash` from live state at Profile B — only signature integrity is enforced.
 
+#### 2.2.5 KRL Integrity at Profile B
+
+Profile B requires verifying the external provider's receipt-signing key is not revoked.
+A KRL (Key Revocation List) maintained by the provider records revoked `kid` values.
+
+**KRL transport integrity options:**
+
+| Option | Integrity guarantee | Status |
+|--------|---------------------|--------|
+| `unsigned_legacy` | Transport security (HTTPS) only | Deprecated — residual risk |
+| `signed_preferred` with unsigned fallback | Transport security for unsigned KRLs; cryptographic for signed KRLs | Transition mode |
+| `signed_required` | Cryptographic — `SignedKRLV1` verified via `verifySignedKrl` | Recommended for production |
+
+**`SignedKRLV1` specification.** `SignedKRLV1` is a provider-neutral OxDeAI protocol artifact
+defined in `docs/spec/artifacts/signed-krl-v1.md`. It carries a `revoked_kids` list signed
+with an Ed25519 key whose trust is configured statically at the verifier — independent of
+transport security.
+
+**Signing domain.** `OXDEAI_KRL_V1\n` + `canonicalJson(signingPayload)` — using OxDeAI
+canonicalization-v1, not Sift canonicalization.
+
+**Trust domain separation.**
+
+```text
+Sift provider receipt-signing key  ≠  OxDeAI AuthorizationV1 signing key
+                                   ≠  KRL signing key
+```
+
+All three are distinct key pairs. The KRL signing key is configured statically in the
+adapter (via `trustedKeySets` passed to `verifyKrl`), not fetched from the provider at
+verification time.
+
+**Fail-closed KRL behavior in `signed_preferred`:**
+
+- KRL body has no `signature` key → unsigned fallback (accepted; `lastIntegrity: "unsigned_fallback"`)
+- KRL body has any `signature` key → signed path (must verify via `verifyKrl`)
+- Signed path without `verifyKrl` configured → refresh fails closed (no unsigned fallback)
+- Malformed/partial `signature` field → signed path → fails closed
+
+**Residual limitations (Profile B with `unsigned_legacy` or `signed_preferred` unsigned fallback):**
+A compromised transport path can return a modified KRL that omits revoked kids.
+Unknown and revoked kids still fail closed, but suppressed revocations bypass the revocation
+check. This risk is only closed by deploying `signed_required` mode.
+
+**KRL reason-code ownership.** `SiftHttpKeyStore` surfaces two sets of codes:
+
+*Sift-local mode/contract codes* (NOT from `@oxdeai/core`):
+
+| Code | Trigger |
+|------|---------|
+| `KRL_UNSIGNED_IN_SIGNED_REQUIRED` | Unsigned KRL rejected in `signed_required` before `verifyKrl` is called |
+| `KRL_MISSING_VERIFY_CALLBACK` | KRL has a `signature` field but no `verifyKrl` configured |
+| `KRL_VERIFY_CALLBACK_ERROR` | `verifyKrl` callback threw unexpectedly |
+| `KRL_VERIFY_RESULT_INCOMPLETE` | `verifyKrl` returned `ok: true` without `accepted` metadata |
+
+*Core KRL codes* (passed through from `verifyKrl` as opaque strings):
+`KRL_MALFORMED`, `KRL_SIG_INVALID`, `KRL_EXPIRED`, `KRL_UNSUPPORTED_ALG`,
+`KRL_UNKNOWN_SIGNING_KID`, `KRL_SIGNING_KEY_INACTIVE`, `KRL_VERSION_REGRESSION`.
+
 ---
 
 ### 2.3 Profile C — Full Semantic State Verification

--- a/packages/sift/README.md
+++ b/packages/sift/README.md
@@ -303,7 +303,76 @@ Minimum requirements:
 - no fallback guessing
 - deterministic key selection
 
-**KRL payload integrity limitation.** `SiftHttpKeyStore` checks whether a `kid` appears in the fetched KRL but does NOT verify a cryptographic signature over the KRL payload itself. KRL payload integrity depends on transport security (HTTPS to a trusted endpoint). A compromised intermediary could return a modified KRL that omits specific revoked kids. Unknown and revoked kids still fail closed. Production deployments requiring cryptographic revocation integrity must wait for a signed KRL contract from Sift.
+**KRL integrity modes.** `SiftHttpKeyStore` supports three KRL integrity modes controlled by the `krlMode` constructor option:
+
+| Mode | Description | Production status |
+|------|-------------|------------------|
+| `"signed_required"` | Every KRL must be cryptographically signed (`SignedKRLV1`). Unsigned KRLs are rejected with `KRL_UNSIGNED_IN_SIGNED_REQUIRED` *before* calling `verifyKrl`. Requires a `verifyKrl` callback at construction. **Closes the transport-integrity gap.** | Recommended |
+| `"signed_preferred"` *(default)* | Signed KRLs are verified when present; unsigned KRLs are accepted as a transport-trust fallback (`unsigned_fallback` status). If a signature field is present but no `verifyKrl` is configured, refresh fails closed — there is no downgrade path. | Default transition mode |
+| `"unsigned_legacy"` | Preserves pre-Patch-B unsigned KRL behavior. Deprecated. Emits a warning at construction. **Residual risk: transport security only.** | Deprecated |
+
+**Wiring signed KRL verification.** Supply a `verifyKrl` callback that delegates to `verifySignedKrl` from `@oxdeai/core`. This preserves `@oxdeai/sift`'s zero-dependency boundary:
+
+```ts
+import { verifySignedKrl } from "@oxdeai/core";
+import type { KeySet } from "@oxdeai/core";
+
+const krlSigningKeySets: KeySet[] = [/* your trusted KRL signing key sets */];
+
+const store = new SiftHttpKeyStore({
+  jwksUrl: "https://your-sift-host/sift-jwks.json",
+  krlUrl:  "https://your-sift-host/sift-krl.json",
+  krlMode: "signed_required",
+  verifyKrl: (payload, ctx) => verifySignedKrl(payload, {
+    trustedKeySets: krlSigningKeySets,
+    ...ctx,
+  }),
+});
+```
+
+**KRL status surface.** `store.getKrlStatus()` returns an integrity snapshot:
+
+```ts
+const status = store.getKrlStatus();
+// {
+//   mode: "signed_required",
+//   lastIntegrity: "signed" | "unsigned_fallback" | "unsigned_legacy" | "failed" | "none",
+//   lastReason: undefined,           // cleared on success; error code on failure
+//   unsignedFallbackActive: false,
+//   lastVerifiedAt: 1744550000,      // unix seconds of last accepted KRL
+//   lastKrlVersionByIssuer: { "krl-authority": 5 }
+// }
+```
+
+`lastReason` is always cleared to `undefined` on a successful refresh. It never carries a stale failure reason after a later success.
+
+**Version watermark.** `SiftHttpKeyStore` tracks the highest accepted `krl_version` per issuer in memory during its lifetime and passes this to `verifyKrl` as `previousKrlVersionByIssuer`. This causes `verifySignedKrl` to reject any KRL whose `krl_version` is less than the previously accepted version (`KRL_VERSION_REGRESSION`). **This watermark is in-memory only and resets on process restart.**
+
+**Unsigned path behavior (legacy).** The unsigned fallback path (used by `unsigned_legacy` and by `signed_preferred` when the fetched KRL has no `signature` field) silently skips non-string entries in `revoked_kids`. **This is legacy behavior and is NOT `SignedKRLV1` semantics.** `SignedKRLV1` verification rejects non-string entries and duplicate entries as `KRL_MALFORMED`.
+
+**KRL reason codes.** Two sets of codes are surfaced in `krlStatus.lastReason` and `KeyStoreError` messages:
+
+*Sift-local mode/contract codes* — produced by `SiftHttpKeyStore` mode logic; never imported from `@oxdeai/core`:
+
+| Code | Trigger |
+|------|---------|
+| `KRL_UNSIGNED_IN_SIGNED_REQUIRED` | Unsigned KRL rejected in `signed_required` mode before `verifyKrl` is called |
+| `KRL_MISSING_VERIFY_CALLBACK` | KRL has a `signature` field but no `verifyKrl` callback configured; refresh fails closed |
+| `KRL_VERIFY_CALLBACK_ERROR` | `verifyKrl` callback threw instead of returning a result; refresh fails closed |
+| `KRL_VERIFY_RESULT_INCOMPLETE` | `verifyKrl` returned `ok: true` but omitted `accepted` issuer/`krl_version` metadata; refresh fails closed |
+
+*Core KRL codes* — passed through as opaque strings from the `verifyKrl` callback (originated in `@oxdeai/core`):
+`KRL_MALFORMED`, `KRL_SIG_INVALID`, `KRL_EXPIRED`, `KRL_UNSUPPORTED_ALG`, `KRL_UNKNOWN_SIGNING_KID`, `KRL_SIGNING_KEY_INACTIVE`, `KRL_VERSION_REGRESSION`.
+
+**`result.accepted` contract.** When `verifyKrl` returns `ok: true`, it MUST include `accepted: { issuer, krl_version }` populated from the verified `SignedKRLV1` payload fields. This is how `SiftHttpKeyStore` advances the per-issuer version watermark without independently re-parsing the body. Omitting `accepted` fails closed with `KRL_VERIFY_RESULT_INCOMPLETE`.
+
+**Deprecation trajectory:**
+
+| Release | Change |
+|---------|--------|
+| Current (`signed_preferred` default) | `unsigned_legacy` warns at construction; unsigned fallback logs status only |
+| `v-next` | `unsigned_legacy` emits stronger warning; `signed_required` recommended |
+| `v-after` | `unsigned_legacy` removed; default becomes `signed_required` |
 
 ### Prototype safety
 
@@ -407,10 +476,20 @@ await store.refresh();
 // Note: createStagingKeyStore() throws if NODE_ENV === "production".
 // Use new SiftHttpKeyStore({ jwksUrl, krlUrl }) with your production endpoints.
 
-// Production:
+// Production (signed KRL integrity):
+import { verifySignedKrl } from "@oxdeai/core";
 const prodStore = new SiftHttpKeyStore({
   jwksUrl: "https://your-production-sift-host/sift-jwks.json",
   krlUrl:  "https://your-production-sift-host/sift-krl.json",
+  krlMode: "signed_required",
+  verifyKrl: (payload, ctx) => verifySignedKrl(payload, { trustedKeySets: myKrlKeySets, ...ctx }),
+});
+
+// Transition (default — unsigned fallback if KRL is unsigned):
+const transStore = new SiftHttpKeyStore({
+  jwksUrl: "https://your-production-sift-host/sift-jwks.json",
+  krlUrl:  "https://your-production-sift-host/sift-krl.json",
+  // krlMode defaults to "signed_preferred"
 });
 
 // Inject a mock fetch for tests:

--- a/packages/sift/src/index.ts
+++ b/packages/sift/src/index.ts
@@ -47,6 +47,10 @@ export type {
   SiftHttpKeyStoreOptions,
   KeyStoreErrorCode,
   CreateStagingKeyStoreOptions,
+  KrlMode,
+  KrlIntegrity,
+  KrlVerifyFn,
+  KrlStatus,
 } from "./siftKeyStore.js";
 export {
   KeyStoreError,

--- a/packages/sift/src/siftKeyStore.ts
+++ b/packages/sift/src/siftKeyStore.ts
@@ -4,16 +4,57 @@
  *
  * Responsibilities:
  *   - JWKS fetch and parse (RFC 8037 OKP / Ed25519)
- *   - KRL fetch and parse (revoked kid set)
+ *   - KRL fetch, parse, and optional signed-integrity verification
  *   - in-memory key cache keyed by `kid`
  *   - refresh-on-unknown-kid (called externally; one retry is the contract)
- *   - fail-closed on any parse or network failure
+ *   - fail-closed on any parse, network, or integrity failure
+ *   - KRL integrity modes: signed_required, signed_preferred, unsigned_legacy
  *
  * No network calls are made at construction time.  The caller triggers I/O
  * either explicitly via `refresh()` or implicitly via `verifyReceiptWithKeyStore`.
  *
  * The `fetch` option exists for test injection.  Production code leaves it
  * unset, which falls back to `globalThis.fetch`.
+ *
+ * ── KRL integrity modes ───────────────────────────────────────────────────────
+ *
+ *   signed_required
+ *     Strict production mode. Every fetched KRL must carry a SignedKRLV1
+ *     signature verified by the injected `verifyKrl` callback. Unsigned KRLs
+ *     are rejected immediately (without consulting `verifyKrl`) with
+ *     KRL_UNSIGNED_IN_SIGNED_REQUIRED. Constructor throws if `verifyKrl` is
+ *     absent.
+ *
+ *   signed_preferred (default)
+ *     Transition mode. When the fetched KRL has a `signature` field, the
+ *     `verifyKrl` callback is required and verification must succeed. If no
+ *     `signature` field is present, the store falls back to unsigned parsing
+ *     (status `unsigned_fallback`). If a `signature` field is present but no
+ *     `verifyKrl` callback is configured, refresh() fails closed.
+ *
+ *   unsigned_legacy
+ *     Compatibility-only mode. Preserves pre-Patch-B behavior: unsigned KRL
+ *     revoked_kids are parsed via HTTPS transport trust. Emits a deprecation
+ *     warning at construction. Non-string revoked_kids entries are silently
+ *     skipped (this is the legacy behavior and is NOT SignedKRLV1 semantics).
+ *
+ * ── verifyKrl injection ───────────────────────────────────────────────────────
+ *
+ *   `verifyKrl` is an optional callback that delegates signed KRL verification
+ *   to an external implementation (e.g. `verifySignedKrl` from `@oxdeai/core`).
+ *   This preserves @oxdeai/sift's zero-dependency boundary.
+ *
+ *   Production wiring example:
+ *
+ *     import { verifySignedKrl } from "@oxdeai/core";
+ *     const store = new SiftHttpKeyStore({
+ *       jwksUrl, krlUrl,
+ *       krlMode: "signed_required",
+ *       verifyKrl: (payload, ctx) => verifySignedKrl(payload, {
+ *         trustedKeySets: myKrlSigningKeySets,
+ *         ...ctx,
+ *       }),
+ *     });
  */
 
 import { b64uDecode } from "./siftCanonical.js";
@@ -59,11 +100,124 @@ export interface SiftKeyStore {
   /**
    * Fetches and replaces the in-memory JWKS and KRL from the configured
    * remote endpoints.  Both fetches run concurrently.  Throws a
-   * `KeyStoreError` on any network, HTTP, or parse failure.  The in-memory
-   * caches are only swapped if both fetches and parses succeed.
+   * `KeyStoreError` on any network, HTTP, parse, or integrity failure.
+   * The in-memory caches are only swapped if both fetches and all checks succeed.
    */
   refresh(): Promise<void>;
 }
+
+// ─── KRL integrity modes ──────────────────────────────────────────────────────
+
+/** KRL integrity verification mode. Default: "signed_preferred". */
+export type KrlMode = "signed_required" | "signed_preferred" | "unsigned_legacy";
+
+/** Describes the integrity of the most recently accepted KRL. */
+export type KrlIntegrity =
+  | "signed"            // KRL was cryptographically verified via verifyKrl
+  | "unsigned_fallback" // KRL had no signature field; accepted via transport trust
+  | "unsigned_legacy"   // krlMode === "unsigned_legacy"; accepted via transport trust
+  | "failed"            // last refresh attempt failed at the KRL stage
+  | "none";             // no refresh has completed yet
+
+/**
+ * Callback for signed KRL verification.
+ *
+ * This is a structural type — @oxdeai/sift does not import from @oxdeai/core.
+ * In production, wire this to `verifySignedKrl` from `@oxdeai/core`:
+ *
+ *   verifyKrl: (payload, ctx) => verifySignedKrl(payload, {
+ *     trustedKeySets: myKrlSigningKeySets,
+ *     ...ctx,
+ *   })
+ *
+ * The return shape is structurally compatible with VerificationResult from
+ * @oxdeai/core without requiring an import.
+ *
+ * @public
+ */
+export type KrlVerifyFn = (
+  payload: unknown,
+  ctx: {
+    now: number;
+    previousKrlVersionByIssuer?: Readonly<Record<string, number>>;
+  }
+) => {
+  ok: boolean;
+  status?: string;
+  violations: Array<{ code: string; message?: string }>;
+  /**
+   * Verified accepted KRL metadata. Required when `ok: true` for signed KRL paths.
+   * `SiftHttpKeyStore` uses this to advance the per-issuer `krl_version` watermark.
+   *
+   * `accepted.krl_version` MUST be the exact value the verifier validated and used for
+   * its regression check. Do not compute it independently from the KRL body.
+   *
+   * Production wiring example:
+   *   const result = verifySignedKrl(payload, { trustedKeySets, ...ctx });
+   *   if (!result.ok) return result;
+   *   const krl = payload as { issuer: string; krl_version: number };
+   *   return { ...result, accepted: { issuer: krl.issuer, krl_version: krl.krl_version } };
+   *
+   * If absent on `ok: true`, `SiftHttpKeyStore` fails closed with KRL_VERIFY_RESULT_INCOMPLETE.
+   */
+  accepted?: { issuer: string; krl_version: number };
+};
+
+/**
+ * KRL status snapshot returned by `SiftHttpKeyStore.getKrlStatus()`.
+ *
+ * Confidentiality boundary: this surface exposes mode, integrity metadata,
+ * reason codes, issuer names, kid values, version numbers, and timestamps.
+ * It NEVER exposes public-key PEM contents, private keys, raw signature bytes,
+ * full KRL payloads, or trusted signing key material.
+ *
+ * @public
+ */
+export interface KrlStatus {
+  mode: KrlMode;
+  /** Integrity classification of the most recently accepted KRL. */
+  lastIntegrity: KrlIntegrity;
+  /**
+   * Reason code from the last KRL verification failure, or undefined when the
+   * last refresh succeeded. Always cleared to undefined on success.
+   */
+  lastReason?: string;
+  /** True when the active KRL was loaded via unsigned fallback. */
+  unsignedFallbackActive: boolean;
+  /** Unix seconds of the last successful KRL acceptance, or undefined. */
+  lastVerifiedAt?: number;
+  /** Per-issuer high-watermark of accepted krl_version values (in-memory only). */
+  lastKrlVersionByIssuer: Record<string, number>;
+}
+
+// ─── Sift-local KRL mode/contract codes ──────────────────────────────────────
+//
+// These four codes are produced by SiftHttpKeyStore's mode logic and contract
+// enforcement.  They are NOT imported from @oxdeai/core VerificationViolationCode.
+//
+//   KRL_UNSIGNED_IN_SIGNED_REQUIRED
+//     Unsigned KRL rejected in signed_required mode before verifyKrl is called.
+//
+//   KRL_MISSING_VERIFY_CALLBACK
+//     KRL has a signature field but no verifyKrl callback is configured.
+//     Refresh fails closed — no unsigned fallback when signature key is present.
+//
+//   KRL_VERIFY_CALLBACK_ERROR
+//     verifyKrl callback threw instead of returning a result.
+//     Refresh fails closed.
+//
+//   KRL_VERIFY_RESULT_INCOMPLETE
+//     verifyKrl returned ok: true but did not include accepted issuer/krl_version
+//     metadata. This is a contract violation between the injected verifier and
+//     SiftHttpKeyStore. Refresh fails closed.
+//
+// The seven core KRL codes (KRL_MALFORMED, KRL_SIG_INVALID, KRL_EXPIRED,
+// KRL_UNSUPPORTED_ALG, KRL_UNKNOWN_SIGNING_KID, KRL_SIGNING_KEY_INACTIVE,
+// KRL_VERSION_REGRESSION) are passed through as opaque strings from verifyKrl.
+//
+const KRL_UNSIGNED_IN_SIGNED_REQUIRED  = "KRL_UNSIGNED_IN_SIGNED_REQUIRED";
+const KRL_MISSING_VERIFY_CALLBACK      = "KRL_MISSING_VERIFY_CALLBACK";
+const KRL_VERIFY_RESULT_INCOMPLETE     = "KRL_VERIFY_RESULT_INCOMPLETE";
 
 // ─── JWKS parsing ─────────────────────────────────────────────────────────────
 
@@ -76,9 +230,8 @@ export interface SiftKeyStore {
  *   - kid is a non-empty string
  *   - x is a non-empty base64url string that decodes to exactly 32 bytes
  *
- * Invalid entries are silently skipped (ignoring them is safer than partially
- * trusting a malformed entry).  If the response is not a valid JWKS object at
- * all, throws `KeyStoreError("JWKS_FETCH_FAILED", ...)`.
+ * Invalid entries are silently skipped.  If the response is not a valid JWKS
+ * object at all, throws `KeyStoreError("JWKS_FETCH_FAILED", ...)`.
  */
 function parseJwks(body: unknown): Map<string, Uint8Array> {
   if (
@@ -108,10 +261,10 @@ function parseJwks(body: unknown): Map<string, Uint8Array> {
     try {
       raw = b64uDecode(e["x"] as string);
     } catch {
-      continue; // invalid base64url — skip; do not partially trust
+      continue;
     }
 
-    if (raw.length !== 32) continue; // wrong key size — skip
+    if (raw.length !== 32) continue;
 
     result.set(e["kid"] as string, raw);
   }
@@ -119,34 +272,22 @@ function parseJwks(body: unknown): Map<string, Uint8Array> {
   return result;
 }
 
-// ─── KRL parsing ──────────────────────────────────────────────────────────────
+// ─── Unsigned KRL parsing (legacy/fallback) ───────────────────────────────────
 
 /**
- * Parses a KRL response body into a Set of revoked kid strings.
+ * Parses an unsigned KRL response body into a Set of revoked kid strings.
  *
  * Requires `revoked_kids` to be a present array.  Non-string entries within
- * the array are silently skipped (only known string values enter the revoked
- * set — fail-closed: an unknown format entry cannot accidentally un-revoke a
- * key).  Throws `KeyStoreError("KRL_FETCH_FAILED", ...)` if the top-level
- * shape is not a valid KRL object.
+ * the array are silently skipped.
  *
- * ── KRL payload integrity limitation ─────────────────────────────────────────
- * `SiftHttpKeyStore` checks whether a `kid` appears in the fetched KRL, but
- * does NOT verify a cryptographic signature over the KRL payload itself.
+ * ── Behavior note ─────────────────────────────────────────────────────────────
+ * Silent skipping of non-string entries is LEGACY behavior.  It applies only
+ * to the unsigned_legacy mode and the unsigned-fallback path of signed_preferred.
+ * The signed KRL path (via verifyKrl / verifySignedKrl) rejects non-string and
+ * duplicate revoked_kids entries as KRL_MALFORMED.
  *
- * KRL payload integrity therefore depends on transport security (HTTPS to a
- * trusted endpoint).  A compromised intermediary (e.g. a CDN edge, a man-in-
- * the-middle, or a stale unsigned cache entry) could return a modified KRL
- * that omits specific revoked kids — allowing a revoked key to pass the
- * revocation check.
- *
- * Unknown/revoked kids still fail closed:
- *   - kid in revoked_kids   → REVOKED_KID immediately
- *   - kid not found after refresh → UNKNOWN_KID (no guessing)
- *
- * Production deployments that require cryptographic revocation integrity MUST
- * wait for the Sift protocol to define a KRL signing contract.  This code is
- * structured to accept a verify-after-parse step without further refactoring.
+ * Throws `KeyStoreError("KRL_FETCH_FAILED", ...)` if the top-level shape is
+ * not a valid KRL object.
  */
 function parseKrl(body: unknown): Set<string> {
   if (typeof body !== "object" || body === null) {
@@ -165,12 +306,53 @@ function parseKrl(body: unknown): Set<string> {
   const result = new Set<string>();
   for (const kid of krl["revoked_kids"] as unknown[]) {
     if (typeof kid === "string") result.add(kid);
-    // Non-string entries are silently skipped.
-    // Fail-closed: only explicitly known revoked kids enter the set.
+    // Non-string entries are silently skipped (legacy behavior).
   }
 
   return result;
 }
+
+// ─── KRL processing helpers ───────────────────────────────────────────────────
+
+/** Returns true if the parsed JSON body contains any `signature` key (value-agnostic). */
+function hasSignatureField(body: unknown): boolean {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) return false;
+  return "signature" in (body as object);
+}
+
+/**
+ * Extracts `revoked_kids` from a KRL payload that has already been verified
+ * by the `verifyKrl` callback.  Defensive: only string entries are added.
+ */
+function extractRevokedKidsFromVerified(body: unknown): Set<string> {
+  if (typeof body !== "object" || body === null) return new Set();
+  const b = body as Record<string, unknown>;
+  const kids = b["revoked_kids"];
+  if (!Array.isArray(kids)) return new Set();
+  const result = new Set<string>();
+  for (const k of kids) {
+    if (typeof k === "string") result.add(k);
+  }
+  return result;
+}
+
+
+// ─── Internal KRL process result ─────────────────────────────────────────────
+
+type KrlProcessSuccess = {
+  ok: true;
+  revoked: Set<string>;
+  integrity: "signed" | "unsigned_fallback" | "unsigned_legacy";
+  updatedVersion?: { issuer: string; krl_version: number };
+};
+
+type KrlProcessFailure = {
+  ok: false;
+  reason: string;
+  error: KeyStoreError;
+};
+
+type KrlProcessResult = KrlProcessSuccess | KrlProcessFailure;
 
 // ─── HTTP-backed implementation ───────────────────────────────────────────────
 
@@ -182,20 +364,97 @@ export interface SiftHttpKeyStoreOptions {
    * Override in tests to avoid live network calls.
    */
   fetch?: FetchFn;
+  /**
+   * KRL integrity verification mode.
+   *
+   * Default: "signed_preferred"
+   *
+   * - "signed_required"  — all KRLs must be cryptographically signed and
+   *   verified via the `verifyKrl` callback.  Constructor throws if `verifyKrl`
+   *   is absent.  Closes the KRL transport-integrity gap.
+   * - "signed_preferred" — signed KRLs are verified when present; unsigned KRLs
+   *   are accepted via transport trust as a fallback (status: unsigned_fallback).
+   *   If a KRL has any `signature` field but no `verifyKrl` is configured,
+   *   refresh() fails closed.
+   * - "unsigned_legacy"  — preserves pre-Patch-B unsigned KRL behavior.
+   *   Deprecated. Emits a warning at construction.
+   */
+  krlMode?: KrlMode;
+  /**
+   * Signed KRL verification callback.
+   *
+   * Required when krlMode is "signed_required". Optional for "signed_preferred"
+   * but will cause refresh() to fail closed when a signed KRL is encountered
+   * without this callback configured.
+   *
+   * Production wiring:
+   *   import { verifySignedKrl } from "@oxdeai/core";
+   *   verifyKrl: (payload, ctx) => verifySignedKrl(payload, {
+   *     trustedKeySets: myKrlSigningKeySets,
+   *     ...ctx,
+   *   })
+   *
+   * @oxdeai/sift has no runtime dependency on @oxdeai/core. The callback is
+   * the integration seam.
+   */
+  verifyKrl?: KrlVerifyFn;
+  /**
+   * Unix-seconds clock provider for KRL expiry checks passed to `verifyKrl`.
+   * Defaults to `() => Math.floor(Date.now() / 1000)`.
+   * Override in tests for deterministic time-sensitive assertions.
+   * Must remain optional — existing callers work without it.
+   */
+  now?: () => number;
 }
 
 export class SiftHttpKeyStore implements SiftKeyStore {
   private readonly jwksUrl: string;
   private readonly krlUrl: string;
   private readonly fetchFn: FetchFn;
+  private readonly krlMode: KrlMode;
+  private readonly verifyKrl: KrlVerifyFn | undefined;
+  private readonly nowFn: () => number;
 
   private keyCache = new Map<string, Uint8Array>();
   private revokedKids = new Set<string>();
+  private krlVersionByIssuer = new Map<string, number>();
+  private _krlStatus: KrlStatus;
 
   constructor(opts: SiftHttpKeyStoreOptions) {
     this.jwksUrl = opts.jwksUrl;
     this.krlUrl = opts.krlUrl;
     this.fetchFn = opts.fetch ?? globalThis.fetch.bind(globalThis);
+    this.krlMode = opts.krlMode ?? "signed_preferred";
+    this.verifyKrl = opts.verifyKrl;
+    this.nowFn = opts.now ?? (() => Math.floor(Date.now() / 1000));
+
+    // Fast-fail: signed_required mode requires a verifyKrl callback.
+    if (this.krlMode === "signed_required" && !this.verifyKrl) {
+      throw new TypeError(
+        "[SiftHttpKeyStore] krlMode \"signed_required\" requires a verifyKrl callback. " +
+        "Provide a verifyKrl function that calls verifySignedKrl from @oxdeai/core with " +
+        "your trusted KRL signing key sets. This mode closes the KRL transport-integrity gap."
+      );
+    }
+
+    // Deprecation warning for unsigned_legacy.
+    if (this.krlMode === "unsigned_legacy") {
+      console.warn(
+        "[SiftHttpKeyStore] krlMode \"unsigned_legacy\" is deprecated. " +
+        "KRL payload integrity depends on transport security (HTTPS) only. " +
+        "Migrate to \"signed_preferred\" or \"signed_required\" with a verifyKrl callback " +
+        "to enforce cryptographic KRL integrity. See docs/spec/artifacts/signed-krl-v1.md."
+      );
+    }
+
+    this._krlStatus = {
+      mode: this.krlMode,
+      lastIntegrity: "none",
+      lastReason: undefined,
+      unsignedFallbackActive: false,
+      lastVerifiedAt: undefined,
+      lastKrlVersionByIssuer: {},
+    };
   }
 
   async getPublicKeyByKid(kid: string): Promise<Uint8Array | null> {
@@ -204,6 +463,23 @@ export class SiftHttpKeyStore implements SiftKeyStore {
 
   async isKidRevoked(kid: string): Promise<boolean> {
     return this.revokedKids.has(kid);
+  }
+
+  /**
+   * Returns a snapshot of the current KRL integrity status.
+   *
+   * Never exposes public-key PEM contents, private keys, raw signature bytes,
+   * full KRL payloads, or trusted signing key material.
+   */
+  getKrlStatus(): KrlStatus {
+    return {
+      mode: this._krlStatus.mode,
+      lastIntegrity: this._krlStatus.lastIntegrity,
+      lastReason: this._krlStatus.lastReason,
+      unsignedFallbackActive: this._krlStatus.unsignedFallbackActive,
+      lastVerifiedAt: this._krlStatus.lastVerifiedAt,
+      lastKrlVersionByIssuer: { ...this._krlStatus.lastKrlVersionByIssuer },
+    };
   }
 
   async refresh(): Promise<void> {
@@ -249,14 +525,167 @@ export class SiftHttpKeyStore implements SiftKeyStore {
       );
     }
 
-    // Parse both; use specific error codes on failure.
-    // Both parses must succeed before we swap the caches.
-    const newKeys = parseJwks(jwksBody);   // throws JWKS_FETCH_FAILED
-    const newRevoked = parseKrl(krlBody);  // throws KRL_FETCH_FAILED
+    // Parse JWKS — throws JWKS_FETCH_FAILED on malformed input.
+    const newKeys = parseJwks(jwksBody);
 
-    // Atomic swap — only reached if both parses succeed.
+    // Process KRL according to configured mode.
+    const nowSeconds = this.nowFn();
+    const krlResult = this.processKrlForMode(krlBody, nowSeconds);
+
+    if (!krlResult.ok) {
+      // Update status to record failure before throwing (observability).
+      // lastReason is set to the specific KRL code; preserved until next refresh.
+      this._krlStatus = {
+        mode: this.krlMode,
+        lastIntegrity: "failed",
+        lastReason: krlResult.reason,
+        // Preserve previous active-state fields — the cache was not swapped.
+        unsignedFallbackActive: this._krlStatus.unsignedFallbackActive,
+        lastVerifiedAt: this._krlStatus.lastVerifiedAt,
+        lastKrlVersionByIssuer: Object.fromEntries(this.krlVersionByIssuer),
+      };
+      throw krlResult.error;
+    }
+
+    // Both parses and all integrity checks succeeded — atomic cache swap.
     this.keyCache = newKeys;
-    this.revokedKids = newRevoked;
+    this.revokedKids = krlResult.revoked;
+
+    // Update per-issuer krl_version high-watermark for signed KRLs.
+    if (krlResult.updatedVersion) {
+      this.krlVersionByIssuer.set(
+        krlResult.updatedVersion.issuer,
+        krlResult.updatedVersion.krl_version
+      );
+    }
+
+    // Update status — lastReason is ALWAYS cleared on success.
+    this._krlStatus = {
+      mode: this.krlMode,
+      lastIntegrity: krlResult.integrity,
+      lastReason: undefined,
+      unsignedFallbackActive: krlResult.integrity === "unsigned_fallback",
+      lastVerifiedAt: nowSeconds,
+      lastKrlVersionByIssuer: Object.fromEntries(this.krlVersionByIssuer),
+    };
+  }
+
+  // ─── Private: KRL mode routing ──────────────────────────────────────────────
+
+  private processKrlForMode(
+    krlBody: unknown,
+    nowSeconds: number
+  ): KrlProcessResult {
+    // unsigned_legacy: preserve pre-Patch-B behavior exactly.
+    if (this.krlMode === "unsigned_legacy") {
+      try {
+        const revoked = parseKrl(krlBody);
+        return { ok: true, revoked, integrity: "unsigned_legacy" };
+      } catch (err) {
+        const error =
+          err instanceof KeyStoreError
+            ? err
+            : new KeyStoreError("KRL_FETCH_FAILED", `KRL parse error: ${String(err)}`);
+        return { ok: false, reason: error.code, error };
+      }
+    }
+
+    const hasSig = hasSignatureField(krlBody);
+
+    // signed_required: any KRL without a signature field is rejected immediately,
+    // BEFORE consulting verifyKrl. This ensures verifyKrl is never called for
+    // unsigned KRLs in this mode (no bypass path).
+    if (this.krlMode === "signed_required") {
+      if (!hasSig) {
+        const error = new KeyStoreError(
+          "KRL_FETCH_FAILED",
+          `${KRL_UNSIGNED_IN_SIGNED_REQUIRED}: The fetched KRL does not contain a ` +
+          `signature field. Configure the KRL publisher to produce signed KRLs ` +
+          `(SignedKRLV1), or downgrade to "signed_preferred" or "unsigned_legacy" mode.`
+        );
+        return { ok: false, reason: KRL_UNSIGNED_IN_SIGNED_REQUIRED, error };
+      }
+      // verifyKrl is guaranteed non-null (checked at construction).
+      return this.runVerifyKrl(krlBody, nowSeconds);
+    }
+
+    // signed_preferred: route on signature field presence.
+    if (hasSig) {
+      if (!this.verifyKrl) {
+        // KRL has a signature field but no verifyKrl configured — fail closed.
+        // Do NOT fall back to unsigned: presence of signature means the KRL is
+        // attempting the signed path. A fallback would create a downgrade vector.
+        const error = new KeyStoreError(
+          "KRL_FETCH_FAILED",
+          `${KRL_MISSING_VERIFY_CALLBACK}: The fetched KRL contains a signature field ` +
+          `but no verifyKrl callback is configured. Provide a verifyKrl callback to ` +
+          `verify signed KRLs, or configure krlMode "unsigned_legacy" if signature ` +
+          `verification is not yet required.`
+        );
+        return { ok: false, reason: KRL_MISSING_VERIFY_CALLBACK, error };
+      }
+      return this.runVerifyKrl(krlBody, nowSeconds);
+    }
+
+    // signed_preferred + no signature field → unsigned fallback.
+    // verifyKrl is NOT consulted (unsigned KRL path skips it entirely).
+    try {
+      const revoked = parseKrl(krlBody);
+      return { ok: true, revoked, integrity: "unsigned_fallback" };
+    } catch (err) {
+      const error =
+        err instanceof KeyStoreError
+          ? err
+          : new KeyStoreError("KRL_FETCH_FAILED", `KRL parse error: ${String(err)}`);
+      return { ok: false, reason: error.code, error };
+    }
+  }
+
+  /** Calls verifyKrl callback and translates the result into a KrlProcessResult. */
+  private runVerifyKrl(krlBody: unknown, nowSeconds: number): KrlProcessResult {
+    const prevVersions: Record<string, number> = Object.fromEntries(this.krlVersionByIssuer);
+
+    let verifyResult: ReturnType<KrlVerifyFn>;
+    try {
+      verifyResult = this.verifyKrl!(krlBody, {
+        now: nowSeconds,
+        previousKrlVersionByIssuer: prevVersions,
+      });
+    } catch (err) {
+      const error = new KeyStoreError(
+        "KRL_FETCH_FAILED",
+        `verifyKrl callback threw unexpectedly: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return { ok: false, reason: "KRL_VERIFY_CALLBACK_ERROR", error };
+    }
+
+    if (!verifyResult.ok) {
+      const code = verifyResult.violations[0]?.code ?? "KRL_SIG_INVALID";
+      const msg = verifyResult.violations[0]?.message ?? "signed KRL verification failed";
+      const error = new KeyStoreError("KRL_FETCH_FAILED", `${code}: ${msg}`);
+      return { ok: false, reason: code, error };
+    }
+
+    // Verification succeeded — watermark MUST come from result.accepted, never
+    // from an independent re-parse of krlBody.  If the caller omits accepted,
+    // fail closed rather than silently skipping watermark advancement.
+    if (!verifyResult.accepted) {
+      const error = new KeyStoreError(
+        "KRL_FETCH_FAILED",
+        `${KRL_VERIFY_RESULT_INCOMPLETE}: verifyKrl returned ok: true but did not include ` +
+        `accepted issuer/krl_version metadata. Production wiring must populate ` +
+        `result.accepted from the verified SignedKRLV1 payload fields.`
+      );
+      return { ok: false, reason: KRL_VERIFY_RESULT_INCOMPLETE, error };
+    }
+
+    const revoked = extractRevokedKidsFromVerified(krlBody);
+    return {
+      ok: true,
+      revoked,
+      integrity: "signed",
+      updatedVersion: verifyResult.accepted,
+    };
   }
 }
 
@@ -278,7 +707,7 @@ export interface CreateStagingKeyStoreOptions {
 
 /**
  * Returns a new `SiftHttpKeyStore` pre-configured for the Sift **staging**
- * endpoints.  No network calls are made at construction time.
+ * endpoints with the default krlMode of "signed_preferred".
  *
  * @internal
  *
@@ -296,6 +725,8 @@ export interface CreateStagingKeyStoreOptions {
  * const keyStore = new SiftHttpKeyStore({
  *   jwksUrl: "https://your-production-sift-host/sift-jwks.json",
  *   krlUrl:  "https://your-production-sift-host/sift-krl.json",
+ *   krlMode: "signed_required",
+ *   verifyKrl: (payload, ctx) => verifySignedKrl(payload, { trustedKeySets, ...ctx }),
  * });
  * ```
  *

--- a/packages/sift/test/siftKeyStore.krl-modes.test.ts
+++ b/packages/sift/test/siftKeyStore.krl-modes.test.ts
@@ -1,0 +1,809 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * KRL integrity mode tests for SiftHttpKeyStore.
+ *
+ * Tests the three KRL modes (signed_required, signed_preferred, unsigned_legacy)
+ * and their interaction with the verifyKrl callback, now injection, version
+ * watermark tracking, and the getKrlStatus() surface.
+ *
+ * All tests use mock fetch and mock verifyKrl callbacks.  No real cryptographic
+ * signing is needed here — the verifyKrl mock simulates the responses that
+ * verifySignedKrl from @oxdeai/core would produce, and the routing logic of
+ * SiftHttpKeyStore is what is under test.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  SiftHttpKeyStore,
+  KeyStoreError,
+  type KrlVerifyFn,
+} from "../src/siftKeyStore.js";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const JWKS_URL = "https://sift-test.example/sift-jwks.json";
+const KRL_URL  = "https://sift-test.example/sift-krl.json";
+
+// RFC 8037 Appendix A test vector (32-byte Ed25519 public key)
+const RFC8037_X   = "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo";
+const RFC8037_KID = "key-rfc8037";
+
+const VALID_JWKS = {
+  keys: [{ kty: "OKP", crv: "Ed25519", kid: RFC8037_KID, x: RFC8037_X }],
+};
+
+// Fixed clock — 2026-04-14T12:00:00Z in unix seconds.
+const TEST_NOW = 1744632000;
+
+// ─── KRL body fixtures ────────────────────────────────────────────────────────
+
+// Unsigned KRL — no "signature" key.  Used for unsigned_legacy and
+// signed_preferred unsigned-fallback paths.
+const UNSIGNED_KRL_EMPTY = {
+  version: 1,
+  issuer: "sift-staging",
+  revoked_kids: [] as string[],
+};
+
+const UNSIGNED_KRL_WITH_REVOKED = {
+  ...UNSIGNED_KRL_EMPTY,
+  revoked_kids: ["revoked-kid-1"],
+};
+
+// Signed KRL shape — has a "signature" key, triggering the signed path.
+// The actual sig bytes are placeholders; verifyKrl is always mocked.
+const SIGNED_KRL_EMPTY = {
+  version: "SignedKRLV1",
+  issuer: "krl-issuer",
+  krl_version: 1,
+  issued_at: TEST_NOW - 60,
+  not_after: TEST_NOW + 3600,
+  revoked_kids: [] as string[],
+  signature: { alg: "Ed25519", kid: "krl-key-1", sig: "placeholder-sig" },
+};
+
+const SIGNED_KRL_WITH_REVOKED = {
+  ...SIGNED_KRL_EMPTY,
+  revoked_kids: ["revoked-kid-1"],
+};
+
+const SIGNED_KRL_VERSION_5 = {
+  ...SIGNED_KRL_EMPTY,
+  krl_version: 5,
+};
+
+// KRL with a partial/malformed signature field — still triggers signed path
+const KRL_PARTIAL_SIG = {
+  ...UNSIGNED_KRL_EMPTY,
+  signature: {},  // has the key "signature" → signed path
+};
+
+// ─── Mock factories ───────────────────────────────────────────────────────────
+
+type MockResponse = { status: number; body: unknown } | { status: number; error: string };
+
+function makeFetch(routes: Record<string, MockResponse>): typeof globalThis.fetch {
+  return async (input: string | URL | Request) => {
+    const url =
+      typeof input === "string" ? input
+      : input instanceof URL ? input.toString()
+      : input.url;
+    const route = routes[url];
+    if (!route) return new Response(null, { status: 404 }) as Response;
+    if ("error" in route) throw new Error(route.error);
+    return new Response(JSON.stringify(route.body), {
+      status: route.status,
+      headers: { "content-type": "application/json" },
+    }) as Response;
+  };
+}
+
+function happyJwks(): Record<string, MockResponse> {
+  return { [JWKS_URL]: { status: 200, body: VALID_JWKS } };
+}
+
+function routesFor(krlBody: unknown): Record<string, MockResponse> {
+  return {
+    ...happyJwks(),
+    [KRL_URL]: { status: 200, body: krlBody },
+  };
+}
+
+/** Creates a verifyKrl spy that records calls and returns a fixed result. */
+function makeKrlSpy(
+  result: { ok: boolean; violations: Array<{ code: string; message?: string }> }
+): { spy: KrlVerifyFn; calls: { n: number } } {
+  const calls = { n: 0 };
+  const spy: KrlVerifyFn = (_payload, _ctx) => {
+    calls.n++;
+    return result;
+  };
+  return { spy, calls };
+}
+
+// Successful verifyKrl result including accepted metadata.
+// accepted is required by SiftHttpKeyStore to advance the krl_version watermark.
+const KRL_OK = {
+  ok:         true as const,
+  violations: [] as Array<{ code: string; message?: string }>,
+  accepted:   { issuer: "krl-issuer", krl_version: 1 },   // matches SIGNED_KRL_EMPTY
+};
+
+// Variant for SIGNED_KRL_VERSION_5 (krl_version=5) — used in KM-21
+const KRL_OK_V5 = {
+  ...KRL_OK,
+  accepted: { issuer: "krl-issuer", krl_version: 5 },
+};
+
+function krlFail(code: string, message = "verification failed") {
+  return { ok: false, violations: [{ code, message }] };
+}
+
+// ─── KM-1: signed_required without verifyKrl fails at construction ─────────────
+
+test("KM-1: signed_required without verifyKrl throws TypeError at construction", () => {
+  assert.throws(
+    () => new SiftHttpKeyStore({ jwksUrl: JWKS_URL, krlUrl: KRL_URL, krlMode: "signed_required" }),
+    (err: unknown) => {
+      assert.ok(err instanceof TypeError, `expected TypeError, got ${err}`);
+      assert.ok((err as TypeError).message.includes("verifyKrl"), `unexpected message: ${(err as TypeError).message}`);
+      return true;
+    }
+  );
+});
+
+// ─── KM-2: unsigned_legacy emits deprecation status ──────────────────────────
+
+test("KM-2: unsigned_legacy accepted with unsigned_legacy integrity status", async () => {
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "unsigned_legacy",
+    fetch: makeFetch(routesFor(UNSIGNED_KRL_EMPTY)),
+    now: () => TEST_NOW,
+  });
+  await store.refresh();
+  const status = store.getKrlStatus();
+  assert.strictEqual(status.mode, "unsigned_legacy");
+  assert.strictEqual(status.lastIntegrity, "unsigned_legacy");
+  assert.strictEqual(status.unsignedFallbackActive, false);
+  assert.strictEqual(status.lastReason, undefined);
+  assert.strictEqual(status.lastVerifiedAt, TEST_NOW);
+});
+
+// ─── KM-3: valid signed KRL accepted in signed_required ──────────────────────
+
+test("KM-3: valid signed KRL accepted in signed_required", async () => {
+  const { spy, calls } = makeKrlSpy(KRL_OK);
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_required",
+    verifyKrl: spy,
+    fetch: makeFetch(routesFor(SIGNED_KRL_EMPTY)),
+    now: () => TEST_NOW,
+  });
+  await store.refresh();
+  assert.strictEqual(calls.n, 1, "verifyKrl must be called once");
+  assert.strictEqual(store.getKrlStatus().lastIntegrity, "signed");
+  assert.strictEqual(store.getKrlStatus().lastReason, undefined);
+});
+
+// ─── KM-4: invalid signed KRL rejected (KRL_SIG_INVALID) ─────────────────────
+
+test("KM-4: invalid signed KRL rejected with KRL_SIG_INVALID in signed_required", async () => {
+  const { spy, calls } = makeKrlSpy(krlFail("KRL_SIG_INVALID", "signature mismatch"));
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_required",
+    verifyKrl: spy,
+    fetch: makeFetch(routesFor(SIGNED_KRL_EMPTY)),
+    now: () => TEST_NOW,
+  });
+  await assert.rejects(
+    () => store.refresh(),
+    (err: unknown) => {
+      assert.ok(err instanceof KeyStoreError);
+      assert.strictEqual(err.code, "KRL_FETCH_FAILED");
+      assert.ok(err.message.includes("KRL_SIG_INVALID"));
+      return true;
+    }
+  );
+  assert.strictEqual(calls.n, 1, "verifyKrl must be called");
+  assert.strictEqual(store.getKrlStatus().lastIntegrity, "failed");
+  assert.strictEqual(store.getKrlStatus().lastReason, "KRL_SIG_INVALID");
+});
+
+// ─── KM-5: expired signed KRL rejected ───────────────────────────────────────
+
+test("KM-5: expired signed KRL rejected with KRL_EXPIRED", async () => {
+  const { spy } = makeKrlSpy(krlFail("KRL_EXPIRED", "KRL has expired"));
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_required",
+    verifyKrl: spy,
+    fetch: makeFetch(routesFor(SIGNED_KRL_EMPTY)),
+    now: () => TEST_NOW,
+  });
+  await assert.rejects(() => store.refresh());
+  assert.strictEqual(store.getKrlStatus().lastReason, "KRL_EXPIRED");
+});
+
+// ─── KM-6: unsupported alg rejected ──────────────────────────────────────────
+
+test("KM-6: unsupported alg rejected with KRL_UNSUPPORTED_ALG in signed_preferred", async () => {
+  const { spy } = makeKrlSpy(krlFail("KRL_UNSUPPORTED_ALG", "only Ed25519 is supported"));
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl: spy,
+    fetch: makeFetch(routesFor(SIGNED_KRL_EMPTY)),
+    now: () => TEST_NOW,
+  });
+  await assert.rejects(() => store.refresh());
+  assert.strictEqual(store.getKrlStatus().lastReason, "KRL_UNSUPPORTED_ALG");
+});
+
+// ─── KM-7: unknown signing kid rejected ──────────────────────────────────────
+
+test("KM-7: unknown signing kid rejected with KRL_UNKNOWN_SIGNING_KID", async () => {
+  const { spy } = makeKrlSpy(krlFail("KRL_UNKNOWN_SIGNING_KID", "kid not found"));
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl: spy,
+    fetch: makeFetch(routesFor(SIGNED_KRL_EMPTY)),
+    now: () => TEST_NOW,
+  });
+  await assert.rejects(() => store.refresh());
+  assert.strictEqual(store.getKrlStatus().lastReason, "KRL_UNKNOWN_SIGNING_KID");
+});
+
+// ─── KM-8: inactive signing key rejected ─────────────────────────────────────
+
+test("KM-8: inactive signing key rejected with KRL_SIGNING_KEY_INACTIVE", async () => {
+  const { spy } = makeKrlSpy(krlFail("KRL_SIGNING_KEY_INACTIVE", "key is revoked"));
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl: spy,
+    fetch: makeFetch(routesFor(SIGNED_KRL_EMPTY)),
+    now: () => TEST_NOW,
+  });
+  await assert.rejects(() => store.refresh());
+  assert.strictEqual(store.getKrlStatus().lastReason, "KRL_SIGNING_KEY_INACTIVE");
+});
+
+// ─── KM-9: version regression rejected ───────────────────────────────────────
+
+test("KM-9: version regression rejected with KRL_VERSION_REGRESSION", async () => {
+  const { spy } = makeKrlSpy(krlFail("KRL_VERSION_REGRESSION", "version went backwards"));
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl: spy,
+    fetch: makeFetch(routesFor(SIGNED_KRL_EMPTY)),
+    now: () => TEST_NOW,
+  });
+  await assert.rejects(() => store.refresh());
+  assert.strictEqual(store.getKrlStatus().lastReason, "KRL_VERSION_REGRESSION");
+});
+
+// ─── KM-10: unsigned KRL in signed_required rejected WITHOUT calling verifyKrl ─
+
+test("KM-10: unsigned KRL in signed_required rejected before verifyKrl is consulted", async () => {
+  const { spy, calls } = makeKrlSpy(KRL_OK);  // spy that would pass if called
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_required",
+    verifyKrl: spy,
+    fetch: makeFetch(routesFor(UNSIGNED_KRL_EMPTY)),  // no signature field
+    now: () => TEST_NOW,
+  });
+
+  await assert.rejects(
+    () => store.refresh(),
+    (err: unknown) => {
+      assert.ok(err instanceof KeyStoreError);
+      assert.strictEqual(err.code, "KRL_FETCH_FAILED");
+      assert.ok(err.message.includes("KRL_UNSIGNED_IN_SIGNED_REQUIRED"),
+        `expected KRL_UNSIGNED_IN_SIGNED_REQUIRED in message, got: ${err.message}`);
+      return true;
+    }
+  );
+
+  // CRITICAL: verifyKrl must NOT have been called — unsigned detection happens first
+  assert.strictEqual(calls.n, 0, "verifyKrl must NOT be called when unsigned KRL is rejected in signed_required");
+
+  assert.strictEqual(store.getKrlStatus().lastIntegrity, "failed");
+  assert.strictEqual(store.getKrlStatus().lastReason, "KRL_UNSIGNED_IN_SIGNED_REQUIRED");
+});
+
+// ─── KM-11: signed KRL in signed_preferred with no verifyKrl fails closed ────
+
+test("KM-11: signed KRL in signed_preferred with no verifyKrl fails closed", async () => {
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    // No verifyKrl configured
+    fetch: makeFetch(routesFor(SIGNED_KRL_EMPTY)),
+    now: () => TEST_NOW,
+  });
+
+  await assert.rejects(
+    () => store.refresh(),
+    (err: unknown) => {
+      assert.ok(err instanceof KeyStoreError);
+      assert.strictEqual(err.code, "KRL_FETCH_FAILED");
+      assert.ok(err.message.includes("KRL_MISSING_VERIFY_CALLBACK") ||
+                err.message.toLowerCase().includes("no verifyKrl"),
+        `unexpected message: ${(err as Error).message}`);
+      return true;
+    }
+  );
+
+  assert.strictEqual(store.getKrlStatus().lastIntegrity, "failed");
+});
+
+// ─── KM-12: unsigned KRL accepted in signed_preferred WITHOUT calling verifyKrl
+
+test("KM-12: unsigned KRL in signed_preferred uses unsigned fallback, verifyKrl spy not called", async () => {
+  // Configure a spy even though the KRL is unsigned — to prove it is NOT called.
+  const { spy, calls } = makeKrlSpy(KRL_OK);
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl: spy,
+    fetch: makeFetch(routesFor(UNSIGNED_KRL_EMPTY)),  // no signature field
+    now: () => TEST_NOW,
+  });
+
+  await store.refresh();
+
+  // CRITICAL: verifyKrl must NOT be called — unsigned fallback routes around it
+  assert.strictEqual(calls.n, 0,
+    "verifyKrl must NOT be called for unsigned KRL in signed_preferred unsigned fallback");
+
+  const status = store.getKrlStatus();
+  assert.strictEqual(status.lastIntegrity, "unsigned_fallback");
+  assert.strictEqual(status.unsignedFallbackActive, true);
+  assert.strictEqual(status.lastReason, undefined);
+  assert.strictEqual(status.lastVerifiedAt, TEST_NOW);
+});
+
+// ─── KM-13: partial/malformed signature field in signed_preferred fails closed
+
+test("KM-13: partial signature field ({}) in signed_preferred fails closed (no unsigned fallback)", async () => {
+  // KRL_PARTIAL_SIG has `signature: {}` — has the key "signature" → signed path.
+  // No verifyKrl configured → KRL_MISSING_VERIFY_CALLBACK.
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    // No verifyKrl
+    fetch: makeFetch(routesFor(KRL_PARTIAL_SIG)),
+    now: () => TEST_NOW,
+  });
+
+  await assert.rejects(
+    () => store.refresh(),
+    (err: unknown) => {
+      assert.ok(err instanceof KeyStoreError);
+      assert.strictEqual(err.code, "KRL_FETCH_FAILED");
+      return true;
+    }
+  );
+  // Must NOT fall back to unsigned even though the KRL body is "unsigned-like"
+  assert.strictEqual(store.getKrlStatus().lastIntegrity, "failed");
+});
+
+// ─── KM-14: unsigned_legacy preserves current behavior ────────────────────────
+
+test("KM-14: unsigned_legacy mode parses revoked_kids, non-strings silently skipped", async () => {
+  const krlBody = {
+    version: 1,
+    issuer: "sift-staging",
+    revoked_kids: ["kid-string-1", 42, null, "kid-string-2"],  // mixed types
+  };
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "unsigned_legacy",
+    fetch: makeFetch(routesFor(krlBody)),
+    now: () => TEST_NOW,
+  });
+
+  await store.refresh();
+
+  // String entries added; non-strings skipped (legacy behavior)
+  assert.strictEqual(await store.isKidRevoked("kid-string-1"), true);
+  assert.strictEqual(await store.isKidRevoked("kid-string-2"), true);
+  assert.strictEqual(await store.isKidRevoked("42"), false);
+
+  const status = store.getKrlStatus();
+  assert.strictEqual(status.lastIntegrity, "unsigned_legacy");
+  assert.strictEqual(status.lastReason, undefined);
+});
+
+// ─── KM-15: revoked kid blocked in signed_required ────────────────────────────
+
+test("KM-15: revoked kid blocked after signed KRL accepted in signed_required", async () => {
+  const { spy } = makeKrlSpy(KRL_OK);
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_required",
+    verifyKrl: spy,
+    fetch: makeFetch(routesFor(SIGNED_KRL_WITH_REVOKED)),
+    now: () => TEST_NOW,
+  });
+
+  await store.refresh();
+  assert.strictEqual(await store.isKidRevoked("revoked-kid-1"), true);
+  assert.strictEqual(await store.isKidRevoked("other-kid"), false);
+});
+
+// ─── KM-16: revoked kid blocked in signed_preferred (signed path) ─────────────
+
+test("KM-16: revoked kid blocked after signed KRL accepted in signed_preferred", async () => {
+  const { spy } = makeKrlSpy(KRL_OK);
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl: spy,
+    fetch: makeFetch(routesFor(SIGNED_KRL_WITH_REVOKED)),
+    now: () => TEST_NOW,
+  });
+
+  await store.refresh();
+  assert.strictEqual(await store.isKidRevoked("revoked-kid-1"), true);
+});
+
+// ─── KM-17: revoked kid blocked in signed_preferred unsigned fallback ──────────
+
+test("KM-17: revoked kid blocked in signed_preferred unsigned fallback, verifyKrl spy not called", async () => {
+  // Configure a spy even though the KRL is unsigned — to prove it is NOT called.
+  const { spy, calls } = makeKrlSpy(KRL_OK);
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl: spy,
+    fetch: makeFetch(routesFor(UNSIGNED_KRL_WITH_REVOKED)),  // no signature field
+    now: () => TEST_NOW,
+  });
+
+  await store.refresh();
+
+  // CRITICAL: verifyKrl must NOT be called on the unsigned fallback path
+  assert.strictEqual(calls.n, 0,
+    "verifyKrl must NOT be called for unsigned fallback revocation path");
+
+  assert.strictEqual(await store.isKidRevoked("revoked-kid-1"), true);
+  assert.strictEqual(store.getKrlStatus().lastIntegrity, "unsigned_fallback");
+});
+
+// ─── KM-18: revoked kid blocked in unsigned_legacy ───────────────────────────
+
+test("KM-18: revoked kid blocked in unsigned_legacy mode", async () => {
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "unsigned_legacy",
+    fetch: makeFetch(routesFor(UNSIGNED_KRL_WITH_REVOKED)),
+    now: () => TEST_NOW,
+  });
+
+  await store.refresh();
+  assert.strictEqual(await store.isKidRevoked("revoked-kid-1"), true);
+});
+
+// ─── KM-19: now injection is passed to verifyKrl ─────────────────────────────
+
+test("KM-19: now provider value is passed to verifyKrl ctx.now", async () => {
+  const CUSTOM_NOW = 1744550000;
+  let capturedNow: number | undefined;
+
+  const verifyKrl: KrlVerifyFn = (_payload, ctx) => {
+    capturedNow = ctx.now;
+    return { ok: true, violations: [], accepted: { issuer: "krl-issuer", krl_version: 1 } };
+  };
+
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl,
+    fetch: makeFetch(routesFor(SIGNED_KRL_EMPTY)),
+    now: () => CUSTOM_NOW,
+  });
+
+  await store.refresh();
+  assert.strictEqual(capturedNow, CUSTOM_NOW, "ctx.now must match the injected now provider");
+});
+
+// ─── KM-20: previousKrlVersionByIssuer watermark is passed to verifyKrl ──────
+
+test("KM-20: krl_version watermark is passed to verifyKrl on second refresh", async () => {
+  const capturedPrev: Array<Record<string, number>> = [];
+  let callCount = 0;
+
+  const verifyKrl: KrlVerifyFn = (_payload, ctx) => {
+    callCount++;
+    capturedPrev.push({ ...ctx.previousKrlVersionByIssuer });
+    return { ok: true, violations: [], accepted: { issuer: "krl-issuer", krl_version: 1 } };
+  };
+
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl,
+    fetch: makeFetch(routesFor(SIGNED_KRL_EMPTY)),  // krl_version=1, issuer="krl-issuer"
+    now: () => TEST_NOW,
+  });
+
+  // First refresh: no prior version known → empty previousKrlVersionByIssuer
+  await store.refresh();
+  assert.deepStrictEqual(capturedPrev[0], {},
+    "first refresh should have empty previousKrlVersionByIssuer");
+
+  // Second refresh: previous version=1 should be passed
+  await store.refresh();
+  assert.strictEqual(capturedPrev[1]["krl-issuer"], 1,
+    "second refresh should pass krl_version=1 as previous version for krl-issuer");
+
+  assert.strictEqual(callCount, 2);
+});
+
+// ─── KM-21: krlVersionByIssuer updated after successful signed KRL ─────────────
+
+test("KM-21: getKrlStatus().lastKrlVersionByIssuer updated after successful signed KRL", async () => {
+  // Use KRL_OK_V5 so result.accepted.krl_version=5, matching SIGNED_KRL_VERSION_5 body.
+  const { spy } = makeKrlSpy(KRL_OK_V5);
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl: spy,
+    fetch: makeFetch(routesFor(SIGNED_KRL_VERSION_5)),  // krl_version=5 in body
+    now: () => TEST_NOW,
+  });
+
+  // Before refresh: empty
+  assert.deepStrictEqual(store.getKrlStatus().lastKrlVersionByIssuer, {});
+
+  await store.refresh();
+
+  assert.strictEqual(
+    store.getKrlStatus().lastKrlVersionByIssuer["krl-issuer"],
+    5,
+    "lastKrlVersionByIssuer must reflect the accepted krl_version"
+  );
+});
+
+// ─── KM-22: lastIntegrity is "signed" after successful signed path ─────────────
+
+test("KM-22: getKrlStatus().lastIntegrity is \"signed\" after signed KRL success", async () => {
+  const { spy } = makeKrlSpy(KRL_OK);
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl: spy,
+    fetch: makeFetch(routesFor(SIGNED_KRL_EMPTY)),
+    now: () => TEST_NOW,
+  });
+
+  await store.refresh();
+  assert.strictEqual(store.getKrlStatus().lastIntegrity, "signed");
+  assert.strictEqual(store.getKrlStatus().unsignedFallbackActive, false);
+});
+
+// ─── KM-23: lastVerifiedAt is set to nowFn() after success ────────────────────
+
+test("KM-23: lastVerifiedAt is set to the current time on successful refresh", async () => {
+  const { spy } = makeKrlSpy(KRL_OK);
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl: spy,
+    fetch: makeFetch(routesFor(SIGNED_KRL_EMPTY)),
+    now: () => TEST_NOW,
+  });
+
+  assert.strictEqual(store.getKrlStatus().lastVerifiedAt, undefined, "should be undefined before refresh");
+
+  await store.refresh();
+  assert.strictEqual(store.getKrlStatus().lastVerifiedAt, TEST_NOW);
+});
+
+// ─── lastReason cleared on success after failure ──────────────────────────────
+
+test("lastReason is cleared to undefined when a later refresh succeeds", async () => {
+  let shouldFail = true;
+
+  const verifyKrl: KrlVerifyFn = (_payload, _ctx) => {
+    if (shouldFail) {
+      return { ok: false, violations: [{ code: "KRL_SIG_INVALID", message: "bad signature" }] };
+    }
+    return { ok: true, violations: [], accepted: { issuer: "krl-issuer", krl_version: 1 } };
+  };
+
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl,
+    fetch: makeFetch(routesFor(SIGNED_KRL_EMPTY)),
+    now: () => TEST_NOW,
+  });
+
+  // First refresh: fails → lastReason set
+  await assert.rejects(() => store.refresh());
+  assert.strictEqual(store.getKrlStatus().lastReason, "KRL_SIG_INVALID",
+    "lastReason must be set after failure");
+  assert.strictEqual(store.getKrlStatus().lastIntegrity, "failed");
+
+  // Second refresh: succeeds → lastReason MUST be cleared
+  shouldFail = false;
+  await store.refresh();
+  assert.strictEqual(store.getKrlStatus().lastReason, undefined,
+    "lastReason must be cleared to undefined after successful refresh");
+  assert.strictEqual(store.getKrlStatus().lastIntegrity, "signed");
+});
+
+// ─── lastReason cleared on unsigned fallback success ─────────────────────────
+
+test("lastReason is cleared on unsigned fallback success after prior failure", async () => {
+  // Build store in signed_preferred mode, no verifyKrl.
+  // First attempt: signed KRL (has signature) → fails (no verifyKrl).
+  // Second attempt: unsigned KRL (no signature) → unsigned fallback succeeds.
+  let serveSignedKrl = true;
+
+  const mockFetch: typeof globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : (input as URL).toString();
+    if (url === JWKS_URL) {
+      return new Response(JSON.stringify(VALID_JWKS), {
+        status: 200, headers: { "content-type": "application/json" },
+      }) as Response;
+    }
+    const body = serveSignedKrl ? SIGNED_KRL_EMPTY : UNSIGNED_KRL_EMPTY;
+    return new Response(JSON.stringify(body), {
+      status: 200, headers: { "content-type": "application/json" },
+    }) as Response;
+  };
+
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    // No verifyKrl — will fail for signed KRL, succeed for unsigned fallback
+    fetch: mockFetch,
+    now: () => TEST_NOW,
+  });
+
+  // First: fail (signed KRL, no verifyKrl)
+  await assert.rejects(() => store.refresh());
+  assert.ok(store.getKrlStatus().lastReason !== undefined, "lastReason must be set after failure");
+
+  // Second: succeed via unsigned fallback
+  serveSignedKrl = false;
+  await store.refresh();
+  assert.strictEqual(store.getKrlStatus().lastReason, undefined,
+    "lastReason must be cleared even on unsigned fallback success");
+  assert.strictEqual(store.getKrlStatus().lastIntegrity, "unsigned_fallback");
+});
+
+// ─── lastReason cleared on unsigned_legacy success ───────────────────────────
+
+test("lastReason remains undefined after unsigned_legacy refresh success", async () => {
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "unsigned_legacy",
+    fetch: makeFetch(routesFor(UNSIGNED_KRL_EMPTY)),
+    now: () => TEST_NOW,
+  });
+
+  await store.refresh();
+  assert.strictEqual(store.getKrlStatus().lastReason, undefined);
+});
+
+// ─── getKrlStatus() returns a snapshot (not mutable shared state) ─────────────
+
+test("getKrlStatus() returns an independent snapshot of lastKrlVersionByIssuer", async () => {
+  const { spy } = makeKrlSpy(KRL_OK);
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl: spy,
+    fetch: makeFetch(routesFor(SIGNED_KRL_EMPTY)),  // krl_version=1
+    now: () => TEST_NOW,
+  });
+
+  await store.refresh();
+  const snap1 = store.getKrlStatus();
+  assert.strictEqual(snap1.lastKrlVersionByIssuer["krl-issuer"], 1);
+
+  // Mutate the snapshot — store must not be affected
+  snap1.lastKrlVersionByIssuer["krl-issuer"] = 999;
+  const snap2 = store.getKrlStatus();
+  assert.strictEqual(snap2.lastKrlVersionByIssuer["krl-issuer"], 1,
+    "mutating the returned snapshot must not affect internal state");
+});
+
+// ─── signed_preferred + no now provider uses real clock (smoke test) ──────────
+
+test("signed_preferred with no now option uses real clock (smoke: lastVerifiedAt is positive integer)", async () => {
+  const before = Math.floor(Date.now() / 1000);
+  const { spy } = makeKrlSpy(KRL_OK);
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl: spy,
+    fetch: makeFetch(routesFor(SIGNED_KRL_EMPTY)),
+    // No `now` override — uses real clock
+  });
+
+  await store.refresh();
+  const after = Math.floor(Date.now() / 1000);
+  const verifiedAt = store.getKrlStatus().lastVerifiedAt;
+
+  assert.ok(verifiedAt !== undefined, "lastVerifiedAt must be set");
+  assert.ok(verifiedAt >= before, "lastVerifiedAt must be >= time before refresh");
+  assert.ok(verifiedAt <= after, "lastVerifiedAt must be <= time after refresh");
+});
+
+// ─── Existing behavior: default mode is signed_preferred (smoke) ───────────────
+
+test("default krlMode is signed_preferred", () => {
+  const store = new SiftHttpKeyStore({ jwksUrl: JWKS_URL, krlUrl: KRL_URL });
+  assert.strictEqual(store.getKrlStatus().mode, "signed_preferred");
+});
+
+// ─── KRL_VERIFY_RESULT_INCOMPLETE: ok: true without accepted fails closed ─────
+
+test("verifyKrl returning ok: true without accepted fails closed with KRL_VERIFY_RESULT_INCOMPLETE", async () => {
+  // verifyKrl returns ok: true but omits accepted — contract violation
+  const verifyKrl: KrlVerifyFn = () => ({ ok: true, violations: [] });
+
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl,
+    fetch: makeFetch(routesFor(SIGNED_KRL_EMPTY)),
+    now: () => TEST_NOW,
+  });
+
+  await assert.rejects(
+    () => store.refresh(),
+    (err: unknown) => {
+      assert.ok(err instanceof KeyStoreError);
+      assert.strictEqual(err.code, "KRL_FETCH_FAILED");
+      assert.ok(err.message.includes("KRL_VERIFY_RESULT_INCOMPLETE"),
+        `expected KRL_VERIFY_RESULT_INCOMPLETE in message, got: ${err.message}`);
+      return true;
+    }
+  );
+
+  assert.strictEqual(store.getKrlStatus().lastIntegrity, "failed");
+  assert.strictEqual(store.getKrlStatus().lastReason, "KRL_VERIFY_RESULT_INCOMPLETE");
+});
+
+// ─── Watermark sourced from result.accepted, not body re-parse ───────────────
+
+test("watermark advances from result.accepted, not an independent body re-parse", async () => {
+  // verifyKrl returns accepted.krl_version=99 while the body has krl_version=1.
+  // SiftHttpKeyStore must use result.accepted, so the watermark should be 99.
+  const verifyKrl: KrlVerifyFn = () => ({
+    ok: true,
+    violations: [],
+    accepted: { issuer: "krl-issuer", krl_version: 99 },  // differs from body krl_version=1
+  });
+
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl,
+    fetch: makeFetch(routesFor(SIGNED_KRL_EMPTY)),  // body has krl_version=1
+    now: () => TEST_NOW,
+  });
+
+  await store.refresh();
+
+  // Watermark must come from result.accepted (99), not from independent body re-parse (1)
+  assert.strictEqual(
+    store.getKrlStatus().lastKrlVersionByIssuer["krl-issuer"],
+    99,
+    "watermark must be sourced from result.accepted.krl_version, not body krl_version"
+  );
+});


### PR DESCRIPTION
## Summary

Closes #113.

Integrates `SignedKRLV1` verification into `SiftHttpKeyStore` with explicit KRL integrity modes.

Patch A added `SignedKRLV1` as a provider-neutral OxDeAI protocol artifact. This Patch B wires that artifact into the Sift / Profile B runtime path through callback injection, preserving the current `@oxdeai/sift` zero-dependency boundary from `@oxdeai/core`.

## What changed

- Added `krlMode` support:
  - `signed_required`
  - `signed_preferred`
  - `unsigned_legacy`
- Added structural `verifyKrl` callback injection
- Added optional `now` provider for deterministic tests
- Added `getKrlStatus()` status surface
- Added in-memory per-issuer `krl_version` watermark
- Updated watermark logic to use verified `accepted` metadata from `verifyKrl`, not KRL body re-parsing
- Added fail-closed handling for incomplete successful verifier results
- Preserved existing throw-without-cache-swap refresh behavior
- Added 31 KRL mode tests
- Updated Sift README
- Updated external-provider profile docs
- Updated audit with precise per-mode caveats

## Mode behavior

### `signed_required`

- unsigned KRL fails closed with `KRL_UNSIGNED_IN_SIGNED_REQUIRED`
- unsigned KRL is rejected before `verifyKrl` is called
- signed KRL must verify successfully
- invalid / expired / regressed / malformed signed KRL fails closed
- constructor fails fast if no `verifyKrl` callback is configured

### `signed_preferred`

- default transition mode
- signed KRL is verified when a `signature` field is present
- signed KRL without `verifyKrl` fails closed with `KRL_MISSING_VERIFY_CALLBACK`
- invalid signed KRL fails closed
- unsigned KRL is accepted as transport-only fallback
- unsigned fallback is surfaced through status:
  - `lastIntegrity: "unsigned_fallback"`
  - `unsignedFallbackActive: true`

### `unsigned_legacy`

- preserves current unsigned KRL behavior
- explicitly documented as transport-integrity-only
- deprecated with migration path toward signed KRL verification

## KRL reason-code ownership

Sift-local mode / contract codes:

- `KRL_UNSIGNED_IN_SIGNED_REQUIRED`
- `KRL_MISSING_VERIFY_CALLBACK`
- `KRL_VERIFY_CALLBACK_ERROR`
- `KRL_VERIFY_RESULT_INCOMPLETE`

Core-originated KRL reason codes are passed through from the injected `verifyKrl` callback as opaque strings.

`@oxdeai/sift` does not import `VerificationViolationCode` from `@oxdeai/core`.

## Security / boundary notes

`@oxdeai/sift` still does not import from `@oxdeai/core`.

The status surface does not expose key material, public-key PEM contents, private keys, raw signature bytes, full KRL payloads, or trusted signing key material.

`lastReason` is failure-only and is cleared on every successful accepted KRL.

## Validation

- `pnpm --filter @oxdeai/sift test`: 150/150 passing
- `pnpm -C packages/conformance validate`: 209/209 assertions passing
- `pnpm test:vectors:all`: passing
- `pnpm typecheck`: passing
- `pnpm test`: passing
- `pnpm security:gate`: ALLOW
- `packages/core/API_FINGERPRINT`: unchanged

## Residual limitations

- The KRL transport-integrity gap is closed only for deployments using `signed_required` with a configured `verifyKrl` callback.
- `signed_preferred` unsigned fallback and `unsigned_legacy` retain residual transport-trust risk.
- `krl_version` high-watermark is in-memory only and resets on process restart.
- No persistent last-known-good cache in this patch.
- No cross-language SignedKRLV1 harness coverage yet.