### PR TITLE
test(conformance): add Python Profile C and SignedKRLV1 vectors

### DIFF
--- a/docs/audits/protocol-audit-post-interoperability.md
+++ b/docs/audits/protocol-audit-post-interoperability.md
@@ -154,7 +154,7 @@
 | Profile A (Core-native) | `DONE` | Defined, implemented, conformance covered by existing auth-sig and auth-verify vectors. |
 | Profile B (External wire-compatible) | `DONE` | Defined. Encoding B accepted in verifyAuthorization. Conformance vector `authorization-sig-010`. Trust separation proven: `pb-trust-oxdeai-key-allow` (OxDeAI key in trustedKeySets → ALLOW) and `pb-trust-provider-key-rejected` (provider receipt key absent from trustedKeySets → DENY/UNKNOWN_KID). Resolved in #108. |
 | Profile C (Full semantic state verification) | `DONE` | Defined. Implemented via pluggable `computeStateHash`. 12 executable conformance assertions across 8 vectors. Encoding B path tested. |
-| Profile C cross-language | `PARTIAL` | Go harness validates state-hash semantics (modes 001–005) via `docs/spec/test-vectors/profile-c-state-verification.json`. Profile C Encoding B modes 006–008 remain TypeScript-only. Python pending. |
+| Profile C cross-language | `DONE` | Go + Python harnesses validate state-hash semantics (modes 001–005) via `docs/spec/test-vectors/profile-c-state-verification.json`. Profile C Encoding B modes 006–008 remain TypeScript-only and are tracked separately. |
 | Interoperability matrix | `DOCUMENTED ONLY` | Matrix in `external-provider-profile.md`. Not backed by conformance automation. |
 
 ---
@@ -422,7 +422,7 @@ DelegationV1                 █████████████████
 Profile A interop            ████████████████████  DONE
 Profile B interop            ████████████████░░░░  PARTIAL (trust sep. gap)
 Profile C interop            ████████████████████  DONE (state-hash semantics; Encoding B modes 006–008 TS-only)
-Profile C cross-language     ████████████████░░░░  PARTIAL (Go state-hash 001–005; Python pending; EB modes TS-only)
+Profile C cross-language     ████████████████████  DONE (Go + Python state-hash semantics; Encoding B modes 006–008 TS-only)
 Replay durability            ████████████████░░░░  PARTIAL (in-memory default risk)
 Key rotation                 ██████████░░░░░░░░░░  DOCUMENTED ONLY
 Threat model                 ██████████░░░░░░░░░░  DOCUMENTED ONLY
@@ -476,18 +476,22 @@ Caveats: transport-integrity gap is only fully closed when callers deploy `signe
 **P1-5: Mark HMAC-SHA256 as deprecated** ✓ RESOLVED
 Resolution: `authorization-v1.md §5` now carries an explicit "Deprecated legacy algorithm" section: HMAC-SHA256 is not standard, is symmetric/non-portable, and its migration path is documented. `legacyHmacSecret` in `VerifyAuthorizationOptions` carries a `@deprecated` JSDoc with removal notice. `authorization_signing_alg: "HMAC-SHA256"` default in `EngineOptions` carries a `@deprecated` JSDoc directing new users to Ed25519. Two explicit legacy-path tests document backward-compat guarantee and the fail-closed behavior when `legacyHmacSecret` is absent. Resolved in #107.
 
-**P1-6: Add cross-language Profile C and SignedKRLV1 conformance vectors**
-Status: **PARTIAL — Go cross-language coverage for Profile C state-hash semantics and SignedKRLV1 merged; Python pending; Profile C Encoding B modes 006–008 remain TypeScript-only.**
+**P1-6: Add cross-language Profile C and SignedKRLV1 conformance vectors** ✓ RESOLVED for Profile C state-hash semantics and SignedKRLV1 cross-language coverage (Go + Python). Profile C Encoding B modes 006–008 remain TypeScript-only and are tracked separately.
 
-Go coverage (merged, #119 Go PR):
-- `go-harness/profile_c_verify.go` validates Profile C state-hash semantics modes 001–005: live-state-match, live-state-mismatch, hash-strategy-mismatch, compute-throws, toctou-stale-state. Independently computes SHA-256 of `canonicalJson(state)` (core) and SHA-256 of `"PROVIDER:" + canonicalJson(state)` (provider) using Go stdlib.
-- `go-harness/signed_krl_verify.go` validates all 9 SignedKRLV1 portable vectors. Independently reconstructs the `OXDEAI_KRL_V1` signing preimage and verifies Ed25519 signatures using Go `crypto/ed25519`. Checks all 7 reason codes: `KRL_MALFORMED`, `KRL_SIG_INVALID`, `KRL_EXPIRED`, `KRL_UNSUPPORTED_ALG`, `KRL_UNKNOWN_SIGNING_KID`, `KRL_SIGNING_KEY_INACTIVE`, `KRL_VERSION_REGRESSION`.
-- Portable vector files added: `docs/spec/test-vectors/profile-c-state-verification.json`, `docs/spec/test-vectors/signed-krl-v1.json`.
+Go coverage (#119 Go PR):
+- `go-harness/profile_c_verify.go` validates Profile C state-hash semantics modes 001–005 independently.
+- `go-harness/signed_krl_verify.go` validates all 9 SignedKRLV1 portable vectors with independent Ed25519 verification.
+- Portable vector files: `docs/spec/test-vectors/profile-c-state-verification.json`, `docs/spec/test-vectors/signed-krl-v1.json`.
 
-Remaining:
-- Python cross-language coverage (next PR).
-- Profile C Encoding B modes 006–008 remain TypeScript-only; tracked as a separate P2 issue.
-- P1-6 remains open until Python coverage lands.
+Python coverage (#119 Python PR):
+- `python-harness/verify_profile_c_vectors.py` validates Profile C state-hash semantics modes 001–005 independently using canonicalization-v1 and SHA-256 via Python stdlib.
+- `python-harness/verify_signed_krl_vectors.py` validates all 9 SignedKRLV1 portable vectors using canonicalization-v1 and Ed25519 via ctypes + libcrypto (no external packages).
+- Cross-language byte-equivalence proven: duplicate-kids signature `+mwEd2QP5+tx...` verifies identically in Go and Python.
+
+Residual limitations:
+- Profile C Encoding B modes 006–008 remain TypeScript-only (require AuthorizationV1 Encoding B infrastructure; tracked separately).
+- State provider trust (RT-TRUST-1, P2-4) and independent security review remain open.
+- No full standardization readiness claim.
 
 ---
 
@@ -524,9 +528,9 @@ Scope: `pep-gateway-v1.md` §7 or a new `state-provider-requirements.md`.
 | `MISSING` | 5 |
 | `RISK` | 4 |
 
-**Conformance:** 209 TypeScript assertions (16 TS vector files + 12 portable `authorization-v1.json` vectors) + 25 Go harness assertions (11 canonicalization + 5 Profile C state-hash + 9 SignedKRLV1). Remaining gaps reduced (P0-1–P0-4, P1-1–P1-5 resolved; P1-4 resolved with caveats; P1-6 partial — Go merged, Python pending).
+**Conformance:** 209 TypeScript assertions (16 TS vector files + 12 portable `authorization-v1.json` vectors) + 25 Go harness assertions (11 canonicalization + 5 Profile C state-hash + 9 SignedKRLV1) + 25 Python harness assertions (same coverage as Go). All P0 and P1 items resolved; P1-6 cross-language coverage complete for state-hash semantics (Encoding B modes remain TS-only).
 
-**Follow-up issue counts:** P0: 0 open · P1: 1 open (P1-6 partial) · P2: 4 · Total: 5 open
+**Follow-up issue counts:** P0: 0 open · P1: 0 open · P2: 4 · Total: 4 open
 
 **Critical path to external adoption:**
 
@@ -543,7 +547,7 @@ Scope: `pep-gateway-v1.md` §7 or a new `state-provider-requirements.md`.
 
 OxDeAI is a working, tested execution authorization boundary protocol at the **interoperable protocol** maturity level. Core invariants are implemented and tested. AuthorizationV1, wire encodings, signature verification, replay protection, state binding, and delegation are all in solid shape. Profile A/B/C are specified; Profile A and C have executable conformance coverage.
 
-The protocol is **not yet ready for standard adoption**. Key lifecycle, clock skew, parentScope type safety, public artifact boundary separation, intent hash mismatch portability, expiry precedence, HMAC-SHA256 deprecation, and KRL transport integrity (for `signed_required` mode deployments) are now resolved. State provider trust, Profile C cross-language coverage, and independent security review remain open before that claim can be made honestly.
+The protocol is **not yet ready for standard adoption**. Key lifecycle, clock skew, parentScope type safety, public artifact boundary separation, intent hash mismatch portability, expiry precedence, HMAC-SHA256 deprecation, KRL transport integrity (for `signed_required` mode deployments), and Profile C / SignedKRLV1 cross-language coverage (Go + Python) are now resolved. State provider trust (RT-TRUST-1) and independent security review remain open before that claim can be made honestly.
 
 ---
 

--- a/docs/spec/artifacts/signed-krl-v1.md
+++ b/docs/spec/artifacts/signed-krl-v1.md
@@ -242,7 +242,7 @@ The following are explicitly out of scope for Patch A and will be addressed in s
 | Persistent per-issuer `krl_version` high-watermark storage | Patch B |
 | Last-known-good KRL cache | Patch B |
 | Cross-language conformance vectors — Go | #119 Go PR (merged) |
-| Cross-language conformance vectors — Python | Next PR |
+| Cross-language conformance vectors — Python | #119 Python PR (merged) |
 | Cross-language conformance vectors — Rust | Future |
 | KRL signing key rotation automation | Future |
 | `krlStatus` / `getKrlStatus()` surface | Patch B |
@@ -273,8 +273,7 @@ Runner: `pnpm -C packages/conformance validate`
 |--------|---------|---------|
 | TypeScript (`@oxdeai/core`) | `pnpm -C packages/conformance validate` | 9 mode-based vectors (dynamic artifact construction) |
 | **Go harness** | `pnpm test:vectors:go` | **9 portable vectors with committed artifacts — independent Ed25519 verification** |
-
-Python cross-language coverage is pending the next PR.
+| **Python harness** | `pnpm test:vectors:py` | **9 portable vectors with committed artifacts — independent Ed25519 verification via ctypes + libcrypto** |
 
 **Vector relationship.** `docs/spec/test-vectors/signed-krl-v1.json` is the normative
 portable cross-language vector source for SignedKRLV1. It contains committed
@@ -284,8 +283,10 @@ reproduce independently using only canonicalization-v1 and standard Ed25519 libr
 conformance mirror (mode-driven, no committed artifacts). Future changes must keep
 both files aligned or document divergence explicitly.
 
-**Independent verification model.** The Go harness does not consume TypeScript-generated
-intermediate artifacts (canonical bytes, signing preimages). It reconstructs the signing
-preimage from the committed vector inputs using its own canonicalization-v1 implementation
-and verifies the Ed25519 signature independently using `crypto/ed25519` from the Go
-standard library.
+**Independent verification model.** The Go and Python harnesses do not consume
+TypeScript-generated intermediate artifacts (canonical bytes, signing preimages). Each
+independently reconstructs the signing preimage from committed vector inputs using its
+own canonicalization-v1 implementation and verifies the Ed25519 signature using its
+own crypto library (`crypto/ed25519` for Go; `ctypes + libcrypto` for Python). The
+duplicate-kids signature (`+mwEd2QP5+...`) serves as the cross-language byte-equivalence
+proof point.

--- a/docs/spec/interoperability/external-provider-profile.md
+++ b/docs/spec/interoperability/external-provider-profile.md
@@ -242,7 +242,7 @@ all 9 SignedKRLV1 portable vectors (`docs/spec/test-vectors/signed-krl-v1.json`)
 Go's `crypto/ed25519` standard library. Each vector contains a committed `SignedKRLV1`
 artifact; the harness reconstructs the `OXDEAI_KRL_V1` signing preimage independently
 using canonicalization-v1 and verifies the Ed25519 signature without consuming any
-TypeScript-generated intermediate artifact. Python cross-language coverage is pending.
+TypeScript-generated intermediate artifact. Python cross-language coverage is also complete — `python-harness/verify_signed_krl_vectors.py` uses ctypes + libcrypto for independent Ed25519 verification.
 
 ---
 
@@ -295,10 +295,12 @@ state JSON objects; the harness computes SHA-256 of `canonicalJson(state)` (core
 or SHA-256 of `"PROVIDER:" + canonicalJson(state)` (provider strategy) independently and
 compares outcomes against expected verdicts (`ok`, `state-hash-mismatch`, `compute-error`).
 
-**Scope of Go coverage:** state-hash comparison semantics only (modes 001–005).
+**Scope of Go + Python coverage:** state-hash comparison semantics only (modes 001–005).
+Both Go (`go-harness/profile_c_verify.go`) and Python (`python-harness/verify_profile_c_vectors.py`)
+independently compute SHA-256 of `canonicalJson(state)` (core) and SHA-256 of
+`"PROVIDER:" + canonicalJson(state)` (provider) and compare outcomes against expected verdicts.
 Profile C Encoding B modes 006–008 (which require AuthorizationV1 Encoding B signature
 verification) remain TypeScript-only and are tracked as a separate issue.
-Python cross-language coverage is pending.
 
 #### 2.3.5 Distinguishing Profile B and Profile C
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:vectors": "pnpm test:vectors:ts",
     "test:vectors:ts": "tsx scripts/verify-canonicalization-vectors.ts",
     "test:vectors:go": "cd go-harness && go run .",
-    "test:vectors:py": "python3 python-harness/verify_canonicalization_vectors.py",
+    "test:vectors:py": "python3 python-harness/verify_canonicalization_vectors.py && python3 python-harness/verify_profile_c_vectors.py && python3 python-harness/verify_signed_krl_vectors.py",
     "test:vectors:auth": "node scripts/verify-authorization-vectors.mjs",
     "test:vectors:pep": "node scripts/verify-pep-vectors.mjs",
     "test:vectors:delegation": "node scripts/verify-delegation-vectors.mjs",

--- a/python-harness/verify_profile_c_vectors.py
+++ b/python-harness/verify_profile_c_vectors.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""
+Profile C state-hash semantics cross-language conformance verifier.
+
+Validates modes 001–005 from docs/spec/test-vectors/profile-c-state-verification.json.
+Modes 006–008 (Encoding B) are TypeScript-only and are NOT validated here.
+
+Reuses the canonicalization-v1 implementation from verify_canonicalization_vectors.py.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable
+
+# Reuse canonical JSON and SHA-256 from the existing canonicalization harness.
+# main() in that module is guarded by __name__, so it will not run on import.
+from verify_canonicalization_vectors import canonicalize, sha256_hex, CanonicalError  # noqa: E402
+
+
+# ── Typed outcome constants ───────────────────────────────────────────────────
+
+class ProfileCOutcome(str, Enum):
+    OK                  = "ok"
+    STATE_HASH_MISMATCH = "state-hash-mismatch"
+    COMPUTE_ERROR       = "compute-error"
+
+
+# ── Hash strategies ───────────────────────────────────────────────────────────
+
+def _compute_core_hash(state: Any) -> str:
+    """SHA-256(canonicalJson(state)) — standard OxDeAI state hash."""
+    return sha256_hex(canonicalize(state))
+
+
+def _compute_provider_hash(state: Any) -> str:
+    """SHA-256('PROVIDER:' + canonicalJson(state)) — external provider hash."""
+    return sha256_hex("PROVIDER:" + canonicalize(state))
+
+
+def _compute_throws_hash(_state: Any) -> str:
+    """Simulates a computeStateHash failure (compute-error outcome)."""
+    raise RuntimeError("hash backend unavailable")
+
+
+def _get_hash_fn(strategy: str) -> Callable[[Any], str] | None:
+    return {
+        "core":     _compute_core_hash,
+        "provider": _compute_provider_hash,
+        "throws":   _compute_throws_hash,
+    }.get(strategy)
+
+
+# ── Outcome computation ───────────────────────────────────────────────────────
+
+def _compute_outcome(vector: dict[str, Any]) -> ProfileCOutcome:
+    mode: str = vector.get("mode", "")
+
+    # compute-throws: directly simulate computeStateHash failure.
+    if mode == "compute-throws":
+        return ProfileCOutcome.COMPUTE_ERROR
+
+    # Resolve signing and verify strategies.
+    hash_strategy: str = vector.get("hash_strategy", "core")
+    signing_strategy: str = vector.get("signing_strategy", hash_strategy)
+    verify_strategy: str  = vector.get("verify_strategy",  hash_strategy)
+
+    signing_fn = _get_hash_fn(signing_strategy)
+    verify_fn  = _get_hash_fn(verify_strategy)
+    if signing_fn is None or verify_fn is None:
+        return ProfileCOutcome.COMPUTE_ERROR
+
+    # Compute committed hash from state_input.
+    state_input = vector.get("state_input")
+    try:
+        committed_hash = signing_fn(state_input)
+    except Exception:
+        return ProfileCOutcome.COMPUTE_ERROR
+
+    # Live state falls back to state_input when live_state_input is absent.
+    live_state = vector.get("live_state_input", state_input)
+
+    # Compute live hash with verify strategy.
+    try:
+        live_hash = verify_fn(live_state)
+    except Exception:
+        return ProfileCOutcome.COMPUTE_ERROR
+
+    if live_hash == committed_hash:
+        return ProfileCOutcome.OK
+    return ProfileCOutcome.STATE_HASH_MISMATCH
+
+
+# ── Vector loading ────────────────────────────────────────────────────────────
+
+def _load_vectors() -> list[dict[str, Any]]:
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "docs" / "spec" / "test-vectors"
+        / "profile-c-state-verification.json"
+    )
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data["vectors"]
+
+
+# ── Runner ────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    vectors = _load_vectors()
+    failed = 0
+
+    for vector in vectors:
+        vid: str = vector["id"]
+        expected_outcome: str = vector["expected"]["outcome"]
+
+        computed = _compute_outcome(vector)
+
+        if computed.value != expected_outcome:
+            failed += 1
+            print(f"FAIL {vid}: outcome mismatch", file=sys.stderr)
+            print(f"  expected: {expected_outcome}", file=sys.stderr)
+            print(f"  actual:   {computed.value}", file=sys.stderr)
+            continue
+
+        print(f"PASS {vid}")
+
+    if failed:
+        print(f"\n{failed} Profile C vector(s) failed", file=sys.stderr)
+        return 1
+
+    print(f"\nAll {len(vectors)} Profile C vector(s) passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python-harness/verify_signed_krl_vectors.py
+++ b/python-harness/verify_signed_krl_vectors.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""
+SignedKRLV1 cross-language conformance verifier.
+
+Reads docs/spec/test-vectors/signed-krl-v1.json and independently
+reconstructs each signing preimage, verifies Ed25519 signatures via
+ctypes + libcrypto (OpenSSL), and checks all 9 portable vectors against
+expected reason-code verdicts.
+
+Reuses the canonicalization-v1 implementation from verify_canonicalization_vectors.py.
+"""
+from __future__ import annotations
+
+import base64
+import ctypes
+import ctypes.util
+import json
+import sys
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+# Reuse canonical JSON from the existing canonicalization harness.
+# main() in that module is guarded by __name__, so it will not run on import.
+from verify_canonicalization_vectors import canonicalize  # noqa: E402
+
+
+# ── KRL reason-code constants ─────────────────────────────────────────────────
+
+# KRL verification status strings — module constants so no inline literals.
+_STATUS_OK      = "ok"
+_STATUS_INVALID = "invalid"
+
+
+class KrlReasonCode(str, Enum):
+    MALFORMED              = "KRL_MALFORMED"
+    SIG_INVALID            = "KRL_SIG_INVALID"
+    EXPIRED                = "KRL_EXPIRED"
+    UNSUPPORTED_ALG        = "KRL_UNSUPPORTED_ALG"
+    UNKNOWN_SIGNING_KID    = "KRL_UNKNOWN_SIGNING_KID"
+    SIGNING_KEY_INACTIVE   = "KRL_SIGNING_KEY_INACTIVE"
+    VERSION_REGRESSION     = "KRL_VERSION_REGRESSION"
+
+
+# ── OpenSSL loading ───────────────────────────────────────────────────────────
+
+def _load_openssl() -> ctypes.CDLL:
+    """Load libcrypto. Exits non-zero if not found — infrastructure failure."""
+    candidates = [
+        ctypes.util.find_library("crypto"),
+        "libcrypto.so.3",
+        "libcrypto.so.1.1",
+        "libcrypto.dylib",
+    ]
+    for path in candidates:
+        if path is None:
+            continue
+        try:
+            lib = ctypes.CDLL(path)
+            # Configure required function signatures.
+            lib.EVP_PKEY_free.restype = None
+            lib.EVP_PKEY_free.argtypes = [ctypes.c_void_p]
+            lib.EVP_MD_CTX_free.restype = None
+            lib.EVP_MD_CTX_free.argtypes = [ctypes.c_void_p]
+            lib.EVP_PKEY_new_raw_public_key.restype = ctypes.c_void_p
+            lib.EVP_PKEY_new_raw_public_key.argtypes = [
+                ctypes.c_int, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_size_t,
+            ]
+            lib.EVP_MD_CTX_new.restype = ctypes.c_void_p
+            lib.EVP_DigestVerifyInit.restype = ctypes.c_int
+            lib.EVP_DigestVerifyInit.argtypes = [
+                ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p,
+                ctypes.c_void_p, ctypes.c_void_p,
+            ]
+            lib.EVP_DigestVerify.restype = ctypes.c_int
+            lib.EVP_DigestVerify.argtypes = [
+                ctypes.c_void_p, ctypes.c_char_p, ctypes.c_size_t,
+                ctypes.c_char_p, ctypes.c_size_t,
+            ]
+            return lib
+        except OSError:
+            continue
+    print(
+        "FATAL: OpenSSL libcrypto not found. Required for Ed25519 signature verification. "
+        "Tried: " + ", ".join(repr(c) for c in candidates),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+# Load once at module level — failure is an infrastructure error.
+_OPENSSL = _load_openssl()
+
+# EVP_PKEY type ID for Ed25519 in OpenSSL.
+_EVP_PKEY_ED25519 = 1087
+
+# Fixed byte length of the SPKI DER prefix for Ed25519 (302a300506032b6570032100).
+_SPKI_PREFIX_LEN = 12
+
+
+# ── Infrastructure errors ─────────────────────────────────────────────────────
+
+class _InfrastructureError(Exception):
+    """Non-recoverable infrastructure failure (PEM parse, key creation, etc.)."""
+
+
+# ── Key helpers ───────────────────────────────────────────────────────────────
+
+def _parse_ed25519_pem(pem_str: str) -> bytes:
+    """Parse SPKI PEM-encoded Ed25519 public key to raw 32 bytes.
+
+    Strips PEM armor, base64-decodes the DER body, and extracts the last
+    32 bytes (the raw public key material after the 12-byte SPKI prefix).
+
+    Raises _InfrastructureError on malformed input.
+    No vector tests malformed key material — any parse failure is a bug.
+    """
+    lines = [
+        line.strip()
+        for line in pem_str.strip().splitlines()
+        if not line.strip().startswith("-----")
+    ]
+    try:
+        der = base64.b64decode("".join(lines))
+    except Exception as exc:
+        raise _InfrastructureError(
+            f"Failed to base64-decode PEM body: {exc}"
+        ) from exc
+
+    expected_total = _SPKI_PREFIX_LEN + 32
+    if len(der) != expected_total:
+        raise _InfrastructureError(
+            f"Unexpected DER key length: {len(der)} bytes (expected {expected_total})"
+        )
+
+    return der[_SPKI_PREFIX_LEN:]
+
+
+def _ed25519_verify(raw_pub: bytes, message: bytes, sig_bytes: bytes) -> bool:
+    """Verify an Ed25519 signature using the EVP path in libcrypto.
+
+    Uses NULL digest (Ed25519 signs the exact message bytes without pre-hashing).
+    Returns True on valid signature, False otherwise.
+    """
+    lib = _OPENSSL
+    pkey = lib.EVP_PKEY_new_raw_public_key(_EVP_PKEY_ED25519, None, raw_pub, len(raw_pub))
+    if not pkey:
+        return False
+
+    ctx = lib.EVP_MD_CTX_new()
+    if not ctx:
+        lib.EVP_PKEY_free(pkey)
+        return False
+
+    try:
+        if lib.EVP_DigestVerifyInit(ctx, None, None, None, pkey) != 1:
+            return False
+        return lib.EVP_DigestVerify(ctx, sig_bytes, len(sig_bytes), message, len(message)) == 1
+    finally:
+        lib.EVP_MD_CTX_free(ctx)
+        lib.EVP_PKEY_free(pkey)
+
+
+def _find_krl_key(
+    trusted_key_sets: list[dict[str, Any]],
+    issuer: str,
+    kid: str,
+) -> dict[str, Any] | None:
+    """Return the first key entry matching issuer, kid, and alg=='Ed25519'."""
+    for ks in trusted_key_sets:
+        if ks.get("issuer") != issuer:
+            continue
+        for key in ks.get("keys", []):
+            if key.get("kid") == kid and key.get("alg") == "Ed25519":
+                return key
+    return None
+
+
+def _key_is_active_at(key: dict[str, Any], now_sec: int) -> bool:
+    """Mirror keyIsActiveAt from @oxdeai/core.
+
+    - status == "revoked" → False
+    - not_before present && now < not_before → False
+    - not_after  present && now > not_after  → False
+    - otherwise → True
+    """
+    if key.get("status") == "revoked":
+        return False
+    not_before = key.get("not_before")
+    if not_before is not None and now_sec < not_before:
+        return False
+    not_after = key.get("not_after")
+    if not_after is not None and now_sec > not_after:
+        return False
+    return True
+
+
+# ── Signing payload ───────────────────────────────────────────────────────────
+
+def _build_krl_signing_payload(envelope: dict[str, Any]) -> dict[str, Any]:
+    """Reconstruct signedKrlSigningPayload from a full SignedKRLV1 envelope.
+
+    Includes all normative fields except signature.sig:
+    version, issuer, krl_version, issued_at, not_after, revoked_kids,
+    nonce (when present), signature.alg, signature.kid.
+    """
+    sig = envelope["signature"]
+    payload: dict[str, Any] = {
+        "version":      envelope["version"],
+        "issuer":       envelope["issuer"],
+        "krl_version":  envelope["krl_version"],
+        "issued_at":    envelope["issued_at"],
+        "not_after":    envelope["not_after"],
+        "revoked_kids": envelope["revoked_kids"],
+        "signature": {
+            "alg": sig["alg"],
+            "kid": sig["kid"],
+            # sig.sig intentionally excluded
+        },
+    }
+    if "nonce" in envelope:
+        payload["nonce"] = envelope["nonce"]
+    return payload
+
+
+# ── Verifier ──────────────────────────────────────────────────────────────────
+
+def _invalid(code: KrlReasonCode) -> tuple[str, list[dict[str, str]]]:
+    return _STATUS_INVALID, [{"code": code.value}]
+
+
+def _verify_signed_krl(
+    envelope: dict[str, Any],
+    now_sec: int,
+    trusted_key_sets: list[dict[str, Any]],
+    prev_versions: dict[str, int] | None,
+) -> tuple[str, list[dict[str, str]]]:
+    """Verify a SignedKRLV1 envelope.
+
+    Returns (status, violations) where status is _STATUS_OK or _STATUS_INVALID.
+    Raises _InfrastructureError on infrastructure failure (PEM parse, etc.).
+
+    Check order (mirrors @oxdeai/core verifySignedKrl and Go signed_krl_verify.go):
+      1. structural / malformed  → KRL_MALFORMED
+      2. unsupported alg         → KRL_UNSUPPORTED_ALG
+      3. kid lookup              → KRL_UNKNOWN_SIGNING_KID
+      4. key activity            → KRL_SIGNING_KEY_INACTIVE
+      5. expiry                  → KRL_EXPIRED
+      6. version regression      → KRL_VERSION_REGRESSION
+      7. signature               → KRL_SIG_INVALID
+    """
+    # ── 1. Structural checks (early return on first violation) ────────────
+
+    # version
+    if envelope.get("version") != "SignedKRLV1":
+        return _invalid(KrlReasonCode.MALFORMED)
+
+    # issuer
+    issuer = envelope.get("issuer")
+    if not isinstance(issuer, str) or not issuer:
+        return _invalid(KrlReasonCode.MALFORMED)
+
+    # krl_version (non-negative integer)
+    krl_version = envelope.get("krl_version")
+    if not isinstance(krl_version, int) or isinstance(krl_version, bool) or krl_version < 0:
+        return _invalid(KrlReasonCode.MALFORMED)
+
+    # issued_at (integer — informational only)
+    if not isinstance(envelope.get("issued_at"), int) or isinstance(envelope.get("issued_at"), bool):
+        return _invalid(KrlReasonCode.MALFORMED)
+
+    # not_after (integer)
+    not_after = envelope.get("not_after")
+    if not isinstance(not_after, int) or isinstance(not_after, bool):
+        return _invalid(KrlReasonCode.MALFORMED)
+
+    # revoked_kids: array of strings, no duplicates
+    revoked_kids = envelope.get("revoked_kids")
+    if not isinstance(revoked_kids, list):
+        return _invalid(KrlReasonCode.MALFORMED)
+    seen_kids: set[str] = set()
+    for k in revoked_kids:
+        if not isinstance(k, str):
+            return _invalid(KrlReasonCode.MALFORMED)
+        if k in seen_kids:
+            return _invalid(KrlReasonCode.MALFORMED)
+        seen_kids.add(k)
+
+    # signature object
+    sig = envelope.get("signature")
+    if not isinstance(sig, dict):
+        return _invalid(KrlReasonCode.MALFORMED)
+
+    # ── 2. Unsupported algorithm ──────────────────────────────────────────
+    alg = sig.get("alg")
+    if not isinstance(alg, str) or not alg:
+        return _invalid(KrlReasonCode.MALFORMED)
+    if alg != "Ed25519":
+        return _invalid(KrlReasonCode.UNSUPPORTED_ALG)
+
+    # signature.kid and signature.sig structural presence
+    kid = sig.get("kid")
+    if not isinstance(kid, str) or not kid:
+        return _invalid(KrlReasonCode.MALFORMED)
+    sig_str = sig.get("sig")
+    if not isinstance(sig_str, str) or not sig_str:
+        return _invalid(KrlReasonCode.MALFORMED)
+
+    # ── 3. Kid lookup ─────────────────────────────────────────────────────
+    key_entry = _find_krl_key(trusted_key_sets, issuer, kid)
+    if key_entry is None:
+        return _invalid(KrlReasonCode.UNKNOWN_SIGNING_KID)
+
+    # ── 4. Key activity ───────────────────────────────────────────────────
+    if not _key_is_active_at(key_entry, now_sec):
+        return _invalid(KrlReasonCode.SIGNING_KEY_INACTIVE)
+
+    # ── 5. Expiry (strict zero-tolerance: now >= not_after → KRL_EXPIRED) ─
+    if now_sec >= not_after:
+        return _invalid(KrlReasonCode.EXPIRED)
+
+    # ── 6. Version regression ─────────────────────────────────────────────
+    if prev_versions:
+        prev = prev_versions.get(issuer)
+        if prev is not None and krl_version < prev:
+            return _invalid(KrlReasonCode.VERSION_REGRESSION)
+
+    # ── 7. Signature verification ─────────────────────────────────────────
+
+    # PEM parse failure is an infrastructure error, not a test outcome.
+    pub_key_pem: str = key_entry.get("public_key", "")
+    raw_pub = _parse_ed25519_pem(pub_key_pem)  # raises _InfrastructureError on failure
+
+    # Reconstruct signing payload and build domain-prefixed preimage.
+    signing_payload = _build_krl_signing_payload(envelope)
+    canonical = canonicalize(signing_payload)
+    preimage = b"OXDEAI_KRL_V1\n" + canonical.encode("utf-8")
+
+    # Decode base64 signature (standard base64 as committed in the vector file).
+    try:
+        sig_bytes = base64.b64decode(sig_str)
+    except Exception:
+        return _invalid(KrlReasonCode.SIG_INVALID)
+
+    if not _ed25519_verify(raw_pub, preimage, sig_bytes):
+        return _invalid(KrlReasonCode.SIG_INVALID)
+
+    return _STATUS_OK, []
+
+
+# ── Vector loading ────────────────────────────────────────────────────────────
+
+def _load_vectors() -> list[dict[str, Any]]:
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "docs" / "spec" / "test-vectors"
+        / "signed-krl-v1.json"
+    )
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data["vectors"]
+
+
+# ── Runner ────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    vectors = _load_vectors()
+    failed = 0
+
+    for vector in vectors:
+        vid: str = vector["id"]
+        inp = vector["input"]
+        envelope: dict[str, Any] = inp["envelope"]
+        opts: dict[str, Any] = inp["opts"]
+        expected: dict[str, Any] = vector["expected"]
+
+        now_sec: int = opts["now"]
+        trusted_key_sets: list[dict[str, Any]] = opts["trustedKeySets"]
+        prev_versions: dict[str, int] | None = opts.get("previousKrlVersionByIssuer")
+
+        try:
+            status, violations = _verify_signed_krl(
+                envelope, now_sec, trusted_key_sets, prev_versions
+            )
+        except _InfrastructureError as exc:
+            print(f"FATAL [{vid}]: infrastructure error: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+        expected_status: str = expected["status"]
+        expected_violations: list[dict[str, Any]] = expected["violations"]
+
+        # Compare status
+        if status != expected_status:
+            failed += 1
+            print(f"FAIL {vid}: status mismatch", file=sys.stderr)
+            print(f"  expected: {expected_status}", file=sys.stderr)
+            print(f"  actual:   {status}", file=sys.stderr)
+            continue
+
+        # Compare violations
+        if len(violations) != len(expected_violations):
+            failed += 1
+            print(
+                f"FAIL {vid}: violations count mismatch "
+                f"(expected {len(expected_violations)}, got {len(violations)})",
+                file=sys.stderr,
+            )
+            continue
+
+        mismatch = False
+        for i, ev in enumerate(expected_violations):
+            expected_code: str = ev["code"]
+            actual_code: str = violations[i]["code"] if i < len(violations) else "(missing)"
+            if actual_code != expected_code:
+                mismatch = True
+                print(f"FAIL {vid}: violation[{i}] code mismatch", file=sys.stderr)
+                print(f"  expected: {expected_code}", file=sys.stderr)
+                print(f"  actual:   {actual_code}", file=sys.stderr)
+                break
+
+        if mismatch:
+            failed += 1
+            continue
+
+        print(f"PASS {vid}")
+
+    if failed:
+        print(f"\n{failed} SignedKRL vector(s) failed", file=sys.stderr)
+        return 1
+
+    print(f"\nAll {len(vectors)} SignedKRL vector(s) passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #119.

## Summary

Adds Python cross-language conformance coverage for:

- Profile C state-hash semantics, modes 001–005
- SignedKRLV1 verification, all 9 portable vectors

This completes the Python half of #119. The Go half landed in #121.

## What changed

- Added `python-harness/verify_profile_c_vectors.py`
- Added `python-harness/verify_signed_krl_vectors.py`
- Updated `test:vectors:py` to run canonicalization, Profile C, and SignedKRLV1 suites
- Updated docs and audit status for completed Go + Python cross-language coverage

## Coverage

Profile C coverage includes:

- live-state match
- live-state mismatch
- hash strategy mismatch
- computeStateHash failure
- stale state / TOCTOU-style mismatch

Profile C Encoding B modes 006–008 remain TypeScript-only and are tracked separately.

SignedKRLV1 coverage includes:

- valid signed KRL
- invalid signature
- expired KRL
- malformed `revoked_kids`
- duplicate `revoked_kids`
- unknown signing kid
- inactive signing key
- unsupported algorithm
- version regression

## Boundary guarantees

No changes were made to:

- `packages/core/**`
- `packages/sift/**`
- `packages/conformance/**`
- `go-harness/**`
- `docs/spec/test-vectors/*.json`
- `packages/core/API_FINGERPRINT`

No protocol semantics were changed.

## Audit status

P1-6 is now resolved for Profile C state-hash semantics and SignedKRLV1 cross-language coverage:

`✓ RESOLVED for Profile C state-hash semantics and SignedKRLV1 cross-language coverage (Go + Python). Profile C Encoding B modes 006–008 remain TypeScript-only and are tracked separately.`

## Validation

- `pnpm test:vectors:py`: 25/25 passing
- `pnpm test:vectors:all`: passing
- `pnpm -C packages/conformance validate`: 209/209 passing
- `pnpm typecheck`: passing
- `pnpm test`: passing
- `pnpm security:gate`: ALLOW
- `git diff --check`: clean
- `packages/core/API_FINGERPRINT`: unchanged

## Residual limitations

- Profile C Encoding B modes 006–008 remain TypeScript-only.
- State provider trust remains open.
- This PR does not claim full standardization readiness.