### PR TITLE
test(conformance): add Profile C Encoding B cross-language coverage

### DIFF
--- a/docs/audits/protocol-audit-post-interoperability.md
+++ b/docs/audits/protocol-audit-post-interoperability.md
@@ -154,7 +154,7 @@
 | Profile A (Core-native) | `DONE` | Defined, implemented, conformance covered by existing auth-sig and auth-verify vectors. |
 | Profile B (External wire-compatible) | `DONE` | Defined. Encoding B accepted in verifyAuthorization. Conformance vector `authorization-sig-010`. Trust separation proven: `pb-trust-oxdeai-key-allow` (OxDeAI key in trustedKeySets → ALLOW) and `pb-trust-provider-key-rejected` (provider receipt key absent from trustedKeySets → DENY/UNKNOWN_KID). Resolved in #108. |
 | Profile C (Full semantic state verification) | `DONE` | Defined. Implemented via pluggable `computeStateHash`. 12 executable conformance assertions across 8 vectors. Encoding B path tested. |
-| Profile C cross-language | `DONE` | Go + Python harnesses validate state-hash semantics (modes 001–005) via `docs/spec/test-vectors/profile-c-state-verification.json`. Profile C Encoding B modes 006–008 remain TypeScript-only and are tracked separately. |
+| Profile C cross-language | `DONE` | Go + Python harnesses validate all 8 Profile C vectors (#120): modes 001–005 (state-hash semantics) and modes 006–008 (Encoding B, independent Ed25519 sig verification + state hash comparison). No domain prefix; preimage is `canonicalJson(signingPayload)`. |
 | Interoperability matrix | `DOCUMENTED ONLY` | Matrix in `external-provider-profile.md`. Not backed by conformance automation. |
 
 ---
@@ -421,8 +421,8 @@ Key lifecycle (lifecycle)    █████████████████
 DelegationV1                 ████████████████████  DONE
 Profile A interop            ████████████████████  DONE
 Profile B interop            ████████████████░░░░  PARTIAL (trust sep. gap)
-Profile C interop            ████████████████████  DONE (state-hash semantics; Encoding B modes 006–008 TS-only)
-Profile C cross-language     ████████████████████  DONE (Go + Python state-hash semantics; Encoding B modes 006–008 TS-only)
+Profile C interop            ████████████████████  DONE (all 8 modes; Encoding B verified cross-language #120)
+Profile C cross-language     ████████████████████  DONE (Go + Python, all 8 Profile C modes including Encoding B)
 Replay durability            ████████████████░░░░  PARTIAL (in-memory default risk)
 Key rotation                 ██████████░░░░░░░░░░  DOCUMENTED ONLY
 Threat model                 ██████████░░░░░░░░░░  DOCUMENTED ONLY
@@ -476,7 +476,7 @@ Caveats: transport-integrity gap is only fully closed when callers deploy `signe
 **P1-5: Mark HMAC-SHA256 as deprecated** ✓ RESOLVED
 Resolution: `authorization-v1.md §5` now carries an explicit "Deprecated legacy algorithm" section: HMAC-SHA256 is not standard, is symmetric/non-portable, and its migration path is documented. `legacyHmacSecret` in `VerifyAuthorizationOptions` carries a `@deprecated` JSDoc with removal notice. `authorization_signing_alg: "HMAC-SHA256"` default in `EngineOptions` carries a `@deprecated` JSDoc directing new users to Ed25519. Two explicit legacy-path tests document backward-compat guarantee and the fail-closed behavior when `legacyHmacSecret` is absent. Resolved in #107.
 
-**P1-6: Add cross-language Profile C and SignedKRLV1 conformance vectors** ✓ RESOLVED for Profile C state-hash semantics and SignedKRLV1 cross-language coverage (Go + Python). Profile C Encoding B modes 006–008 remain TypeScript-only and are tracked separately.
+**P1-6: Add cross-language Profile C and SignedKRLV1 conformance vectors** ✓ RESOLVED for all Profile C modes and SignedKRLV1 (Go + Python). #120 closed Profile C Encoding B modes 006–008 with independent Encoding B signature verification in Go and Python (no domain prefix; base64url; reusable `ed25519_utils.py` shared helper).
 
 Go coverage (#119 Go PR):
 - `go-harness/profile_c_verify.go` validates Profile C state-hash semantics modes 001–005 independently.
@@ -489,7 +489,7 @@ Python coverage (#119 Python PR):
 - Cross-language byte-equivalence proven: duplicate-kids signature `+mwEd2QP5+tx...` verifies identically in Go and Python.
 
 Residual limitations:
-- Profile C Encoding B modes 006–008 remain TypeScript-only (require AuthorizationV1 Encoding B infrastructure; tracked separately).
+- Profile C Encoding B modes 006–008: closed by #120 — Go and Python now independently verify Encoding B signatures (preimage = `canonicalJson(signingPayload)`, no domain prefix).
 - State provider trust (RT-TRUST-1, P2-4) and independent security review remain open.
 - No full standardization readiness claim.
 
@@ -528,7 +528,7 @@ Scope: `pep-gateway-v1.md` §7 or a new `state-provider-requirements.md`.
 | `MISSING` | 5 |
 | `RISK` | 4 |
 
-**Conformance:** 209 TypeScript assertions (16 TS vector files + 12 portable `authorization-v1.json` vectors) + 25 Go harness assertions (11 canonicalization + 5 Profile C state-hash + 9 SignedKRLV1) + 25 Python harness assertions (same coverage as Go). All P0 and P1 items resolved; P1-6 cross-language coverage complete for state-hash semantics (Encoding B modes remain TS-only).
+**Conformance:** 209 TypeScript assertions (16 TS vector files + 12 portable `authorization-v1.json` vectors) + 28 Go harness assertions (11 canonicalization + 8 Profile C all modes + 9 SignedKRLV1) + 28 Python harness assertions (same coverage as Go). All P0 and P1 items resolved; P1-6 fully closed including Profile C Encoding B modes 006–008 (#120).
 
 **Follow-up issue counts:** P0: 0 open · P1: 0 open · P2: 4 · Total: 4 open
 

--- a/docs/spec/interoperability/external-provider-profile.md
+++ b/docs/spec/interoperability/external-provider-profile.md
@@ -295,18 +295,25 @@ wrong hash strategy - both produce DENY. Deployers must ensure alignment.
 
 #### 2.3.4 Cross-language conformance
 
-Go harness now validates Profile C **state-hash semantics** (modes 001–005) independently
-via `docs/spec/test-vectors/profile-c-state-verification.json`. Each vector provides raw
-state JSON objects; the harness computes SHA-256 of `canonicalJson(state)` (core strategy)
-or SHA-256 of `"PROVIDER:" + canonicalJson(state)` (provider strategy) independently and
-compares outcomes against expected verdicts (`ok`, `state-hash-mismatch`, `compute-error`).
+Go and Python harnesses now validate **all 8 Profile C vectors** independently via
+`docs/spec/test-vectors/profile-c-state-verification.json`:
 
-**Scope of Go + Python coverage:** state-hash comparison semantics only (modes 001–005).
-Both Go (`go-harness/profile_c_verify.go`) and Python (`python-harness/verify_profile_c_vectors.py`)
-independently compute SHA-256 of `canonicalJson(state)` (core) and SHA-256 of
-`"PROVIDER:" + canonicalJson(state)` (provider) and compare outcomes against expected verdicts.
-Profile C Encoding B modes 006–008 (which require AuthorizationV1 Encoding B signature
-verification) remain TypeScript-only and are tracked as a separate issue.
+- **Modes 001–005** (state-hash semantics): canonicalization-v1 + SHA-256 only
+- **Modes 006–008** (Encoding B): additionally require independent Encoding B
+  AuthorizationV1 signature verification (`alg: "ed25519"` lowercase, `expires_at`,
+  base64url signature, **no domain prefix**)
+
+For Encoding B modes, each harness:
+1. Independently reconstructs the signing payload from the committed artifact
+   (all fields + `signature.{alg,kid}`, excluding `signature.sig`)
+2. Computes `canonicalJson(signingPayload)` — no domain prefix (distinct from
+   SignedKRLV1 which uses `OXDEAI_KRL_V1\n`)
+3. Verifies the Ed25519 signature (Go: `crypto/ed25519`; Python: `ctypes + libcrypto`)
+4. Cross-checks independently-computed `committedHash` against committed `auth.state_hash`
+   (byte-equivalence proof — any divergence is a harness canonicalization bug)
+5. Compares `liveHash` vs `committedHash` for the state-hash outcome
+
+No protocol semantics were changed. This is conformance coverage, not a runtime security change.
 
 #### 2.3.5 Distinguishing Profile B and Profile C
 

--- a/docs/spec/test-vectors/profile-c-state-verification.json
+++ b/docs/spec/test-vectors/profile-c-state-verification.json
@@ -1,8 +1,8 @@
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "profile": "C",
   "portable": true,
-  "description": "Portable Profile C state-hash semantics vectors for cross-language conformance (Go, Python). Covers modes 001–005 only — these require only canonicalization-v1 and SHA-256, which every compliant implementation must support independently. Modes 006–008 (Encoding B Authorization variants) are TypeScript-only and tracked separately. See packages/conformance/vectors/profile-c-state-verification.json for the full TypeScript set.",
+  "description": "Portable Profile C state-hash semantics vectors for cross-language conformance (Go, Python). Modes 001–005 require only canonicalization-v1 and SHA-256. Modes 006–008 additionally require AuthorizationV1 Encoding B signature verification (alg='ed25519', expires_at, base64url signature, no domain prefix). See packages/conformance/vectors/profile-c-state-verification.json for the full TypeScript set.",
   "hash_strategies": {
     "core": "SHA-256(canonicalJson(state)) — standard OxDeAI state hash",
     "provider": "SHA-256('PROVIDER:' + canonicalJson(state)) — simulates external provider algorithm",
@@ -12,6 +12,13 @@
     "ok": "Committed hash equals live-state hash — Profile C step 10 passes",
     "state-hash-mismatch": "Committed hash does not equal live-state hash — Profile C step 10 blocks execution",
     "compute-error": "computeStateHash threw — execution blocked fail-closed"
+  },
+  "encoding_b_notes": {
+    "signing_preimage": "canonicalJson(signingPayload) — NO domain prefix. Different from SignedKRLV1 which uses 'OXDEAI_KRL_V1\\n' prefix.",
+    "signing_payload": "All auth fields except signature.sig. signature becomes { alg, kid } with sig excluded.",
+    "alg": "ed25519 (lowercase — Sift-compatible Encoding B)",
+    "signature_encoding": "base64url (RFC 4648 §5, no padding)",
+    "expiry_field": "expires_at (not expiry — Encoding B wire format)"
   },
   "vectors": [
     {
@@ -62,6 +69,110 @@
       "state_input": { "period": "p1", "spent": 0 },
       "live_state_input": { "period": "p2", "spent": 5000000 },
       "hash_strategy": "core",
+      "expected": {
+        "outcome": "state-hash-mismatch"
+      }
+    },
+    {
+      "id": "profile-c-006",
+      "mode": "encoding-b-live-state-match",
+      "description": "Encoding B AuthorizationV1 (alg='ed25519', expires_at, base64url sig) + provider hash strategy, matching state. Harness: (1) verify Encoding B signature independently, (2) compute committedHash=providerHash(state_input), cross-check with auth.state_hash, (3) liveHash=providerHash(state_input) — same, outcome ok.",
+      "state_input": { "period": "p1", "spent": 0 },
+      "hash_strategy": "provider",
+      "auth": {
+        "auth_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "issuer": "oxdeai.policy-engine",
+        "audience": "merchant-gateway",
+        "intent_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "state_hash": "6a3b184144ed303c66357aa212d7432be648b5a2b3b0d56974bc91ca7a6732c7",
+        "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "decision": "ALLOW",
+        "issued_at": 1730000000,
+        "expires_at": 1730000060,
+        "signature": {
+          "alg": "ed25519",
+          "kid": "2026-01",
+          "sig": "jMyip7h-GMgl2nV_q8Cz-MuqbD4vgba6vseRejY13e-w8WZeW7UU7ft58JHJFJR0fyZ3NGXvjJBGeKSSJLThCA"
+        }
+      },
+      "opts": {
+        "now": 1730000010,
+        "trustedKey": {
+          "kid": "2026-01",
+          "alg": "Ed25519",
+          "public_key": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAWiMMGTYK7zzHwZXLzDpCshxAH6Lgx8gVsJaixePuY7g=\n-----END PUBLIC KEY-----"
+        }
+      },
+      "expected": {
+        "outcome": "ok"
+      }
+    },
+    {
+      "id": "profile-c-007",
+      "mode": "encoding-b-live-state-mismatch",
+      "description": "Encoding B AuthorizationV1 + provider hash strategy, stale state. Signature verifies. committedHash=providerHash({period:p1,spent:0}), liveHash=providerHash({period:p1,spent:250000}) — mismatch, outcome state-hash-mismatch.",
+      "state_input": { "period": "p1", "spent": 0 },
+      "live_state_input": { "period": "p1", "spent": 250000 },
+      "hash_strategy": "provider",
+      "auth": {
+        "auth_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "issuer": "oxdeai.policy-engine",
+        "audience": "merchant-gateway",
+        "intent_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "state_hash": "6a3b184144ed303c66357aa212d7432be648b5a2b3b0d56974bc91ca7a6732c7",
+        "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "decision": "ALLOW",
+        "issued_at": 1730000000,
+        "expires_at": 1730000060,
+        "signature": {
+          "alg": "ed25519",
+          "kid": "2026-01",
+          "sig": "jMyip7h-GMgl2nV_q8Cz-MuqbD4vgba6vseRejY13e-w8WZeW7UU7ft58JHJFJR0fyZ3NGXvjJBGeKSSJLThCA"
+        }
+      },
+      "opts": {
+        "now": 1730000010,
+        "trustedKey": {
+          "kid": "2026-01",
+          "alg": "Ed25519",
+          "public_key": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAWiMMGTYK7zzHwZXLzDpCshxAH6Lgx8gVsJaixePuY7g=\n-----END PUBLIC KEY-----"
+        }
+      },
+      "expected": {
+        "outcome": "state-hash-mismatch"
+      }
+    },
+    {
+      "id": "profile-c-008",
+      "mode": "encoding-b-hash-strategy-mismatch",
+      "description": "Encoding B AuthorizationV1 + hash strategy mismatch: provider committed, core used for live verification. Signature verifies. committedHash=providerHash(state_input), liveHash=coreHash(state_input) — different algorithms, mismatch, outcome state-hash-mismatch.",
+      "state_input": { "period": "p1", "spent": 0 },
+      "signing_strategy": "provider",
+      "verify_strategy": "core",
+      "auth": {
+        "auth_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "issuer": "oxdeai.policy-engine",
+        "audience": "merchant-gateway",
+        "intent_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "state_hash": "6a3b184144ed303c66357aa212d7432be648b5a2b3b0d56974bc91ca7a6732c7",
+        "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "decision": "ALLOW",
+        "issued_at": 1730000000,
+        "expires_at": 1730000060,
+        "signature": {
+          "alg": "ed25519",
+          "kid": "2026-01",
+          "sig": "jMyip7h-GMgl2nV_q8Cz-MuqbD4vgba6vseRejY13e-w8WZeW7UU7ft58JHJFJR0fyZ3NGXvjJBGeKSSJLThCA"
+        }
+      },
+      "opts": {
+        "now": 1730000010,
+        "trustedKey": {
+          "kid": "2026-01",
+          "alg": "Ed25519",
+          "public_key": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAWiMMGTYK7zzHwZXLzDpCshxAH6Lgx8gVsJaixePuY7g=\n-----END PUBLIC KEY-----"
+        }
+      },
       "expected": {
         "outcome": "state-hash-mismatch"
       }

--- a/go-harness/profile_c_verify.go
+++ b/go-harness/profile_c_verify.go
@@ -1,15 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
-// Profile C state-hash semantics conformance vectors (modes 001–005).
-// Modes 006–008 (Encoding B) are TypeScript-only and are not implemented here.
+// Profile C state-hash semantics conformance vectors (modes 001–008).
+// Modes 001–005: canonicalization-v1 + SHA-256 only.
+// Modes 006–008: additionally require Encoding B AuthorizationV1 signature
+// verification (alg='ed25519', expires_at, base64url signature, no domain prefix).
 package main
 
 import (
+	"crypto/ed25519"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // ProfileCOutcome is the result of a Profile C state-hash comparison.
@@ -56,6 +61,76 @@ func getProfileCHashFn(strategy string) func(interface{}) (string, error) {
 	default:
 		return nil
 	}
+}
+
+// ── Encoding B AuthorizationV1 verification ───────────────────────────────────
+
+// buildEncodingBSigningPayload reconstructs the Encoding B signing payload
+// from a committed auth artifact.
+//
+// The signing payload includes all auth fields EXCEPT signature.sig.
+// signature becomes { alg, kid } with sig excluded.
+// The preimage is canonicalJson(signingPayload) with NO domain prefix.
+//
+// This is the Sift-compatible Encoding B wire format - distinct from:
+//   - Encoding A: uses "OXDEAI_AUTH_V1\n" domain prefix
+//   - SignedKRLV1: uses "OXDEAI_KRL_V1\n" domain prefix
+func buildEncodingBSigningPayload(auth map[string]interface{}) map[string]interface{} {
+	sig, _ := auth["signature"].(map[string]interface{})
+	payload := make(map[string]interface{})
+	for k, v := range auth {
+		if k == "signature" {
+			// Include only alg and kid - sig is intentionally excluded.
+			payload["signature"] = map[string]interface{}{
+				"alg": sig["alg"],
+				"kid": sig["kid"],
+			}
+		} else {
+			payload[k] = v
+		}
+	}
+	return payload
+}
+
+// verifyEncodingBAuth verifies an Encoding B AuthorizationV1 artifact.
+//
+// Preimage: canonicalJson(signingPayload) - NO domain prefix.
+// Signature: base64url Ed25519 (RFC 4648 §5, no padding).
+//
+// Infrastructure failures (malformed PEM, invalid base64) call os.Exit(1).
+// This function is only called for committed portable vectors; any failure
+// is a harness implementation bug, not a test outcome.
+func verifyEncodingBAuth(auth map[string]interface{}, pubKeyPem string, id string) bool {
+	// Extract signature bytes (base64url).
+	sig, _ := auth["signature"].(map[string]interface{})
+	sigStr, _ := sig["sig"].(string)
+
+	sigBytes, err := base64.RawURLEncoding.DecodeString(sigStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL [%s]: failed to decode base64url signature: %v\n", id, err)
+		os.Exit(1)
+	}
+
+	// Parse the Ed25519 public key from SPKI PEM.
+	// Reuses parseEd25519PEM from signed_krl_verify.go (same package).
+	pubKey, err := parseEd25519PEM(pubKeyPem)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL [%s]: failed to parse Ed25519 PEM key: %v\n", id, err)
+		os.Exit(1)
+	}
+
+	// Reconstruct the signing payload and canonicalize.
+	signingPayload := buildEncodingBSigningPayload(auth)
+	canonical, err := canonicalize(signingPayload)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL [%s]: canonicalization failed: %v\n", id, err)
+		os.Exit(1)
+	}
+
+	// Preimage: canonical JSON bytes with NO domain prefix.
+	preimage := []byte(canonical)
+
+	return ed25519.Verify(pubKey, preimage, sigBytes)
 }
 
 // ── Vector loading ────────────────────────────────────────────────────────────
@@ -110,12 +185,21 @@ func computeProfileCOutcome(v map[string]interface{}) ProfileCOutcome {
 	mode, _ := v["mode"].(string)
 
 	// compute-throws: simulate computeStateHash failure directly.
-	// The "throws" strategy always errors; no state hash is computed.
 	if mode == "compute-throws" {
 		return ProfileCOutcomeComputeError
 	}
 
-	// Determine signing and verify strategies.
+	// Encoding B modes: verify Encoding B signature, then compare state hashes.
+	if strings.HasPrefix(mode, "encoding-b-") {
+		return computeEncodingBOutcome(v)
+	}
+
+	// Modes 001–005: pure state-hash comparison, no signature work.
+	return computeStateHashOutcome(v)
+}
+
+// computeStateHashOutcome handles modes 001–005 (no signature).
+func computeStateHashOutcome(v map[string]interface{}) ProfileCOutcome {
 	hashStrategy, _ := v["hash_strategy"].(string)
 	signingStrategy := hashStrategy
 	if s, ok := v["signing_strategy"].(string); ok && s != "" {
@@ -132,25 +216,96 @@ func computeProfileCOutcome(v map[string]interface{}) ProfileCOutcome {
 		return ProfileCOutcomeComputeError
 	}
 
-	// Compute committed hash from state_input.
 	stateInput := v["state_input"]
 	committedHash, err := signingFn(stateInput)
 	if err != nil {
 		return ProfileCOutcomeComputeError
 	}
 
-	// Live state defaults to state_input when live_state_input is absent.
 	liveState := stateInput
 	if ls, ok := v["live_state_input"]; ok && ls != nil {
 		liveState = ls
 	}
 
-	// Compute live hash (verify strategy).
 	liveHash, err := verifyFn(liveState)
 	if err != nil {
 		return ProfileCOutcomeComputeError
 	}
 
+	if liveHash == committedHash {
+		return ProfileCOutcomeOk
+	}
+	return ProfileCOutcomeStateHashMismatch
+}
+
+// computeEncodingBOutcome handles modes 006–008 (Encoding B).
+//
+// Step 1: Verify Encoding B signature (fatal on failure - harness bug).
+// Step 2: Independently compute committedHash from state_input.
+// Step 3: Cross-check committedHash against auth.state_hash (byte-equivalence proof).
+// Step 4: Compute liveHash using verify strategy.
+// Step 5: Compare liveHash vs committedHash.
+func computeEncodingBOutcome(v map[string]interface{}) ProfileCOutcome {
+	id, _ := v["id"].(string)
+	auth, _ := v["auth"].(map[string]interface{})
+	opts, _ := v["opts"].(map[string]interface{})
+	trustedKey, _ := opts["trustedKey"].(map[string]interface{})
+	pubKeyPem, _ := trustedKey["public_key"].(string)
+
+	// Step 1: Verify Encoding B signature independently.
+	// Preimage = canonicalJson(signingPayload), NO domain prefix.
+	if !verifyEncodingBAuth(auth, pubKeyPem, id) {
+		fmt.Fprintf(os.Stderr, "FATAL [%s]: Encoding B signature verification failed - harness bug (wrong preimage or key?)\n", id)
+		os.Exit(1)
+	}
+
+	// Step 2: Independently compute committedHash from state_input.
+	hashStrategy, _ := v["hash_strategy"].(string)
+	signingStrategy := hashStrategy
+	if s, ok := v["signing_strategy"].(string); ok && s != "" {
+		signingStrategy = s
+	}
+	verifyStrategy := hashStrategy
+	if s, ok := v["verify_strategy"].(string); ok && s != "" {
+		verifyStrategy = s
+	}
+
+	signingFn := getProfileCHashFn(signingStrategy)
+	verifyFn := getProfileCHashFn(verifyStrategy)
+	if signingFn == nil || verifyFn == nil {
+		return ProfileCOutcomeComputeError
+	}
+
+	stateInput := v["state_input"]
+	committedHash, err := signingFn(stateInput)
+	if err != nil {
+		return ProfileCOutcomeComputeError
+	}
+
+	// Step 3: Cross-check committedHash against committed auth.state_hash.
+	// If they differ, the canonicalization or hash strategy in this harness is
+	// wrong - this is a byte-equivalence failure, not a test outcome.
+	authStateHash, _ := auth["state_hash"].(string)
+	if committedHash != authStateHash {
+		fmt.Fprintf(os.Stderr,
+			"FATAL [%s]: independently-computed committedHash %s does not match committed auth.state_hash %s\n"+
+				"  This indicates a canonicalization or hash-strategy bug in the Go harness.\n",
+			id, committedHash, authStateHash)
+		os.Exit(1)
+	}
+
+	// Step 4: Compute liveHash using verify strategy.
+	liveState := stateInput
+	if ls, ok := v["live_state_input"]; ok && ls != nil {
+		liveState = ls
+	}
+
+	liveHash, err := verifyFn(liveState)
+	if err != nil {
+		return ProfileCOutcomeComputeError
+	}
+
+	// Step 5: Compare liveHash vs committedHash.
 	if liveHash == committedHash {
 		return ProfileCOutcomeOk
 	}

--- a/packages/conformance/README.md
+++ b/packages/conformance/README.md
@@ -58,56 +58,56 @@ Encoding B vectors (`profile-c-006` through `profile-c-008`) exercise the Sift-c
 
 ### Key Lifecycle (v1.5+)
 
-- `key-lifecycle-verification.json` — exercises `keyIsActiveAt`, `findKeyInKeySets`, and `AUTH_KEY_INACTIVE` / `AUTH_KID_UNKNOWN` enforcement across all key status and time-window states.
+- `key-lifecycle-verification.json` - exercises `keyIsActiveAt`, `findKeyInKeySets`, and `AUTH_KEY_INACTIVE` / `AUTH_KID_UNKNOWN` enforcement across all key status and time-window states.
 
 Ten vectors covering:
 
 | Vector | Mode | Expected outcome |
 |--------|------|-----------------|
-| `key-lifecycle-001` | `key-active` | `ok` — active key, no time constraints |
-| `key-lifecycle-002` | `key-revoked` | `AUTH_KEY_INACTIVE` — revoked key rejected |
-| `key-lifecycle-003` | `key-not-before-future` | `AUTH_KEY_INACTIVE` — key not yet active |
-| `key-lifecycle-004` | `key-not-after-past` | `AUTH_KEY_INACTIVE` — validity window expired |
-| `key-lifecycle-005` | `key-valid-window` | `ok` — explicit `not_before`/`not_after` window active |
-| `key-lifecycle-006` | `key-expired-window` | `AUTH_KEY_INACTIVE` — `not_after` in the past |
-| `key-lifecycle-007` | `key-retired-within-window` | `ok` — retired key accepted during dual-sign overlap window |
-| `key-lifecycle-008` | `key-retired-past-window` | `AUTH_KEY_INACTIVE` — retired key, window closed |
-| `key-lifecycle-009` | `key-revoked-valid-window` | `AUTH_KEY_INACTIVE` — revocation overrides valid time window |
-| `key-lifecycle-010` | `wrong-kid-known-issuer` | `AUTH_KID_UNKNOWN` — correct issuer, unknown kid |
+| `key-lifecycle-001` | `key-active` | `ok` - active key, no time constraints |
+| `key-lifecycle-002` | `key-revoked` | `AUTH_KEY_INACTIVE` - revoked key rejected |
+| `key-lifecycle-003` | `key-not-before-future` | `AUTH_KEY_INACTIVE` - key not yet active |
+| `key-lifecycle-004` | `key-not-after-past` | `AUTH_KEY_INACTIVE` - validity window expired |
+| `key-lifecycle-005` | `key-valid-window` | `ok` - explicit `not_before`/`not_after` window active |
+| `key-lifecycle-006` | `key-expired-window` | `AUTH_KEY_INACTIVE` - `not_after` in the past |
+| `key-lifecycle-007` | `key-retired-within-window` | `ok` - retired key accepted during dual-sign overlap window |
+| `key-lifecycle-008` | `key-retired-past-window` | `AUTH_KEY_INACTIVE` - retired key, window closed |
+| `key-lifecycle-009` | `key-revoked-valid-window` | `AUTH_KEY_INACTIVE` - revocation overrides valid time window |
+| `key-lifecycle-010` | `wrong-kid-known-issuer` | `AUTH_KID_UNKNOWN` - correct issuer, unknown kid |
 
 ### Clock Semantics (v1.5+)
 
-- `clock-semantics-verification.json` — exercises strict zero-tolerance expiry enforcement (`now < expiry`) and `issued_at` informational-only semantics for both wire encodings.
+- `clock-semantics-verification.json` - exercises strict zero-tolerance expiry enforcement (`now < expiry`) and `issued_at` informational-only semantics for both wire encodings.
 
 Five vectors covering:
 
 | Vector | Mode | Expected outcome |
 |--------|------|-----------------|
-| `clock-001` | `last-valid-second` | `ok` — `now = expiry - 1`, last valid second |
-| `clock-002` | `one-past-expiry` | `AUTH_EXPIRED` — `now = expiry + 1`, no grace period |
-| `clock-003` | `verifier-clock-behind` | `ok` — `now < issued_at`, `issued_at` not enforced as lower bound |
-| `clock-004` | `encoding-b-last-valid-second` | `ok` — Encoding B (`expires_at`), `now = expires_at - 1` |
-| `clock-005` | `encoding-b-verifier-clock-behind` | `ok` — Encoding B, `now < issued_at` |
+| `clock-001` | `last-valid-second` | `ok` - `now = expiry - 1`, last valid second |
+| `clock-002` | `one-past-expiry` | `AUTH_EXPIRED` - `now = expiry + 1`, no grace period |
+| `clock-003` | `verifier-clock-behind` | `ok` - `now < issued_at`, `issued_at` not enforced as lower bound |
+| `clock-004` | `encoding-b-last-valid-second` | `ok` - Encoding B (`expires_at`), `now = expires_at - 1` |
+| `clock-005` | `encoding-b-verifier-clock-behind` | `ok` - Encoding B, `now < issued_at` |
 
 Clock model: **strict zero tolerance**. Valid iff `now < expiry`. No skew parameter, no grace period. Issuers must build delivery latency into the expiry window. See `authorization-v1.md §17`.
 
 ### SignedKRLV1 Verification (v1.6+)
 
-- `signed-krl-verification.json` — exercises `verifySignedKrl` across all verification paths for the `SignedKRLV1` protocol artifact.
+- `signed-krl-verification.json` - exercises `verifySignedKrl` across all verification paths for the `SignedKRLV1` protocol artifact.
 
 Nine vectors covering:
 
 | Vector | Mode | Expected outcome |
 |--------|------|-----------------|
-| `krl-001` | `valid` | `ok` — signature verifies, not expired |
-| `krl-002` | `invalid-signature` | `KRL_SIG_INVALID` — tampered signature |
-| `krl-003` | `expired` | `KRL_EXPIRED` — `now >= not_after` (strict zero-tolerance) |
-| `krl-004` | `malformed-revoked-kids` | `KRL_MALFORMED` — `revoked_kids` is a string, not an array |
-| `krl-005` | `duplicate-revoked-kids` | `KRL_MALFORMED` — duplicate entries in `revoked_kids` |
-| `krl-006` | `unknown-signing-kid` | `KRL_UNKNOWN_SIGNING_KID` — kid not in trusted KRL signing key set |
-| `krl-007` | `signing-key-inactive` | `KRL_SIGNING_KEY_INACTIVE` — key found but `keyIsActiveAt` returns false |
-| `krl-008` | `unsupported-alg` | `KRL_UNSUPPORTED_ALG` — `signature.alg != "Ed25519"` |
-| `krl-009` | `version-regression` | `KRL_VERSION_REGRESSION` — `krl_version` less than previous accepted value |
+| `krl-001` | `valid` | `ok` - signature verifies, not expired |
+| `krl-002` | `invalid-signature` | `KRL_SIG_INVALID` - tampered signature |
+| `krl-003` | `expired` | `KRL_EXPIRED` - `now >= not_after` (strict zero-tolerance) |
+| `krl-004` | `malformed-revoked-kids` | `KRL_MALFORMED` - `revoked_kids` is a string, not an array |
+| `krl-005` | `duplicate-revoked-kids` | `KRL_MALFORMED` - duplicate entries in `revoked_kids` |
+| `krl-006` | `unknown-signing-kid` | `KRL_UNKNOWN_SIGNING_KID` - kid not in trusted KRL signing key set |
+| `krl-007` | `signing-key-inactive` | `KRL_SIGNING_KEY_INACTIVE` - key found but `keyIsActiveAt` returns false |
+| `krl-008` | `unsupported-alg` | `KRL_UNSUPPORTED_ALG` - `signature.alg != "Ed25519"` |
+| `krl-009` | `version-regression` | `KRL_VERSION_REGRESSION` - `krl_version` less than previous accepted value |
 
 Signing domain: `OXDEAI_KRL_V1`. KRL signing fixture key (`krl-2026-01`, issuer `krl.issuer`) is distinct from the AuthorizationV1 / DelegationV1 signing fixture key to exercise trust-domain separation.
 
@@ -141,9 +141,9 @@ compatibility but not used by the harness runners.
 | `delegation-verification.json` | Field checks, expiry, scope, replay, trust-missing | Yes - no crypto required |
 | `delegation-chain-verification.json` | Chain structural checks (hash binding, delegator, expiry ceiling, policy) | Yes - independently recomputed |
 | `delegation-signature-verification.json` | Ed25519 verification path | Yes - independently verified |
-| `key-lifecycle-verification.json` | Key status (active/revoked/retired), `not_before`/`not_after` windows, wrong-kid rejection | Yes — portable across any `verifyAuthorization` implementation |
-| `clock-semantics-verification.json` | Strict zero-tolerance expiry, `issued_at` informational, Encoding A + B boundary pins | Yes — portable; no crypto required |
-| `profile-c-state-verification.json` | Semantic state verification: hash comparison, strategy mismatch, compute-throws, TOCTOU, Encoding B | TypeScript only (requires `computeStateHash` integration) |
+| `key-lifecycle-verification.json` | Key status (active/revoked/retired), `not_before`/`not_after` windows, wrong-kid rejection | Yes - portable across any `verifyAuthorization` implementation |
+| `clock-semantics-verification.json` | Strict zero-tolerance expiry, `issued_at` informational, Encoding A + B boundary pins | Yes - portable; no crypto required |
+| `profile-c-state-verification.json` | Semantic state verification: hash comparison, strategy mismatch, compute-throws, TOCTOU, Encoding B | TypeScript only (TS runner); **Go + Python cover all 8 modes** via `docs/spec/test-vectors/profile-c-state-verification.json` (#120) |
 | `delegation.property.test.ts` (D-P1–D-P5) | PBT over scope / hash / mutation | TypeScript only |
 | `guard.delegation.property.test.ts` (G-D1–G-D3) | Guard PEP delegation path | TypeScript only |
 | `cross-adapter.test.ts` (CA-1–CA-10) | Cross-adapter equivalence, I6 | TypeScript only |

--- a/python-harness/ed25519_utils.py
+++ b/python-harness/ed25519_utils.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""
+Shared Ed25519 verification utilities for cross-language conformance harnesses.
+
+Provides OpenSSL-backed Ed25519 verification via ctypes (no external Python packages).
+Used by both verify_signed_krl_vectors.py and verify_profile_c_vectors.py.
+"""
+from __future__ import annotations
+
+import base64
+import ctypes
+import ctypes.util
+import sys
+from typing import Optional
+
+
+# ── OpenSSL loading ───────────────────────────────────────────────────────────
+
+def load_openssl() -> ctypes.CDLL:
+    """Load libcrypto. Exits non-zero if not found — infrastructure failure."""
+    candidates = [
+        ctypes.util.find_library("crypto"),
+        "libcrypto.so.3",
+        "libcrypto.so.1.1",
+        "libcrypto.dylib",
+    ]
+    for path in candidates:
+        if path is None:
+            continue
+        try:
+            lib = ctypes.CDLL(path)
+            # Configure required function signatures.
+            lib.EVP_PKEY_free.restype = None
+            lib.EVP_PKEY_free.argtypes = [ctypes.c_void_p]
+            lib.EVP_MD_CTX_free.restype = None
+            lib.EVP_MD_CTX_free.argtypes = [ctypes.c_void_p]
+            lib.EVP_PKEY_new_raw_public_key.restype = ctypes.c_void_p
+            lib.EVP_PKEY_new_raw_public_key.argtypes = [
+                ctypes.c_int, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_size_t,
+            ]
+            lib.EVP_MD_CTX_new.restype = ctypes.c_void_p
+            lib.EVP_DigestVerifyInit.restype = ctypes.c_int
+            lib.EVP_DigestVerifyInit.argtypes = [
+                ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p,
+                ctypes.c_void_p, ctypes.c_void_p,
+            ]
+            lib.EVP_DigestVerify.restype = ctypes.c_int
+            lib.EVP_DigestVerify.argtypes = [
+                ctypes.c_void_p, ctypes.c_char_p, ctypes.c_size_t,
+                ctypes.c_char_p, ctypes.c_size_t,
+            ]
+            return lib
+        except OSError:
+            continue
+    print(
+        "FATAL: OpenSSL libcrypto not found. Required for Ed25519 signature verification. "
+        "Tried: " + ", ".join(repr(c) for c in candidates),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+# Load once at module level — failure is an infrastructure error.
+OPENSSL: ctypes.CDLL = load_openssl()
+
+# EVP_PKEY type ID for Ed25519 in OpenSSL.
+EVP_PKEY_ED25519: int = 1087
+
+# Fixed byte length of the SPKI DER prefix for Ed25519 (302a300506032b6570032100).
+SPKI_PREFIX_LEN: int = 12
+
+
+# ── Infrastructure errors ─────────────────────────────────────────────────────
+
+class InfrastructureError(Exception):
+    """Non-recoverable infrastructure failure (PEM parse, key creation, etc.)."""
+
+
+# ── Key helpers ───────────────────────────────────────────────────────────────
+
+def parse_ed25519_pem(pem_str: str) -> bytes:
+    """Parse SPKI PEM-encoded Ed25519 public key to raw 32 bytes.
+
+    Strips PEM armor, base64-decodes the DER body, and extracts the last
+    32 bytes (the raw public key material after the 12-byte SPKI prefix).
+
+    Raises InfrastructureError on malformed input.
+    No vector tests malformed key material — any parse failure is a bug.
+    """
+    lines = [
+        line.strip()
+        for line in pem_str.strip().splitlines()
+        if not line.strip().startswith("-----")
+    ]
+    try:
+        der = base64.b64decode("".join(lines))
+    except Exception as exc:
+        raise InfrastructureError(
+            f"Failed to base64-decode PEM body: {exc}"
+        ) from exc
+
+    expected_total = SPKI_PREFIX_LEN + 32
+    if len(der) != expected_total:
+        raise InfrastructureError(
+            f"Unexpected DER key length: {len(der)} bytes (expected {expected_total})"
+        )
+
+    return der[SPKI_PREFIX_LEN:]
+
+
+def ed25519_verify(raw_pub: bytes, message: bytes, sig_bytes: bytes) -> bool:
+    """Verify an Ed25519 signature using the EVP path in libcrypto.
+
+    Uses NULL digest (Ed25519 signs the exact message bytes without pre-hashing).
+    Returns True on valid signature, False otherwise.
+    """
+    lib = OPENSSL
+    pkey = lib.EVP_PKEY_new_raw_public_key(EVP_PKEY_ED25519, None, raw_pub, len(raw_pub))
+    if not pkey:
+        return False
+
+    ctx = lib.EVP_MD_CTX_new()
+    if not ctx:
+        lib.EVP_PKEY_free(pkey)
+        return False
+
+    try:
+        if lib.EVP_DigestVerifyInit(ctx, None, None, None, pkey) != 1:
+            return False
+        return lib.EVP_DigestVerify(ctx, sig_bytes, len(sig_bytes), message, len(message)) == 1
+    finally:
+        lib.EVP_MD_CTX_free(ctx)
+        lib.EVP_PKEY_free(pkey)
+
+
+def decode_base64url(s: str) -> bytes:
+    """Decode a base64url-encoded string (no padding required).
+
+    Used for Encoding B AuthorizationV1 signature bytes (base64url, RFC 4648 §5).
+    SignedKRLV1 uses standard base64; only Encoding B uses base64url.
+    """
+    padded = s + "=" * (-len(s) % 4)
+    return base64.urlsafe_b64decode(padded)

--- a/python-harness/verify_profile_c_vectors.py
+++ b/python-harness/verify_profile_c_vectors.py
@@ -3,13 +3,23 @@
 """
 Profile C state-hash semantics cross-language conformance verifier.
 
-Validates modes 001–005 from docs/spec/test-vectors/profile-c-state-verification.json.
-Modes 006–008 (Encoding B) are TypeScript-only and are NOT validated here.
+Validates all 8 modes from docs/spec/test-vectors/profile-c-state-verification.json:
+  - Modes 001–005: canonicalization-v1 + SHA-256 only
+  - Modes 006–008: additionally require Encoding B AuthorizationV1 signature
+    verification (alg='ed25519', expires_at, base64url signature, NO domain prefix)
 
-Reuses the canonicalization-v1 implementation from verify_canonicalization_vectors.py.
+Independent verification model:
+  - Modes 001–005: compute state hashes from raw state_input JSON, compare outcomes
+  - Modes 006–008: (1) independently verify Encoding B signature using canonical
+    signing payload, (2) compute committedHash from state_input, cross-check with
+    auth.state_hash as byte-equivalence proof, (3) compare with liveHash
+
+Reuses canonicalization-v1 from verify_canonicalization_vectors.py.
+Reuses Ed25519 utilities from ed25519_utils.py.
 """
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 import sys
@@ -20,6 +30,14 @@ from typing import Any, Callable
 # Reuse canonical JSON and SHA-256 from the existing canonicalization harness.
 # main() in that module is guarded by __name__, so it will not run on import.
 from verify_canonicalization_vectors import canonicalize, sha256_hex, CanonicalError  # noqa: E402
+
+# Shared Ed25519 / OpenSSL utilities (also used by verify_signed_krl_vectors.py).
+from ed25519_utils import (  # noqa: E402
+    InfrastructureError as _InfrastructureError,
+    parse_ed25519_pem as _parse_ed25519_pem,
+    ed25519_verify as _ed25519_verify,
+    decode_base64url as _decode_base64url,
+)
 
 
 # ── Typed outcome constants ───────────────────────────────────────────────────
@@ -55,6 +73,50 @@ def _get_hash_fn(strategy: str) -> Callable[[Any], str] | None:
     }.get(strategy)
 
 
+# ── Encoding B AuthorizationV1 verification ───────────────────────────────────
+
+def _build_encoding_b_signing_payload(auth: dict[str, Any]) -> dict[str, Any]:
+    """Build Encoding B signing payload from committed auth artifact.
+
+    Includes all auth fields EXCEPT signature.sig.
+    signature becomes { alg, kid } with sig excluded.
+
+    Preimage: canonicalJson(result) — NO domain prefix.
+    This is the Sift-compatible Encoding B wire format. Different from:
+      - Encoding A: uses 'OXDEAI_AUTH_V1\\n' domain prefix
+      - SignedKRLV1: uses 'OXDEAI_KRL_V1\\n' domain prefix
+    """
+    sig = auth["signature"]
+    payload = {k: v for k, v in auth.items() if k != "signature"}
+    payload["signature"] = {"alg": sig["alg"], "kid": sig["kid"]}
+    return payload
+
+
+def _verify_encoding_b_auth(auth: dict[str, Any], trusted_key_pem: str, vid: str) -> bool:
+    """Verify Encoding B AuthorizationV1 artifact.
+
+    Preimage: canonicalJson(signingPayload) — NO domain prefix.
+    Signature: base64url Ed25519 (RFC 4648 §5, no padding).
+
+    Raises _InfrastructureError on PEM parse failure.
+    Returns True on valid signature, False otherwise.
+    """
+    sig_str: str = auth["signature"]["sig"]
+
+    # Decode base64url signature (no padding).
+    sig_bytes = _decode_base64url(sig_str)
+
+    # Parse public key from SPKI PEM.
+    raw_pub = _parse_ed25519_pem(trusted_key_pem)
+
+    # Build signing payload and canonicalize — NO domain prefix.
+    signing_payload = _build_encoding_b_signing_payload(auth)
+    canonical = canonicalize(signing_payload)
+    preimage = canonical.encode("utf-8")
+
+    return _ed25519_verify(raw_pub, preimage, sig_bytes)
+
+
 # ── Outcome computation ───────────────────────────────────────────────────────
 
 def _compute_outcome(vector: dict[str, Any]) -> ProfileCOutcome:
@@ -64,7 +126,16 @@ def _compute_outcome(vector: dict[str, Any]) -> ProfileCOutcome:
     if mode == "compute-throws":
         return ProfileCOutcome.COMPUTE_ERROR
 
-    # Resolve signing and verify strategies.
+    # Encoding B modes: verify signature first, then compare state hashes.
+    if mode.startswith("encoding-b-"):
+        return _compute_encoding_b_outcome(vector)
+
+    # Modes 001–005: pure state-hash comparison, no signature work.
+    return _compute_state_hash_outcome(vector)
+
+
+def _compute_state_hash_outcome(vector: dict[str, Any]) -> ProfileCOutcome:
+    """Handles modes 001–005 (no signature)."""
     hash_strategy: str = vector.get("hash_strategy", "core")
     signing_strategy: str = vector.get("signing_strategy", hash_strategy)
     verify_strategy: str  = vector.get("verify_strategy",  hash_strategy)
@@ -74,22 +145,89 @@ def _compute_outcome(vector: dict[str, Any]) -> ProfileCOutcome:
     if signing_fn is None or verify_fn is None:
         return ProfileCOutcome.COMPUTE_ERROR
 
-    # Compute committed hash from state_input.
     state_input = vector.get("state_input")
     try:
         committed_hash = signing_fn(state_input)
     except Exception:
         return ProfileCOutcome.COMPUTE_ERROR
 
-    # Live state falls back to state_input when live_state_input is absent.
     live_state = vector.get("live_state_input", state_input)
 
-    # Compute live hash with verify strategy.
     try:
         live_hash = verify_fn(live_state)
     except Exception:
         return ProfileCOutcome.COMPUTE_ERROR
 
+    if live_hash == committed_hash:
+        return ProfileCOutcome.OK
+    return ProfileCOutcome.STATE_HASH_MISMATCH
+
+
+def _compute_encoding_b_outcome(vector: dict[str, Any]) -> ProfileCOutcome:
+    """Handles modes 006–008 (Encoding B).
+
+    Step 1: Verify Encoding B signature independently (fatal on failure — harness bug).
+    Step 2: Independently compute committedHash from state_input.
+    Step 3: Cross-check committedHash against auth.state_hash (byte-equivalence proof).
+    Step 4: Compute liveHash using verify strategy.
+    Step 5: Compare liveHash vs committedHash.
+    """
+    vid: str = vector.get("id", "?")
+    auth: dict[str, Any] = vector["auth"]
+    opts: dict[str, Any] = vector["opts"]
+    trusted_key_pem: str = opts["trustedKey"]["public_key"]
+
+    # Step 1: Verify Encoding B signature independently.
+    try:
+        sig_valid = _verify_encoding_b_auth(auth, trusted_key_pem, vid)
+    except _InfrastructureError as exc:
+        print(f"FATAL [{vid}]: Encoding B infrastructure error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if not sig_valid:
+        print(
+            f"FATAL [{vid}]: Encoding B signature verification failed — harness bug "
+            f"(wrong preimage or key?)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Step 2: Independently compute committedHash from state_input.
+    hash_strategy: str = vector.get("hash_strategy", "provider")
+    signing_strategy: str = vector.get("signing_strategy", hash_strategy)
+    verify_strategy: str  = vector.get("verify_strategy",  hash_strategy)
+
+    signing_fn = _get_hash_fn(signing_strategy)
+    verify_fn  = _get_hash_fn(verify_strategy)
+    if signing_fn is None or verify_fn is None:
+        return ProfileCOutcome.COMPUTE_ERROR
+
+    state_input = vector.get("state_input")
+    try:
+        committed_hash = signing_fn(state_input)
+    except Exception:
+        return ProfileCOutcome.COMPUTE_ERROR
+
+    # Step 3: Cross-check committedHash against committed auth.state_hash.
+    # If they differ, canonicalization or hash strategy in this harness is wrong.
+    auth_state_hash: str = auth["state_hash"]
+    if committed_hash != auth_state_hash:
+        print(
+            f"FATAL [{vid}]: independently-computed committedHash {committed_hash!r} "
+            f"does not match committed auth.state_hash {auth_state_hash!r}\n"
+            f"  This indicates a canonicalization or hash-strategy bug in the Python harness.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Step 4: Compute liveHash using verify strategy.
+    live_state = vector.get("live_state_input", state_input)
+    try:
+        live_hash = verify_fn(live_state)
+    except Exception:
+        return ProfileCOutcome.COMPUTE_ERROR
+
+    # Step 5: Compare liveHash vs committedHash.
     if live_hash == committed_hash:
         return ProfileCOutcome.OK
     return ProfileCOutcome.STATE_HASH_MISMATCH

--- a/python-harness/verify_signed_krl_vectors.py
+++ b/python-harness/verify_signed_krl_vectors.py
@@ -13,8 +13,6 @@ Reuses the canonicalization-v1 implementation from verify_canonicalization_vecto
 from __future__ import annotations
 
 import base64
-import ctypes
-import ctypes.util
 import json
 import sys
 from enum import Enum
@@ -24,6 +22,14 @@ from typing import Any
 # Reuse canonical JSON from the existing canonicalization harness.
 # main() in that module is guarded by __name__, so it will not run on import.
 from verify_canonicalization_vectors import canonicalize  # noqa: E402
+
+# Shared Ed25519 / OpenSSL utilities (extracted to avoid duplication with
+# verify_profile_c_vectors.py which also needs Encoding B verification).
+from ed25519_utils import (  # noqa: E402
+    InfrastructureError as _InfrastructureError,
+    parse_ed25519_pem as _parse_ed25519_pem,
+    ed25519_verify as _ed25519_verify,
+)
 
 
 # ── KRL reason-code constants ─────────────────────────────────────────────────
@@ -41,125 +47,6 @@ class KrlReasonCode(str, Enum):
     UNKNOWN_SIGNING_KID    = "KRL_UNKNOWN_SIGNING_KID"
     SIGNING_KEY_INACTIVE   = "KRL_SIGNING_KEY_INACTIVE"
     VERSION_REGRESSION     = "KRL_VERSION_REGRESSION"
-
-
-# ── OpenSSL loading ───────────────────────────────────────────────────────────
-
-def _load_openssl() -> ctypes.CDLL:
-    """Load libcrypto. Exits non-zero if not found — infrastructure failure."""
-    candidates = [
-        ctypes.util.find_library("crypto"),
-        "libcrypto.so.3",
-        "libcrypto.so.1.1",
-        "libcrypto.dylib",
-    ]
-    for path in candidates:
-        if path is None:
-            continue
-        try:
-            lib = ctypes.CDLL(path)
-            # Configure required function signatures.
-            lib.EVP_PKEY_free.restype = None
-            lib.EVP_PKEY_free.argtypes = [ctypes.c_void_p]
-            lib.EVP_MD_CTX_free.restype = None
-            lib.EVP_MD_CTX_free.argtypes = [ctypes.c_void_p]
-            lib.EVP_PKEY_new_raw_public_key.restype = ctypes.c_void_p
-            lib.EVP_PKEY_new_raw_public_key.argtypes = [
-                ctypes.c_int, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_size_t,
-            ]
-            lib.EVP_MD_CTX_new.restype = ctypes.c_void_p
-            lib.EVP_DigestVerifyInit.restype = ctypes.c_int
-            lib.EVP_DigestVerifyInit.argtypes = [
-                ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p,
-                ctypes.c_void_p, ctypes.c_void_p,
-            ]
-            lib.EVP_DigestVerify.restype = ctypes.c_int
-            lib.EVP_DigestVerify.argtypes = [
-                ctypes.c_void_p, ctypes.c_char_p, ctypes.c_size_t,
-                ctypes.c_char_p, ctypes.c_size_t,
-            ]
-            return lib
-        except OSError:
-            continue
-    print(
-        "FATAL: OpenSSL libcrypto not found. Required for Ed25519 signature verification. "
-        "Tried: " + ", ".join(repr(c) for c in candidates),
-        file=sys.stderr,
-    )
-    sys.exit(1)
-
-
-# Load once at module level — failure is an infrastructure error.
-_OPENSSL = _load_openssl()
-
-# EVP_PKEY type ID for Ed25519 in OpenSSL.
-_EVP_PKEY_ED25519 = 1087
-
-# Fixed byte length of the SPKI DER prefix for Ed25519 (302a300506032b6570032100).
-_SPKI_PREFIX_LEN = 12
-
-
-# ── Infrastructure errors ─────────────────────────────────────────────────────
-
-class _InfrastructureError(Exception):
-    """Non-recoverable infrastructure failure (PEM parse, key creation, etc.)."""
-
-
-# ── Key helpers ───────────────────────────────────────────────────────────────
-
-def _parse_ed25519_pem(pem_str: str) -> bytes:
-    """Parse SPKI PEM-encoded Ed25519 public key to raw 32 bytes.
-
-    Strips PEM armor, base64-decodes the DER body, and extracts the last
-    32 bytes (the raw public key material after the 12-byte SPKI prefix).
-
-    Raises _InfrastructureError on malformed input.
-    No vector tests malformed key material — any parse failure is a bug.
-    """
-    lines = [
-        line.strip()
-        for line in pem_str.strip().splitlines()
-        if not line.strip().startswith("-----")
-    ]
-    try:
-        der = base64.b64decode("".join(lines))
-    except Exception as exc:
-        raise _InfrastructureError(
-            f"Failed to base64-decode PEM body: {exc}"
-        ) from exc
-
-    expected_total = _SPKI_PREFIX_LEN + 32
-    if len(der) != expected_total:
-        raise _InfrastructureError(
-            f"Unexpected DER key length: {len(der)} bytes (expected {expected_total})"
-        )
-
-    return der[_SPKI_PREFIX_LEN:]
-
-
-def _ed25519_verify(raw_pub: bytes, message: bytes, sig_bytes: bytes) -> bool:
-    """Verify an Ed25519 signature using the EVP path in libcrypto.
-
-    Uses NULL digest (Ed25519 signs the exact message bytes without pre-hashing).
-    Returns True on valid signature, False otherwise.
-    """
-    lib = _OPENSSL
-    pkey = lib.EVP_PKEY_new_raw_public_key(_EVP_PKEY_ED25519, None, raw_pub, len(raw_pub))
-    if not pkey:
-        return False
-
-    ctx = lib.EVP_MD_CTX_new()
-    if not ctx:
-        lib.EVP_PKEY_free(pkey)
-        return False
-
-    try:
-        if lib.EVP_DigestVerifyInit(ctx, None, None, None, pkey) != 1:
-            return False
-        return lib.EVP_DigestVerify(ctx, sig_bytes, len(sig_bytes), message, len(message)) == 1
-    finally:
-        lib.EVP_MD_CTX_free(ctx)
-        lib.EVP_PKEY_free(pkey)
 
 
 def _find_krl_key(


### PR DESCRIPTION
Closes #120.

## Summary

Adds cross-language conformance coverage for the remaining Profile C Encoding B modes.

Issue #119 added Go and Python coverage for:

- Profile C state-hash semantics, modes 001–005
- SignedKRLV1 verification

This PR completes the remaining Profile C gap by adding Go and Python coverage for modes 006–008, which require AuthorizationV1 Encoding B signature verification.

## What changed

Added three portable Profile C Encoding B vectors to:

- `docs/spec/test-vectors/profile-c-state-verification.json`

Updated Go harness:

- `go-harness/profile_c_verify.go`

Updated Python harness:

- `python-harness/verify_profile_c_vectors.py`
- `python-harness/verify_signed_krl_vectors.py`
- `python-harness/ed25519_utils.py`

Updated documentation:

- `docs/spec/interoperability/external-provider-profile.md`
- `docs/audits/protocol-audit-post-interoperability.md`
- `packages/conformance/README.md`

## Vectors added

Added:

- `profile-c-006`: `encoding-b-live-state-match` -> `ok`
- `profile-c-007`: `encoding-b-live-state-mismatch` -> `state-hash-mismatch`
- `profile-c-008`: `encoding-b-hash-strategy-mismatch` -> `state-hash-mismatch`

All three vectors use the same committed Encoding B AuthorizationV1 artifact.

The committed artifact contains:

- provider-computed `state_hash`
- lowercase `signature.alg: "ed25519"`
- `expires_at`
- base64url Ed25519 signature

## Encoding B verification

This PR adds independent Encoding B verification in Go and Python.

Encoding B signing payload rules:

- include all AuthorizationV1 fields
- include `signature.alg`
- include `signature.kid`
- exclude `signature.sig`
- canonicalize with `canonicalization-v1`
- verify Ed25519 signature over the canonical JSON bytes

Critical distinction:

```text
Encoding B preimage = canonicalJson(signingPayload)
````

There is no domain prefix.

This differs from:

```text
SignedKRLV1 = "OXDEAI_KRL_V1\n" + canonicalJson(payload)
AuthorizationV1 Encoding A = "OXDEAI_AUTH_V1\n" + canonicalJson(payload)
```

## Coverage

Go harness:

* before: 25 assertions
* after: 28 assertions

Python harness:

* before: 25 assertions
* after: 28 assertions

TypeScript conformance:

* unchanged: 209 assertions

Profile C now has Go and Python coverage for all 8 portable vectors.

## Boundary guarantees

No changes were made to:

* `packages/core/**`
* `packages/core/API_FINGERPRINT`
* `packages/conformance/vectors/**`
* `packages/sift/**`
* `AuthorizationV1` semantics
* `Profile C` semantics
* `canonicalization-v1`
* `SignedKRLV1`
* `verifyKrl`

No new reason codes were added.

No external dependencies were added.

## Validation

* `pnpm test:vectors:go`: 28 passing
* `pnpm test:vectors:py`: 28 passing
* `pnpm test:vectors:all`: passing
* `pnpm -C packages/conformance validate`: 209/209 passing
* `pnpm typecheck`: passing
* `pnpm test`: passing
* `pnpm security:gate`: ALLOW
* `git diff --check`: clean
* `packages/core/API_FINGERPRINT`: unchanged

## Residual limitations

This PR is a conformance coverage improvement, not a runtime security change.

It removes the caveat that Profile C Encoding B modes 006–008 are TypeScript-only.

It does not change protocol semantics or claim broader standardization readiness.