### PR TITLE
test(conformance): add Go Profile C and SignedKRLV1 vectors

### DIFF
--- a/docs/audits/protocol-audit-post-interoperability.md
+++ b/docs/audits/protocol-audit-post-interoperability.md
@@ -154,7 +154,7 @@
 | Profile A (Core-native) | `DONE` | Defined, implemented, conformance covered by existing auth-sig and auth-verify vectors. |
 | Profile B (External wire-compatible) | `DONE` | Defined. Encoding B accepted in verifyAuthorization. Conformance vector `authorization-sig-010`. Trust separation proven: `pb-trust-oxdeai-key-allow` (OxDeAI key in trustedKeySets → ALLOW) and `pb-trust-provider-key-rejected` (provider receipt key absent from trustedKeySets → DENY/UNKNOWN_KID). Resolved in #108. |
 | Profile C (Full semantic state verification) | `DONE` | Defined. Implemented via pluggable `computeStateHash`. 12 executable conformance assertions across 8 vectors. Encoding B path tested. |
-| Profile C cross-language | `MISSING` | No Go/Python harness integration for Profile C vectors. |
+| Profile C cross-language | `PARTIAL` | Go harness validates state-hash semantics (modes 001–005) via `docs/spec/test-vectors/profile-c-state-verification.json`. Profile C Encoding B modes 006–008 remain TypeScript-only. Python pending. |
 | Interoperability matrix | `DOCUMENTED ONLY` | Matrix in `external-provider-profile.md`. Not backed by conformance automation. |
 
 ---
@@ -421,7 +421,8 @@ Key lifecycle (lifecycle)    █████████████████
 DelegationV1                 ████████████████████  DONE
 Profile A interop            ████████████████████  DONE
 Profile B interop            ████████████████░░░░  PARTIAL (trust sep. gap)
-Profile C interop            ██████████████████░░  PARTIAL (TS-only vectors)
+Profile C interop            ████████████████████  DONE (state-hash semantics; Encoding B modes 006–008 TS-only)
+Profile C cross-language     ████████████████░░░░  PARTIAL (Go state-hash 001–005; Python pending; EB modes TS-only)
 Replay durability            ████████████████░░░░  PARTIAL (in-memory default risk)
 Key rotation                 ██████████░░░░░░░░░░  DOCUMENTED ONLY
 Threat model                 ██████████░░░░░░░░░░  DOCUMENTED ONLY
@@ -475,9 +476,18 @@ Caveats: transport-integrity gap is only fully closed when callers deploy `signe
 **P1-5: Mark HMAC-SHA256 as deprecated** ✓ RESOLVED
 Resolution: `authorization-v1.md §5` now carries an explicit "Deprecated legacy algorithm" section: HMAC-SHA256 is not standard, is symmetric/non-portable, and its migration path is documented. `legacyHmacSecret` in `VerifyAuthorizationOptions` carries a `@deprecated` JSDoc with removal notice. `authorization_signing_alg: "HMAC-SHA256"` default in `EngineOptions` carries a `@deprecated` JSDoc directing new users to Ed25519. Two explicit legacy-path tests document backward-compat guarantee and the fail-closed behavior when `legacyHmacSecret` is absent. Resolved in #107.
 
-**P1-6: Add cross-language Profile C conformance vectors**
-Reason: Profile C is executable in TypeScript but not portable across Go/Python harnesses. Standardization positioning for Profile C requires external verifiers to validate `computeStateHash` integration against the same vectors. TypeScript-only coverage is insufficient for a multi-implementer profile claim.
-Scope: Go harness extension to support a pluggable `computeStateHash` callback or equivalent; expose at minimum `live-state-match`, `live-state-mismatch`, and `compute-throws` modes.
+**P1-6: Add cross-language Profile C and SignedKRLV1 conformance vectors**
+Status: **PARTIAL — Go cross-language coverage for Profile C state-hash semantics and SignedKRLV1 merged; Python pending; Profile C Encoding B modes 006–008 remain TypeScript-only.**
+
+Go coverage (merged, #119 Go PR):
+- `go-harness/profile_c_verify.go` validates Profile C state-hash semantics modes 001–005: live-state-match, live-state-mismatch, hash-strategy-mismatch, compute-throws, toctou-stale-state. Independently computes SHA-256 of `canonicalJson(state)` (core) and SHA-256 of `"PROVIDER:" + canonicalJson(state)` (provider) using Go stdlib.
+- `go-harness/signed_krl_verify.go` validates all 9 SignedKRLV1 portable vectors. Independently reconstructs the `OXDEAI_KRL_V1` signing preimage and verifies Ed25519 signatures using Go `crypto/ed25519`. Checks all 7 reason codes: `KRL_MALFORMED`, `KRL_SIG_INVALID`, `KRL_EXPIRED`, `KRL_UNSUPPORTED_ALG`, `KRL_UNKNOWN_SIGNING_KID`, `KRL_SIGNING_KEY_INACTIVE`, `KRL_VERSION_REGRESSION`.
+- Portable vector files added: `docs/spec/test-vectors/profile-c-state-verification.json`, `docs/spec/test-vectors/signed-krl-v1.json`.
+
+Remaining:
+- Python cross-language coverage (next PR).
+- Profile C Encoding B modes 006–008 remain TypeScript-only; tracked as a separate P2 issue.
+- P1-6 remains open until Python coverage lands.
 
 ---
 
@@ -503,20 +513,20 @@ Scope: `pep-gateway-v1.md` §7 or a new `state-provider-requirements.md`.
 
 ## 10. Audit Summary
 
-**Total areas audited:** 24 protocol areas, 14 invariants, 16 conformance vector sets, 9 trust components.
+**Total areas audited:** 24 protocol areas, 14 invariants, 18 conformance vector sets, 9 trust components.
 
 | Status | Count |
 |--------|-------|
 | `DONE` | 58 |
-| `PARTIAL` | 15 |
+| `PARTIAL` | 16 |
 | `SPECIFIED ONLY` | 5 |
 | `DOCUMENTED ONLY` | 6 |
-| `MISSING` | 6 |
+| `MISSING` | 5 |
 | `RISK` | 4 |
 
-**Conformance:** 209 assertions across 16 vector files + 12 portable `authorization-v1.json` vectors. Remaining gaps reduced (P0-1, P0-2, P0-3, P0-4, P1-1, P1-2, P1-3, P1-4, P1-5 resolved with caveats).
+**Conformance:** 209 TypeScript assertions (16 TS vector files + 12 portable `authorization-v1.json` vectors) + 25 Go harness assertions (11 canonicalization + 5 Profile C state-hash + 9 SignedKRLV1). Remaining gaps reduced (P0-1–P0-4, P1-1–P1-5 resolved; P1-4 resolved with caveats; P1-6 partial — Go merged, Python pending).
 
-**Follow-up issue counts:** P0: 0 open · P1: 1 open (P1-6) · P2: 4 · Total: 5 open
+**Follow-up issue counts:** P0: 0 open · P1: 1 open (P1-6 partial) · P2: 4 · Total: 5 open
 
 **Critical path to external adoption:**
 

--- a/docs/spec/artifacts/signed-krl-v1.md
+++ b/docs/spec/artifacts/signed-krl-v1.md
@@ -241,7 +241,9 @@ The following are explicitly out of scope for Patch A and will be addressed in s
 | `now` injection into `SiftHttpKeyStore.refresh()` | Patch B |
 | Persistent per-issuer `krl_version` high-watermark storage | Patch B |
 | Last-known-good KRL cache | Patch B |
-| Cross-language conformance vectors (Go, Python, Rust) | Future |
+| Cross-language conformance vectors — Go | #119 Go PR (merged) |
+| Cross-language conformance vectors — Python | Next PR |
+| Cross-language conformance vectors — Rust | Future |
 | KRL signing key rotation automation | Future |
 | `krlStatus` / `getKrlStatus()` surface | Patch B |
 
@@ -265,5 +267,25 @@ Runner: `pnpm -C packages/conformance validate`
 | `krl-008` | `unsupported-alg` | `KRL_UNSUPPORTED_ALG` — `alg != "Ed25519"` |
 | `krl-009` | `version-regression` | `KRL_VERSION_REGRESSION` — version went backwards |
 
-**Coverage scope:** TypeScript / `@oxdeai/core` conformance runner. Cross-language
-harnesses (Go, Python) do not yet include SignedKRLV1 vectors.
+**Coverage scope:** Two runners:
+
+| Runner | Command | Coverage |
+|--------|---------|---------|
+| TypeScript (`@oxdeai/core`) | `pnpm -C packages/conformance validate` | 9 mode-based vectors (dynamic artifact construction) |
+| **Go harness** | `pnpm test:vectors:go` | **9 portable vectors with committed artifacts — independent Ed25519 verification** |
+
+Python cross-language coverage is pending the next PR.
+
+**Vector relationship.** `docs/spec/test-vectors/signed-krl-v1.json` is the normative
+portable cross-language vector source for SignedKRLV1. It contains committed
+`SignedKRLV1` artifacts with pre-computed Ed25519 signatures that Go and Python
+reproduce independently using only canonicalization-v1 and standard Ed25519 libraries.
+`packages/conformance/vectors/signed-krl-verification.json` is the TypeScript
+conformance mirror (mode-driven, no committed artifacts). Future changes must keep
+both files aligned or document divergence explicitly.
+
+**Independent verification model.** The Go harness does not consume TypeScript-generated
+intermediate artifacts (canonical bytes, signing preimages). It reconstructs the signing
+preimage from the committed vector inputs using its own canonicalization-v1 implementation
+and verifies the Ed25519 signature independently using `crypto/ed25519` from the Go
+standard library.

--- a/docs/spec/interoperability/external-provider-profile.md
+++ b/docs/spec/interoperability/external-provider-profile.md
@@ -237,6 +237,13 @@ check. This risk is only closed by deploying `signed_required` mode.
 `KRL_MALFORMED`, `KRL_SIG_INVALID`, `KRL_EXPIRED`, `KRL_UNSUPPORTED_ALG`,
 `KRL_UNKNOWN_SIGNING_KID`, `KRL_SIGNING_KEY_INACTIVE`, `KRL_VERSION_REGRESSION`.
 
+**Cross-language SignedKRLV1 conformance.** The Go harness now independently verifies
+all 9 SignedKRLV1 portable vectors (`docs/spec/test-vectors/signed-krl-v1.json`) using
+Go's `crypto/ed25519` standard library. Each vector contains a committed `SignedKRLV1`
+artifact; the harness reconstructs the `OXDEAI_KRL_V1` signing preimage independently
+using canonicalization-v1 and verifies the Ed25519 signature without consuming any
+TypeScript-generated intermediate artifact. Python cross-language coverage is pending.
+
 ---
 
 ### 2.3 Profile C — Full Semantic State Verification
@@ -280,7 +287,20 @@ MISCONFIGURED (fail-closed, but blocks legitimate execution):
 The guard cannot detect whether a state_hash mismatch is due to actual state change or
 wrong hash strategy — both produce DENY. Deployers must ensure alignment.
 
-#### 2.3.4 Distinguishing Profile B and Profile C
+#### 2.3.4 Cross-language conformance
+
+Go harness now validates Profile C **state-hash semantics** (modes 001–005) independently
+via `docs/spec/test-vectors/profile-c-state-verification.json`. Each vector provides raw
+state JSON objects; the harness computes SHA-256 of `canonicalJson(state)` (core strategy)
+or SHA-256 of `"PROVIDER:" + canonicalJson(state)` (provider strategy) independently and
+compares outcomes against expected verdicts (`ok`, `state-hash-mismatch`, `compute-error`).
+
+**Scope of Go coverage:** state-hash comparison semantics only (modes 001–005).
+Profile C Encoding B modes 006–008 (which require AuthorizationV1 Encoding B signature
+verification) remain TypeScript-only and are tracked as a separate issue.
+Python cross-language coverage is pending.
+
+#### 2.3.5 Distinguishing Profile B and Profile C
 
 | Concern | Profile B | Profile C |
 |---|---|---|

--- a/docs/spec/test-vectors/profile-c-state-verification.json
+++ b/docs/spec/test-vectors/profile-c-state-verification.json
@@ -1,0 +1,70 @@
+{
+  "version": "1.0.0",
+  "profile": "C",
+  "portable": true,
+  "description": "Portable Profile C state-hash semantics vectors for cross-language conformance (Go, Python). Covers modes 001–005 only — these require only canonicalization-v1 and SHA-256, which every compliant implementation must support independently. Modes 006–008 (Encoding B Authorization variants) are TypeScript-only and tracked separately. See packages/conformance/vectors/profile-c-state-verification.json for the full TypeScript set.",
+  "hash_strategies": {
+    "core": "SHA-256(canonicalJson(state)) — standard OxDeAI state hash",
+    "provider": "SHA-256('PROVIDER:' + canonicalJson(state)) — simulates external provider algorithm",
+    "throws": "Simulates a computeStateHash failure; harness must return outcome 'compute-error' without computing any hash"
+  },
+  "outcomes": {
+    "ok": "Committed hash equals live-state hash — Profile C step 10 passes",
+    "state-hash-mismatch": "Committed hash does not equal live-state hash — Profile C step 10 blocks execution",
+    "compute-error": "computeStateHash threw — execution blocked fail-closed"
+  },
+  "vectors": [
+    {
+      "id": "profile-c-001",
+      "mode": "live-state-match",
+      "description": "Core strategy: same state at signing and verification — hashes are identical, outcome ok.",
+      "state_input": { "period": "p1", "spent": 0 },
+      "hash_strategy": "core",
+      "expected": {
+        "outcome": "ok"
+      }
+    },
+    {
+      "id": "profile-c-002",
+      "mode": "live-state-mismatch",
+      "description": "Core strategy: live state has advanced since signing — hashes differ, outcome state-hash-mismatch.",
+      "state_input": { "period": "p1", "spent": 0 },
+      "live_state_input": { "period": "p1", "spent": 500000 },
+      "hash_strategy": "core",
+      "expected": {
+        "outcome": "state-hash-mismatch"
+      }
+    },
+    {
+      "id": "profile-c-003",
+      "mode": "hash-strategy-mismatch",
+      "description": "Provider hash committed at signing; core hash used at verification. Even with the same state, hashes differ — outcome state-hash-mismatch. Models a missing or wrong computeStateHash configuration.",
+      "state_input": { "period": "p1", "spent": 0 },
+      "signing_strategy": "provider",
+      "verify_strategy": "core",
+      "expected": {
+        "outcome": "state-hash-mismatch"
+      }
+    },
+    {
+      "id": "profile-c-004",
+      "mode": "compute-throws",
+      "description": "computeStateHash throws — execution blocked fail-closed. Harness must return compute-error without computing any hash.",
+      "hash_strategy": "throws",
+      "expected": {
+        "outcome": "compute-error"
+      }
+    },
+    {
+      "id": "profile-c-005",
+      "mode": "toctou-stale-state",
+      "description": "TOCTOU / stale state: authorization issued against an earlier state; live state has advanced to a different period and higher spend. Core hash of live state does not match committed hash — outcome state-hash-mismatch.",
+      "state_input": { "period": "p1", "spent": 0 },
+      "live_state_input": { "period": "p2", "spent": 5000000 },
+      "hash_strategy": "core",
+      "expected": {
+        "outcome": "state-hash-mismatch"
+      }
+    }
+  ]
+}

--- a/docs/spec/test-vectors/signed-krl-v1.json
+++ b/docs/spec/test-vectors/signed-krl-v1.json
@@ -1,0 +1,387 @@
+{
+  "version": "1.0.0",
+  "description": "Portable SignedKRLV1 cross-language conformance vectors. Each harness independently reconstructs the signing payload, builds the OXDEAI_KRL_V1 domain-prefixed preimage, and verifies the Ed25519 signature using its own crypto library. Committed signatures are deterministic Ed25519 outputs (RFC 8032). This file is the normative portable cross-language vector source for SignedKRLV1. packages/conformance/vectors/signed-krl-verification.json is the TypeScript conformance mirror. Future changes must keep them aligned or document divergence.",
+  "signing_domain": "OXDEAI_KRL_V1",
+  "signing_preimage": "domain + '\\n' + canonicalJson(signedKrlSigningPayload(envelope)) where signedKrlSigningPayload excludes only signature.sig",
+  "constants": {
+    "KRL_T_ISSUED": 1730000000,
+    "KRL_T_NOT_AFTER": 1730003600,
+    "KRL_T_NOW": 1730000010,
+    "KRL_T_NOW_EXPIRED": 1730003601
+  },
+  "keys": [
+    {
+      "id": "krl-signing-key",
+      "note": "TEST ONLY — KRL signing fixture key, kid krl-2026-01. Distinct from the AuthorizationV1 / DelegationV1 signing fixture key. issuer krl.issuer.",
+      "issuer": "krl.issuer",
+      "kid": "krl-2026-01",
+      "alg": "Ed25519",
+      "public_key_pem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAoNLRsm0uJ8Zb4z9BErD/xcPyN8kK1Y3zTrpdxDGiT2A=\n-----END PUBLIC KEY-----"
+    }
+  ],
+  "vectors": [
+    {
+      "id": "KRL_SIGNED_VALID",
+      "description": "Valid signed KRL: signature verifies, KRL is not expired, no version regression. Expected: ok, no violations.",
+      "input": {
+        "envelope": {
+          "version": "SignedKRLV1",
+          "issuer": "krl.issuer",
+          "krl_version": 1,
+          "issued_at": 1730000000,
+          "not_after": 1730003600,
+          "revoked_kids": ["kid-provider-1", "kid-provider-2"],
+          "signature": {
+            "alg": "Ed25519",
+            "kid": "krl-2026-01",
+            "sig": "lg4uUp/qZ11JARiO/N+YCP9pJkISzJMCCyXpb3ibd1oNuyFMZ428842Q9fpD10MiQB+9QEXwSgUXjMsgsV4ZBg=="
+          }
+        },
+        "opts": {
+          "now": 1730000010,
+          "trustedKeySets": [
+            {
+              "issuer": "krl.issuer",
+              "version": "1",
+              "keys": [
+                {
+                  "kid": "krl-2026-01",
+                  "alg": "Ed25519",
+                  "public_key": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAoNLRsm0uJ8Zb4z9BErD/xcPyN8kK1Y3zTrpdxDGiT2A=\n-----END PUBLIC KEY-----",
+                  "status": "active"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "expected": {
+        "status": "ok",
+        "violations": []
+      }
+    },
+    {
+      "id": "KRL_SIGNED_INVALID_SIG",
+      "description": "Tampered signature: base signature with last 4 base64 characters replaced by AAAA. Ed25519 verification fails — KRL_SIG_INVALID.",
+      "input": {
+        "envelope": {
+          "version": "SignedKRLV1",
+          "issuer": "krl.issuer",
+          "krl_version": 1,
+          "issued_at": 1730000000,
+          "not_after": 1730003600,
+          "revoked_kids": ["kid-provider-1", "kid-provider-2"],
+          "signature": {
+            "alg": "Ed25519",
+            "kid": "krl-2026-01",
+            "sig": "lg4uUp/qZ11JARiO/N+YCP9pJkISzJMCCyXpb3ibd1oNuyFMZ428842Q9fpD10MiQB+9QEXwSgUXjMsgsV4ZAAAA"
+          }
+        },
+        "opts": {
+          "now": 1730000010,
+          "trustedKeySets": [
+            {
+              "issuer": "krl.issuer",
+              "version": "1",
+              "keys": [
+                {
+                  "kid": "krl-2026-01",
+                  "alg": "Ed25519",
+                  "public_key": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAoNLRsm0uJ8Zb4z9BErD/xcPyN8kK1Y3zTrpdxDGiT2A=\n-----END PUBLIC KEY-----",
+                  "status": "active"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "expected": {
+        "status": "invalid",
+        "violations": [{ "code": "KRL_SIG_INVALID" }]
+      }
+    },
+    {
+      "id": "KRL_SIGNED_EXPIRED",
+      "description": "Verification time is not_after + 1 (1730003601 >= 1730003600). Strict zero-tolerance expiry: now >= not_after — KRL_EXPIRED.",
+      "input": {
+        "envelope": {
+          "version": "SignedKRLV1",
+          "issuer": "krl.issuer",
+          "krl_version": 1,
+          "issued_at": 1730000000,
+          "not_after": 1730003600,
+          "revoked_kids": ["kid-provider-1", "kid-provider-2"],
+          "signature": {
+            "alg": "Ed25519",
+            "kid": "krl-2026-01",
+            "sig": "lg4uUp/qZ11JARiO/N+YCP9pJkISzJMCCyXpb3ibd1oNuyFMZ428842Q9fpD10MiQB+9QEXwSgUXjMsgsV4ZBg=="
+          }
+        },
+        "opts": {
+          "now": 1730003601,
+          "trustedKeySets": [
+            {
+              "issuer": "krl.issuer",
+              "version": "1",
+              "keys": [
+                {
+                  "kid": "krl-2026-01",
+                  "alg": "Ed25519",
+                  "public_key": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAoNLRsm0uJ8Zb4z9BErD/xcPyN8kK1Y3zTrpdxDGiT2A=\n-----END PUBLIC KEY-----",
+                  "status": "active"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "expected": {
+        "status": "invalid",
+        "violations": [{ "code": "KRL_EXPIRED" }]
+      }
+    },
+    {
+      "id": "KRL_MALFORMED_REVOKED_KIDS",
+      "description": "revoked_kids is a JSON string, not an array. Structural malformation detected before signature verification — KRL_MALFORMED.",
+      "input": {
+        "envelope": {
+          "version": "SignedKRLV1",
+          "issuer": "krl.issuer",
+          "krl_version": 1,
+          "issued_at": 1730000000,
+          "not_after": 1730003600,
+          "revoked_kids": "not-an-array",
+          "signature": {
+            "alg": "Ed25519",
+            "kid": "krl-2026-01",
+            "sig": "lg4uUp/qZ11JARiO/N+YCP9pJkISzJMCCyXpb3ibd1oNuyFMZ428842Q9fpD10MiQB+9QEXwSgUXjMsgsV4ZBg=="
+          }
+        },
+        "opts": {
+          "now": 1730000010,
+          "trustedKeySets": [
+            {
+              "issuer": "krl.issuer",
+              "version": "1",
+              "keys": [
+                {
+                  "kid": "krl-2026-01",
+                  "alg": "Ed25519",
+                  "public_key": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAoNLRsm0uJ8Zb4z9BErD/xcPyN8kK1Y3zTrpdxDGiT2A=\n-----END PUBLIC KEY-----",
+                  "status": "active"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "expected": {
+        "status": "invalid",
+        "violations": [{ "code": "KRL_MALFORMED" }]
+      }
+    },
+    {
+      "id": "KRL_DUPLICATE_REVOKED_KIDS",
+      "description": "revoked_kids contains [\"kid-1\", \"kid-1\"]. Producers MUST deduplicate; verifiers MUST reject duplicates as KRL_MALFORMED before signature verification. The signature is valid over this envelope but the structural check fires first.",
+      "input": {
+        "envelope": {
+          "version": "SignedKRLV1",
+          "issuer": "krl.issuer",
+          "krl_version": 1,
+          "issued_at": 1730000000,
+          "not_after": 1730003600,
+          "revoked_kids": ["kid-1", "kid-1"],
+          "signature": {
+            "alg": "Ed25519",
+            "kid": "krl-2026-01",
+            "sig": "+mwEd2QP5+tx6pCKAiF8BKzMAHf1c28mcTQF575pDn/DwgRiJ+PkYnv+sasIdgj1S7E9mSZZK1pOTP43nlnsDA=="
+          }
+        },
+        "opts": {
+          "now": 1730000010,
+          "trustedKeySets": [
+            {
+              "issuer": "krl.issuer",
+              "version": "1",
+              "keys": [
+                {
+                  "kid": "krl-2026-01",
+                  "alg": "Ed25519",
+                  "public_key": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAoNLRsm0uJ8Zb4z9BErD/xcPyN8kK1Y3zTrpdxDGiT2A=\n-----END PUBLIC KEY-----",
+                  "status": "active"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "expected": {
+        "status": "invalid",
+        "violations": [{ "code": "KRL_MALFORMED" }]
+      }
+    },
+    {
+      "id": "KRL_UNKNOWN_SIGNING_KID",
+      "description": "signature.kid tampered to \"unknown-kid\" after signing. The trusted key set contains only krl-2026-01; unknown-kid is not found — KRL_UNKNOWN_SIGNING_KID. The signature field is the base valid signature but is never reached.",
+      "input": {
+        "envelope": {
+          "version": "SignedKRLV1",
+          "issuer": "krl.issuer",
+          "krl_version": 1,
+          "issued_at": 1730000000,
+          "not_after": 1730003600,
+          "revoked_kids": ["kid-provider-1", "kid-provider-2"],
+          "signature": {
+            "alg": "Ed25519",
+            "kid": "unknown-kid",
+            "sig": "lg4uUp/qZ11JARiO/N+YCP9pJkISzJMCCyXpb3ibd1oNuyFMZ428842Q9fpD10MiQB+9QEXwSgUXjMsgsV4ZBg=="
+          }
+        },
+        "opts": {
+          "now": 1730000010,
+          "trustedKeySets": [
+            {
+              "issuer": "krl.issuer",
+              "version": "1",
+              "keys": [
+                {
+                  "kid": "krl-2026-01",
+                  "alg": "Ed25519",
+                  "public_key": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAoNLRsm0uJ8Zb4z9BErD/xcPyN8kK1Y3zTrpdxDGiT2A=\n-----END PUBLIC KEY-----",
+                  "status": "active"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "expected": {
+        "status": "invalid",
+        "violations": [{ "code": "KRL_UNKNOWN_SIGNING_KID" }]
+      }
+    },
+    {
+      "id": "KRL_SIGNING_KEY_INACTIVE",
+      "description": "The correct kid (krl-2026-01) is found in the trusted key set, but its status is \"revoked\". keyIsActiveAt returns false — KRL_SIGNING_KEY_INACTIVE.",
+      "input": {
+        "envelope": {
+          "version": "SignedKRLV1",
+          "issuer": "krl.issuer",
+          "krl_version": 1,
+          "issued_at": 1730000000,
+          "not_after": 1730003600,
+          "revoked_kids": ["kid-provider-1", "kid-provider-2"],
+          "signature": {
+            "alg": "Ed25519",
+            "kid": "krl-2026-01",
+            "sig": "lg4uUp/qZ11JARiO/N+YCP9pJkISzJMCCyXpb3ibd1oNuyFMZ428842Q9fpD10MiQB+9QEXwSgUXjMsgsV4ZBg=="
+          }
+        },
+        "opts": {
+          "now": 1730000010,
+          "trustedKeySets": [
+            {
+              "issuer": "krl.issuer",
+              "version": "1",
+              "keys": [
+                {
+                  "kid": "krl-2026-01",
+                  "alg": "Ed25519",
+                  "public_key": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAoNLRsm0uJ8Zb4z9BErD/xcPyN8kK1Y3zTrpdxDGiT2A=\n-----END PUBLIC KEY-----",
+                  "status": "revoked"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "expected": {
+        "status": "invalid",
+        "violations": [{ "code": "KRL_SIGNING_KEY_INACTIVE" }]
+      }
+    },
+    {
+      "id": "KRL_UNSUPPORTED_ALG",
+      "description": "signature.alg is \"HMAC-SHA256\". Only Ed25519 is accepted for SignedKRLV1. Structural rejection before key lookup or signature verification — KRL_UNSUPPORTED_ALG.",
+      "input": {
+        "envelope": {
+          "version": "SignedKRLV1",
+          "issuer": "krl.issuer",
+          "krl_version": 1,
+          "issued_at": 1730000000,
+          "not_after": 1730003600,
+          "revoked_kids": ["kid-provider-1"],
+          "signature": {
+            "alg": "HMAC-SHA256",
+            "kid": "krl-2026-01",
+            "sig": "lg4uUp/qZ11JARiO/N+YCP9pJkISzJMCCyXpb3ibd1oNuyFMZ428842Q9fpD10MiQB+9QEXwSgUXjMsgsV4ZBg=="
+          }
+        },
+        "opts": {
+          "now": 1730000010,
+          "trustedKeySets": [
+            {
+              "issuer": "krl.issuer",
+              "version": "1",
+              "keys": [
+                {
+                  "kid": "krl-2026-01",
+                  "alg": "Ed25519",
+                  "public_key": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAoNLRsm0uJ8Zb4z9BErD/xcPyN8kK1Y3zTrpdxDGiT2A=\n-----END PUBLIC KEY-----",
+                  "status": "active"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "expected": {
+        "status": "invalid",
+        "violations": [{ "code": "KRL_UNSUPPORTED_ALG" }]
+      }
+    },
+    {
+      "id": "KRL_VERSION_REGRESSION",
+      "description": "krl_version=1 but previousKrlVersionByIssuer[\"krl.issuer\"]=5 — version went backwards. The envelope is otherwise valid; version regression check fires before signature verification.",
+      "input": {
+        "envelope": {
+          "version": "SignedKRLV1",
+          "issuer": "krl.issuer",
+          "krl_version": 1,
+          "issued_at": 1730000000,
+          "not_after": 1730003600,
+          "revoked_kids": ["kid-provider-1", "kid-provider-2"],
+          "signature": {
+            "alg": "Ed25519",
+            "kid": "krl-2026-01",
+            "sig": "lg4uUp/qZ11JARiO/N+YCP9pJkISzJMCCyXpb3ibd1oNuyFMZ428842Q9fpD10MiQB+9QEXwSgUXjMsgsV4ZBg=="
+          }
+        },
+        "opts": {
+          "now": 1730000010,
+          "trustedKeySets": [
+            {
+              "issuer": "krl.issuer",
+              "version": "1",
+              "keys": [
+                {
+                  "kid": "krl-2026-01",
+                  "alg": "Ed25519",
+                  "public_key": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAoNLRsm0uJ8Zb4z9BErD/xcPyN8kK1Y3zTrpdxDGiT2A=\n-----END PUBLIC KEY-----",
+                  "status": "active"
+                }
+              ]
+            }
+          ],
+          "previousKrlVersionByIssuer": {
+            "krl.issuer": 5
+          }
+        }
+      },
+      "expected": {
+        "status": "invalid",
+        "violations": [{ "code": "KRL_VERSION_REGRESSION" }]
+      }
+    }
+  ]
+}

--- a/go-harness/canonicalization_verify.go
+++ b/go-harness/canonicalization_verify.go
@@ -244,13 +244,22 @@ func join(parts []string, sep string) string {
 	return b.String()
 }
 
-func loadVectors() ([]vector, error) {
+// testVectorsDir returns the absolute path to docs/spec/test-vectors/ relative
+// to this source file, so go run . works regardless of working directory.
+func testVectorsDir() string {
 	_, file, _, ok := runtime.Caller(0)
 	if !ok {
+		return ""
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "docs", "spec", "test-vectors"))
+}
+
+func loadVectors() ([]vector, error) {
+	dir := testVectorsDir()
+	if dir == "" {
 		return nil, fmt.Errorf("unable to resolve caller path")
 	}
-	base := filepath.Dir(file)
-	path := filepath.Clean(filepath.Join(base, "..", "docs", "spec", "test-vectors", "canonicalization-v1.json"))
+	path := filepath.Join(dir, "canonicalization-v1.json")
 
 	f, err := os.Open(path)
 	if err != nil {
@@ -273,25 +282,26 @@ func sha256Hex(data []byte) string {
 }
 
 func main() {
+	// ── 1. Canonicalization vectors ──────────────────────────────────────────
 	vectors, err := loadVectors()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to load vectors: %v\n", err)
+		fmt.Fprintf(os.Stderr, "failed to load canonicalization vectors: %v\n", err)
 		os.Exit(1)
 	}
 
-	var failed int
+	var canFailed int
 
 	for _, v := range vectors {
 		switch v.Status {
 		case "ok":
 			canon, err := canonicalize(v.Input)
 			if err != nil {
-				failed++
+				canFailed++
 				fmt.Fprintf(os.Stderr, "FAIL %s: unexpected error %s\n", v.ID, err.Error())
 				continue
 			}
 			if canon != v.ExpectedCanonical {
-				failed++
+				canFailed++
 				fmt.Fprintf(os.Stderr, "FAIL %s: canonical JSON mismatch\n", v.ID)
 				fmt.Fprintf(os.Stderr, "  expected: %s\n", v.ExpectedCanonical)
 				fmt.Fprintf(os.Stderr, "  actual:   %s\n", canon)
@@ -299,7 +309,7 @@ func main() {
 			}
 			hash := sha256Hex([]byte(canon))
 			if v.ExpectedSHA256 != "" && hash != v.ExpectedSHA256 {
-				failed++
+				canFailed++
 				fmt.Fprintf(os.Stderr, "FAIL %s: SHA-256 mismatch\n", v.ID)
 				fmt.Fprintf(os.Stderr, "  expected: %s\n", v.ExpectedSHA256)
 				fmt.Fprintf(os.Stderr, "  actual:   %s\n", hash)
@@ -309,12 +319,12 @@ func main() {
 		case "error":
 			_, err := canonicalize(v.Input)
 			if err == nil {
-				failed++
+				canFailed++
 				fmt.Fprintf(os.Stderr, "FAIL %s: expected error %s, got success\n", v.ID, v.ExpectedError)
 				continue
 			}
 			if err.Error() != v.ExpectedError {
-				failed++
+				canFailed++
 				fmt.Fprintf(os.Stderr, "FAIL %s: wrong error\n", v.ID)
 				fmt.Fprintf(os.Stderr, "  expected: %s\n", v.ExpectedError)
 				fmt.Fprintf(os.Stderr, "  actual:   %s\n", err.Error())
@@ -322,17 +332,37 @@ func main() {
 			}
 			fmt.Printf("PASS %s\n", v.ID)
 		default:
-			failed++
+			canFailed++
 			fmt.Fprintf(os.Stderr, "FAIL %s: unsupported status %s\n", v.ID, v.Status)
 		}
 	}
 
-	if failed > 0 {
-		fmt.Fprintf(os.Stderr, "\n%d vector(s) failed\n", failed)
-		os.Exit(1)
+	if canFailed > 0 {
+		fmt.Fprintf(os.Stderr, "\n%d canonicalization vector(s) failed\n", canFailed)
+	} else {
+		fmt.Printf("\nAll %d canonicalization vector(s) passed\n", len(vectors))
 	}
 
-	fmt.Printf("\nAll %d vector(s) passed\n", len(vectors))
+	// ── 2. Profile C state-hash semantics (modes 001–005) ────────────────────
+	profCPassed, profCFailed := verifyProfileCVectors()
+	if profCFailed > 0 {
+		fmt.Fprintf(os.Stderr, "\n%d Profile C vector(s) failed\n", profCFailed)
+	} else {
+		fmt.Printf("\nAll %d Profile C vector(s) passed\n", profCPassed)
+	}
+
+	// ── 3. SignedKRLV1 verification (9 vectors) ───────────────────────────────
+	krlPassed, krlFailed := verifySignedKrlVectors()
+	if krlFailed > 0 {
+		fmt.Fprintf(os.Stderr, "\n%d SignedKRL vector(s) failed\n", krlFailed)
+	} else {
+		fmt.Printf("\nAll %d SignedKRL vector(s) passed\n", krlPassed)
+	}
+
+	// ── Final exit code ───────────────────────────────────────────────────────
+	if canFailed+profCFailed+krlFailed > 0 {
+		os.Exit(1)
+	}
 }
 
 func reflectInt64(v interface{}) int64 {

--- a/go-harness/profile_c_verify.go
+++ b/go-harness/profile_c_verify.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Profile C state-hash semantics conformance vectors (modes 001–005).
+// Modes 006–008 (Encoding B) are TypeScript-only and are not implemented here.
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ProfileCOutcome is the result of a Profile C state-hash comparison.
+type ProfileCOutcome string
+
+const (
+	ProfileCOutcomeOk                ProfileCOutcome = "ok"
+	ProfileCOutcomeStateHashMismatch ProfileCOutcome = "state-hash-mismatch"
+	ProfileCOutcomeComputeError      ProfileCOutcome = "compute-error"
+)
+
+// ── Hash strategies ───────────────────────────────────────────────────────────
+
+func computeCoreHash(state interface{}) (string, error) {
+	canonical, err := canonicalize(state)
+	if err != nil {
+		return "", err
+	}
+	h := sha256.Sum256([]byte(canonical))
+	return fmt.Sprintf("%x", h[:]), nil
+}
+
+func computeProviderHash(state interface{}) (string, error) {
+	canonical, err := canonicalize(state)
+	if err != nil {
+		return "", err
+	}
+	h := sha256.Sum256([]byte("PROVIDER:" + canonical))
+	return fmt.Sprintf("%x", h[:]), nil
+}
+
+func computeThrowsHash(_ interface{}) (string, error) {
+	return "", errors.New("hash backend unavailable")
+}
+
+func getProfileCHashFn(strategy string) func(interface{}) (string, error) {
+	switch strategy {
+	case "core":
+		return computeCoreHash
+	case "provider":
+		return computeProviderHash
+	case "throws":
+		return computeThrowsHash
+	default:
+		return nil
+	}
+}
+
+// ── Vector loading ────────────────────────────────────────────────────────────
+
+type profileCVectorFile struct {
+	Vectors []json.RawMessage `json:"vectors"`
+}
+
+func loadProfileCVectors() ([]map[string]interface{}, error) {
+	dir := testVectorsDir()
+	if dir == "" {
+		return nil, fmt.Errorf("unable to resolve vectors directory")
+	}
+	path := filepath.Join(dir, "profile-c-state-verification.json")
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var raw interface{}
+	dec := json.NewDecoder(f)
+	dec.UseNumber()
+	if err := dec.Decode(&raw); err != nil {
+		return nil, err
+	}
+
+	top, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("vector file root is not an object")
+	}
+	vectorsRaw, ok := top["vectors"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("vectors field is not an array")
+	}
+
+	result := make([]map[string]interface{}, len(vectorsRaw))
+	for i, v := range vectorsRaw {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("vector %d is not an object", i)
+		}
+		result[i] = m
+	}
+	return result, nil
+}
+
+// ── Outcome computation ───────────────────────────────────────────────────────
+
+func computeProfileCOutcome(v map[string]interface{}) ProfileCOutcome {
+	mode, _ := v["mode"].(string)
+
+	// compute-throws: simulate computeStateHash failure directly.
+	// The "throws" strategy always errors; no state hash is computed.
+	if mode == "compute-throws" {
+		return ProfileCOutcomeComputeError
+	}
+
+	// Determine signing and verify strategies.
+	hashStrategy, _ := v["hash_strategy"].(string)
+	signingStrategy := hashStrategy
+	if s, ok := v["signing_strategy"].(string); ok && s != "" {
+		signingStrategy = s
+	}
+	verifyStrategy := hashStrategy
+	if s, ok := v["verify_strategy"].(string); ok && s != "" {
+		verifyStrategy = s
+	}
+
+	signingFn := getProfileCHashFn(signingStrategy)
+	verifyFn := getProfileCHashFn(verifyStrategy)
+	if signingFn == nil || verifyFn == nil {
+		return ProfileCOutcomeComputeError
+	}
+
+	// Compute committed hash from state_input.
+	stateInput := v["state_input"]
+	committedHash, err := signingFn(stateInput)
+	if err != nil {
+		return ProfileCOutcomeComputeError
+	}
+
+	// Live state defaults to state_input when live_state_input is absent.
+	liveState := stateInput
+	if ls, ok := v["live_state_input"]; ok && ls != nil {
+		liveState = ls
+	}
+
+	// Compute live hash (verify strategy).
+	liveHash, err := verifyFn(liveState)
+	if err != nil {
+		return ProfileCOutcomeComputeError
+	}
+
+	if liveHash == committedHash {
+		return ProfileCOutcomeOk
+	}
+	return ProfileCOutcomeStateHashMismatch
+}
+
+// ── Runner ────────────────────────────────────────────────────────────────────
+
+func verifyProfileCVectors() (passed, failed int) {
+	vectors, err := loadProfileCVectors()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Profile C: failed to load vectors: %v\n", err)
+		os.Exit(1)
+	}
+
+	for _, v := range vectors {
+		id, _ := v["id"].(string)
+		expected, _ := v["expected"].(map[string]interface{})
+		expectedOutcome, _ := expected["outcome"].(string)
+
+		got := computeProfileCOutcome(v)
+
+		if string(got) != expectedOutcome {
+			failed++
+			fmt.Fprintf(os.Stderr, "FAIL %s: outcome mismatch\n", id)
+			fmt.Fprintf(os.Stderr, "  expected: %s\n", expectedOutcome)
+			fmt.Fprintf(os.Stderr, "  actual:   %s\n", string(got))
+			continue
+		}
+		fmt.Printf("PASS %s\n", id)
+		passed++
+	}
+	return
+}

--- a/go-harness/signed_krl_verify.go
+++ b/go-harness/signed_krl_verify.go
@@ -1,0 +1,446 @@
+// SPDX-License-Identifier: Apache-2.0
+// SignedKRLV1 cross-language conformance verifier.
+// Reads docs/spec/test-vectors/signed-krl-v1.json and independently
+// reconstructs each signing preimage, verifies Ed25519 signatures, and
+// checks all 9 portable vectors against expected reason-code verdicts.
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// KrlReasonCode is the exact string code for a SignedKRLV1 violation.
+// These must be the only locations in go-harness/ where the KRL reason code
+// string literals appear.
+type KrlReasonCode string
+
+const (
+	KrlMalformed          KrlReasonCode = "KRL_MALFORMED"
+	KrlSigInvalid         KrlReasonCode = "KRL_SIG_INVALID"
+	KrlExpired            KrlReasonCode = "KRL_EXPIRED"
+	KrlUnsupportedAlg     KrlReasonCode = "KRL_UNSUPPORTED_ALG"
+	KrlUnknownSigningKid  KrlReasonCode = "KRL_UNKNOWN_SIGNING_KID"
+	KrlSigningKeyInactive KrlReasonCode = "KRL_SIGNING_KEY_INACTIVE"
+	KrlVersionRegression  KrlReasonCode = "KRL_VERSION_REGRESSION"
+)
+
+// krlViolation mirrors the violation shape in the vector expected field.
+type krlViolation struct {
+	Code string `json:"code"`
+}
+
+// krlVerifyResult is the outcome of a single SignedKRLV1 verification.
+type krlVerifyResult struct {
+	Status     string
+	Violations []krlViolation
+}
+
+// ── Key helpers ───────────────────────────────────────────────────────────────
+
+// parseEd25519PEM parses an SPKI PEM-encoded Ed25519 public key.
+// PEM parse failures are infrastructure errors — the caller must exit on error.
+func parseEd25519PEM(pemStr string) (ed25519.PublicKey, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM block (empty or malformed)")
+	}
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse PKIX public key: %w", err)
+	}
+	edPub, ok := pub.(ed25519.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("key is not an Ed25519 public key")
+	}
+	return edPub, nil
+}
+
+// findKrlKey returns the first key entry matching issuer, kid, and alg="Ed25519",
+// or nil when no match is found.
+func findKrlKey(trustedKeySets []interface{}, issuer, kid string) map[string]interface{} {
+	for _, ksRaw := range trustedKeySets {
+		ks, ok := ksRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if ks["issuer"] != issuer {
+			continue
+		}
+		keys, _ := ks["keys"].([]interface{})
+		for _, kRaw := range keys {
+			k, ok := kRaw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if k["kid"] == kid && k["alg"] == "Ed25519" {
+				return k
+			}
+		}
+	}
+	return nil
+}
+
+// keyIsActiveAt returns true when the key is valid at the given unix-second
+// timestamp, following the same semantics as keyIsActiveAt in @oxdeai/core:
+//
+//	status == "revoked"                → false
+//	not_before present && now < nb    → false
+//	not_after  present && now > na    → false
+//	otherwise                          → true
+func keyIsActiveAt(key map[string]interface{}, nowSec int64) bool {
+	if status, _ := key["status"].(string); status == "revoked" {
+		return false
+	}
+	if nbRaw, ok := key["not_before"].(json.Number); ok {
+		if nb, err := nbRaw.Int64(); err == nil && nowSec < nb {
+			return false
+		}
+	}
+	if naRaw, ok := key["not_after"].(json.Number); ok {
+		if na, err := naRaw.Int64(); err == nil && nowSec > na {
+			return false
+		}
+	}
+	return true
+}
+
+// ── Signing payload ───────────────────────────────────────────────────────────
+
+// buildKrlSigningPayload constructs the canonical signing payload from an
+// envelope map. It includes all normative fields except signature.sig:
+// version, issuer, krl_version, issued_at, not_after, revoked_kids,
+// nonce (when present), signature.alg, signature.kid.
+func buildKrlSigningPayload(envelope map[string]interface{}) (map[string]interface{}, error) {
+	sig, ok := envelope["signature"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("signature is not an object")
+	}
+
+	payload := make(map[string]interface{})
+	payload["version"] = envelope["version"]
+	payload["issuer"] = envelope["issuer"]
+	payload["krl_version"] = envelope["krl_version"]
+	payload["issued_at"] = envelope["issued_at"]
+	payload["not_after"] = envelope["not_after"]
+	payload["revoked_kids"] = envelope["revoked_kids"]
+
+	if nonce, ok := envelope["nonce"]; ok {
+		payload["nonce"] = nonce
+	}
+
+	// signature.sig is intentionally excluded.
+	payload["signature"] = map[string]interface{}{
+		"alg": sig["alg"],
+		"kid": sig["kid"],
+	}
+	return payload, nil
+}
+
+// ── Verifier ──────────────────────────────────────────────────────────────────
+
+// verifySignedKrl verifies a SignedKRLV1 envelope following the check order
+// specified in docs/spec/artifacts/signed-krl-v1.md and matching
+// @oxdeai/core verifySignedKrl:
+//
+//  1. Structural / malformed    → KRL_MALFORMED (early return)
+//  2. Unsupported algorithm     → KRL_UNSUPPORTED_ALG (early return)
+//  3. Kid lookup                → KRL_UNKNOWN_SIGNING_KID
+//  4. Key activity              → KRL_SIGNING_KEY_INACTIVE
+//  5. Expiry                    → KRL_EXPIRED
+//  6. Version regression        → KRL_VERSION_REGRESSION
+//  7. Signature                 → KRL_SIG_INVALID
+//
+// Returns (result, infraErr). infraErr is non-nil only for infrastructure
+// failures (e.g., PEM parse error on a key that was successfully looked up).
+// The caller must exit non-zero on infrastructure failures.
+func verifySignedKrl(
+	envelope map[string]interface{},
+	nowSec int64,
+	trustedKeySets []interface{},
+	prevVersions map[string]int64,
+) (krlVerifyResult, error) {
+
+	invalid := func(code KrlReasonCode) (krlVerifyResult, error) {
+		return krlVerifyResult{
+			Status:     "invalid",
+			Violations: []krlViolation{{Code: string(code)}},
+		}, nil
+	}
+
+	// ── 1. Structural checks (early return on any violation) ──────────────
+
+	// version
+	version, _ := envelope["version"].(string)
+	if version != "SignedKRLV1" {
+		return invalid(KrlMalformed)
+	}
+
+	// issuer
+	issuer, ok := envelope["issuer"].(string)
+	if !ok || issuer == "" {
+		return invalid(KrlMalformed)
+	}
+
+	// krl_version
+	krlVersionNum, ok := envelope["krl_version"].(json.Number)
+	if !ok {
+		return invalid(KrlMalformed)
+	}
+	krlVersion, err := krlVersionNum.Int64()
+	if err != nil || krlVersion < 0 {
+		return invalid(KrlMalformed)
+	}
+
+	// issued_at (required integer; informational only — not range-checked)
+	if _, ok := envelope["issued_at"].(json.Number); !ok {
+		return invalid(KrlMalformed)
+	}
+
+	// not_after
+	notAfterNum, ok := envelope["not_after"].(json.Number)
+	if !ok {
+		return invalid(KrlMalformed)
+	}
+	notAfter, err := notAfterNum.Int64()
+	if err != nil {
+		return invalid(KrlMalformed)
+	}
+
+	// revoked_kids: must be array of strings with no duplicates
+	kidsRaw, ok := envelope["revoked_kids"].([]interface{})
+	if !ok {
+		return invalid(KrlMalformed)
+	}
+	seenKids := make(map[string]struct{}, len(kidsRaw))
+	for _, k := range kidsRaw {
+		kStr, ok := k.(string)
+		if !ok {
+			return invalid(KrlMalformed)
+		}
+		if _, dup := seenKids[kStr]; dup {
+			return invalid(KrlMalformed)
+		}
+		seenKids[kStr] = struct{}{}
+	}
+
+	// signature object
+	sig, ok := envelope["signature"].(map[string]interface{})
+	if !ok {
+		return invalid(KrlMalformed)
+	}
+
+	// ── 2. Unsupported algorithm ──────────────────────────────────────────
+	alg, _ := sig["alg"].(string)
+	if alg == "" {
+		return invalid(KrlMalformed)
+	}
+	if alg != "Ed25519" {
+		return invalid(KrlUnsupportedAlg)
+	}
+
+	// signature.kid and signature.sig structural presence
+	kid, _ := sig["kid"].(string)
+	if kid == "" {
+		return invalid(KrlMalformed)
+	}
+	sigStr, _ := sig["sig"].(string)
+	if sigStr == "" {
+		return invalid(KrlMalformed)
+	}
+
+	// ── 3. Kid lookup ─────────────────────────────────────────────────────
+	keyEntry := findKrlKey(trustedKeySets, issuer, kid)
+	if keyEntry == nil {
+		return invalid(KrlUnknownSigningKid)
+	}
+
+	// ── 4. Key activity ───────────────────────────────────────────────────
+	if !keyIsActiveAt(keyEntry, nowSec) {
+		return invalid(KrlSigningKeyInactive)
+	}
+
+	// ── 5. Expiry (strict zero-tolerance: now >= not_after → KRL_EXPIRED) ─
+	if nowSec >= notAfter {
+		return invalid(KrlExpired)
+	}
+
+	// ── 6. Version regression ─────────────────────────────────────────────
+	if prevVersions != nil {
+		if prev, ok := prevVersions[issuer]; ok && krlVersion < prev {
+			return invalid(KrlVersionRegression)
+		}
+	}
+
+	// ── 7. Signature verification ─────────────────────────────────────────
+
+	// PEM parse failure is an infrastructure error, not a test outcome.
+	pubKeyPEM, _ := keyEntry["public_key"].(string)
+	pubKey, err := parseEd25519PEM(pubKeyPEM)
+	if err != nil {
+		return krlVerifyResult{}, fmt.Errorf("KRL signing key PEM parse failure: %w", err)
+	}
+
+	// Reconstruct the canonical signing payload independently.
+	signingPayload, err := buildKrlSigningPayload(envelope)
+	if err != nil {
+		return krlVerifyResult{}, fmt.Errorf("failed to build signing payload: %w", err)
+	}
+
+	canonical, err := canonicalize(signingPayload)
+	if err != nil {
+		return krlVerifyResult{}, fmt.Errorf("canonicalization failed: %w", err)
+	}
+
+	// Domain-prefixed preimage: "OXDEAI_KRL_V1\n" + canonicalJson(signingPayload)
+	preimage := []byte("OXDEAI_KRL_V1\n" + canonical)
+
+	sigBytes, err := base64.StdEncoding.DecodeString(sigStr)
+	if err != nil {
+		// Malformed base64 is a signature format problem.
+		return invalid(KrlSigInvalid)
+	}
+
+	if !ed25519.Verify(pubKey, preimage, sigBytes) {
+		return invalid(KrlSigInvalid)
+	}
+
+	return krlVerifyResult{Status: "ok", Violations: []krlViolation{}}, nil
+}
+
+// ── Vector loading ────────────────────────────────────────────────────────────
+
+func loadSignedKrlVectors() ([]map[string]interface{}, error) {
+	dir := testVectorsDir()
+	if dir == "" {
+		return nil, fmt.Errorf("unable to resolve vectors directory")
+	}
+	path := filepath.Join(dir, "signed-krl-v1.json")
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var raw interface{}
+	dec := json.NewDecoder(f)
+	dec.UseNumber()
+	if err := dec.Decode(&raw); err != nil {
+		return nil, err
+	}
+
+	top, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("vector file root is not an object")
+	}
+	vectorsRaw, ok := top["vectors"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("vectors field is not an array")
+	}
+
+	result := make([]map[string]interface{}, len(vectorsRaw))
+	for i, v := range vectorsRaw {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("vector %d is not an object", i)
+		}
+		result[i] = m
+	}
+	return result, nil
+}
+
+// ── Runner ────────────────────────────────────────────────────────────────────
+
+func verifySignedKrlVectors() (passed, failed int) {
+	vectors, err := loadSignedKrlVectors()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "SignedKRL: failed to load vectors: %v\n", err)
+		os.Exit(1)
+	}
+
+	for _, v := range vectors {
+		id, _ := v["id"].(string)
+		input, _ := v["input"].(map[string]interface{})
+		expectedMap, _ := v["expected"].(map[string]interface{})
+
+		envelope, _ := input["envelope"].(map[string]interface{})
+		opts, _ := input["opts"].(map[string]interface{})
+
+		// Extract opts.now
+		nowNum, _ := opts["now"].(json.Number)
+		nowSec, _ := nowNum.Int64()
+
+		// Extract opts.trustedKeySets
+		trustedKeySets, _ := opts["trustedKeySets"].([]interface{})
+
+		// Extract opts.previousKrlVersionByIssuer (optional)
+		var prevVersions map[string]int64
+		if pRaw, ok := opts["previousKrlVersionByIssuer"].(map[string]interface{}); ok {
+			prevVersions = make(map[string]int64, len(pRaw))
+			for issuer, valRaw := range pRaw {
+				if num, ok := valRaw.(json.Number); ok {
+					if v, err := num.Int64(); err == nil {
+						prevVersions[issuer] = v
+					}
+				}
+			}
+		}
+
+		result, infraErr := verifySignedKrl(envelope, nowSec, trustedKeySets, prevVersions)
+		if infraErr != nil {
+			fmt.Fprintf(os.Stderr, "FATAL [%s]: infrastructure error: %v\n", id, infraErr)
+			os.Exit(1)
+		}
+
+		// Compare status
+		expectedStatus, _ := expectedMap["status"].(string)
+		if result.Status != expectedStatus {
+			failed++
+			fmt.Fprintf(os.Stderr, "FAIL %s: status mismatch\n", id)
+			fmt.Fprintf(os.Stderr, "  expected: %s\n", expectedStatus)
+			fmt.Fprintf(os.Stderr, "  actual:   %s\n", result.Status)
+			continue
+		}
+
+		// Compare violations
+		expectedViolsRaw, _ := expectedMap["violations"].([]interface{})
+		if len(result.Violations) != len(expectedViolsRaw) {
+			failed++
+			fmt.Fprintf(os.Stderr, "FAIL %s: violations count mismatch (expected %d, got %d)\n",
+				id, len(expectedViolsRaw), len(result.Violations))
+			continue
+		}
+
+		mismatch := false
+		for i, ev := range expectedViolsRaw {
+			evMap, _ := ev.(map[string]interface{})
+			expectedCode, _ := evMap["code"].(string)
+			if i >= len(result.Violations) || result.Violations[i].Code != expectedCode {
+				mismatch = true
+				fmt.Fprintf(os.Stderr, "FAIL %s: violation[%d] code mismatch\n", id, i)
+				fmt.Fprintf(os.Stderr, "  expected: %s\n", expectedCode)
+				if i < len(result.Violations) {
+					fmt.Fprintf(os.Stderr, "  actual:   %s\n", result.Violations[i].Code)
+				} else {
+					fmt.Fprintf(os.Stderr, "  actual:   (missing)\n")
+				}
+				break
+			}
+		}
+		if mismatch {
+			failed++
+			continue
+		}
+
+		fmt.Printf("PASS %s\n", id)
+		passed++
+	}
+	return
+}


### PR DESCRIPTION
Refs #119.

## Summary

Adds Go cross-language conformance coverage for two previously TypeScript-only protocol surfaces:

- Profile C state-hash semantics
- SignedKRLV1 verification

This PR is the Go half of #119. It does not close #119 because Python cross-language coverage is still pending.

## What changed

- Added portable Profile C state-hash vectors under `docs/spec/test-vectors/profile-c-state-verification.json`
- Added portable SignedKRLV1 vectors under `docs/spec/test-vectors/signed-krl-v1.json`
- Added Go validation for Profile C modes 001–005
- Added Go validation for all 9 SignedKRLV1 vectors
- Updated `go-harness` to run:
  - canonicalization-v1
  - Profile C state-hash semantics
  - SignedKRLV1 verification
- Updated docs and audit wording to reflect partial cross-language coverage

## Scope

Profile C coverage is limited to state-hash semantics:

- live-state match
- live-state mismatch
- hash strategy mismatch
- computeStateHash failure
- stale state / TOCTOU-style mismatch

Profile C Encoding B modes 006–008 remain TypeScript-only and are tracked separately.

SignedKRLV1 coverage includes all 9 portable vectors:

- valid signed KRL
- invalid signature
- expired KRL
- malformed `revoked_kids`
- duplicate `revoked_kids`
- unknown signing kid
- inactive signing key
- unsupported algorithm
- version regression

## Boundary guarantees

This PR does not change protocol semantics.

No changes were made to:

- `packages/core/**`
- `packages/sift/**`
- `packages/guard/**`
- `packages/conformance/src/validate.ts`
- `packages/conformance/vectors/**`
- `packages/core/API_FINGERPRINT`
- `go.mod`
- `go.sum`

The Go harness independently reconstructs canonical payloads and verification inputs from committed portable vectors. It does not rely on TypeScript-generated intermediate artifacts.

## Audit status

P1-6 remains open.

Current status:

`PARTIAL — Go cross-language coverage for Profile C state-hash semantics and SignedKRLV1 merged; Python pending; Profile C Encoding B modes 006–008 remain TypeScript-only.`

## Validation

- `pnpm test:vectors:go`: 25/25 passing
- `pnpm test:vectors:all`: passing
- `pnpm -C packages/conformance validate`: 209/209 passing
- `pnpm typecheck`: passing
- `pnpm test`: passing
- `pnpm security:gate`: ALLOW
- `git diff --check`: clean
- `packages/core/API_FINGERPRINT`: unchanged

## Residual limitations

- Python cross-language coverage is still pending.
- Profile C Encoding B modes 006–008 remain TypeScript-only.
- This PR does not claim full standardization readiness.