### PR TITLE
docs: specify state provider trust boundary

### DIFF
--- a/docs/audits/protocol-audit-post-interoperability.md
+++ b/docs/audits/protocol-audit-post-interoperability.md
@@ -297,17 +297,17 @@ The following areas still have **no portable conformance vector**:
 | Sift KRL (Key Revocation List) | Trusted via HTTPS only | **High** | KRL payload is NOT cryptographically signature-verified. A compromised intermediary can omit revocations. Noted risk. |
 | PEP gateway (`OxDeAIGuard`) | Fully trusted; must be outside agent runtime | Low | Correctly positioned. Guard validates config at construction. |
 | Replay store | Trusted backend | Medium | In-memory default is not durable. Durable backends (Redis) are pluggable but not enforced. |
-| State provider (`getState()`) | Fully trusted | **High** | State is accepted without integrity verification. A compromised state provider can manufacture any `state_hash`. No integrity protocol exists for the state source. |
+| State provider (`getState()`) | Fully trusted | **High** | State is accepted without integrity verification. A compromised state provider can manufacture any `state_hash`. Minimum integrity requirements specified in `docs/spec/state-provider-requirements.md`; deployment compliance is operator responsibility. RT-TRUST-1 residual remains. |
 | Upstream executor (`execute()`) | Fully trusted | Low | By design. Guard decides admission; executor decides actuation. |
 | Offline verifier | No trust required | Low | `verifyAuthorization` is stateless. Can verify without network. |
 | External provider (full Profile C) | Trusted within adapter scope | Medium | `computeStateHash` strategy must match. Mismatch → deterministic fail-closed. Documented. |
 
 ### 5.3 Residual Trust Risks
 
-**RT-TRUST-1: State provider integrity**
-The state provider is unconditionally trusted. A compromised `getState()` implementation can return a state that produces a matching `state_hash` for an authorization, bypassing the semantic check. **No mitigation exists at the protocol layer.** Documented in `threat-model-external-providers.md` (T-8).
+**RT-TRUST-1: State provider integrity** *(SPECIFIED WITH RESIDUAL)*
+OxDeAI defines minimum state provider integrity requirements in `docs/spec/state-provider-requirements.md` (P2-4, #130). The protocol verifies state binding at the PEP: `computeStateHash(liveState) === authorization.state_hash`. This proves hash consistency between the authorization artifact and the live state object, but does not prove that the state provider served honest state. A compromised `getState()` implementation can still return manufactured state that produces a matching hash. **State-source compliance remains a deployment responsibility.** Non-compliant or compromised state providers retain the full RT-TRUST-1 risk. This specification moves the residual from "no requirements exist" to "requirements specified; deployment compliance is operator responsibility." RT-TRUST-1 is not closed.
 
-**RT-TRUST-2: KRL transport integrity** *(migration-tracked — closeable for deployments using signed_required + persistent stores)*
+**RT-TRUST-2: KRL transport integrity** *(migration-tracked - closeable for deployments using signed_required + persistent stores)*
 `SiftHttpKeyStore` supports three KRL integrity modes. `signed_required` closes the transport-integrity gap for deployments that configure it. **Phase A (#117):** persistent `KrlWatermarkStore` closes restart-and-replay downgrade window. **Phase B (#117):** `SignedKrlCache` LKG cache closes cold-start unrevoked window. **#116 v-next:** `unsigned_legacy` promoted to `process.emitWarning(DEP_OXDEAI_KRL_UNSIGNED_LEGACY)` structured deprecation; `signed_preferred` unsigned fallback now emits once-per-instance `console.warn`; migration guide added to `packages/sift/README.md`. `RT-TRUST-2` is fully closeable when `signed_required` + `verifyKrl` + `KrlWatermarkStore` + `SignedKrlCache` are all configured. **Default path residual risk:** the current default (`signed_preferred`) retains transport-trust-only semantics for unsigned fallback cases. This will be resolved when the default flips to `signed_required` in a future breaking release (#116 v-after). `unsigned_legacy` is deprecated and will be removed in that same release. Full ecosystem closure depends on the v-after release timeline.
 
 **RT-TRUST-3: Replay store bootstrapping**
@@ -325,7 +325,7 @@ New deployments start with an empty replay store. Authorization artifacts issued
 | Redis replay store | `DONE` | Implemented, tested (`guard.replay-store.redis.test.ts`). |
 | Clock skew | `DONE` | Strict zero-tolerance specified (`authorization-v1.md §17`). `opts.now` injection required. NTP synchronization required; issuers build latency into expiry. Undefined behavior eliminated. |
 | Key rotation automation | `PARTIAL` | Manual procedures documented (dual-sign + TTL overlap). No automated rotation tooling. |
-| State-source integrity | `RISK` | See RT-TRUST-1. Protocol layer cannot verify state provider integrity. |
+| State-source integrity | `PARTIAL` | RT-TRUST-1 SPECIFIED WITH RESIDUAL. Minimum state provider integrity requirements defined in `docs/spec/state-provider-requirements.md` (P2-4). Protocol layer cannot enforce state-source compliance; deployment compliance is operator responsibility. Non-compliant providers retain the full residual risk. |
 | Monitoring / observability | `PARTIAL` | `onDecision` hook provides per-decision events. No structured event schema, no metrics contract, no alerting spec. |
 | Audit log durability | `PARTIAL` | `verifyAuditEvents` and `ReplayEngine` exist. Audit log persistence is caller responsibility. No storage spec. |
 | Network isolation of PEP | `PARTIAL` | `pep-production-guide.md` recommends isolation. No enforcement mechanism in the protocol. |
@@ -398,11 +398,11 @@ Prerequisites before external standard positioning:
 3. ~~Separate public `AuthorizationV1` artifact boundary from internal legacy shape~~ ✓ resolved - clean public artifact projection added; `DelegationV1` parent hashing no longer depends on internal legacy fields
 4. ~~Close intent hash mismatch portable vector gap~~ ✓ resolved - portable `AuthorizationV1` vector added with `proposed_action`
 5. ~~Close `expiry`/`expires_at` precedence vector gap~~ ✓ resolved - `auth-expiry-wins-over-expires-at` vector locks precedence rule
-6. Resolve or formally mitigate state provider trust risk
+6. ~~Resolve or formally mitigate state provider trust risk~~ ✓ Specified with residual - minimum requirements defined in `docs/spec/state-provider-requirements.md` (P2-4, #130). Deployment compliance is operator responsibility. RT-TRUST-1 remains a named residual; non-compliant deployments retain the full risk.
 7. Resolve or formally mitigate KRL transport integrity risk
 8. Independent security review
 9. Establish external feedback or co-author channel
-10. ~~Establish that execution-time authorization is a recognized architectural category~~ ✓ established — Meyman et al. (2026), "Execution-Time Authorization for AI Agents: A Formal Framework for Deterministic Governance Boundaries," DOI: 10.5281/zenodo.18764561 (CC-BY-4.0), formalizes the ETA framework independently. OxDeAI's convergent design maps to all six ETA §4 invariants. Alignment documented at `docs/standardization/execution-time-authorization-alignment.md`. This is external validation that the architectural category is recognized; it is not a claim that OxDeAI is standard-adoption-ready.
+10. ~~Establish that execution-time authorization is a recognized architectural category~~ ✓ established - Meyman et al. (2026), "Execution-Time Authorization for AI Agents: A Formal Framework for Deterministic Governance Boundaries," DOI: 10.5281/zenodo.18764561 (CC-BY-4.0), formalizes the ETA framework independently. OxDeAI's convergent design maps to all six ETA §4 invariants. Alignment documented at `docs/standardization/execution-time-authorization-alignment.md`. This is external validation that the architectural category is recognized; it is not a claim that OxDeAI is standard-adoption-ready.
 
 ---
 
@@ -490,8 +490,9 @@ Python coverage (#119 Python PR):
 - Cross-language byte-equivalence proven: duplicate-kids signature `+mwEd2QP5+tx...` verifies identically in Go and Python.
 
 Residual limitations:
-- Profile C Encoding B modes 006–008: closed by #120 — Go and Python now independently verify Encoding B signatures (preimage = `canonicalJson(signingPayload)`, no domain prefix).
-- State provider trust (RT-TRUST-1, P2-4) and independent security review remain open.
+- Profile C Encoding B modes 006–008: closed by #120 - Go and Python now independently verify Encoding B signatures (preimage = `canonicalJson(signingPayload)`, no domain prefix).
+- RT-TRUST-1 (state provider trust) is SPECIFIED WITH RESIDUAL - P2-4 resolved via spec, residual acknowledged.
+- Independent security review remains open.
 - No full standardization readiness claim.
 
 ---
@@ -510,9 +511,8 @@ Scope: New `replay-ttl-verification.json` vector set.
 Reason: `onDecision` hook exists but produces no specified schema. Observability tooling cannot be built reliably without a stable event format.
 Scope: `GuardDecisionRecord` type - finalize as a versioned schema; add to `pep-gateway-v1.md`.
 
-**P2-4: Specify state provider trust boundary**
-Reason: `getState()` is unconditionally trusted at the protocol layer. No minimum integrity requirements are specified for the state source. Specify access controls, CAS semantics, and audit expectations for compliant state provider implementations.
-Scope: `pep-gateway-v1.md` §7 or a new `state-provider-requirements.md`.
+**P2-4: Specify state provider trust boundary** ✓ SPECIFIED WITH RESIDUAL (#130)
+Resolution: `docs/spec/state-provider-requirements.md` added. Defines minimum integrity requirements covering: trust boundary and profile-specific applicability, read consistency and CAS requirements, state provenance, write access control, audit emission, replay/rollback expectations, compromise indicators, and compliance evidence. Pointer added to `pep-gateway-v1.md §27` and `external-provider-profile.md §2.3.3`. RT-TRUST-1 moves to SPECIFIED WITH RESIDUAL - not closed. The spec defines what compliant state providers must satisfy; deployment compliance remains operator responsibility. Non-compliant or compromised state providers retain the full RT-TRUST-1 residual risk.
 
 ---
 
@@ -523,15 +523,15 @@ Scope: `pep-gateway-v1.md` §7 or a new `state-provider-requirements.md`.
 | Status | Count |
 |--------|-------|
 | `DONE` | 58 |
-| `PARTIAL` | 16 |
+| `PARTIAL` | 17 |
 | `SPECIFIED ONLY` | 5 |
 | `DOCUMENTED ONLY` | 6 |
 | `MISSING` | 5 |
-| `RISK` | 4 |
+| `RISK` | 3 |
 
-**Conformance:** 209 TypeScript assertions (16 TS vector files + 12 portable `authorization-v1.json` vectors) + 28 Go harness assertions (11 canonicalization + 8 Profile C all modes + 9 SignedKRLV1) + 28 Python harness assertions (same coverage as Go). All P0 and P1 items resolved; P1-6 fully closed including Profile C Encoding B modes 006–008 (#120).
+**Conformance:** 209 TypeScript assertions (16 TS vector files + 12 portable `authorization-v1.json` vectors) + 28 Go harness assertions (11 canonicalization + 8 Profile C all modes + 9 SignedKRLV1) + 28 Python harness assertions (same coverage as Go). All P0 and P1 items resolved; P1-6 fully closed including Profile C Encoding B modes 006–008 (#120). P2-4 specified with residual (#130).
 
-**Follow-up issue counts:** P0: 0 open · P1: 0 open · P2: 4 · Total: 4 open
+**Follow-up issue counts:** P0: 0 open · P1: 0 open · P2: 3 open (P2-4 specified) · Total: 3 open
 
 **Critical path to external adoption:**
 
@@ -548,7 +548,7 @@ Scope: `pep-gateway-v1.md` §7 or a new `state-provider-requirements.md`.
 
 OxDeAI is a working, tested execution authorization boundary protocol at the **interoperable protocol** maturity level. Core invariants are implemented and tested. AuthorizationV1, wire encodings, signature verification, replay protection, state binding, and delegation are all in solid shape. Profile A/B/C are specified; Profile A and C have executable conformance coverage.
 
-The protocol is **not yet ready for standard adoption**. Key lifecycle, clock skew, parentScope type safety, public artifact boundary separation, intent hash mismatch portability, expiry precedence, HMAC-SHA256 deprecation, KRL transport integrity (for `signed_required` mode deployments), and Profile C / SignedKRLV1 cross-language coverage (Go + Python) are now resolved. State provider trust (RT-TRUST-1) and independent security review remain open before that claim can be made honestly.
+The protocol is **not yet ready for standard adoption**. Key lifecycle, clock skew, parentScope type safety, public artifact boundary separation, intent hash mismatch portability, expiry precedence, HMAC-SHA256 deprecation, KRL transport integrity (for `signed_required` mode deployments), Profile C / SignedKRLV1 cross-language coverage (Go + Python), and state provider trust boundary (P2-4 specified with residual) have all been addressed. RT-TRUST-1 moves to SPECIFIED WITH RESIDUAL - minimum requirements defined, but deployment compliance is operator responsibility and non-compliant providers retain the full risk. Independent security review remains open before standard-adoption readiness can be claimed honestly.
 
 ---
 

--- a/docs/spec/enforcement/pep-gateway-v1.md
+++ b/docs/spec/enforcement/pep-gateway-v1.md
@@ -564,3 +564,23 @@ The specification MAY evolve into a multi-document standard:
 This separation would improve modularity, clarity, and independent evolution.
 
 ---
+
+## 27. State Provider Requirements
+
+### 27.1 Normative requirement
+
+Deployments using `OxDeAIGuard` with Profile C - live-state re-verification through `computeStateHash` - **MUST** satisfy the minimum state provider integrity requirements defined in `docs/spec/state-provider-requirements.md`.
+
+For Profile A/B deployments, these requirements are **best-practice guidance** unless the deployment introduces state-dependent enforcement equivalent to Profile C.
+
+### 27.2 Trust boundary
+
+`getState()` is trusted input to the guard. The PEP verifies:
+
+```
+computeStateHash(liveState) === authorization.state_hash
+```
+
+This proves hash consistency between the authorization artifact and the live state object. It does not prove that the state provider served honest state. See `docs/spec/state-provider-requirements.md §1` for the full trust boundary definition.
+
+---

--- a/docs/spec/interoperability/external-provider-profile.md
+++ b/docs/spec/interoperability/external-provider-profile.md
@@ -187,9 +187,9 @@ A KRL (Key Revocation List) maintained by the provider records revoked `kid` val
 
 | Option | Integrity guarantee | Status |
 |--------|---------------------|--------|
-| `unsigned_legacy` | Transport security (HTTPS) only | **Deprecated** — emits `process.emitWarning(DEP_OXDEAI_KRL_UNSIGNED_LEGACY)`; will be removed in a future release |
-| `signed_preferred` with unsigned fallback | Transport security for unsigned KRLs; cryptographic for signed KRLs | **Transition mode** — not the permanent production posture; emits a once-per-instance `console.warn` when unsigned fallback is active |
-| `signed_required` | Cryptographic — `SignedKRLV1` verified via `verifySignedKrl` | **Production target** |
+| `unsigned_legacy` | Transport security (HTTPS) only | **Deprecated** - emits `process.emitWarning(DEP_OXDEAI_KRL_UNSIGNED_LEGACY)`; will be removed in a future release |
+| `signed_preferred` with unsigned fallback | Transport security for unsigned KRLs; cryptographic for signed KRLs | **Transition mode** - not the permanent production posture; emits a once-per-instance `console.warn` when unsigned fallback is active |
+| `signed_required` | Cryptographic - `SignedKRLV1` verified via `verifySignedKrl` | **Production target** |
 
 **Migration.** `signed_required` is the production target. `signed_preferred` is a temporary migration bridge. `unsigned_legacy` is deprecated and will be removed. See `packages/sift/README.md` (Migration guide) for step-by-step migration instructions. Full RT-TRUST-2 closure requires `signed_required` + `verifyKrl` + `KrlWatermarkStore` + `SignedKrlCache`; compatibility modes retain residual transport-trust risk.
 
@@ -293,6 +293,8 @@ MISCONFIGURED (fail-closed, but blocks legitimate execution):
 The guard cannot detect whether a state_hash mismatch is due to actual state change or
 wrong hash strategy - both produce DENY. Deployers must ensure alignment.
 
+**Hash strategy alignment is necessary but not sufficient for Profile C compliance.** A deployment that correctly aligns `computeStateHash` but does not satisfy the minimum state provider integrity requirements defined in `docs/spec/state-provider-requirements.md` retains the RT-TRUST-1 residual risk: the guard verifies that the live state object hashes correctly against the authorization artifact, but cannot verify that the state provider is honest, current, or authoritative. State provider integrity requirements are minimum compliance for Profile C deployments.
+
 #### 2.3.4 Cross-language conformance
 
 Go and Python harnesses now validate **all 8 Profile C vectors** independently via
@@ -306,11 +308,11 @@ Go and Python harnesses now validate **all 8 Profile C vectors** independently v
 For Encoding B modes, each harness:
 1. Independently reconstructs the signing payload from the committed artifact
    (all fields + `signature.{alg,kid}`, excluding `signature.sig`)
-2. Computes `canonicalJson(signingPayload)` — no domain prefix (distinct from
+2. Computes `canonicalJson(signingPayload)` - no domain prefix (distinct from
    SignedKRLV1 which uses `OXDEAI_KRL_V1\n`)
 3. Verifies the Ed25519 signature (Go: `crypto/ed25519`; Python: `ctypes + libcrypto`)
 4. Cross-checks independently-computed `committedHash` against committed `auth.state_hash`
-   (byte-equivalence proof — any divergence is a harness canonicalization bug)
+   (byte-equivalence proof - any divergence is a harness canonicalization bug)
 5. Compares `liveHash` vs `committedHash` for the state-hash outcome
 
 No protocol semantics were changed. This is conformance coverage, not a runtime security change.

--- a/docs/spec/state-provider-requirements.md
+++ b/docs/spec/state-provider-requirements.md
@@ -1,0 +1,310 @@
+# OxDeAI State Provider Requirements
+
+**Version:** v1.0  
+**Status:** Normative (Specification)  
+**Category:** Deployment Compliance  
+**Related:** `docs/spec/enforcement/pep-gateway-v1.md`, `docs/spec/interoperability/external-provider-profile.md`, `docs/audits/protocol-audit-post-interoperability.md`
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHOULD**, **SHOULD NOT**, **MAY**, and **RECOMMENDED** in this document are to be interpreted as described in RFC 2119.
+
+---
+
+## 1. Trust Boundary
+
+### 1.1 What OxDeAI verifies
+
+`OxDeAIGuard` calls `config.getState()` to obtain the live state object at enforcement time. It verifies:
+
+```
+computeStateHash(liveState) === authorization.state_hash
+```
+
+This proves that the state object returned by `getState()` is hash-consistent with the `state_hash` committed in the `AuthorizationV1` artifact at authorization time.
+
+### 1.2 What OxDeAI does not verify
+
+OxDeAI does not verify:
+
+- That `getState()` serves state from an honest, authoritative source
+- That the state object was not manufactured to produce a matching hash
+- That the state source has not been rolled back to an earlier version
+- That the state provider is not experiencing split-brain or replica inconsistency
+- That the state was not mutated by an unauthorized actor between authorization and enforcement
+
+These are deployment-level properties. A compromised or non-compliant state provider can return a manufactured state object whose hash matches a valid authorization, allowing the guard's semantic check to pass against a dishonest state source. **The protocol cannot detect this at the PEP layer.**
+
+### 1.3 The deployment trust contract
+
+`getState()` is trusted input to the guard. A deployment that configures a non-compliant state provider retains the RT-TRUST-1 residual risk: the guard's state-hash verification proves hash consistency between the authorization artifact and the live state object, but does not prove that the state object is honest, current, or derived from a compliant source of truth.
+
+This specification defines minimum integrity requirements that a state provider must satisfy for a deployment to be considered compliant with the OxDeAI state provider trust boundary. Compliance is a deployment responsibility; the protocol cannot enforce it at the wire level.
+
+### 1.4 Profile-specific applicability
+
+#### Profile C (Full semantic state verification)
+
+Deployments using `OxDeAIGuard` with live-state re-verification via `computeStateHash` are **Profile C** deployments. In Profile C, `getState()` is called at enforcement time and the result is directly used for the authorization decision. **State provider integrity requirements in this specification are minimum compliance requirements for Profile C deployments.** A Profile C deployment that cannot demonstrate state provider compliance cannot honestly claim that its authorization decisions are semantically bound to an honest state.
+
+#### Profile A and Profile B
+
+Profile A (Core-native AuthorizationV1) and Profile B (External provider wire-compatible) do not perform live-state re-verification at the gateway level. `state_hash` is protected by Ed25519 signature integrity - tampering `state_hash` produces `AUTH_SIGNATURE_INVALID`. There is no `getState()` call in the enforcement path.
+
+**For Profile A/B deployments, the requirements in this specification are best-practice guidance unless the deployment introduces state-dependent enforcement equivalent to Profile C** (e.g., an adapter that re-fetches live state and re-computes a hash for comparison with the authorization artifact).
+
+---
+
+## 2. Read Consistency
+
+### 2.1 Requirement
+
+A compliant state provider MUST serve a coherent state view to `getState()`.
+
+Specifically:
+
+- The state object returned by `getState()` for a given authorization context MUST reflect the same logical state that the policy engine evaluated when producing the `AuthorizationV1` artifact, unless an authorized state mutation has occurred between authorization and enforcement.
+- The state provider MUST support compare-and-set (CAS) or an equivalent linearizable write mechanism so that concurrent state mutations can be detected atomically at the time `setState(nextState, expectedVersion)` is called.
+- The `StateVersion` token returned by `getState()` MUST NOT be null or undefined. A missing version token causes the guard to fail closed.
+- The state provider MUST NOT return a version token that has been decremented or reset to a prior value unless an authorized rollback/restore event has occurred and been audited.
+
+### 2.2 Concurrent mutation
+
+The guard enforces that the version read by `getState()` matches the version expected by `setState()`. If a concurrent modification advances the version between the `getState()` call and the `setState()` call, `setState()` MUST return `false` and the guard throws `OxDeAIConflictError`, blocking execution.
+
+The state store backing `getState()` and `setState()` MUST provide atomicity guarantees sufficient to make this detection reliable. Implementations SHOULD use database-level CAS, optimistic locking, or conditional write operations.
+
+### 2.3 Stale replica reads
+
+For Profile C deployments, `getState()` MUST read from the authoritative replica of the state store, not from a potentially stale secondary replica. Reading from a lagging replica can produce a hash that matches an old authorization but not the current authoritative state.
+
+### 2.4 Deployment mapping
+
+Compliant deployments may satisfy read consistency requirements through existing relational databases with serializable isolation, distributed key-value stores configured for strong consistency, or append-only state stores where each committed state is addressable by a stable version identifier. No custom state-provider system is required.
+
+---
+
+## 3. State Provenance
+
+### 3.1 Source-of-truth declaration
+
+A compliant state provider MUST be able to identify the authoritative backing storage whose state is served to both the policy engine and the PEP. This declaration does not require cryptographic proof; it is an architectural statement that must be documented and reviewable.
+
+### 3.2 State versioning
+
+The state provider MUST associate each state snapshot with a version identifier that:
+
+- Advances monotonically within the operational lifecycle of the deployment (each successful mutation produces a strictly newer version)
+- Is retained in audit records alongside the mutation that produced it
+- Is unique per mutation event
+
+Version identifiers MUST NOT be reused for different state contents.
+
+### 3.3 Mutation history
+
+A compliant state provider MUST be able to produce evidence that allows an auditor to reconstruct which state version was in effect at any given point in time. This does not require a full event sourcing system - a versioned snapshot store with monotonically advancing version identifiers, or an append-only log of state deltas, both satisfy this requirement.
+
+### 3.4 Mutation attribution
+
+Where the source or actor triggering a state mutation is identifiable, the state provider SHOULD record actor attribution alongside the mutation event. For mutations triggered by `setState()` from the guard, the corresponding `auth_id` of the authorizing `AuthorizationV1` SHOULD be retained in the mutation record.
+
+### 3.5 Deployment mapping
+
+Compliant deployments may satisfy provenance requirements through existing infrastructure such as database row versioning (e.g., PostgreSQL `xmin` or application-managed version columns), CDC (change data capture) streams that capture each state mutation with a timestamp and actor, append-only Kafka topics, or Git-based state stores with immutable commit history. No custom state-provider system is required.
+
+---
+
+## 4. Write Access Control
+
+### 4.1 Controlled mutation authority
+
+The set of entities permitted to mutate state MUST be explicitly controlled, authenticated, and auditable. The specific mechanism - role-based access control, capability tokens, service account restrictions, or database-level permissions - is deployment-specific. The deployment MUST document which identities hold write authority.
+
+### 4.2 Agent isolation
+
+Agents that consume state through the OxDeAI execution boundary MUST NOT hold credentials that allow them to directly mutate the backing state store by any path that bypasses the policy engine's `nextState` mechanism. The write path used by the guard's `setState()` MUST be the authoritative mutation path for policy-governed state changes.
+
+### 4.3 Administrative and debug writes
+
+Out-of-band state mutations - including administrative overrides, debugging modifications, and disaster-recovery restores - MUST be auditable. Such writes MUST produce audit events that are distinguishable from guard-mediated writes. Administrative write authority MUST be separate from agent-level authority.
+
+### 4.4 Unauthorized write handling
+
+Attempts to mutate state by entities without write authority MUST fail closed (rejected, not silently ignored). Failed write attempts MUST produce an audit event with sufficient context to identify the requestor and the attempted operation.
+
+### 4.5 Deployment mapping
+
+Compliant deployments may satisfy write access control requirements through existing IAM systems (AWS IAM, GCP IAM, Azure RBAC), Kubernetes RBAC for service accounts, database-level row security or schema permissions, or network-level service mesh policies that restrict which services may reach the state store write path. No custom access control system is required, provided the existing system prevents unauthorized state mutations and produces auditable records.
+
+---
+
+## 5. Audit Emission
+
+### 5.1 Required audit events
+
+A compliant state provider MUST be able to produce records for the following event classes:
+
+| Event class | Requirement |
+|-------------|-------------|
+| State mutation (successful) | MUST |
+| State mutation (failed / rejected) | MUST |
+| Administrative override / out-of-band write | MUST |
+| Rollback or restore event | MUST |
+
+### 5.2 Recommended audit events
+
+The following event classes SHOULD be produced where technically feasible:
+
+| Event class | Requirement |
+|-------------|-------------|
+| State read for authorization (policy engine evaluation) | SHOULD |
+| State read for enforcement (guard's `getState()` call) | SHOULD |
+| Version conflict / CAS failure | SHOULD |
+
+### 5.3 Minimum event fields
+
+Each audit event SHOULD include at minimum:
+
+- Event type (mutation, read, conflict, rollback, override)
+- State version identifier before and after (where applicable)
+- Timestamp (UTC, monotonic or wall-clock with NTP-synchronized source)
+- Actor / source identifier (where identifiable)
+- Outcome (success, failure, rejection)
+
+### 5.4 OxDeAI ingestion in v1
+
+OxDeAI v1 does not specify an ingestion protocol for state provider audit events. This specification defines what compliant deployments must be able to produce and retain. Future versions of the protocol may define structured event schemas that state providers can emit and OxDeAI tooling can consume.
+
+### 5.5 Retention
+
+State provider audit records MUST be retained for a period sufficient for post-hoc incident review. As a minimum baseline, records SHOULD be retained for a period not less than the longest `AuthorizationV1` expiry window used in the deployment, plus an operational buffer appropriate to the deployment's incident response SLA.
+
+### 5.6 Deployment mapping
+
+Compliant deployments may satisfy audit emission requirements through existing database transaction logs, application-level event emission to Kafka or equivalent durable message buses, cloud-native audit log services (e.g., AWS CloudTrail, GCP Cloud Audit Logs, Azure Monitor), or structured application logging with sufficient retention guarantees. No custom audit infrastructure is required, provided the records are retained and reviewable.
+
+---
+
+## 6. Replay and Rollback Expectations
+
+### 6.1 Version monotonicity
+
+State version identifiers MUST advance monotonically with each successful mutation. A decreasing version value MUST be treated as a rollback indicator and MUST produce an alert or audit event.
+
+### 6.2 Rollback events
+
+When state is restored to an earlier version - whether for disaster recovery, testing, or administrative purposes - the rollback event MUST:
+
+- Produce an audit record identifying the source version, the target version, the actor, the timestamp, and the authorization for the rollback
+- Be distinguishable in the audit log from normal state mutations
+
+### 6.3 Old state not served as current
+
+A compliant state provider MUST NOT serve an old state snapshot as the current state unless a rollback event has been explicitly authorized, audited, and recorded. Serving stale state that produces a hash match against an expired or superseded authorization without a corresponding rollback event is non-compliant.
+
+### 6.4 Interaction with authorization expiry
+
+State rollback can create a window where a non-expired `AuthorizationV1` might be evaluated against a rolled-back state snapshot. The `auth_id` replay check mitigates this at the authorization level for previously-consumed tokens, but authorizations that have not yet been consumed may be affected by rollback. Deployments performing state rollbacks SHOULD evaluate whether concurrent or pending authorizations remain valid against the restored state.
+
+### 6.5 Deployment mapping
+
+Compliant deployments may satisfy rollback expectations through existing database point-in-time recovery procedures with mandatory audit entries, change management processes that require authorization records for state restores, or infrastructure-as-code pipelines where state changes produce immutable audit trails. No custom rollback mechanism is required, provided rollback events are authorized, audited, and distinguishable from normal mutations.
+
+---
+
+## 7. Compromise Indicators
+
+The following observable patterns indicate state provider compromise or non-compliance. Deployments SHOULD implement monitoring and alerting for these patterns.
+
+### 7.1 High-priority indicators (MUST alert)
+
+| Indicator | Notes |
+|-----------|-------|
+| `state_hash` matches an authorization but mutation history cannot explain the match | Strongest indicator of manufactured state; requires forensic review |
+| Policy engine and PEP observe divergent states for the same version | Indicates split-brain or replica inconsistency |
+| State version decreases unexpectedly | Rollback indicator |
+| Administrative write performed without corresponding authorized rollback or maintenance event | Indicates unauthorized out-of-band modification |
+| Rollback or restore performed without an audit record | Unauthorized state manipulation |
+
+### 7.2 Anomaly indicators (SHOULD alert)
+
+| Indicator | Notes |
+|-----------|-------|
+| Repeated CAS conflicts for the same agent or resource | May indicate racing writes or adversarial concurrent submission |
+| State reads without corresponding audit records | May indicate audit bypass or logging failure |
+| State mutation without identifiable actor | May indicate audit configuration failure |
+
+### 7.3 Deployment-specific indicators (MAY alert)
+
+| Indicator | Notes |
+|-----------|-------|
+| Impossible state transitions (e.g., budget decreases without corresponding authorized spend, velocity counters reset without period rollover) | Requires knowledge of policy semantics; thresholds are deployment-specific |
+| State read timestamp gaps (extended periods without audit records corresponding to guard activity) | Deployment-specific; indicates possible stale-read or audit bypass |
+
+### 7.4 Deployment mapping
+
+Compliant deployments may satisfy compromise detection requirements through existing monitoring infrastructure such as SIEM systems ingesting state store audit logs, database anomaly detection, or custom alerting pipelines configured to detect the indicators listed in §7.1. Automated alerting for §7.1 indicators is strongly recommended for production deployments operating under Profile C.
+
+---
+
+## 8. Compliance Evidence
+
+Integrators claiming state-provider compliance MUST be able to provide the following evidence on request:
+
+### 8.1 Required evidence
+
+| Evidence | Description |
+|----------|-------------|
+| Architecture description | Identifies the authoritative state source, the read/write paths, and how they relate to `getState()` and `setState()` in the guard configuration |
+| Source-of-truth declaration | Names the backing storage system and its consistency model |
+| Access-control model | Documents which identities hold write authority and how that authority is enforced |
+| Mutation authorization rules | Describes which actors may trigger state mutations, under what conditions, and through what paths |
+| State versioning model | Describes how version identifiers are assigned, how monotonicity is enforced, and how mutation history is retained |
+| Audit event schema | Describes what events are produced, their fields, and how they are retained |
+| Rollback policy | Describes the procedure for authorized state restores, including audit requirements |
+
+### 8.2 Recommended evidence
+
+| Evidence | Description |
+|----------|-------------|
+| Operational runbook | Incident response procedures for state provider compromise or anomaly |
+| Evidence retention policy | Retention duration and access controls for audit records |
+| Monitoring and alerting plan | Maps compromise indicators from §7 to specific alerts or dashboards |
+| CAS configuration documentation | Confirms that the backing store provides linearizable or serializable write semantics |
+
+---
+
+## 9. Non-Goals and Residuals
+
+This specification explicitly does not:
+
+- **Cryptographically prove state-source honesty.** The protocol verifies hash binding, not state-source integrity. A sophisticated adversary who constructs state matching a valid authorization hash without triggering any observable indicators is not detectable at the PEP layer.
+- **Implement a state provider.** This specification defines requirements; it does not provide a reference implementation or mandate a specific database, event store, or infrastructure component.
+- **Require a specific backend.** Any storage system that satisfies the requirements in §2–§8 is compliant, regardless of vendor or technology.
+- **Make RT-TRUST-1 disappear for non-compliant deployments.** The RT-TRUST-1 residual exists precisely because OxDeAI cannot verify state-source compliance at the protocol layer. Deployments that do not satisfy these requirements retain the full RT-TRUST-1 risk.
+- **Make OxDeAI standard-adoption-ready by itself.** RT-TRUST-1 specified with residual is progress; it is not the same as RT-TRUST-1 closed. Independent security review and other open prerequisites remain.
+- **Change `AuthorizationV1`, `DelegationV1`, `SignedKRLV1`, or `canonicalization-v1`.** These protocol artifacts are unchanged.
+- **Change OxDeAI runtime behavior.** `getState()` continues to be trusted input to the guard. This specification does not change how the guard processes the state object.
+
+### 9.1 Named residuals
+
+Even a fully compliant state provider (satisfying all requirements in this specification) does not eliminate the following risks:
+
+- **Hash collision:** An adversary who can produce a state object whose canonical hash matches a valid `state_hash` would pass the guard's check. This is computationally infeasible with SHA-256 but remains a theoretical residual.
+- **Insider threat at the state provider:** An authorized actor with write access who manufactures state within normal operational bounds (producing valid version tokens, plausible mutation history, correct audit entries) may not be detectable by the indicators in §7.
+- **Cryptographic compromise of the state hash function:** If `computeStateHash` is weakened by a future cryptographic vulnerability, state binding guarantees weaken proportionally. This is not OxDeAI-specific.
+
+---
+
+## 10. Relationship to Other Specifications
+
+| Specification | Relationship |
+|--------------|-------------|
+| `docs/spec/enforcement/pep-gateway-v1.md` | The PEP gateway spec defines the enforcement boundary; this specification defines what the state provider behind `getState()` must satisfy |
+| `docs/spec/interoperability/external-provider-profile.md §2.3` | Profile C adds live-state re-verification; state provider requirements are minimum compliance for Profile C |
+| `docs/audits/protocol-audit-post-interoperability.md` RT-TRUST-1 | This specification moves RT-TRUST-1 from RISK to SPECIFIED WITH RESIDUAL |
+| `docs/standardization/execution-time-authorization-alignment.md §7.1` | ETA §10.1 (policy composability) maps to RT-TRUST-1 / P2-4; this specification is the concrete closure of P2-4 |
+| `packages/guard/src/types.ts` | `OxDeAIGuardConfig.getState` and `.setState` define the interface; this specification defines the integrity requirements for compliant implementations |
+| `packages/guard/src/test/guard.state-binding.test.ts` | SB-1 through SB-13 verify hash-binding behavior at the protocol layer; this specification defines deployment requirements beyond what the protocol layer verifies |
+
+---
+
+*This specification was added to close audit item P2-4 (Specify state provider trust boundary). It moves RT-TRUST-1 from RISK to SPECIFIED WITH RESIDUAL. State-source compliance remains a deployment responsibility.*

--- a/docs/standardization/execution-time-authorization-alignment.md
+++ b/docs/standardization/execution-time-authorization-alignment.md
@@ -2,7 +2,7 @@
 
 **Document type:** Standardization positioning artifact  
 **Status:** Working draft  
-**Scope:** Conceptual alignment mapping only — no protocol changes, no code changes, no conformance vector changes  
+**Scope:** Conceptual alignment mapping only - no protocol changes, no code changes, no conformance vector changes
 **Related audit:** `docs/audits/protocol-audit-post-interoperability.md`
 
 ---
@@ -38,7 +38,7 @@ The ETA framework formalizes a class of systems that enforce pre-execution autho
 | Invariant | Location | Core requirement |
 |-----------|----------|-----------------|
 | I1: Determinism | §3.2, §4.1 | Authorization outcomes are fully determined by inputs; identical inputs must produce identical outputs across implementations and executions |
-| I2: Fail-closed enforcement | §4.2 | Any verification failure or ambiguity produces non-execution — there is no path to execution through failure |
+| I2: Fail-closed enforcement | §4.2 | Any verification failure or ambiguity produces non-execution - there is no path to execution through failure |
 | I3: Non-bypassability | §4.3 | The enforcement boundary cannot be circumvented by actors within the agent runtime |
 | I4: Decision artifact completeness | §4.4 | The authorization decision is captured in a verifiable artifact that carries the full decision context |
 | I5: Replayability | §4.5 | Governance decisions are independently reproducible from committed evidence |
@@ -62,7 +62,7 @@ Attribution: the invariant names and section references above are drawn from the
 
 **AuthorizationV1 and signing domain prefixes** ([`docs/spec/artifacts/authorization-v1.md`](../spec/artifacts/authorization-v1.md)) bind each verification operation to a distinct domain (`OXDEAI_AUTH_V1\n`, `OXDEAI_DELEGATION_V1\n`, `OXDEAI_KRL_V1\n`) via `signatureInput()` in `packages/core/src/crypto/signatures.ts`. This prevents cross-artifact signature confusion without coordination between contexts.
 
-**The cross-language conformance suite** demonstrates that determinism holds across implementations. All three Encoding B Profile C vectors (modes 006–008) now have independent Go and Python verification (#120): the duplicate-kids SignedKRLV1 signature (`+mwEd2QP5+tx6pCKAiF8BKzMAHf1c28mcTQF575pDn/DwgRiJ+PkYnv+sasIdgj1S7E9mSZZK1pOTP43nlnsDA==`) serves as the cross-language byte-equivalence proof point — three independent implementations computing identical canonical bytes from the same input.
+**The cross-language conformance suite** demonstrates that determinism holds across implementations. All three Encoding B Profile C vectors (modes 006–008) now have independent Go and Python verification (#120): the duplicate-kids SignedKRLV1 signature (`+mwEd2QP5+tx6pCKAiF8BKzMAHf1c28mcTQF575pDn/DwgRiJ+PkYnv+sasIdgj1S7E9mSZZK1pOTP43nlnsDA==`) serves as the cross-language byte-equivalence proof point - three independent implementations computing identical canonical bytes from the same input.
 
 **Relevant conformance artifacts:** canonicalization vectors v1-object-key-ordering through i4-float-timestamp-rejected; authorization-sig-001 (Encoding A); authorization-sig-010 (Encoding B); profile-c-001 through profile-c-008; KRL_SIGNED_VALID through KRL_VERSION_REGRESSION (Go and Python).
 
@@ -82,7 +82,7 @@ Attribution: the invariant names and section references above are drawn from the
 
 **`signed_required` mode** closes the KRL transport-integrity gap: unsigned KRLs are rejected before `verifyKrl` is consulted (`KRL_UNSIGNED_IN_SIGNED_REQUIRED`), ensuring revocation data is never accepted via transport trust when the configuration mandates cryptographic verification.
 
-**Property tests** in `packages/guard/src/test/guard.pep-conformance.test.ts` (GPC-1 through GPC-11) explicitly verify that every failure mode — kill-switch DENY, invalid signature, audience mismatch, expiry, state hash mismatch, auth_id replay, CAS version conflict, missing auth artifact, missing required fields — blocks `execute()`, `setState()`, and `beforeExecute()`.
+**Property tests** in `packages/guard/src/test/guard.pep-conformance.test.ts` (GPC-1 through GPC-11) explicitly verify that every failure mode - kill-switch DENY, invalid signature, audience mismatch, expiry, state hash mismatch, auth_id replay, CAS version conflict, missing auth artifact, missing required fields - blocks `execute()`, `setState()`, and `beforeExecute()`.
 
 **Residual:** Fail-closed behavior is only as strong as the configuration. In `signed_preferred` mode with unsigned KRL fallback, the revocation data is transport-trusted rather than cryptographically verified. This is documented in `RT-TRUST-2` of the audit and explicitly surfaced in the status surface (`unsignedFallbackActive: true`, `DEP_OXDEAI_KRL_UNSIGNED_FALLBACK` warning). Callers who do not configure `signed_required` + `KrlWatermarkStore` + `SignedKrlCache` retain residual risk on the KRL path. The #116 v-next migration PR establishes the deprecation trajectory; the default flip to `signed_required` remains pending a versioned release.
 
@@ -94,7 +94,7 @@ Attribution: the invariant names and section references above are drawn from the
 
 **OxDeAI mechanisms:**
 
-**Guard placement.** `OxDeAIGuard` is a higher-order function that wraps `execute()`. The contract is structural: the guarded action is only reachable via the returned `guard(action, execute)` function, which enforces verification before forwarding. Agents within the OxDeAI execution boundary do not receive a direct reference to `execute()` — they receive the guarded closure. This is an architectural constraint, not a runtime check.
+**Guard placement.** `OxDeAIGuard` is a higher-order function that wraps `execute()`. The contract is structural: the guarded action is only reachable via the returned `guard(action, execute)` function, which enforces verification before forwarding. Agents within the OxDeAI execution boundary do not receive a direct reference to `execute()` - they receive the guarded closure. This is an architectural constraint, not a runtime check.
 
 **No bypass paths in the PEP.** The guard implementation in `guard.ts` has no escape hatch, no `trusted_caller` flag, and no backdoor that allows verification to be skipped. All 11 GPC conformance tests verify this under different failure conditions. Property test G1 (`engine DENY always prevents execute() and setState()`) and G5 (`successful ALLOW always calls setState() before execute()`) confirm the invariant holds across arbitrary `ProposedAction` inputs.
 
@@ -110,7 +110,7 @@ Attribution: the invariant names and section references above are drawn from the
 
 **OxDeAI mechanisms:**
 
-**AuthorizationV1** ([`docs/spec/artifacts/authorization-v1.md`](../spec/artifacts/authorization-v1.md)) is the primary decision artifact. It carries: `auth_id` (unique single-use identifier), `issuer`, `audience`, `intent_hash` (binds decision to the specific proposed action), `state_hash` (binds decision to the specific state snapshot at evaluation time), `policy_id`, `decision`, `issued_at`, `expiry`, `alg`, `kid`, and `signature`. The signed artifact is verifiable by any implementation with the correct `trustedKeySets` — no access to internal engine state is required.
+**AuthorizationV1** ([`docs/spec/artifacts/authorization-v1.md`](../spec/artifacts/authorization-v1.md)) is the primary decision artifact. It carries: `auth_id` (unique single-use identifier), `issuer`, `audience`, `intent_hash` (binds decision to the specific proposed action), `state_hash` (binds decision to the specific state snapshot at evaluation time), `policy_id`, `decision`, `issued_at`, `expiry`, `alg`, `kid`, and `signature`. The signed artifact is verifiable by any implementation with the correct `trustedKeySets` - no access to internal engine state is required.
 
 **`toPublicAuthorizationV1()`** ([`packages/core/src/verification/verifyAuthorization.ts`](../../packages/core/src/verification/verifyAuthorization.ts)) strips all engine-internal fields (`authorization_id`, `engine_signature`, `state_snapshot_hash`, `policy_version`, `expires_at`) from the signing and hashing surface, resolved in [P0-4](../audits/protocol-audit-post-interoperability.md). Independent implementations can reproduce the same hash and signature preimage without access to engine internals.
 
@@ -137,19 +137,19 @@ Attribution: the invariant names and section references above are drawn from the
 - Independently perform Ed25519 verification using platform-native crypto libraries
 - Independently compare results against committed expected verdicts
 
-**Byte-equivalence proof.** The `KRL_DUPLICATE_REVOKED_KIDS` vector signature (`+mwEd2QP5+tx...nlnsDA==`) and the Profile C mode 006–008 Encoding B artifact signature (`jMyip7h-GMgl2nV_q8Cz...JLThCA`) serve as concrete byte-equivalence proof points: three independent implementations (TypeScript, Go, Python) compute identical preimage bytes from identical inputs and verify identical signatures. This is not a claimed property — it is a mechanically verified fact with every run of `pnpm test:vectors:all`.
+**Byte-equivalence proof.** The `KRL_DUPLICATE_REVOKED_KIDS` vector signature (`+mwEd2QP5+tx...nlnsDA==`) and the Profile C mode 006–008 Encoding B artifact signature (`jMyip7h-GMgl2nV_q8Cz...JLThCA`) serve as concrete byte-equivalence proof points: three independent implementations (TypeScript, Go, Python) compute identical preimage bytes from identical inputs and verify identical signatures. This is not a claimed property - it is a mechanically verified fact with every run of `pnpm test:vectors:all`.
 
 **Cross-language harness assertion counts** as of #120: 209 TypeScript assertions, 28 Go assertions, 28 Python assertions, covering canonicalization, AuthorizationV1 verification, Profile C state-hash semantics, Profile C Encoding B, and SignedKRLV1.
 
 **Replayability of individual authorization decisions.** Any verifier holding the issuer's public key, the AuthorizationV1 artifact, and the proposed action can independently verify: signature validity, expiry, audience, issuer, intent hash binding, and (with the live state) state hash binding. The `verify-authorization-vectors.mjs` script demonstrates this for the portable authorization vectors.
 
-**Residual:** Replayability is verified for the cryptographic surfaces of AuthorizationV1. State provider behavior — whether the `state_hash` committed in an authorization accurately represents the state that was presented — is not verifiable from the artifact alone. This is the RT-TRUST-1 residual.
+**Residual:** Replayability is verified for the cryptographic surfaces of AuthorizationV1. State provider behavior - whether the `state_hash` committed in an authorization accurately represents the state that was presented - is not verifiable from the artifact alone. This is the RT-TRUST-1 residual.
 
 ---
 
 ### 3.6 I6: Time-Bounded Evaluation Without Fail-Open (ETA §4.6)
 
-**ETA requirement:** Evaluation is bounded in time. When an authorization's validity window expires, execution is blocked — there is no grace period, no implicit extension, and no silent fallthrough.
+**ETA requirement:** Evaluation is bounded in time. When an authorization's validity window expires, execution is blocked - there is no grace period, no implicit extension, and no silent fallthrough.
 
 **OxDeAI mechanisms:**
 
@@ -167,7 +167,7 @@ Attribution: the invariant names and section references above are drawn from the
 
 ### 4.1 OxDeAI's binary gate
 
-OxDeAI v1 uses a binary execution gate. `AuthorizationV1.decision` is either `"ALLOW"` or excluded from the execution path entirely. A non-ALLOW outcome — including invalid artifacts, expired artifacts, audience mismatch, signature failure, state hash mismatch, or replay detection — produces `OxDeAIAuthorizationError` or `OxDeAIDenyError` before `execute()` is reached. There is no `"ABSTAIN"` verdict in `AuthorizationV1` v1.
+OxDeAI v1 uses a binary execution gate. `AuthorizationV1.decision` is either `"ALLOW"` or excluded from the execution path entirely. A non-ALLOW outcome - including invalid artifacts, expired artifacts, audience mismatch, signature failure, state hash mismatch, or replay detection - produces `OxDeAIAuthorizationError` or `OxDeAIDenyError` before `execute()` is reached. There is no `"ABSTAIN"` verdict in `AuthorizationV1` v1.
 
 ### 4.2 Why ABSTAIN is not a first-class protocol verdict in v1
 
@@ -177,13 +177,13 @@ OxDeAI deliberately separates two concerns that ABSTAIN would conflate:
 
 **Decision authority** belongs to the protocol layer. The PEP says ALLOW or non-ALLOW; that verdict is deterministic, bounded, and verifiable. Introducing ABSTAIN at the protocol level would make the authorization verdict non-deterministic in a way that cannot be mechanically tested: whether a given input produces ABSTAIN or a binary outcome becomes a function of policy state that varies by deployment.
 
-**Workflow continuation** belongs to the orchestration layer above the PEP. What happens when the PEP says no — whether the action is terminally refused, escalated to a human, retried with narrowed parameters, queued for out-of-band review, or delegated to a different agent — is an orchestration decision. OxDeAI does not prescribe orchestration behavior; it provides a reliable ALLOW/non-ALLOW signal that orchestration systems can act on.
+**Workflow continuation** belongs to the orchestration layer above the PEP. What happens when the PEP says no - whether the action is terminally refused, escalated to a human, retried with narrowed parameters, queued for out-of-band review, or delegated to a different agent - is an orchestration decision. OxDeAI does not prescribe orchestration behavior; it provides a reliable ALLOW/non-ALLOW signal that orchestration systems can act on.
 
-This separation keeps AuthorizationV1's semantics narrow, decidable, and independently verifiable. It is consistent with the ETA framework's requirement that enforcement boundaries be non-bypassable: a first-class ABSTAIN verdict, if improperly handled by an orchestration layer, could create a path to execution through unresolved authorization — precisely the failure mode I2 (fail-closed enforcement) is designed to prevent.
+This separation keeps AuthorizationV1's semantics narrow, decidable, and independently verifiable. It is consistent with the ETA framework's requirement that enforcement boundaries be non-bypassable: a first-class ABSTAIN verdict, if improperly handled by an orchestration layer, could create a path to execution through unresolved authorization - precisely the failure mode I2 (fail-closed enforcement) is designed to prevent.
 
 ### 4.3 ABSTAIN at the orchestration layer
 
-ABSTAIN-with-escalation is not precluded; it is simply out of scope for the protocol layer. An orchestration system consuming OxDeAI can implement any escalation behavior it chooses when it receives a non-ALLOW signal from the guard. The protocol makes no assumption about what the orchestration layer does with that signal — it only guarantees that execution did not occur.
+ABSTAIN-with-escalation is not precluded; it is simply out of scope for the protocol layer. An orchestration system consuming OxDeAI can implement any escalation behavior it chooses when it receives a non-ALLOW signal from the guard. The protocol makes no assumption about what the orchestration layer does with that signal - it only guarantees that execution did not occur.
 
 Future versions of the protocol may revisit this separation if escalation patterns prove to need first-class protocol support (e.g., multi-round authorization workflows, federated delegation with escalation paths). This is acknowledged as a potential future direction, not a current gap.
 
@@ -240,9 +240,9 @@ Issue #122 establishes the following pattern for attaching external observabilit
 
 External systems may attach metadata that audits, explains, or annotates agent behavior, provided that metadata:
 
-1. Is cryptographically isolated from `AuthorizationV1` — it does not appear in `intent_hash`, `state_hash`, or any field that influences the PEP's ALLOW/non-ALLOW decision
-2. Does not influence PEP enforcement — the guard's verification pipeline is not conditioned on the presence or content of the external metadata
-3. Follows its own versioned canonicalization, separate from canonicalization-v1 — external metadata schemas evolve independently without affecting the protocol's verification surfaces
+1. Is cryptographically isolated from `AuthorizationV1` - it does not appear in `intent_hash`, `state_hash`, or any field that influences the PEP's ALLOW/non-ALLOW decision
+2. Does not influence PEP enforcement - the guard's verification pipeline is not conditioned on the presence or content of the external metadata
+3. Follows its own versioned canonicalization, separate from canonicalization-v1 - external metadata schemas evolve independently without affecting the protocol's verification surfaces
 
 This pattern allows rich external observability (routing evidence, provenance attestations, cost attribution metadata) without creating a side-channel through which external actors could influence authorization outcomes. The metadata is evidence; the `AuthorizationV1` is authority.
 
@@ -258,21 +258,23 @@ The ETA paper (§10) identifies open research directions. OxDeAI has concrete ex
 
 **ETA framing:** How should authorization policies be composed across multiple policy engines, organizational boundaries, and trust contexts?
 
-**OxDeAI residual:** P2-4 (Specify state provider trust boundary) and RT-TRUST-1 (State provider integrity) in `docs/audits/protocol-audit-post-interoperability.md`.
+**OxDeAI status:** P2-4 ✓ SPECIFIED WITH RESIDUAL (#130). RT-TRUST-1 moves from RISK to SPECIFIED WITH RESIDUAL.
 
-`getState()` in `OxDeAIGuardConfig` is unconditionally trusted at the protocol layer. A compromised state provider can return a state that produces a matching `state_hash` for an authorization, bypassing the semantic check. No integrity protocol exists for the state source at the protocol layer.
+`docs/spec/state-provider-requirements.md` defines minimum integrity requirements for compliant OxDeAI state providers: read consistency and CAS semantics, state provenance, write access control, audit emission, replay/rollback expectations, compromise indicators, and compliance evidence. Pointers added to `pep-gateway-v1.md §27` and `external-provider-profile.md §2.3.3`.
 
-This is the concrete instantiation of ETA §10.1 policy composability: when authorization spans multiple components (the policy engine, the state provider, the PEP), the integrity of the overall authorization chain depends on the integrity of each component. OxDeAI has closed the boundary at the PEP and policy engine layers; the state provider boundary is a known open residual that requires a separate spec effort to close. This is not a protocol weakness that can be fixed with a one-liner — it requires a principled specification of minimum state provider integrity requirements, which is the scope of P2-4.
+The state provider boundary remains open as a named residual: **OxDeAI defines minimum requirements; the protocol cannot enforce state-source compliance at the wire level.** A compromised state provider that satisfies no requirement in the spec can still return manufactured state that produces a matching `state_hash`. `getState()` remains trusted input to the guard. Deployment compliance is operator responsibility.
+
+This is the concrete instantiation of ETA §10.1 policy composability: when authorization spans multiple components (the policy engine, the state provider, the PEP), the integrity of the overall authorization chain depends on the integrity of each component. OxDeAI has closed the boundary at the PEP and policy engine layers and has now specified what the state provider boundary must satisfy. The residual is bounded; it is not closed.
 
 ### 7.2 Cross-domain authorization (ETA §10.2)
 
 **ETA framing:** How should authorization be extended across organizational trust boundaries?
 
-**OxDeAI coverage:** Profile B ([`docs/spec/interoperability/external-provider-profile.md`](../spec/interoperability/external-provider-profile.md)) establishes the adapter trust model: an external provider (e.g., Sift) signs a receipt with its own key; the adapter re-signs an `AuthorizationV1` with an OxDeAI key from `trustedKeySets`. The external provider receipt key and the OxDeAI signing key are distinct trust domains — the cross-domain boundary is explicit and cryptographically enforced.
+**OxDeAI coverage:** Profile B ([`docs/spec/interoperability/external-provider-profile.md`](../spec/interoperability/external-provider-profile.md)) establishes the adapter trust model: an external provider (e.g., Sift) signs a receipt with its own key; the adapter re-signs an `AuthorizationV1` with an OxDeAI key from `trustedKeySets`. The external provider receipt key and the OxDeAI signing key are distinct trust domains - the cross-domain boundary is explicit and cryptographically enforced.
 
 DelegationV1 handles intra-agent cross-domain cases: a parent agent's authority can be narrowed and delegated to a child agent with explicit scope constraints, policy binding, and expiry enforcement.
 
-**Residual:** Full cross-organizational federation — where multiple independent policy engines from different organizations share a single execution boundary — is not in scope for v1. Profile B handles the specific case of an external governance layer (Sift) delegating to the OxDeAI enforcement layer; it does not handle arbitrary organizational federation.
+**Residual:** Full cross-organizational federation - where multiple independent policy engines from different organizations share a single execution boundary - is not in scope for v1. Profile B handles the specific case of an external governance layer (Sift) delegating to the OxDeAI enforcement layer; it does not handle arbitrary organizational federation.
 
 ### 7.3 Formal verification (ETA §10.4)
 
@@ -290,7 +292,7 @@ Out of scope for v1. OxDeAI operates at the TypeScript/Node.js layer. Non-bypass
 
 ## 8. Independent-Development Statement
 
-OxDeAI's core architecture — canonicalization-v1, AuthorizationV1, the PEP boundary and OxDeAIGuard implementation, DelegationV1, SignedKRLV1, the cross-language conformance vector suite (TypeScript, Go, Python), and the Sift/Profile B integration — was developed independently of the Meyman ETA paper and predates its February 2026 publication.
+OxDeAI's core architecture - canonicalization-v1, AuthorizationV1, the PEP boundary and OxDeAIGuard implementation, DelegationV1, SignedKRLV1, the cross-language conformance vector suite (TypeScript, Go, Python), and the Sift/Profile B integration - was developed independently of the Meyman ETA paper and predates its February 2026 publication.
 
 The alignment described in this document is **convergent design**: two independent efforts arriving at structurally similar conclusions because the underlying problem (deterministic pre-execution authorization for AI agents) constrains the solution space. Systems that must enforce a verifiable, non-bypassable, fail-closed boundary between agent decision-making and action execution are led by the problem structure toward similar architectural choices: canonical serialization, signed decision artifacts, replay protection, time-bounded validity, independent verifiability.
 
@@ -305,16 +307,16 @@ No FERZ-specific system names (LASO, DELIA, 4TS, Type-Level Policy Encoding) are
 ### What this alignment supports
 
 - OxDeAI can be accurately described as **an execution-time authorization system**, in the sense developed by Meyman et al. (2026) and consistent with prior work in the field
-- The six ETA invariants provide a vocabulary for describing OxDeAI's design choices to external audiences — policy makers, procurement, integrators — who may be familiar with the ETA framework or adjacent governance literature
+- The six ETA invariants provide a vocabulary for describing OxDeAI's design choices to external audiences - policy makers, procurement, integrators - who may be familiar with the ETA framework or adjacent governance literature
 - Cross-language independent verification (Go + Python) of all 8 Profile C modes and 9 SignedKRLV1 vectors provides external evidence of the determinism and replayability invariants that goes beyond self-attestation
 - The convergent independent design is itself a validation signal that the invariants OxDeAI implements are structurally necessary for the problem, not arbitrary design choices
 
 ### What this alignment does not claim
 
-- **Full standardization readiness.** The audit (`docs/audits/protocol-audit-post-interoperability.md §7.6`) marks this NOT READY. State provider trust (RT-TRUST-1), independent security review, and a formal external feedback channel remain prerequisites.
+- **Full standardization readiness.** The audit (`docs/audits/protocol-audit-post-interoperability.md §7.6`) marks this NOT READY. RT-TRUST-1 is now SPECIFIED WITH RESIDUAL - minimum requirements defined, deployment compliance is operator responsibility. Independent security review and a formal external feedback channel remain open prerequisites.
 - **Conformance with the ETA framework.** No formal conformance process exists. This document is a mapping artifact, not a certification.
-- **Closure of the open problems in ETA §10.** Policy composability (RT-TRUST-1 / P2-4), cross-domain federation beyond Profile B, formal verification, semantic stability, and hardware-bound enforcement all remain open.
-- **Resolution of audit residuals.** The residuals enumerated in §3 of this document (unsigned fallback KRL, state provider trust, independent security review) remain open. This document does not change those.
+- **Closure of the open problems in ETA §10.** Policy composability (ETA §10.1) is partially addressed: P2-4 is specified with residual; the state provider boundary is bounded, not closed. Cross-domain federation beyond Profile B, formal verification, semantic stability, and hardware-bound enforcement all remain open.
+- **Resolution of audit residuals.** State provider trust (RT-TRUST-1) moves from RISK to SPECIFIED WITH RESIDUAL (#130). KRL unsigned fallback risk and independent security review remain open. The ETA alignment mapping in §3 accurately describes residuals; this document does not retroactively close them.
 - **Any claim of regulatory compliance or legal certification.** This is a technical mapping document.
 
 ### Re-read commitment
@@ -323,4 +325,4 @@ Per the acceptance criteria for this document, it should be re-read with at leas
 
 ---
 
-*This document was added alongside the completion of Profile C Encoding B cross-language conformance coverage (#120). It should be revisited when RT-TRUST-1 / P2-4 is addressed and when an independent security review is commissioned.*
+*This document was added alongside the completion of Profile C Encoding B cross-language conformance coverage (#120). RT-TRUST-1 / P2-4 was addressed in #130 (state provider trust boundary specified with residual). This document should be revisited when an independent security review is commissioned.*


### PR DESCRIPTION
Closes #130.

## Summary

Adds a docs-only specification for the OxDeAI state provider trust boundary.

This PR addresses P2-4 / RT-TRUST-1 by defining the minimum integrity requirements a state provider must satisfy for an OxDeAI deployment to be considered compliant.

This closes the documentation issue #130 because the state-provider requirements spec is added.

It does **not** fully close RT-TRUST-1. RT-TRUST-1 is now **SPECIFIED WITH RESIDUAL**: state-provider compliance remains a deployment responsibility, and non-compliant or compromised state providers retain the risk.

## What changed

Added:

- `docs/spec/state-provider-requirements.md`

Updated:

- `docs/spec/enforcement/pep-gateway-v1.md`
- `docs/spec/interoperability/external-provider-profile.md`
- `docs/audits/protocol-audit-post-interoperability.md`
- `docs/standardization/execution-time-authorization-alignment.md`

## Specification scope

The new state provider requirements spec defines the trust contract between OxDeAI and the deployment-provided state source.

It documents that OxDeAI verifies state binding at the PEP:

```text
computeStateHash(liveState) === authorization.state_hash
````

but does not independently prove that the state provider is honest, current, coherent, authorized, or derived from a compliant source of truth.

## Profile applicability

The spec distinguishes Profile C from Profile A/B:

* For Profile C deployments, state provider integrity requirements are minimum compliance requirements because `computeStateHash` depends on deployment state integrity.
* For Profile A/B deployments, the requirements are best-practice guidance unless the deployment introduces equivalent state-dependent enforcement.

## Requirements covered

The spec covers:

* trust boundary
* read consistency
* state provenance
* write access control
* audit emission
* replay and rollback expectations
* compromise indicators
* compliance evidence
* deployment mapping
* non-goals and residuals
* relationship to other OxDeAI specifications

## Deployment mapping

The spec avoids requiring a custom OxDeAI-specific state provider.

Compliant deployments may satisfy the requirements through existing infrastructure such as:

* database audit logs
* CDC streams
* append-only ledgers
* access-control systems
* attestation infrastructure

provided the evidence is retained and reviewable.

## Audit posture

The audit now describes RT-TRUST-1 as:

```text
SPECIFIED WITH RESIDUAL
```

Meaning:

* OxDeAI defines minimum state provider integrity requirements.
* The protocol verifies state binding at the PEP.
* State-source compliance remains a deployment responsibility.
* Non-compliant or compromised state providers retain the full RT-TRUST-1 risk.

P2-4 is marked resolved because the requested specification was added.

RT-TRUST-1 remains a named residual and is not marked fully resolved.

## Boundary guarantees

This PR is docs-only.

No changes were made to:

* `packages/**`
* `go-harness/**`
* `python-harness/**`
* conformance vectors
* protocol artifact formats
* runtime behavior
* `AuthorizationV1`
* `DelegationV1`
* `SignedKRLV1`
* `canonicalization-v1`
* `packages/core/API_FINGERPRINT`

No conformance vectors were added.

No runtime mitigation was implemented.

No claim of full standardization readiness is made.

## Validation

* docs-only scope check: passing
* no code changes: confirmed
* `packages/core/API_FINGERPRINT`: unchanged
* `git diff --check`: clean
* `pnpm typecheck`: passing
* `pnpm test`: passing
* `pnpm -C packages/conformance validate`: 209/209 passing
* `pnpm test:vectors:all`: passing
* `pnpm security:gate`: ALLOW

## Residual limitations

This PR specifies the state provider trust boundary but does not make the protocol capable of proving state-source honesty.

A deployment using a non-compliant or compromised state provider remains exposed to RT-TRUST-1.

Independent security review remains a separate prerequisite before standard-adoption readiness can be claimed.