### PR TITLE
feat(sift): add persistent KRL watermark store

### DIFF
--- a/docs/audits/protocol-audit-post-interoperability.md
+++ b/docs/audits/protocol-audit-post-interoperability.md
@@ -1,6 +1,6 @@
 # Protocol Audit - Post-Interoperability Hardening
 
-**Date:** 2026-05-17
+**Date:** 2026-06-02
 **Scope:** OxDeAI execution authorization boundary protocol, after completion of the external-provider interoperability hardening sequence
 **Auditor:** Internal protocol audit (Ange)
 **Protocol invariant under audit:**
@@ -90,7 +90,7 @@
 | `not_after` enforcement | `DONE` | Implemented. Conformance vectors `key-lifecycle-004`, `key-lifecycle-006`, `key-lifecycle-008` (expired windows). |
 | Key rotation (dual-sign) | `PARTIAL` | Rotation procedure documented in `key-custody-and-rotation.md`. Dual-sign overlap verified by `key-lifecycle-007` (retired key within window → ok). No automated rotation machinery. |
 | Sift KRL (Key Revocation List) | `DONE` | `SiftHttpKeyStore` now supports three KRL integrity modes: `signed_required` (closes transport gap), `signed_preferred` (default, signed when present), `unsigned_legacy` (deprecated). `verifyKrl` callback injection preserves `@oxdeai/sift` zero-dependency boundary. 29 new tests. See `packages/sift/README.md`. |
-| `SignedKRLV1` artifact | `DONE` | Defined in `docs/spec/artifacts/signed-krl-v1.md`. `verifySignedKrl` verifier in `@oxdeai/core` with 9 conformance vectors. Integrated into `SiftHttpKeyStore` via `verifyKrl` callback (`signed_required` mode closes the transport-integrity gap). Residual: persistent high-watermark storage and cross-language vectors deferred to future patches. |
+| `SignedKRLV1` artifact | `DONE` | Defined in `docs/spec/artifacts/signed-krl-v1.md`. `verifySignedKrl` verifier in `@oxdeai/core` with 9 conformance vectors. Integrated into `SiftHttpKeyStore` via `verifyKrl` callback. Phase A (#117): `KrlWatermarkStore` + `createFileBackedKrlWatermarkStore` added - persistent watermark closes the restart-and-replay downgrade window when configured. Residual: LKG cache (Phase B) pending. |
 
 ---
 
@@ -255,7 +255,7 @@ The following areas still have **no portable conformance vector**:
 | Gap | Risk Level | Notes |
 |-----|-----------|-------|
 | `decision != "ALLOW"` portable vector | **Medium** | Only checked structurally; no dedicated cross-language vector. |
-| Both `expiry` and `expires_at` present simultaneously | ~~**Medium**~~ | ✓ Resolved: vector `auth-expiry-wins-over-expires-at` locks the precedence rule — `expiry` expired + `expires_at` valid → DENY/EXPIRED. Resolved in #106. |
+| Both `expiry` and `expires_at` present simultaneously | ~~**Medium**~~ | ✓ Resolved: vector `auth-expiry-wins-over-expires-at` locks the precedence rule - `expiry` expired + `expires_at` valid → DENY/EXPIRED. Resolved in #106. |
 | Intent hash mismatch → DENY (cross-language) | ~~**Medium**~~ | ✓ Resolved: `authorization-v1.json` now includes `proposed_action` field enabling independent hash derivation. Portable ALLOW case `auth-intent-action-match-1` and `portable-key-1` fixture key added. Go/Python authorization harness integration remains a future item. Resolved in #105. |
 | Profile B trust separation vector | ~~**Medium**~~ | ✓ Resolved: `pb-trust-oxdeai-key-allow` proves OxDeAI key (in trustedKeySets) verifies correctly; `pb-trust-provider-key-rejected` proves provider receipt key absent from trustedKeySets returns DENY/UNKNOWN_KID. Resolved in #108. |
 | Profile C cross-language vectors | **Medium** | Profile C vectors are TypeScript-only. `computeStateHash` requires adapter integration. |
@@ -308,7 +308,7 @@ The following areas still have **no portable conformance vector**:
 The state provider is unconditionally trusted. A compromised `getState()` implementation can return a state that produces a matching `state_hash` for an authorization, bypassing the semantic check. **No mitigation exists at the protocol layer.** Documented in `threat-model-external-providers.md` (T-8).
 
 **RT-TRUST-2: KRL transport integrity** *(mitigated by `signed_required` mode; residual in default mode)*
-`SiftHttpKeyStore` now supports three KRL integrity modes. `signed_required` mode (via `verifyKrl` callback + `verifySignedKrl` from `@oxdeai/core`) closes the transport-integrity gap for deployments that configure it. The default `signed_preferred` mode accepts unsigned KRLs as a fallback. **Residual risk:** the gap is only eliminated when `signed_required` is actively deployed. `unsigned_legacy` and unsigned fallback in `signed_preferred` remain transport-trust-only. See deprecation trajectory in `packages/sift/README.md`.
+`SiftHttpKeyStore` now supports three KRL integrity modes. `signed_required` mode closes the transport-integrity gap for deployments that configure it. **Phase A (#117):** `KrlWatermarkStore` interface and `createFileBackedKrlWatermarkStore` reference implementation added. With `signed_required` + persistent watermark store, the restart-and-replay downgrade window is also closed. **Residual risk:** the gap is only fully closed when `signed_required` + a persistent `KrlWatermarkStore` are both actively deployed. `signed_preferred` unsigned fallback and `unsigned_legacy` retain transport-trust-only semantics. Two new sift-local reason codes: `KRL_WATERMARK_LOAD_FAILED` (store unreadable before verification) and `KRL_WATERMARK_PERSIST_FAILED` (verified KRL could not be durably recorded; fails closed before cache swap). Phase B (#117): last-known-good cache pending.
 
 **RT-TRUST-3: Replay store bootstrapping**
 New deployments start with an empty replay store. Authorization artifacts issued before the store was populated can replay within their validity window. No mitigation; documented in `replay-store-ttl-alignment.md` (RT-3: clock-skew edge) and adjacent scenarios.
@@ -342,8 +342,8 @@ New deployments start with an empty replay store. Authorization artifacts issued
 - `AuthorizationV1` is well-specified and has cross-language conformance vectors (Go harness).
 - Canonicalization-v1 is fully specified with cross-language vectors.
 - `DelegationV1` has cross-language vectors.
-- ~~**Gap:** Key lifecycle (`revoked`, `not_before`, `not_after`) has no portable conformance vectors.~~ ✓ resolved — `key-lifecycle-verification.json` added (P0-1).
-- ~~**Gap:** Intent hash mismatch has no cross-language vector.~~ ✓ resolved — portable `authorization-v1.json` vector with `proposed_action` added (P1-1).
+- ~~**Gap:** Key lifecycle (`revoked`, `not_before`, `not_after`) has no portable conformance vectors.~~ ✓ resolved - `key-lifecycle-verification.json` added (P0-1).
+- ~~**Gap:** Intent hash mismatch has no cross-language vector.~~ ✓ resolved - portable `authorization-v1.json` vector with `proposed_action` added (P1-1).
 - **Gap:** State hash mismatch has no cross-language vector.
 - **Gap:** Profile C is TypeScript-only; `computeStateHash` integration requires external harness work.
 
@@ -354,7 +354,7 @@ New deployments start with an empty replay store. Authorization artifacts issued
 `verifyAuthorization` is stateless and fully portable. An independent verifier can reproduce all signature checks and field validation with the existing conformance vectors. However:
 
 - No vector for `AUTH_KEY_INACTIVE` (revoked or window-expired key).
-- ~~No vector for simultaneous `expiry`/`expires_at` precedence.~~ ✓ resolved — `auth-expiry-wins-over-expires-at` vector added (P1-2).
+- ~~No vector for simultaneous `expiry`/`expires_at` precedence.~~ ✓ resolved - `auth-expiry-wins-over-expires-at` vector added (P1-2).
 - Strict-mode behavior (no `trustedKeySets` provided) is not covered by a portable vector.
 
 ### 7.3 Conformance Suite Readiness
@@ -363,10 +363,10 @@ New deployments start with an empty replay store. Authorization artifacts issued
 
 191 assertions across 15 vector files + 10 portable `authorization-v1.json` vectors. Key lifecycle, intent hash mismatch, and expiry precedence coverage resolved. Remaining gaps:
 
-1. ~~Key lifecycle vectors (revoked, not_before, not_after)~~ ✓ resolved — `key-lifecycle-verification.json`
-2. ~~Intent hash mismatch portable vector~~ ✓ resolved — `authorization-v1.json` vectors include `proposed_action` mismatch case and portable ALLOW case; Go/Python auth harness integration is a future item
-3. ~~`expiry`/`expires_at` simultaneous presence precedence vector~~ ✓ resolved — `auth-expiry-wins-over-expires-at` vector locks precedence rule
-4. Cross-language Profile C vectors — important for Profile C adoption
+1. ~~Key lifecycle vectors (revoked, not_before, not_after)~~ ✓ resolved - `key-lifecycle-verification.json`
+2. ~~Intent hash mismatch portable vector~~ ✓ resolved - `authorization-v1.json` vectors include `proposed_action` mismatch case and portable ALLOW case; Go/Python auth harness integration is a future item
+3. ~~`expiry`/`expires_at` simultaneous presence precedence vector~~ ✓ resolved - `auth-expiry-wins-over-expires-at` vector locks precedence rule
+4. Cross-language Profile C vectors - important for Profile C adoption
 
 ### 7.4 Interoperability Profile Readiness
 
@@ -395,9 +395,9 @@ Prerequisites before external standard positioning:
 
 1. ~~Close key lifecycle conformance vector gap~~ ✓ resolved
 2. ~~Define clock skew tolerance specification~~ ✓ resolved
-3. ~~Separate public `AuthorizationV1` artifact boundary from internal legacy shape~~ ✓ resolved — clean public artifact projection added; `DelegationV1` parent hashing no longer depends on internal legacy fields
-4. ~~Close intent hash mismatch portable vector gap~~ ✓ resolved — portable `AuthorizationV1` vector added with `proposed_action`
-5. ~~Close `expiry`/`expires_at` precedence vector gap~~ ✓ resolved — `auth-expiry-wins-over-expires-at` vector locks precedence rule
+3. ~~Separate public `AuthorizationV1` artifact boundary from internal legacy shape~~ ✓ resolved - clean public artifact projection added; `DelegationV1` parent hashing no longer depends on internal legacy fields
+4. ~~Close intent hash mismatch portable vector gap~~ ✓ resolved - portable `AuthorizationV1` vector added with `proposed_action`
+5. ~~Close `expiry`/`expires_at` precedence vector gap~~ ✓ resolved - `auth-expiry-wins-over-expires-at` vector locks precedence rule
 6. Resolve or formally mitigate state provider trust risk
 7. Resolve or formally mitigate KRL transport integrity risk
 8. Independent security review
@@ -440,10 +440,10 @@ Structured events / metrics  ░░░░░░░░░░░░░░░░░
 ### P0 - Must resolve before external adoption
 
 **P0-1: Add portable conformance vectors for key lifecycle** ✓ RESOLVED
-Resolution: `key-lifecycle-verification.json` added — 10 vectors, 20 assertions covering active, revoked, retired (within/past window), `not_before`/`not_after` time windows, revocation-overrides-window, and wrong-kid-known-issuer. Conformance count: 161 → 181.
+Resolution: `key-lifecycle-verification.json` added - 10 vectors, 20 assertions covering active, revoked, retired (within/past window), `not_before`/`not_after` time windows, revocation-overrides-window, and wrong-kid-known-issuer. Conformance count: 161 → 181.
 
 **P0-2: Define and specify clock skew tolerance** ✓ RESOLVED
-Resolution: Strict zero-tolerance selected and specified. `authorization-v1.md §17` defines: valid iff `now < expiry`, no grace period, `issued_at` informational-only (no lower-bound enforcement), NTP synchronization required, issuers must build delivery latency into expiry window. `clock-semantics-verification.json` added — 5 vectors, 10 assertions covering last-valid-second, one-past-expiry, verifier-clock-behind, and Encoding B variants. Conformance count: 181 → 191.
+Resolution: Strict zero-tolerance selected and specified. `authorization-v1.md §17` defines: valid iff `now < expiry`, no grace period, `issued_at` informational-only (no lower-bound enforcement), NTP synchronization required, issuers must build delivery latency into expiry window. `clock-semantics-verification.json` added - 5 vectors, 10 assertions covering last-valid-second, one-past-expiry, verifier-clock-behind, and Encoding B variants. Conformance count: 181 → 191.
 
 **P0-3: Harden `parentScope` handling in `OxDeAIGuard`** ✓ RESOLVED
 Resolution: `GuardDelegationInput` now requires `parentScope: DelegationScope` as an explicit typed field. `isValidDelegationScope` validates the structure before chain verification. The unsafe `(parentAuth as any).scope` cast has been removed from `guard.ts`. All delegation tests and the `delegation-demo` example updated to pass `parentScope` explicitly. Missing or malformed `parentScope` fails closed before execution; `OxDeAIAuthorizationError` is thrown before the delegation chain verification path is reached.
@@ -466,9 +466,9 @@ Resolution: Two vectors added to `authorization-v1.json`: `pb-trust-oxdeai-key-a
 
 **P1-4: Resolve KRL transport integrity risk** ✓ RESOLVED for `signed_required`; residual risk in default mode
 Resolution: `SiftHttpKeyStore` now supports three KRL integrity modes via `verifyKrl` callback injection (Patch A + Patch B):
-- `signed_required` — closes the transport-integrity gap. Every KRL must be a signed `SignedKRLV1` verified by `verifySignedKrl` from `@oxdeai/core`. Unsigned KRLs rejected before `verifyKrl` is consulted. Constructor fails fast without `verifyKrl`.
-- `signed_preferred` (default) — signed KRLs verified when present; unsigned fallback for unsigned KRLs. Signed KRL with missing `verifyKrl` fails closed.
-- `unsigned_legacy` — deprecated; transport-trust-only; warns at construction.
+- `signed_required` - closes the transport-integrity gap. Every KRL must be a signed `SignedKRLV1` verified by `verifySignedKrl` from `@oxdeai/core`. Unsigned KRLs rejected before `verifyKrl` is consulted. Constructor fails fast without `verifyKrl`.
+- `signed_preferred` (default) - signed KRLs verified when present; unsigned fallback for unsigned KRLs. Signed KRL with missing `verifyKrl` fails closed.
+- `unsigned_legacy` - deprecated; transport-trust-only; warns at construction.
 `@oxdeai/sift` zero-dependency boundary preserved via callback injection. `krl_version` per-issuer watermark tracked in memory. `getKrlStatus()` status surface added. 29 new mode tests in `siftKeyStore.krl-modes.test.ts`.
 Caveats: transport-integrity gap is only fully closed when callers deploy `signed_required`. `signed_preferred` unsigned fallback and `unsigned_legacy` retain transport-trust-only semantics. Persistent high-watermark storage and cross-language KRL vectors remain future work. Non-string `revoked_kids` skipping is legacy-path-only behavior, not `SignedKRLV1` semantics.
 **KRL reason-code ownership:** Four codes are Sift-local (produced by mode logic, NOT from `@oxdeai/core`): `KRL_UNSIGNED_IN_SIGNED_REQUIRED`, `KRL_MISSING_VERIFY_CALLBACK`, `KRL_VERIFY_CALLBACK_ERROR`, `KRL_VERIFY_RESULT_INCOMPLETE`. Seven core codes are passed through as opaque strings from the `verifyKrl` callback: `KRL_MALFORMED`, `KRL_SIG_INVALID`, `KRL_EXPIRED`, `KRL_UNSUPPORTED_ALG`, `KRL_UNKNOWN_SIGNING_KID`, `KRL_SIGNING_KEY_INACTIVE`, `KRL_VERSION_REGRESSION`.
@@ -534,13 +534,13 @@ Scope: `pep-gateway-v1.md` §7 or a new `state-provider-requirements.md`.
 
 **Critical path to external adoption:**
 
-1. ~~Key lifecycle portable vectors (P0-1)~~ ✓ resolved — 20 assertions added
-2. ~~Clock skew specification (P0-2)~~ ✓ resolved — strict zero-tolerance specified, 10 assertions added
-3. ~~parentScope type safety in guard (P0-3)~~ ✓ resolved — unsafe cast removed, fail-closed before chain verification
-4. ~~Public `AuthorizationV1` artifact boundary (P0-4)~~ ✓ resolved — clean public artifact projection added; `DelegationV1` parent hashing no longer depends on internal legacy fields
-5. ~~Intent hash mismatch portable vector (P1-1)~~ ✓ resolved — portable `AuthorizationV1` vector added for `proposed_action` mismatch
-6. ~~`expiry`/`expires_at` precedence vector (P1-2)~~ ✓ resolved — `auth-expiry-wins-over-expires-at` vector locks precedence rule
-7. ~~HMAC-SHA256 deprecation (P1-5)~~ ✓ resolved — spec deprecation notice added; `@deprecated` JSDoc on `legacyHmacSecret` and `authorization_signing_alg`
+1. ~~Key lifecycle portable vectors (P0-1)~~ ✓ resolved - 20 assertions added
+2. ~~Clock skew specification (P0-2)~~ ✓ resolved - strict zero-tolerance specified, 10 assertions added
+3. ~~parentScope type safety in guard (P0-3)~~ ✓ resolved - unsafe cast removed, fail-closed before chain verification
+4. ~~Public `AuthorizationV1` artifact boundary (P0-4)~~ ✓ resolved - clean public artifact projection added; `DelegationV1` parent hashing no longer depends on internal legacy fields
+5. ~~Intent hash mismatch portable vector (P1-1)~~ ✓ resolved - portable `AuthorizationV1` vector added for `proposed_action` mismatch
+6. ~~`expiry`/`expires_at` precedence vector (P1-2)~~ ✓ resolved - `auth-expiry-wins-over-expires-at` vector locks precedence rule
+7. ~~HMAC-SHA256 deprecation (P1-5)~~ ✓ resolved - spec deprecation notice added; `@deprecated` JSDoc on `legacyHmacSecret` and `authorization_signing_alg`
 8. Cross-language Profile C vectors (P1-6)
 
 **Protocol positioning:**
@@ -551,4 +551,4 @@ The protocol is **not yet ready for standard adoption**. Key lifecycle, clock sk
 
 ---
 
-*This document reflects the protocol state as of 2026-05-17. It should be revisited after each significant milestone.*
+*This document reflects the protocol state as of 2026-06-02. It should be revisited after each significant milestone.*

--- a/docs/spec/interoperability/external-provider-profile.md
+++ b/docs/spec/interoperability/external-provider-profile.md
@@ -18,8 +18,8 @@ provider ambiguity → not interoperable → DENY → no execution
 
 ## Related Documents
 
-- [AuthorizationV1 specification](../artifacts/authorization-v1.md) — accepted wire encodings (normative)
-- [PEP Gateway specification](../enforcement/pep-gateway-v1.md) — enforcement contract (normative)
+- [AuthorizationV1 specification](../artifacts/authorization-v1.md) - accepted wire encodings (normative)
+- [PEP Gateway specification](../enforcement/pep-gateway-v1.md) - enforcement contract (normative)
 - [Threat model: external providers](../../architecture/threat-model-external-providers.md)
 - [Key custody and rotation guide](../../architecture/key-custody-and-rotation.md)
 - [Replay-store TTL alignment guide](../../architecture/replay-store-ttl-alignment.md)
@@ -57,23 +57,23 @@ Three compatibility profiles are defined. Each is cumulative: Profile C requires
 ```text
 Profile A ⊂ Profile B ⊂ Profile C
 
-Profile A — Core-native AuthorizationV1
+Profile A - Core-native AuthorizationV1
   Valid ALLOW artifact, Ed25519 signature, expiry, replay, intent binding.
   State binding via signature integrity only (state_hash is signed but not
   re-verified against live state at the gateway level).
 
-Profile B — External provider wire-compatible
+Profile B - External provider wire-compatible
   Extends Profile A with Sift-compatible wire encoding and adapter trust model.
   Gateway-level only: signature integrity protects state_hash.
 
-Profile C — Full semantic state verification
+Profile C - Full semantic state verification
   Extends Profile B with live-state re-verification using a pluggable
   computeStateHash strategy. Requires OxDeAIGuard (not just PEP gateway).
 ```
 
 ---
 
-### 2.1 Profile A — Core-native AuthorizationV1
+### 2.1 Profile A - Core-native AuthorizationV1
 
 **Summary:** The provider uses Core-native encoding. The verifier applies all standard checks.
 This is the default integration path for providers using `@oxdeai/core`.
@@ -83,7 +83,7 @@ This is the default integration path for providers using `@oxdeai/core`.
 | Requirement | Specification |
 |---|---|
 | Artifact type | `AuthorizationV1` |
-| Wire encoding | Encoding A (Core-native) — see §3.1 |
+| Wire encoding | Encoding A (Core-native) - see §3.1 |
 | `decision` | Must be `"ALLOW"` |
 | `issuer` | Non-empty string; must match a `KeySet.issuer` in verifier's `trustedKeySets` |
 | `audience` | Non-empty string; must match verifier's `expectedAudience` |
@@ -120,7 +120,7 @@ This is the default integration path for providers using `@oxdeai/core`.
 
 Profile A enforces state_hash integrity via signature: any post-issuance tamper of `state_hash`
 breaks the Ed25519 signature. However, the verifier does NOT re-verify `state_hash` against live
-state — there is no live-state access at the gateway level. Profile A is suitable when the
+state - there is no live-state access at the gateway level. Profile A is suitable when the
 issuing policy engine is the sole source of state truth.
 
 #### 2.1.4 Fail-Closed Behavior
@@ -130,7 +130,7 @@ Exception during signature verification → DENY. Replay store exception → DEN
 
 ---
 
-### 2.2 Profile B — External Provider Wire-Compatible
+### 2.2 Profile B - External Provider Wire-Compatible
 
 **Summary:** The provider uses Sift-compatible encoding or another accepted external encoding.
 The verifier accepts both Encoding A and Encoding B. The trust root is the adapter's Ed25519 key,
@@ -142,10 +142,10 @@ Profile B is a strict superset of Profile A. A Profile B-capable verifier accept
 
 | Requirement | Specification |
 |---|---|
-| Wire encoding | Encoding B (Sift-compatible) — see §3.2 — OR Encoding A |
+| Wire encoding | Encoding B (Sift-compatible) - see §3.2 - OR Encoding A |
 | `expires_at` | May be used instead of `expiry` (see §3.3 expiry resolution) |
-| `signature.alg` | `"ed25519"` (lowercase) — OR `"Ed25519"` for Encoding A |
-| Signature encoding | Base64url (RFC 4648 §5) for `sig` field — OR standard base64 |
+| `signature.alg` | `"ed25519"` (lowercase) - OR `"Ed25519"` for Encoding A |
+| Signature encoding | Base64url (RFC 4648 §5) for `sig` field - OR standard base64 |
 | Signing preimage | `canonicalJson(payload_without_sig_bytes)` (no domain prefix) for Encoding B |
 | Adapter identity | Provider output must be re-signed by an adapter Ed25519 key listed in `trustedKeySets`; the external provider's receipt-signing key is NOT the OxDeAI trust root |
 | `state_hash` | Computed by the adapter using a defined canonicalization function (e.g., `siftCanonicalJsonHash`); the function used must be documented and stable |
@@ -176,7 +176,7 @@ provider cannot produce a guard-passing authorization without the adapter's Ed25
 
 Same as Profile A: `state_hash` is protected by signature integrity. The adapter computes
 `state_hash` using its own canonicalization function. The verifier does not re-compute
-`state_hash` from live state at Profile B — only signature integrity is enforced.
+`state_hash` from live state at Profile B - only signature integrity is enforced.
 
 #### 2.2.5 KRL Integrity at Profile B
 
@@ -187,16 +187,16 @@ A KRL (Key Revocation List) maintained by the provider records revoked `kid` val
 
 | Option | Integrity guarantee | Status |
 |--------|---------------------|--------|
-| `unsigned_legacy` | Transport security (HTTPS) only | Deprecated — residual risk |
+| `unsigned_legacy` | Transport security (HTTPS) only | Deprecated - residual risk |
 | `signed_preferred` with unsigned fallback | Transport security for unsigned KRLs; cryptographic for signed KRLs | Transition mode |
-| `signed_required` | Cryptographic — `SignedKRLV1` verified via `verifySignedKrl` | Recommended for production |
+| `signed_required` | Cryptographic - `SignedKRLV1` verified via `verifySignedKrl` | Recommended for production |
 
 **`SignedKRLV1` specification.** `SignedKRLV1` is a provider-neutral OxDeAI protocol artifact
 defined in `docs/spec/artifacts/signed-krl-v1.md`. It carries a `revoked_kids` list signed
-with an Ed25519 key whose trust is configured statically at the verifier — independent of
+with an Ed25519 key whose trust is configured statically at the verifier - independent of
 transport security.
 
-**Signing domain.** `OXDEAI_KRL_V1\n` + `canonicalJson(signingPayload)` — using OxDeAI
+**Signing domain.** `OXDEAI_KRL_V1\n` + `canonicalJson(signingPayload)` - using OxDeAI
 canonicalization-v1, not Sift canonicalization.
 
 **Trust domain separation.**
@@ -232,6 +232,8 @@ check. This risk is only closed by deploying `signed_required` mode.
 | `KRL_MISSING_VERIFY_CALLBACK` | KRL has a `signature` field but no `verifyKrl` configured |
 | `KRL_VERIFY_CALLBACK_ERROR` | `verifyKrl` callback threw unexpectedly |
 | `KRL_VERIFY_RESULT_INCOMPLETE` | `verifyKrl` returned `ok: true` without `accepted` metadata |
+| `KRL_WATERMARK_LOAD_FAILED` | *(Phase A, #117)* `KrlWatermarkStore.list()` failed before verification; refresh fails closed before `verifyKrl` is called |
+| `KRL_WATERMARK_PERSIST_FAILED` | *(Phase A, #117)* Signed KRL verified but `KrlWatermarkStore.set()` failed; refresh fails closed before cache swap |
 
 *Core KRL codes* (passed through from `verifyKrl` as opaque strings):
 `KRL_MALFORMED`, `KRL_SIG_INVALID`, `KRL_EXPIRED`, `KRL_UNSUPPORTED_ALG`,
@@ -242,11 +244,11 @@ all 9 SignedKRLV1 portable vectors (`docs/spec/test-vectors/signed-krl-v1.json`)
 Go's `crypto/ed25519` standard library. Each vector contains a committed `SignedKRLV1`
 artifact; the harness reconstructs the `OXDEAI_KRL_V1` signing preimage independently
 using canonicalization-v1 and verifies the Ed25519 signature without consuming any
-TypeScript-generated intermediate artifact. Python cross-language coverage is also complete — `python-harness/verify_signed_krl_vectors.py` uses ctypes + libcrypto for independent Ed25519 verification.
+TypeScript-generated intermediate artifact. Python cross-language coverage is also complete - `python-harness/verify_signed_krl_vectors.py` uses ctypes + libcrypto for independent Ed25519 verification.
 
 ---
 
-### 2.3 Profile C — Full Semantic State Verification
+### 2.3 Profile C - Full Semantic State Verification
 
 **Summary:** Extends Profile B with live-state re-verification. The verifier re-computes
 `state_hash` from the live state snapshot using the same canonicalization function the
@@ -285,7 +287,7 @@ MISCONFIGURED (fail-closed, but blocks legitimate execution):
 ```
 
 The guard cannot detect whether a state_hash mismatch is due to actual state change or
-wrong hash strategy — both produce DENY. Deployers must ensure alignment.
+wrong hash strategy - both produce DENY. Deployers must ensure alignment.
 
 #### 2.3.4 Cross-language conformance
 
@@ -316,7 +318,7 @@ verification) remain TypeScript-only and are tracked as a separate issue.
 
 ## 3. Wire Encoding Reference
 
-### 3.1 Encoding A — Core-native
+### 3.1 Encoding A - Core-native
 
 See [`docs/spec/artifacts/authorization-v1.md §5.1`](../artifacts/authorization-v1.md) for the normative definition.
 
@@ -345,7 +347,7 @@ Or with nested signature object:
 }
 ```
 
-### 3.2 Encoding B — Sift-compatible
+### 3.2 Encoding B - Sift-compatible
 
 ```json
 {

--- a/packages/sift/README.md
+++ b/packages/sift/README.md
@@ -308,7 +308,7 @@ Minimum requirements:
 | Mode | Description | Production status |
 |------|-------------|------------------|
 | `"signed_required"` | Every KRL must be cryptographically signed (`SignedKRLV1`). Unsigned KRLs are rejected with `KRL_UNSIGNED_IN_SIGNED_REQUIRED` *before* calling `verifyKrl`. Requires a `verifyKrl` callback at construction. **Closes the transport-integrity gap.** | Recommended |
-| `"signed_preferred"` *(default)* | Signed KRLs are verified when present; unsigned KRLs are accepted as a transport-trust fallback (`unsigned_fallback` status). If a signature field is present but no `verifyKrl` is configured, refresh fails closed — there is no downgrade path. | Default transition mode |
+| `"signed_preferred"` *(default)* | Signed KRLs are verified when present; unsigned KRLs are accepted as a transport-trust fallback (`unsigned_fallback` status). If a signature field is present but no `verifyKrl` is configured, refresh fails closed - there is no downgrade path. | Default transition mode |
 | `"unsigned_legacy"` | Preserves pre-Patch-B unsigned KRL behavior. Deprecated. Emits a warning at construction. **Residual risk: transport security only.** | Deprecated |
 
 **Wiring signed KRL verification.** Supply a `verifyKrl` callback that delegates to `verifySignedKrl` from `@oxdeai/core`. This preserves `@oxdeai/sift`'s zero-dependency boundary:
@@ -346,13 +346,13 @@ const status = store.getKrlStatus();
 
 `lastReason` is always cleared to `undefined` on a successful refresh. It never carries a stale failure reason after a later success.
 
-**Version watermark.** `SiftHttpKeyStore` tracks the highest accepted `krl_version` per issuer in memory during its lifetime and passes this to `verifyKrl` as `previousKrlVersionByIssuer`. This causes `verifySignedKrl` to reject any KRL whose `krl_version` is less than the previously accepted version (`KRL_VERSION_REGRESSION`). **This watermark is in-memory only and resets on process restart.**
+**Version watermark.** `SiftHttpKeyStore` tracks the highest accepted `krl_version` per issuer and passes this to `verifyKrl` as `previousKrlVersionByIssuer`. This causes `verifySignedKrl` to reject any KRL whose `krl_version` is less than the previously accepted version (`KRL_VERSION_REGRESSION`). By default the watermark is in-memory and resets on process restart. Configure a `KrlWatermarkStore` to persist the watermark across restarts - see **Persistent KRL high-watermark** below.
 
 **Unsigned path behavior (legacy).** The unsigned fallback path (used by `unsigned_legacy` and by `signed_preferred` when the fetched KRL has no `signature` field) silently skips non-string entries in `revoked_kids`. **This is legacy behavior and is NOT `SignedKRLV1` semantics.** `SignedKRLV1` verification rejects non-string entries and duplicate entries as `KRL_MALFORMED`.
 
 **KRL reason codes.** Two sets of codes are surfaced in `krlStatus.lastReason` and `KeyStoreError` messages:
 
-*Sift-local mode/contract codes* — produced by `SiftHttpKeyStore` mode logic; never imported from `@oxdeai/core`:
+*Sift-local mode/contract codes* - produced by `SiftHttpKeyStore` mode logic; never imported from `@oxdeai/core`:
 
 | Code | Trigger |
 |------|---------|
@@ -360,11 +360,52 @@ const status = store.getKrlStatus();
 | `KRL_MISSING_VERIFY_CALLBACK` | KRL has a `signature` field but no `verifyKrl` callback configured; refresh fails closed |
 | `KRL_VERIFY_CALLBACK_ERROR` | `verifyKrl` callback threw instead of returning a result; refresh fails closed |
 | `KRL_VERIFY_RESULT_INCOMPLETE` | `verifyKrl` returned `ok: true` but omitted `accepted` issuer/`krl_version` metadata; refresh fails closed |
+| `KRL_WATERMARK_LOAD_FAILED` | *(Phase A)* Persistent watermark store could not be loaded before verification; refresh fails closed before `verifyKrl` is called |
+| `KRL_WATERMARK_PERSIST_FAILED` | *(Phase A)* Signed KRL verified but persisting the new watermark failed; refresh fails closed before cache swap |
 
-*Core KRL codes* — passed through as opaque strings from the `verifyKrl` callback (originated in `@oxdeai/core`):
+*Core KRL codes* - passed through as opaque strings from the `verifyKrl` callback (originated in `@oxdeai/core`):
 `KRL_MALFORMED`, `KRL_SIG_INVALID`, `KRL_EXPIRED`, `KRL_UNSUPPORTED_ALG`, `KRL_UNKNOWN_SIGNING_KID`, `KRL_SIGNING_KEY_INACTIVE`, `KRL_VERSION_REGRESSION`.
 
 **`result.accepted` contract.** When `verifyKrl` returns `ok: true`, it MUST include `accepted: { issuer, krl_version }` populated from the verified `SignedKRLV1` payload fields. This is how `SiftHttpKeyStore` advances the per-issuer version watermark without independently re-parsing the body. Omitting `accepted` fails closed with `KRL_VERIFY_RESULT_INCOMPLETE`.
+
+**Persistent KRL high-watermark.** By default, the per-issuer `krl_version` watermark is in-memory only and resets on process restart, opening a one-cycle downgrade window. Supply a `KrlWatermarkStore` to make the watermark durable:
+
+```ts
+import {
+  SiftHttpKeyStore,
+  createFileBackedKrlWatermarkStore,
+} from "@oxdeai/sift";
+import { verifySignedKrl } from "@oxdeai/core";
+
+const store = new SiftHttpKeyStore({
+  jwksUrl, krlUrl,
+  krlMode: "signed_required",
+  verifyKrl: (payload, ctx) => {
+    const result = verifySignedKrl(payload, { trustedKeySets: myKrlKeys, ...ctx });
+    if (!result.ok) return result;
+    const krl = payload as { issuer: string; krl_version: number };
+    return { ...result, accepted: { issuer: krl.issuer, krl_version: krl.krl_version } };
+  },
+  // Phase A: persistent high-watermark (single-node)
+  krlWatermarkStore: createFileBackedKrlWatermarkStore("/var/app/krl-watermark.json"),
+});
+```
+
+| Interface | Description |
+|-----------|-------------|
+| `KrlWatermarkStore` | Pluggable interface: `get(issuer)`, `set(issuer, version)`, `list()` |
+| `createInMemoryKrlWatermarkStore()` | Default in-process store (current behavior, no persistence) |
+| `createFileBackedKrlWatermarkStore(path)` | Persistent single-node store; atomic write via temp-file + rename |
+
+**No constructor I/O.** The store is never accessed at construction time. On the first signed `refresh()`, `list()` is called to load persisted watermarks and merge them into the in-memory map.
+
+**Persist-before-cache-swap.** After signed KRL verification succeeds, the new `krl_version` is written to the store *before* the in-memory revocation cache is swapped. If the write fails, `refresh()` throws `KRL_WATERMARK_PERSIST_FAILED` and the cache is not updated. A KRL is only accepted if its version was durably recorded.
+
+**Restart downgrade protection.** With a persistent store configured, an older signed KRL replayed after process restart will be rejected with `KRL_VERSION_REGRESSION` because the persisted watermark is restored before `verifyKrl` is called on the new refresh.
+
+**`krlStatus.watermarkStore`:** `"memory"` when no store is configured (default); `"persistent"` when a `KrlWatermarkStore` is configured.
+
+**Single-node / single-writer.** `createFileBackedKrlWatermarkStore` uses read-modify-write and is NOT safe for concurrent writes from multiple processes. Multi-node deployments should implement `KrlWatermarkStore` backed by a database with atomic compare-and-set.
 
 **Deprecation trajectory:**
 
@@ -470,7 +511,7 @@ latency requirements - not just on startup.
 ```ts
 import { SiftHttpKeyStore, createStagingKeyStore, type SiftKeyStore } from "@oxdeai/sift";
 
-// Staging (development / testing only — NOT for production):
+// Staging (development / testing only - NOT for production):
 const store = createStagingKeyStore();
 await store.refresh();
 // Note: createStagingKeyStore() throws if NODE_ENV === "production".
@@ -485,7 +526,7 @@ const prodStore = new SiftHttpKeyStore({
   verifyKrl: (payload, ctx) => verifySignedKrl(payload, { trustedKeySets: myKrlKeySets, ...ctx }),
 });
 
-// Transition (default — unsigned fallback if KRL is unsigned):
+// Transition (default - unsigned fallback if KRL is unsigned):
 const transStore = new SiftHttpKeyStore({
   jwksUrl: "https://your-production-sift-host/sift-jwks.json",
   krlUrl:  "https://your-production-sift-host/sift-krl.json",

--- a/packages/sift/src/index.ts
+++ b/packages/sift/src/index.ts
@@ -57,3 +57,8 @@ export {
   SiftHttpKeyStore,
   createStagingKeyStore,
 } from "./siftKeyStore.js";
+
+// KRL watermark store (persistent per-issuer krl_version high-watermark)
+export type { KrlWatermarkStore } from "./krlWatermarkStore.js";
+export { createInMemoryKrlWatermarkStore } from "./krlWatermarkStore.js";
+export { createFileBackedKrlWatermarkStore } from "./krlWatermarkStore.file.js";

--- a/packages/sift/src/krlWatermarkStore.file.ts
+++ b/packages/sift/src/krlWatermarkStore.file.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * File-backed KrlWatermarkStore - reference implementation for single-node
+ * deployments that require watermark persistence across process restarts.
+ *
+ * ── File format ───────────────────────────────────────────────────────────────
+ *
+ *   JSON object: { "issuer-string": version-integer, ... }
+ *   Example: { "krl.issuer": 5, "other.authority.example.com": 12 }
+ *
+ * ── Atomicity ─────────────────────────────────────────────────────────────────
+ *
+ *   set() uses write-to-temp-then-rename:
+ *     1. Write new content to <filePath>.tmp
+ *     2. fsync the temp file
+ *     3. rename() - atomic on POSIX (same filesystem)
+ *     4. Best-effort directory fsync (Linux; ignored if unsupported)
+ *
+ *   A process kill between step 2 and step 3 leaves an orphaned .tmp file.
+ *   The live path file is unchanged. On the next read the old watermarks
+ *   survive - no regression attack is possible from partial writes.
+ *
+ * ── Single-node / single-writer only ─────────────────────────────────────────
+ *
+ *   set() performs a read-modify-write cycle that is NOT safe under concurrent
+ *   writers. It is intended for single-process deployments only.
+ *   Multi-node or multi-process deployments MUST use a database-backed
+ *   KrlWatermarkStore that provides atomic compare-and-set or equivalent.
+ *
+ * ── Missing file ─────────────────────────────────────────────────────────────
+ *
+ *   list() returns {} when the file does not exist. This is the expected
+ *   behavior on first use (cold start with no prior watermarks).
+ *
+ * ── Malformed file ────────────────────────────────────────────────────────────
+ *
+ *   list() throws when the file exists but is not valid JSON or does not
+ *   contain a plain object of string→integer entries. This is fail-closed:
+ *   SiftHttpKeyStore will block the refresh rather than silently accepting
+ *   a KRL without knowing the correct version floor. Operators should delete
+ *   or fix the malformed file; SiftHttpKeyStore will recover on the next
+ *   refresh after the file is corrected.
+ */
+
+import { open, rename, readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { KrlWatermarkStore } from "./krlWatermarkStore.js";
+
+export type { KrlWatermarkStore };
+
+/**
+ * Creates a file-backed KrlWatermarkStore.
+ *
+ * @param filePath - Absolute or relative path to the JSON watermark file.
+ *   The directory must already exist and be writable.
+ *
+ * @public
+ */
+export function createFileBackedKrlWatermarkStore(filePath: string): KrlWatermarkStore {
+  /**
+   * Reads and validates the watermark file.
+   * Returns {} on missing file.
+   * Throws on I/O errors or malformed content.
+   */
+  async function readWatermarks(): Promise<Record<string, number>> {
+    let raw: string;
+    try {
+      raw = await readFile(filePath, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return {}; // missing file = cold start, no prior watermarks
+      }
+      throw err;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new Error(
+        `Malformed KRL watermark file at "${filePath}": ` +
+        `content is not valid JSON. Delete or fix the file to recover.`
+      );
+    }
+
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new Error(
+        `Malformed KRL watermark file at "${filePath}": ` +
+        `expected a JSON object but got ${Array.isArray(parsed) ? "array" : typeof parsed}.`
+      );
+    }
+
+    const result: Record<string, number> = {};
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof k !== "string" || typeof v !== "number" || !Number.isInteger(v) || v < 0) {
+        throw new Error(
+          `Malformed KRL watermark file at "${filePath}": ` +
+          `entry for issuer "${k}" has an invalid value (expected a non-negative integer, got ${JSON.stringify(v)}).`
+        );
+      }
+      result[k] = v;
+    }
+    return result;
+  }
+
+  /**
+   * Writes the watermark map to disk atomically:
+   * write to temp file → fsync → rename → best-effort dir fsync.
+   */
+  async function atomicWrite(watermarks: Record<string, number>): Promise<void> {
+    const tmpPath = filePath + ".tmp";
+    const content = JSON.stringify(watermarks, null, 2);
+
+    // Write to temp file and fsync.
+    const fh = await open(tmpPath, "w");
+    try {
+      await fh.writeFile(content, "utf8");
+      await fh.sync(); // flush data to disk before rename
+    } finally {
+      await fh.close();
+    }
+
+    // Atomic rename (POSIX: atomic same-filesystem; Windows: best-effort).
+    await rename(tmpPath, filePath);
+
+    // Best-effort directory fsync so the directory entry is flushed on Linux.
+    // Silently ignored if the platform does not support it.
+    try {
+      const dirFh = await open(dirname(filePath), "r");
+      try {
+        await dirFh.sync();
+      } catch {
+        /* not all platforms support fsync on directories; ignore */
+      } finally {
+        await dirFh.close();
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return {
+    async get(issuer: string): Promise<number | undefined> {
+      const all = await readWatermarks();
+      return all[issuer];
+    },
+
+    async set(issuer: string, krlVersion: number): Promise<void> {
+      // Read-modify-write: always raise the floor, never lower it.
+      const current = await readWatermarks();
+      current[issuer] = Math.max(current[issuer] ?? 0, krlVersion);
+      await atomicWrite(current);
+    },
+
+    async list(): Promise<Record<string, number>> {
+      return readWatermarks();
+    },
+  };
+}

--- a/packages/sift/src/krlWatermarkStore.ts
+++ b/packages/sift/src/krlWatermarkStore.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * KrlWatermarkStore - pluggable persistent store for per-issuer krl_version
+ * high-watermarks.
+ *
+ * The watermark records the highest `krl_version` accepted by this keystore for
+ * each issuer. Persisting it across process restarts prevents a restart-and-replay
+ * attack where an attacker replays an older signed KRL after the in-memory map is
+ * cleared.
+ *
+ * ── Durability tiers ──────────────────────────────────────────────────────────
+ *
+ *   In-memory (default):
+ *     Preserves current Patch-B behavior for callers who do not configure
+ *     persistence. Watermark is lost on process restart; restart downgrade
+ *     protection is limited to the process lifetime. Suitable for development
+ *     and testing.
+ *
+ *   File-backed (see krlWatermarkStore.file.ts):
+ *     Survives process restarts on single-node deployments. Uses atomic
+ *     write-then-rename. Single-writer only - not safe for multi-process
+ *     or horizontally-scaled deployments.
+ *
+ *   Database / Redis (caller-supplied):
+ *     Full multi-node safety. Implement this interface against any store that
+ *     supports atomic compare-and-set or equivalent. The interface is designed
+ *     so any backend can implement it.
+ *
+ * ── Fail-closed contract ──────────────────────────────────────────────────────
+ *
+ *   All methods must throw on infrastructure failure rather than returning a
+ *   permissive result. SiftHttpKeyStore treats any thrown error as a reason
+ *   to block the refresh.
+ *
+ * ── No constructor I/O ────────────────────────────────────────────────────────
+ *
+ *   SiftHttpKeyStore does not call any KrlWatermarkStore method at construction
+ *   time. The store is only accessed during refresh().
+ */
+
+/**
+ * Pluggable persistent store for per-issuer KRL version high-watermarks.
+ *
+ * Implementations MUST be fail-closed: throw on infrastructure failure.
+ * SiftHttpKeyStore will block the refresh if any method throws.
+ *
+ * @public
+ */
+export interface KrlWatermarkStore {
+  /**
+   * Returns the highest accepted krl_version for the given issuer, or
+   * undefined if no version has been recorded for this issuer.
+   */
+  get(issuer: string): Promise<number | undefined>;
+
+  /**
+   * Records the given krl_version as the new high-watermark for the issuer.
+   *
+   * Implementations MUST ensure the value is durable before resolving.
+   * If the new version is lower than the currently stored version (due to
+   * concurrent writes or races), implementations SHOULD keep the higher value.
+   *
+   * @throws If the value cannot be persisted - the caller (SiftHttpKeyStore)
+   *   will fail the refresh closed.
+   */
+  set(issuer: string, krlVersion: number): Promise<void>;
+
+  /**
+   * Returns all recorded issuer → krl_version pairs as a plain object.
+   * Returns an empty object when no watermarks have been recorded.
+   *
+   * @throws If the store cannot be read - the caller (SiftHttpKeyStore)
+   *   will fail the refresh closed.
+   */
+  list(): Promise<Record<string, number>>;
+}
+
+/**
+ * createInMemoryKrlWatermarkStore - default single-process watermark store.
+ *
+ * Preserves current Patch-B in-memory behavior. Watermarks are lost on
+ * process restart. Suitable for development, testing, and deployments that
+ * accept the in-process-lifetime-only downgrade protection guarantee.
+ *
+ * NOT suitable for:
+ *   - Deployments requiring restart downgrade protection.
+ *   - Multi-process / horizontally-scaled deployments.
+ *
+ * For persistent watermark storage, use createFileBackedKrlWatermarkStore
+ * (single-node) or supply a database-backed KrlWatermarkStore implementation.
+ *
+ * @public
+ */
+export function createInMemoryKrlWatermarkStore(): KrlWatermarkStore {
+  const store = new Map<string, number>();
+
+  return {
+    async get(issuer: string): Promise<number | undefined> {
+      return store.get(issuer);
+    },
+
+    async set(issuer: string, krlVersion: number): Promise<void> {
+      const current = store.get(issuer) ?? 0;
+      store.set(issuer, Math.max(current, krlVersion));
+    },
+
+    async list(): Promise<Record<string, number>> {
+      return Object.fromEntries(store);
+    },
+  };
+}

--- a/packages/sift/src/siftKeyStore.ts
+++ b/packages/sift/src/siftKeyStore.ts
@@ -58,6 +58,7 @@
  */
 
 import { b64uDecode } from "./siftCanonical.js";
+import type { KrlWatermarkStore } from "./krlWatermarkStore.js";
 
 // ─── Fetch abstraction ────────────────────────────────────────────────────────
 
@@ -188,6 +189,15 @@ export interface KrlStatus {
   lastVerifiedAt?: number;
   /** Per-issuer high-watermark of accepted krl_version values (in-memory only). */
   lastKrlVersionByIssuer: Record<string, number>;
+  /**
+   * Whether a persistent KrlWatermarkStore is configured.
+   *
+   * - "memory"     — no KrlWatermarkStore configured; watermark is in-memory only
+   *                  and resets on process restart (default, current behavior).
+   * - "persistent" — a KrlWatermarkStore is configured; watermark survives
+   *                  process restarts and prevents restart-and-replay attacks.
+   */
+  watermarkStore: "memory" | "persistent";
 }
 
 // ─── Sift-local KRL mode/contract codes ──────────────────────────────────────
@@ -215,9 +225,29 @@ export interface KrlStatus {
 // KRL_UNSUPPORTED_ALG, KRL_UNKNOWN_SIGNING_KID, KRL_SIGNING_KEY_INACTIVE,
 // KRL_VERSION_REGRESSION) are passed through as opaque strings from verifyKrl.
 //
+//   KRL_WATERMARK_LOAD_FAILED (Phase A, #117)
+//     The configured KrlWatermarkStore could not be loaded (list() threw) before
+//     KRL verification. Refresh fails closed before calling verifyKrl and before
+//     any cache swap. Without the durable floor, previousKrlVersionByIssuer would
+//     be incomplete, opening a downgrade window.
+//
+//   KRL_WATERMARK_PERSIST_FAILED (Phase A, #117)
+//     A signed KRL verified successfully (verifyKrl returned ok: true with accepted
+//     issuer/krl_version), but persisting the new high-watermark to the configured
+//     KrlWatermarkStore failed. Refresh is blocked before cache swap to prevent
+//     accepting a KRL whose version was not durably recorded.
+//
 const KRL_UNSIGNED_IN_SIGNED_REQUIRED  = "KRL_UNSIGNED_IN_SIGNED_REQUIRED";
 const KRL_MISSING_VERIFY_CALLBACK      = "KRL_MISSING_VERIFY_CALLBACK";
 const KRL_VERIFY_RESULT_INCOMPLETE     = "KRL_VERIFY_RESULT_INCOMPLETE";
+const KRL_WATERMARK_PERSIST_FAILED     = "KRL_WATERMARK_PERSIST_FAILED";
+//
+//   KRL_WATERMARK_LOAD_FAILED (Phase A, #117)
+//     The configured KrlWatermarkStore could not be read (list() threw) before
+//     verification started. Refresh fails closed before calling verifyKrl and
+//     before any cache swap, so the durable floor cannot be established.
+//
+const KRL_WATERMARK_LOAD_FAILED        = "KRL_WATERMARK_LOAD_FAILED";
 
 // ─── JWKS parsing ─────────────────────────────────────────────────────────────
 
@@ -405,6 +435,29 @@ export interface SiftHttpKeyStoreOptions {
    * Must remain optional — existing callers work without it.
    */
   now?: () => number;
+  /**
+   * Pluggable persistent store for per-issuer KRL version high-watermarks.
+   *
+   * When configured, the watermark is persisted across process restarts,
+   * closing the restart-and-replay downgrade window. On each signed refresh,
+   * the store is queried via list() and its values are merged into the
+   * in-memory watermark map before verifyKrl is called, ensuring
+   * previousKrlVersionByIssuer reflects the durable floor.
+   *
+   * After successful signed KRL verification, the new krl_version is written
+   * to the store before the in-memory cache is swapped. If the write fails,
+   * refresh() fails closed and the cache is not updated.
+   *
+   * Default: undefined (in-memory watermark only — current Patch-B behavior).
+   * No I/O is performed at construction time regardless of this option.
+   *
+   * Reference implementations:
+   *   - createInMemoryKrlWatermarkStore()  — default in-process store
+   *   - createFileBackedKrlWatermarkStore(filePath)  — single-node persistent
+   *
+   * @public
+   */
+  krlWatermarkStore?: KrlWatermarkStore;
 }
 
 export class SiftHttpKeyStore implements SiftKeyStore {
@@ -414,6 +467,9 @@ export class SiftHttpKeyStore implements SiftKeyStore {
   private readonly krlMode: KrlMode;
   private readonly verifyKrl: KrlVerifyFn | undefined;
   private readonly nowFn: () => number;
+  private readonly krlWatermarkStore: KrlWatermarkStore | undefined;
+  /** Derived at construction; stable for the lifetime of the instance. */
+  private readonly watermarkStoreType: "memory" | "persistent";
 
   private keyCache = new Map<string, Uint8Array>();
   private revokedKids = new Set<string>();
@@ -427,6 +483,8 @@ export class SiftHttpKeyStore implements SiftKeyStore {
     this.krlMode = opts.krlMode ?? "signed_preferred";
     this.verifyKrl = opts.verifyKrl;
     this.nowFn = opts.now ?? (() => Math.floor(Date.now() / 1000));
+    this.krlWatermarkStore = opts.krlWatermarkStore;
+    this.watermarkStoreType = opts.krlWatermarkStore ? "persistent" : "memory";
 
     // Fast-fail: signed_required mode requires a verifyKrl callback.
     if (this.krlMode === "signed_required" && !this.verifyKrl) {
@@ -454,6 +512,7 @@ export class SiftHttpKeyStore implements SiftKeyStore {
       unsignedFallbackActive: false,
       lastVerifiedAt: undefined,
       lastKrlVersionByIssuer: {},
+      watermarkStore: this.watermarkStoreType,
     };
   }
 
@@ -479,6 +538,7 @@ export class SiftHttpKeyStore implements SiftKeyStore {
       unsignedFallbackActive: this._krlStatus.unsignedFallbackActive,
       lastVerifiedAt: this._krlStatus.lastVerifiedAt,
       lastKrlVersionByIssuer: { ...this._krlStatus.lastKrlVersionByIssuer },
+      watermarkStore: this._krlStatus.watermarkStore,
     };
   }
 
@@ -528,8 +588,47 @@ export class SiftHttpKeyStore implements SiftKeyStore {
     // Parse JWKS — throws JWKS_FETCH_FAILED on malformed input.
     const newKeys = parseJwks(jwksBody);
 
-    // Process KRL according to configured mode.
     const nowSeconds = this.nowFn();
+
+    // ── Lazy watermark load ────────────────────────────────────────────────
+    // Merge the persisted per-issuer high-watermarks into the in-memory map
+    // before processKrlForMode runs. This ensures previousKrlVersionByIssuer
+    // passed to verifyKrl reflects durable state from prior process lifetimes.
+    //
+    // Skipped for unsigned_legacy (no signed path, no watermark relevance).
+    // Fail closed if the store is unavailable — we cannot safely proceed
+    // without knowing the current durable floor.
+    if (this.krlWatermarkStore && this.krlMode !== "unsigned_legacy") {
+      let persisted: Record<string, number>;
+      try {
+        persisted = await this.krlWatermarkStore.list();
+      } catch (err) {
+        this._krlStatus = {
+          mode: this.krlMode,
+          lastIntegrity: "failed",
+          lastReason: KRL_WATERMARK_LOAD_FAILED,
+          unsignedFallbackActive: this._krlStatus.unsignedFallbackActive,
+          lastVerifiedAt: this._krlStatus.lastVerifiedAt,
+          lastKrlVersionByIssuer: Object.fromEntries(this.krlVersionByIssuer),
+          watermarkStore: this.watermarkStoreType,
+        };
+        throw new KeyStoreError(
+          "KEYSTORE_REFRESH_FAILED",
+          `${KRL_WATERMARK_LOAD_FAILED}: Persistent watermark store could not be loaded ` +
+          `before KRL verification — refresh fails closed. ` +
+          `Error: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+      // Monotonic merge — only raise the floor, never lower it.
+      for (const [issuer, version] of Object.entries(persisted)) {
+        const current = this.krlVersionByIssuer.get(issuer);
+        if (current === undefined || version > current) {
+          this.krlVersionByIssuer.set(issuer, version);
+        }
+      }
+    }
+
+    // Process KRL according to configured mode.
     const krlResult = this.processKrlForMode(krlBody, nowSeconds);
 
     if (!krlResult.ok) {
@@ -543,15 +642,48 @@ export class SiftHttpKeyStore implements SiftKeyStore {
         unsignedFallbackActive: this._krlStatus.unsignedFallbackActive,
         lastVerifiedAt: this._krlStatus.lastVerifiedAt,
         lastKrlVersionByIssuer: Object.fromEntries(this.krlVersionByIssuer),
+        watermarkStore: this.watermarkStoreType,
       };
       throw krlResult.error;
     }
 
-    // Both parses and all integrity checks succeeded — atomic cache swap.
+    // ── Persist watermark BEFORE cache swap (invariant 2) ─────────────────
+    // If the signed KRL was verified and the write fails, fail closed before
+    // swapping the cache. A KRL must not be accepted unless its krl_version
+    // was durably recorded when a persistent store is configured.
+    if (this.krlWatermarkStore && krlResult.updatedVersion) {
+      try {
+        await this.krlWatermarkStore.set(
+          krlResult.updatedVersion.issuer,
+          krlResult.updatedVersion.krl_version
+        );
+      } catch (err) {
+        // Fail closed — do not swap caches.
+        this._krlStatus = {
+          mode: this.krlMode,
+          lastIntegrity: "failed",
+          lastReason: KRL_WATERMARK_PERSIST_FAILED,
+          unsignedFallbackActive: this._krlStatus.unsignedFallbackActive,
+          lastVerifiedAt: this._krlStatus.lastVerifiedAt,
+          lastKrlVersionByIssuer: Object.fromEntries(this.krlVersionByIssuer),
+          watermarkStore: this.watermarkStoreType,
+        };
+        throw new KeyStoreError(
+          "KRL_FETCH_FAILED",
+          `${KRL_WATERMARK_PERSIST_FAILED}: Signed KRL verified successfully but persisting ` +
+          `the krl_version watermark to the configured KrlWatermarkStore failed. ` +
+          `Refresh is blocked to prevent accepting a KRL whose version was not durably recorded. ` +
+          `Error: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
+
+    // Both parses, all integrity checks, and (if configured) watermark
+    // persistence succeeded — atomic in-memory cache swap.
     this.keyCache = newKeys;
     this.revokedKids = krlResult.revoked;
 
-    // Update per-issuer krl_version high-watermark for signed KRLs.
+    // Update in-memory per-issuer krl_version high-watermark.
     if (krlResult.updatedVersion) {
       this.krlVersionByIssuer.set(
         krlResult.updatedVersion.issuer,
@@ -567,6 +699,7 @@ export class SiftHttpKeyStore implements SiftKeyStore {
       unsignedFallbackActive: krlResult.integrity === "unsigned_fallback",
       lastVerifiedAt: nowSeconds,
       lastKrlVersionByIssuer: Object.fromEntries(this.krlVersionByIssuer),
+      watermarkStore: this.watermarkStoreType,
     };
   }
 

--- a/packages/sift/test/siftKeyStore.watermark.test.ts
+++ b/packages/sift/test/siftKeyStore.watermark.test.ts
@@ -1,0 +1,635 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Phase A (#117): Persistent KRL high-watermark tests for SiftHttpKeyStore.
+ *
+ * Tests the KrlWatermarkStore interface, in-memory and file-backed implementations,
+ * SiftHttpKeyStore integration, and the persist-before-cache-swap invariant.
+ *
+ * Tests are separated by concern (not parameterized) to keep failure semantics clear.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { writeFile, unlink } from "node:fs/promises";
+
+import {
+  SiftHttpKeyStore,
+  KeyStoreError,
+  type KrlVerifyFn,
+} from "../src/siftKeyStore.js";
+import {
+  createInMemoryKrlWatermarkStore,
+  type KrlWatermarkStore,
+} from "../src/krlWatermarkStore.js";
+import { createFileBackedKrlWatermarkStore } from "../src/krlWatermarkStore.file.js";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const JWKS_URL = "https://sift-wm-test.example/sift-jwks.json";
+const KRL_URL  = "https://sift-wm-test.example/sift-krl.json";
+
+const RFC8037_X   = "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo";
+const RFC8037_KID = "key-rfc8037";
+const VALID_JWKS  = { keys: [{ kty: "OKP", crv: "Ed25519", kid: RFC8037_KID, x: RFC8037_X }] };
+
+const TEST_NOW    = 1744632000;
+const KRL_ISSUER  = "krl-issuer";
+
+const SIGNED_KRL_V1 = {
+  version: "SignedKRLV1", issuer: KRL_ISSUER, krl_version: 1,
+  issued_at: TEST_NOW - 60, not_after: TEST_NOW + 3600,
+  revoked_kids: [] as string[],
+  signature: { alg: "Ed25519", kid: "krl-key-1", sig: "placeholder-sig" },
+};
+
+const SIGNED_KRL_V5 = { ...SIGNED_KRL_V1, krl_version: 5 };
+const SIGNED_KRL_V3 = { ...SIGNED_KRL_V1, krl_version: 3 };
+
+// ─── Mock helpers ─────────────────────────────────────────────────────────────
+
+type MockResponse = { status: number; body: unknown } | { status: number; error: string };
+
+function makeFetch(routes: Record<string, MockResponse>): typeof globalThis.fetch {
+  return async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : (input as URL).toString();
+    const route = routes[url];
+    if (!route) return new Response(null, { status: 404 }) as Response;
+    if ("error" in route) throw new Error(route.error);
+    return new Response(JSON.stringify(route.body), {
+      status: route.status,
+      headers: { "content-type": "application/json" },
+    }) as Response;
+  };
+}
+
+function happyRoutes(krlBody: unknown): Record<string, MockResponse> {
+  return {
+    [JWKS_URL]: { status: 200, body: VALID_JWKS },
+    [KRL_URL]:  { status: 200, body: krlBody },
+  };
+}
+
+function makeKrlOk(
+  accepted: { issuer: string; krl_version: number }
+): ReturnType<KrlVerifyFn> {
+  return { ok: true, violations: [], accepted };
+}
+
+function makeKrlFail(code: string): ReturnType<KrlVerifyFn> {
+  return { ok: false, violations: [{ code, message: `${code} from test` }] };
+}
+
+/** A spy verifyKrl that returns a fixed result and records how it was called. */
+function makeVerifyKrlSpy(
+  result: ReturnType<KrlVerifyFn>
+): { fn: KrlVerifyFn; calls: Array<{ prevVersions: Record<string, number> }> } {
+  const calls: Array<{ prevVersions: Record<string, number> }> = [];
+  const fn: KrlVerifyFn = (_payload, ctx) => {
+    calls.push({ prevVersions: { ...(ctx.previousKrlVersionByIssuer ?? {}) } });
+    return result;
+  };
+  return { fn, calls };
+}
+
+function tmpWatermarkPath(): string {
+  return join(tmpdir(), `krl-wm-test-${randomBytes(6).toString("hex")}.json`);
+}
+
+// ─── WM-1: Default behavior unchanged with no store configured ─────────────
+
+test("WM-1: no krlWatermarkStore configured - behavior unchanged, watermarkStore is memory", async () => {
+  const { fn, calls } = makeVerifyKrlSpy(
+    makeKrlOk({ issuer: KRL_ISSUER, krl_version: 1 })
+  );
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl: fn,
+    fetch: makeFetch(happyRoutes(SIGNED_KRL_V1)),
+    now: () => TEST_NOW,
+  });
+
+  await store.refresh();
+
+  const status = store.getKrlStatus();
+  assert.strictEqual(status.watermarkStore, "memory");
+  assert.strictEqual(status.lastKrlVersionByIssuer[KRL_ISSUER], 1);
+  assert.strictEqual(calls.length, 1);
+  // On first call with no store, prevVersions is empty
+  assert.deepStrictEqual(calls[0].prevVersions, {});
+});
+
+// ─── WM-2: Persistent store not touched in constructor ─────────────────────
+
+test("WM-2: KrlWatermarkStore is not called at construction time", () => {
+  const calls = { list: 0, get: 0, set: 0 };
+  const spy: KrlWatermarkStore = {
+    async list() { calls.list++; return {}; },
+    async get() { calls.get++; return undefined; },
+    async set() { calls.set++; },
+  };
+
+  new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl: () => makeKrlOk({ issuer: KRL_ISSUER, krl_version: 1 }),
+    krlWatermarkStore: spy,
+    fetch: makeFetch(happyRoutes(SIGNED_KRL_V1)),
+  });
+
+  assert.strictEqual(calls.list, 0, "list() must not be called at construction");
+  assert.strictEqual(calls.get,  0, "get()  must not be called at construction");
+  assert.strictEqual(calls.set,  0, "set()  must not be called at construction");
+});
+
+// ─── WM-3: watermarkStore status field ─────────────────────────────────────
+
+test("WM-3a: watermarkStore field is 'memory' when no store configured", () => {
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    verifyKrl: () => makeKrlOk({ issuer: KRL_ISSUER, krl_version: 1 }),
+  });
+  assert.strictEqual(store.getKrlStatus().watermarkStore, "memory");
+});
+
+test("WM-3b: watermarkStore field is 'persistent' when store configured", () => {
+  const wm = createInMemoryKrlWatermarkStore();
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    verifyKrl: () => makeKrlOk({ issuer: KRL_ISSUER, krl_version: 1 }),
+    krlWatermarkStore: wm,
+  });
+  assert.strictEqual(store.getKrlStatus().watermarkStore, "persistent");
+});
+
+// ─── WM-4: Persistent watermark survives process restart ──────────────────
+
+test("WM-4: persistent watermark bootstraps previousKrlVersionByIssuer after restart", async () => {
+  // Simulate a persistent store that survives across "process" lifetimes.
+  const sharedWm = createInMemoryKrlWatermarkStore();
+
+  // First "process": refresh with KRL version 5.
+  const store1 = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl: () => makeKrlOk({ issuer: KRL_ISSUER, krl_version: 5 }),
+    krlWatermarkStore: sharedWm,
+    fetch: makeFetch(happyRoutes(SIGNED_KRL_V5)),
+    now: () => TEST_NOW,
+  });
+  await store1.refresh();
+
+  // Confirm persisted.
+  const persisted = await sharedWm.list();
+  assert.strictEqual(persisted[KRL_ISSUER], 5, "version 5 should be persisted after first refresh");
+
+  // Second "process": new SiftHttpKeyStore with the same store.
+  const { fn: spy2, calls: calls2 } = makeVerifyKrlSpy(
+    makeKrlOk({ issuer: KRL_ISSUER, krl_version: 6 })
+  );
+  const store2 = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl: spy2,
+    krlWatermarkStore: sharedWm,
+    fetch: makeFetch(happyRoutes({ ...SIGNED_KRL_V1, krl_version: 6 })),
+    now: () => TEST_NOW,
+  });
+  await store2.refresh();
+
+  assert.strictEqual(calls2.length, 1);
+  // verifyKrl should receive previousKrlVersionByIssuer sourced from the store
+  assert.strictEqual(
+    calls2[0].prevVersions[KRL_ISSUER], 5,
+    "second instance must receive persisted watermark version 5"
+  );
+  assert.strictEqual(store2.getKrlStatus().lastKrlVersionByIssuer[KRL_ISSUER], 6);
+});
+
+// ─── WM-5: Restart-and-replay attack blocked ───────────────────────────────
+
+test("WM-5: restart-and-replay attack - older KRL rejected via persisted watermark", async () => {
+  const sharedWm = createInMemoryKrlWatermarkStore();
+
+  // First refresh: accept version 5, persist watermark.
+  const store1 = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_required",
+    verifyKrl: () => makeKrlOk({ issuer: KRL_ISSUER, krl_version: 5 }),
+    krlWatermarkStore: sharedWm,
+    fetch: makeFetch(happyRoutes(SIGNED_KRL_V5)),
+    now: () => TEST_NOW,
+  });
+  await store1.refresh();
+  assert.strictEqual((await sharedWm.list())[KRL_ISSUER], 5);
+
+  // "Process restart": new instance with same store.
+  // Attack: replay KRL version 3 (older than persisted 5).
+  const { fn: attackSpy, calls: attackCalls } = makeVerifyKrlSpy(
+    makeKrlFail("KRL_VERSION_REGRESSION")
+  );
+  const store2 = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_required",
+    verifyKrl: attackSpy,
+    krlWatermarkStore: sharedWm,
+    fetch: makeFetch(happyRoutes(SIGNED_KRL_V3)),
+    now: () => TEST_NOW,
+  });
+
+  await assert.rejects(
+    () => store2.refresh(),
+    (err: unknown) => {
+      assert.ok(err instanceof KeyStoreError);
+      assert.strictEqual(err.code, "KRL_FETCH_FAILED");
+      assert.ok(err.message.includes("KRL_VERSION_REGRESSION"));
+      return true;
+    }
+  );
+
+  // Attack was blocked: verifyKrl received prevVersions with version 5
+  assert.strictEqual(attackCalls[0].prevVersions[KRL_ISSUER], 5,
+    "attack verifyKrl must receive persisted watermark version 5");
+  assert.strictEqual(store2.getKrlStatus().lastReason, "KRL_VERSION_REGRESSION");
+});
+
+// ─── WM-6: KRL_WATERMARK_PERSIST_FAILED - fail closed before cache swap ───
+
+test("WM-6: watermarkStore.set() failure fails closed before cache swap", async () => {
+  const failingStore: KrlWatermarkStore = {
+    async list() { return {}; },
+    async get() { return undefined; },
+    async set() { throw new Error("disk full"); },
+  };
+
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_required",
+    verifyKrl: () => makeKrlOk({ issuer: KRL_ISSUER, krl_version: 1 }),
+    krlWatermarkStore: failingStore,
+    fetch: makeFetch(happyRoutes(SIGNED_KRL_V1)),
+    now: () => TEST_NOW,
+  });
+
+  // Before refresh: no revocation data.
+  assert.strictEqual(await store.isKidRevoked("any-kid"), false);
+
+  await assert.rejects(
+    () => store.refresh(),
+    (err: unknown) => {
+      assert.ok(err instanceof KeyStoreError);
+      assert.strictEqual(err.code, "KRL_FETCH_FAILED");
+      assert.ok(err.message.includes("KRL_WATERMARK_PERSIST_FAILED"),
+        `expected KRL_WATERMARK_PERSIST_FAILED in message, got: ${(err as Error).message}`);
+      return true;
+    }
+  );
+
+  // Cache must NOT have been swapped.
+  assert.strictEqual(await store.isKidRevoked("any-kid"), false,
+    "revokedKids must not be updated when watermark persist fails");
+
+  // Status records the failure reason.
+  const status = store.getKrlStatus();
+  assert.strictEqual(status.lastReason, "KRL_WATERMARK_PERSIST_FAILED");
+  assert.strictEqual(status.lastIntegrity, "failed");
+  // lastReason cleared on subsequent success - tested in WM-7b
+});
+
+test("WM-6b: lastReason cleared after successful refresh following persist failure", async () => {
+  let shouldFail = true;
+  const conditionalStore: KrlWatermarkStore = {
+    async list() { return {}; },
+    async get() { return undefined; },
+    async set() {
+      if (shouldFail) throw new Error("transient failure");
+    },
+  };
+
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_required",
+    verifyKrl: () => makeKrlOk({ issuer: KRL_ISSUER, krl_version: 1 }),
+    krlWatermarkStore: conditionalStore,
+    fetch: makeFetch(happyRoutes(SIGNED_KRL_V1)),
+    now: () => TEST_NOW,
+  });
+
+  // First: fail
+  await assert.rejects(() => store.refresh());
+  assert.strictEqual(store.getKrlStatus().lastReason, "KRL_WATERMARK_PERSIST_FAILED");
+
+  // Second: succeed
+  shouldFail = false;
+  await store.refresh();
+  assert.strictEqual(store.getKrlStatus().lastReason, undefined,
+    "lastReason must be cleared on successful refresh");
+  assert.strictEqual(store.getKrlStatus().lastIntegrity, "signed");
+});
+
+// ─── WM-7: persist-before-swap ordering proof ─────────────────────────────
+
+test("WM-7: watermarkStore.set() is called before revokedKids is updated", async () => {
+  const eventLog: string[] = [];
+
+  const observingStore: KrlWatermarkStore = {
+    async list() { return {}; },
+    async get() { return undefined; },
+    async set(issuer, version) {
+      eventLog.push(`set(${issuer},${version})`);
+    },
+  };
+
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_required",
+    verifyKrl: () => makeKrlOk({ issuer: KRL_ISSUER, krl_version: 1 }),
+    krlWatermarkStore: observingStore,
+    fetch: makeFetch(happyRoutes({ ...SIGNED_KRL_V1, revoked_kids: ["kid-to-revoke"] })),
+    now: () => TEST_NOW,
+  });
+
+  // Before refresh: not revoked
+  assert.strictEqual(await store.isKidRevoked("kid-to-revoke"), false);
+
+  await store.refresh();
+
+  // After refresh: set was called
+  assert.deepStrictEqual(eventLog, [`set(${KRL_ISSUER},1)`]);
+  // And revocation data is now live
+  assert.strictEqual(await store.isKidRevoked("kid-to-revoke"), true);
+});
+
+// ─── WM-8: lazy load merges persisted watermarks into in-memory map ────────
+
+test("WM-8: lazy load - list() is called during refresh() and merged monotonically", async () => {
+  const listCalls: Array<Record<string, number>> = [];
+  let persisted: Record<string, number> = { [KRL_ISSUER]: 7 };
+
+  const observingStore: KrlWatermarkStore = {
+    async list() {
+      listCalls.push({ ...persisted });
+      return { ...persisted };
+    },
+    async get() { return undefined; },
+    async set(issuer, version) {
+      persisted = { ...persisted, [issuer]: Math.max(persisted[issuer] ?? 0, version) };
+    },
+  };
+
+  // Spy verifyKrl: capture prevVersions passed to it
+  let capturedPrev: Record<string, number> = {};
+  const fn: KrlVerifyFn = (_payload, ctx) => {
+    capturedPrev = { ...ctx.previousKrlVersionByIssuer };
+    return makeKrlOk({ issuer: KRL_ISSUER, krl_version: 8 });
+  };
+
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_preferred",
+    verifyKrl: fn,
+    krlWatermarkStore: observingStore,
+    fetch: makeFetch(happyRoutes({ ...SIGNED_KRL_V1, krl_version: 8 })),
+    now: () => TEST_NOW,
+  });
+
+  // list() should NOT be called at construction
+  assert.strictEqual(listCalls.length, 0, "list() must not be called at construction");
+
+  await store.refresh();
+
+  // list() must have been called during refresh()
+  assert.strictEqual(listCalls.length, 1, "list() must be called once during refresh()");
+  // verifyKrl must have received the persisted watermark (7)
+  assert.strictEqual(capturedPrev[KRL_ISSUER], 7,
+    "verifyKrl must receive previousKrlVersionByIssuer sourced from the persistent store");
+  // After refresh, in-memory watermark should be 8 (from accepted)
+  assert.strictEqual(store.getKrlStatus().lastKrlVersionByIssuer[KRL_ISSUER], 8);
+});
+
+// ─── WM-9: KRL_WATERMARK_LOAD_FAILED - list() failure ──────────────────────
+
+test("WM-9: watermarkStore.list() failure produces KRL_WATERMARK_LOAD_FAILED, fails closed before verification", async () => {
+  let verifyKrlCalled = false;
+  const unavailableStore: KrlWatermarkStore = {
+    async list() { throw new Error("storage unavailable"); },
+    async get() { return undefined; },
+    async set() {},
+  };
+
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "signed_required",
+    verifyKrl: (_payload, _ctx) => {
+      verifyKrlCalled = true;
+      return makeKrlOk({ issuer: KRL_ISSUER, krl_version: 1 });
+    },
+    krlWatermarkStore: unavailableStore,
+    fetch: makeFetch(happyRoutes(SIGNED_KRL_V1)),
+    now: () => TEST_NOW,
+  });
+
+  await assert.rejects(
+    () => store.refresh(),
+    (err: unknown) => {
+      assert.ok(err instanceof KeyStoreError);
+      assert.strictEqual(err.code, "KEYSTORE_REFRESH_FAILED");
+      assert.ok(err.message.includes("KRL_WATERMARK_LOAD_FAILED"),
+        `expected KRL_WATERMARK_LOAD_FAILED in message, got: ${(err as Error).message}`);
+      return true;
+    }
+  );
+
+  assert.strictEqual(store.getKrlStatus().lastReason, "KRL_WATERMARK_LOAD_FAILED");
+  assert.strictEqual(store.getKrlStatus().lastIntegrity, "failed");
+  assert.strictEqual(verifyKrlCalled, false,
+    "verifyKrl must not be called when list() fails (fail closed before verification)");
+});
+
+// ─── WM-10: unsigned_legacy skips watermark store ─────────────────────────
+
+test("WM-10: unsigned_legacy mode never touches the watermark store", async () => {
+  const calls = { list: 0, set: 0 };
+  const spy: KrlWatermarkStore = {
+    async list() { calls.list++; return {}; },
+    async get() { return undefined; },
+    async set() { calls.set++; },
+  };
+
+  const store = new SiftHttpKeyStore({
+    jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+    krlMode: "unsigned_legacy",
+    krlWatermarkStore: spy,
+    fetch: makeFetch(happyRoutes({ version: 1, issuer: "s", revoked_kids: [] })),
+    now: () => TEST_NOW,
+  });
+
+  await store.refresh();
+
+  assert.strictEqual(calls.list, 0, "list() must not be called in unsigned_legacy mode");
+  assert.strictEqual(calls.set,  0, "set()  must not be called in unsigned_legacy mode");
+});
+
+// ─── WM-11: in-memory store - round-trip ──────────────────────────────────
+
+test("WM-11: createInMemoryKrlWatermarkStore - round-trip get/set/list", async () => {
+  const wm = createInMemoryKrlWatermarkStore();
+
+  assert.deepStrictEqual(await wm.list(), {});
+  assert.strictEqual(await wm.get("a"), undefined);
+
+  await wm.set("issuer-a", 3);
+  await wm.set("issuer-b", 7);
+
+  assert.strictEqual(await wm.get("issuer-a"), 3);
+  assert.strictEqual(await wm.get("issuer-b"), 7);
+  assert.deepStrictEqual(await wm.list(), { "issuer-a": 3, "issuer-b": 7 });
+
+  // Monotonic: set lower version does not decrease the watermark
+  await wm.set("issuer-a", 1);
+  assert.strictEqual(await wm.get("issuer-a"), 3, "lower version must not overwrite higher");
+});
+
+// ─── WM-12: file-backed store - round-trip ────────────────────────────────
+
+test("WM-12: createFileBackedKrlWatermarkStore - round-trip write and read", async () => {
+  const path = tmpWatermarkPath();
+  const wm = createFileBackedKrlWatermarkStore(path);
+
+  try {
+    // Missing file → empty
+    assert.deepStrictEqual(await wm.list(), {});
+    assert.strictEqual(await wm.get("test-issuer"), undefined);
+
+    // Write and read back
+    await wm.set("test-issuer", 5);
+    assert.strictEqual(await wm.get("test-issuer"), 5);
+    assert.deepStrictEqual(await wm.list(), { "test-issuer": 5 });
+
+    // Second issuer
+    await wm.set("other-issuer", 12);
+    const all = await wm.list();
+    assert.strictEqual(all["test-issuer"], 5);
+    assert.strictEqual(all["other-issuer"], 12);
+
+    // Monotonic: lower version does not overwrite
+    await wm.set("test-issuer", 3);
+    assert.strictEqual(await wm.get("test-issuer"), 5,
+      "lower version must not overwrite higher in file-backed store");
+
+    // No orphaned .tmp file
+    const { stat } = await import("node:fs/promises");
+    await assert.rejects(
+      () => stat(path + ".tmp"),
+      { code: "ENOENT" },
+      ".tmp file must not remain after successful write"
+    );
+  } finally {
+    await unlink(path).catch(() => {});
+  }
+});
+
+// ─── WM-13: file-backed store - malformed content fails closed ─────────────
+
+test("WM-13: file-backed store with malformed content fails closed (throws on list)", async () => {
+  const path = tmpWatermarkPath();
+  const wm = createFileBackedKrlWatermarkStore(path);
+
+  try {
+    // Write garbage JSON
+    await writeFile(path, "not valid json!!!", "utf8");
+
+    await assert.rejects(
+      () => wm.list(),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.ok(err.message.includes("Malformed KRL watermark file"),
+          `expected malformed-file message, got: ${err.message}`);
+        return true;
+      }
+    );
+
+    // set() should also fail because it reads first
+    await assert.rejects(
+      () => wm.set("issuer", 1),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        return true;
+      }
+    );
+  } finally {
+    await unlink(path).catch(() => {});
+  }
+});
+
+// ─── WM-14: file-backed store - structurally invalid JSON object ────────────
+
+test("WM-14: file-backed store with invalid value types fails closed", async () => {
+  const path = tmpWatermarkPath();
+  const wm = createFileBackedKrlWatermarkStore(path);
+
+  try {
+    // Valid JSON but wrong types for values
+    await writeFile(path, JSON.stringify({ "issuer": "not-a-number" }), "utf8");
+
+    await assert.rejects(
+      () => wm.list(),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.ok(err.message.includes("Malformed KRL watermark file"),
+          `expected malformed message, got: ${err.message}`);
+        return true;
+      }
+    );
+  } finally {
+    await unlink(path).catch(() => {});
+  }
+});
+
+// ─── WM-15: file-backed store - SiftHttpKeyStore integration ───────────────
+
+test("WM-15: SiftHttpKeyStore with file-backed store - version survives 'restart'", async () => {
+  const path = tmpWatermarkPath();
+
+  try {
+    // First "process"
+    const store1 = new SiftHttpKeyStore({
+      jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+      krlMode: "signed_required",
+      verifyKrl: () => makeKrlOk({ issuer: KRL_ISSUER, krl_version: 9 }),
+      krlWatermarkStore: createFileBackedKrlWatermarkStore(path),
+      fetch: makeFetch(happyRoutes({ ...SIGNED_KRL_V1, krl_version: 9 })),
+      now: () => TEST_NOW,
+    });
+    await store1.refresh();
+
+    // Confirm file has version 9
+    const wmRead = createFileBackedKrlWatermarkStore(path);
+    assert.strictEqual((await wmRead.list())[KRL_ISSUER], 9);
+
+    // Second "process": new instance, same file.
+    // Try to replay version 5 (should be rejected with KRL_VERSION_REGRESSION).
+    const attackSpy = makeVerifyKrlSpy(makeKrlFail("KRL_VERSION_REGRESSION"));
+    const store2 = new SiftHttpKeyStore({
+      jwksUrl: JWKS_URL, krlUrl: KRL_URL,
+      krlMode: "signed_required",
+      verifyKrl: attackSpy.fn,
+      krlWatermarkStore: createFileBackedKrlWatermarkStore(path),
+      fetch: makeFetch(happyRoutes(SIGNED_KRL_V5)),
+      now: () => TEST_NOW,
+    });
+
+    await assert.rejects(() => store2.refresh());
+
+    // verifyKrl received the persisted watermark (9)
+    assert.strictEqual(attackSpy.calls[0].prevVersions[KRL_ISSUER], 9,
+      "second instance must use persisted watermark version 9");
+    assert.strictEqual(store2.getKrlStatus().lastReason, "KRL_VERSION_REGRESSION");
+  } finally {
+    await unlink(path).catch(() => {});
+    await unlink(path + ".tmp").catch(() => {});
+  }
+});


### PR DESCRIPTION
Refs #117.

## Summary

Adds Phase A of persistent KRL revocation hardening for `SiftHttpKeyStore`.

This PR introduces an opt-in persistent KRL high-watermark store so signed KRL version-downgrade protection can survive process restarts.

This does **not** close #117 because Phase B, last-known-good signed-KRL cache, is still pending.

## What changed

Added `KrlWatermarkStore` as a pluggable Sift-local interface.

Added two implementations:

- In-memory watermark store for current default behavior and tests.
- File-backed watermark store for single-node persistent deployments.

Updated `SiftHttpKeyStore` to support an optional `krlWatermarkStore`.

When configured, persistent watermarks are lazily loaded during `refresh()` and merged monotonically into the in-memory per-issuer `krl_version` map.

Signed KRL verification now receives `previousKrlVersionByIssuer` sourced from the persistent store when configured.

## Security behavior

This PR preserves the critical fail-closed boundary.

For signed KRL refreshes:

1. Fetch JWKS and KRL.
2. Verify signed KRL.
3. Load and merge persisted watermark.
4. Persist accepted `krl_version`.
5. Only then swap `keyCache` / `revokedKids`.

If watermark persistence fails, `refresh()` fails closed before cache swap.

This prevents a process from accepting a newer KRL in memory without durably recording the new high-watermark.

## New Sift-local reason codes

Added two Sift-local codes:

### `KRL_WATERMARK_LOAD_FAILED`

Persistent watermark store could not be loaded before verification. `refresh()` fails closed before verification and before cache swap.

### `KRL_WATERMARK_PERSIST_FAILED`

Signed KRL verified successfully, but the accepted `krl_version` could not be durably persisted. `refresh()` fails closed before cache swap.

These are Sift-local only.

No `@oxdeai/core` reason codes were added.

## Status surface

`KrlStatus` now exposes:

```ts
watermarkStore: "memory" | "persistent"
````

This makes the active trust posture explicit without exposing store internals, key material, signatures, or KRL payloads.

## Boundary guarantees

No changes were made to `packages/core`.

No changes were made to:

* `AuthorizationV1`
* `DelegationV1`
* `SignedKRLV1` artifact shape
* `verifyKrl` callback contract
* `packages/core/API_FINGERPRINT`

No constructor I/O was introduced.

Persistence remains opt-in.

Callers without `krlWatermarkStore` configured keep the existing in-memory behavior.

## File-backed store

The file-backed reference implementation uses atomic write semantics for single-node deployments.

It is intended for single-node / single-writer use only.

Multi-node deployments should provide a database-backed `KrlWatermarkStore` implementation.

## Tests

Added 17 watermark tests covering:

* Default behavior unchanged without persistence.
* No constructor I/O.
* Persistent watermark survives simulated restart.
* Restart-and-replay downgrade blocked with `KRL_VERSION_REGRESSION`.
* Watermark load failure fails closed.
* Watermark persist failure fails closed before cache swap.
* Monotonic merge behavior.
* File-backed store read/write.
* Missing file behavior.
* Malformed file failure behavior.

## Validation

* `pnpm --filter @oxdeai/sift test`: 167/167 passing
* `pnpm -C packages/conformance validate`: 209/209 passing
* `pnpm test:vectors:all`: passing
* `pnpm typecheck`: passing
* `pnpm test`: passing
* `pnpm security:gate`: ALLOW
* `git diff --check`: clean
* `packages/core/API_FINGERPRINT`: unchanged

## Residual limitations

Phase B is not implemented in this PR.

Last-known-good signed-KRL cache is still pending.

Cold-start fetch failure can still leave the keystore without revocation data until Phase B lands.

RT-TRUST-2 is now closer to operational closure, but full closeability requires `signed_required` plus persistent watermark plus future LKG cache configuration.
