### PR TITLE
docs: add project readiness documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,46 +1,477 @@
-# Contributing
+# Contributing to OxDeAI
 
-## Setup
+**Status:** Working contribution guide for OxDeAI v1
+**Last updated:** 2026-06-04
 
-pnpm install  
-pnpm build  
-pnpm test  
+Thank you for considering contributing to OxDeAI.
 
-## Core Principles
-
-- deterministic evaluation only
-- no side effects in policy
-- fail-closed by default
-
-## Validation
-
-Before opening a PR:
-
-pnpm -r build  
-pnpm -r test  
-pnpm -C packages/conformance validate  
-pnpm validate:adapters  
-
-## Guidelines
-
-- keep changes minimal and focused
-- separate protocol vs documentation changes
-- preserve determinism guarantees
-- update tests when behavior changes
-
-## PRs
-
-- include rationale
-- reference affected artifacts (AuthorizationV1, DelegationV1, etc.)
-- ensure reproducibility
-
-## Scope
+OxDeAI is an open-source protocol for execution-time authorization of AI agents. The project values deterministic behavior, fail-closed enforcement, cross-language verifiability, conservative claims, and minimal changes that strengthen the protocol boundary.
 
 OxDeAI is:
 
 - an execution authorization boundary
+- a protocol and reference implementation for deterministic pre-execution authorization
+- a conformance-driven project
 
 OxDeAI is not:
 
-- a framework
-- a runtime
+- an agent framework
+- an AI runtime
+- a policy-authoring product
+- a model-alignment system
+- a sandboxing system
+
+Core invariant:
+
+```text
+No valid authorization → no execution path
+````
+
+---
+
+## 1. Setup
+
+From the repository root:
+
+```bash
+pnpm install
+pnpm build
+pnpm test
+```
+
+Recommended full validation before opening a pull request:
+
+```bash
+pnpm typecheck
+pnpm test
+pnpm -C packages/conformance validate
+pnpm test:vectors:all
+pnpm security:gate
+```
+
+Adapter validation, when relevant:
+
+```bash
+pnpm validate:adapters
+```
+
+Workspace-wide validation, when relevant:
+
+```bash
+pnpm -r build
+pnpm -r test
+```
+
+---
+
+## 2. Core Principles
+
+Contributions must preserve OxDeAI’s core principles:
+
+* deterministic evaluation only
+* no hidden side effects in policy evaluation
+* fail-closed by default
+* no valid authorization means no execution path
+* execution authority must be explicit and verifiable
+* external metadata must not modify authority unless processed through the documented authorization path
+* protocol behavior must be reproducible across implementations
+* claims must be tied to tests, specs, vectors, or audit evidence
+
+---
+
+## 3. Developer Certificate of Origin
+
+OxDeAI requires all commits to be signed off under the Developer Certificate of Origin.
+
+Use:
+
+```bash
+git commit -s
+```
+
+Each commit must include a line like:
+
+```text
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+### Why DCO instead of CLA
+
+OxDeAI uses DCO rather than a Contributor License Agreement because:
+
+* it is lightweight
+* it preserves contributor copyright
+* it avoids contributor copyright assignment
+* it is widely used in major open-source projects
+* it fits Apache-2.0 open-source protocol development
+
+By contributing, you certify that you have the right to submit the contribution under the project license.
+
+DCO enforcement may be automated through CI. If automation is not present yet, DCO sign-off is still required by project policy.
+
+---
+
+## 4. Before You Start
+
+Open a GitHub issue before starting substantial work.
+
+This includes:
+
+* protocol specification changes
+* conformance vector additions or changes
+* new cross-language harnesses
+* new integration adapters
+* changes to `AuthorizationV1`
+* changes to `DelegationV1`
+* changes to `SignedKRLV1`
+* changes to `canonicalization-v1`
+* changes to PEP enforcement behavior
+* significant refactors
+* security-sensitive changes
+
+Small fixes can go directly to a pull request:
+
+* typo fixes
+* small documentation corrections
+* obvious test fixes
+* small bug fixes with narrow scope
+
+---
+
+## 5. Contribution Types
+
+### 5.1 Protocol specification changes
+
+Protocol semantic changes are high scrutiny.
+
+Examples:
+
+* changing verification ordering
+* changing signature preimages
+* changing canonicalization rules
+* changing artifact fields
+* changing fail-closed behavior
+* changing replay semantics
+* changing state binding behavior
+
+Protocol changes must include:
+
+* issue discussion
+* discovery or design notes
+* spec update
+* tests or vectors where applicable
+* audit update where applicable
+* validation output
+
+Do not silently redefine protocol behavior in implementation code.
+
+---
+
+### 5.2 Conformance vector contributions
+
+Conformance vectors are one of OxDeAI’s most important assets.
+
+Good vector contributions:
+
+* test one behavior clearly
+* are deterministic
+* are minimal
+* are portable across implementations
+* include expected result and reason code where applicable
+* strengthen external implementer readiness
+* do not mix unrelated behaviors in one vector
+
+Changing expected outcomes in existing vectors is treated as a protocol semantic change unless the existing vector is demonstrably wrong.
+
+---
+
+### 5.3 Cross-language harness contributions
+
+Cross-language harnesses strengthen OxDeAI’s standardization posture.
+
+A new harness should:
+
+* independently implement canonicalization
+* independently verify hashes and signatures
+* consume the official conformance vectors
+* avoid runtime dependency on the TypeScript reference implementation
+* produce clear pass/fail output
+* fail closed on ambiguity
+* use native cryptographic libraries where possible
+
+Existing Go and Python harnesses are the current template for independent verification.
+
+---
+
+### 5.4 External integration adapters
+
+External integration adapters are welcome when they strengthen OxDeAI’s protocol surface rather than creating provider-specific shortcuts.
+
+A good adapter contribution should:
+
+* preserve the invariant: no valid authorization → no execution path
+* document trust boundaries clearly
+* avoid coupling OxDeAI protocol semantics to one provider’s internal model
+* keep non-authoritative metadata outside the authority path
+* include tests, examples, or vectors where applicable
+* surface protocol-level improvements that benefit future integrators
+
+The `@oxdeai/sift` adapter is the current template: an external integration that exposed wire-format, key lifecycle, and revocation alignment issues, which were resolved at the protocol/specification layer rather than hidden as provider-specific shims.
+
+Integration feedback is valuable when it produces general protocol improvements. It should not force OxDeAI semantics to follow one integrator’s private model or product timeline.
+
+---
+
+### 5.5 Documentation contributions
+
+Documentation contributions are welcome.
+
+Good documentation contributions:
+
+* clarify behavior
+* reduce ambiguity
+* improve cross-references
+* preserve conservative wording
+* distinguish implemented, specified, documented, and residual behavior
+* avoid marketing language
+
+If documentation changes a claim about coverage, maturity, or risk, check whether the audit also needs updating.
+
+---
+
+### 5.6 Bug reports and bug fixes
+
+Good bug reports include:
+
+* affected version or commit
+* affected package or spec
+* reproduction steps
+* expected behavior
+* actual behavior
+* security impact, if any
+
+Bug fixes should include tests where behavior changes.
+
+Security-sensitive bugs should be reported privately. See `SECURITY.md`.
+
+---
+
+## 6. Pull Request Process
+
+### 6.1 PR expectations
+
+A good pull request:
+
+* is focused
+* includes rationale
+* references affected artifacts, such as `AuthorizationV1`, `DelegationV1`, `SignedKRLV1`, `canonicalization-v1`, or PEP behavior
+* includes tests when behavior changes
+* updates documentation when semantics or claims change
+* preserves reproducibility
+* includes validation output
+
+### 6.2 PR body should include
+
+For non-trivial PRs, include:
+
+```text
+Summary:
+What changed:
+
+Why:
+Why the change is needed:
+
+Boundary:
+What this does not change:
+
+Validation:
+Commands run and results:
+```
+
+For protocol or security-sensitive PRs, also include:
+
+```text
+Invariants preserved:
+Residual risks:
+Audit/spec updates:
+```
+
+### 6.3 Validation before PR
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm test
+pnpm -C packages/conformance validate
+pnpm test:vectors:all
+pnpm security:gate
+```
+
+When adapters are affected:
+
+```bash
+pnpm validate:adapters
+```
+
+When workspace packages are affected:
+
+```bash
+pnpm -r build
+pnpm -r test
+```
+
+For docs-only PRs, still run at minimum:
+
+```bash
+git diff --check
+git diff -- packages/core/API_FINGERPRINT
+```
+
+and preferably the full validation suite.
+
+---
+
+## 7. What May Not Be Merged
+
+The following changes will not be accepted:
+
+* changes that create an execution path without valid authorization
+* fail-open behavior
+* advisory-only enforcement
+* bypass paths around the PEP
+* weakening signature verification
+* weakening replay protection
+* weakening canonicalization determinism
+* making residual risks less visible
+* overclaiming standardization readiness
+* adopting external patent-encumbered system names as OxDeAI component names
+* coupling OxDeAI protocol semantics to a single external provider
+* large refactors without clear protocol or maintainability benefit
+* feature additions without a defined boundary rationale
+
+When a contribution is not accepted, the reason should be explained.
+
+---
+
+## 8. Audit and Documentation Discipline
+
+OxDeAI maintains an internal protocol audit at:
+
+```text
+docs/audits/protocol-audit-post-interoperability.md
+```
+
+If a contribution changes maturity, coverage, risk, or conformance posture, update the audit.
+
+When a P-item or residual changes state, check all affected sections, not only the primary follow-up entry.
+
+Audit updates should remain conservative:
+
+* do not mark residuals closed unless they are actually closed
+* do not claim full standardization readiness prematurely
+* distinguish protocol guarantees from deployment responsibilities
+* preserve named residuals where risk remains
+
+---
+
+## 9. Security
+
+Security issues must be reported privately.
+
+Do not open public GitHub issues for vulnerabilities.
+
+Security reports:
+
+```text
+security@oxdeai.dev
+```
+
+General contact:
+
+```text
+contact@oxdeai.dev
+```
+
+See `SECURITY.md` for the disclosure process.
+
+OxDeAI has not yet undergone independent security review. Do not describe the project as independently audited or production-certified.
+
+---
+
+## 10. Coding Standards
+
+### TypeScript
+
+* keep types explicit
+* avoid `any` unless narrowly justified
+* preserve public API stability
+* add tests for behavior changes
+* avoid unnecessary runtime dependencies
+* keep packages maintainable and minimal
+
+### Go and Python harnesses
+
+* prefer standard library where possible
+* keep harnesses independent from TypeScript runtime code
+* produce deterministic output
+* fail non-zero on mismatch
+* keep verification logic readable for external review
+
+### Markdown and specs
+
+* use clear headings
+* use RFC 2119 language carefully
+* avoid vague claims
+* cross-reference specs and vectors
+* keep examples mechanically checkable where possible
+
+---
+
+## 11. Recognition
+
+Contributors are credited through:
+
+* git history
+* pull request history
+* issue discussion
+* release notes where applicable
+
+A separate `CONTRIBUTORS.md` may be added if the contributor base grows.
+
+---
+
+## 12. Questions
+
+For contribution questions, open a GitHub issue or contact:
+
+```text
+contact@oxdeai.dev
+```
+
+For security matters, use:
+
+```text
+security@oxdeai.dev
+```
+
+---
+
+## 13. Summary
+
+OxDeAI contributions should make the protocol more precise, more verifiable, or easier to evaluate.
+
+The project prefers:
+
+* small, focused changes
+* clear boundaries
+* deterministic behavior
+* fail-closed semantics
+* cross-language evidence
+* honest documentation
+
+The invariant remains:
+
+```text
+No valid authorization → no execution path
+```

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,416 @@
+# OxDeAI Governance
+
+**Status:** Working governance model for OxDeAI v1  
+**Last updated:** 2026-06-04
+
+This document describes how OxDeAI is governed: who decides what, how decisions are made, and how the project relates to contributors, adopters, security reviewers, and the broader execution-time authorization community.
+
+OxDeAI is still early. This governance model reflects the project’s current state honestly: solo-maintained, Apache-2.0 licensed, no foundation governance yet, and no independent security review completed yet. The model may evolve as the project grows, but the project’s governing discipline is stable:
+
+- discovery before implementation
+- decisions pinned upstream in specs or audit documents
+- conformance-driven claims
+- conservative documentationf
+- named residual risks
+
+---
+
+## 1. Project Stewardship
+
+OxDeAI is currently maintained by **Ange Yobo** as the original author and lead architect.
+
+The project is open-source under the Apache License 2.0.
+
+A separate legal vehicle for OxDeAI may be established in the future. Until then, copyright is held by the respective authors and licensed under Apache 2.0.
+
+OxDeAI is maintained as a separate open-source project from Oxalio Labs. Oxalio Labs is a separate fintech infrastructure company where the author serves in a different role. Any future commercial relationship, sponsorship, or shared infrastructure would be disclosed.
+
+OxDeAI is not currently governed by a foundation, standards body, steering committee, or formal multi-maintainer council.
+
+---
+
+## 2. Scope of Governance
+
+This governance document covers decisions about:
+
+- OxDeAI protocol specifications
+- `AuthorizationV1`
+- `DelegationV1`
+- `SignedKRLV1`
+- `canonicalization-v1`
+- state-provider trust boundary requirements
+- PEP gateway behavior
+- conformance vectors
+- cross-language harnesses
+- reference implementation packages
+- audit and standardization documentation
+- project contribution process
+- project security disclosure process
+- project naming, licensing, and IP discipline
+
+This document does not govern:
+
+- independent third-party implementations
+- private deployments
+- forks that intentionally diverge from the canonical repository
+- commercial services built on top of OxDeAI
+- unrelated projects maintained by the same author
+
+---
+
+## 3. Decision Model
+
+### 3.1 Current model: BDFL with documented discipline
+
+OxDeAI currently uses a **BDFL with documented discipline** model.
+
+The lead architect makes final decisions on protocol design, specification changes, conformance scope, and contribution acceptance.
+
+This is appropriate for the project’s current stage: early, technically coherent, and still primarily maintained by the original author.
+
+However, decisions are constrained by the project’s documented discipline:
+
+### Discovery before implementation
+
+Substantial protocol, security, or conformance changes should begin with discovery.
+
+Discovery means reading the affected specs, implementation, tests, vectors, and audit entries before changing behavior.
+
+### Decisions pinned upstream
+
+Protocol decisions should be captured in the relevant specification, audit entry, or issue before implementation.
+
+Implementation should not silently redefine protocol semantics.
+
+### Conformance-driven claims
+
+OxDeAI should only claim behavior as portable or externally verifiable when there are corresponding specs, vectors, tests, or cross-language harnesses.
+
+Claims must be tied to evidence.
+
+### Conservative documentation
+
+OxDeAI documentation should avoid marketing-style overclaiming.
+
+If something is partial, deployment-dependent, not independently reviewed, or not yet standardized, the documentation should say so.
+
+### Residuals named
+
+Known risks must remain visible in the audit and related specifications.
+
+Residual risks should not be hidden behind vague language.
+
+---
+
+## 4. Decision Categories
+
+Different decisions require different levels of review.
+
+### 4.1 Protocol semantic changes
+
+Examples:
+
+- changes to `AuthorizationV1`
+- changes to `DelegationV1`
+- changes to `SignedKRLV1`
+- changes to `canonicalization-v1`
+- changes to fail-closed semantics
+- changes to PEP enforcement behavior
+
+These require:
+
+- an issue
+- discovery or design notes
+- spec updates
+- conformance vector updates where applicable
+- audit updates
+- validation before merge
+
+Protocol semantic changes should be rare and deliberate.
+
+### 4.2 Conformance vector changes
+
+Conformance vectors define portable behavior.
+
+New vectors are welcome when they strengthen external verifiability.
+
+Changing expected outcomes in existing vectors is treated as a protocol semantic change unless the existing vector is demonstrably wrong.
+
+### 4.3 Cross-language harness changes
+
+Cross-language harnesses should independently verify protocol behavior.
+
+They must not depend on the TypeScript reference implementation at runtime.
+
+New harnesses should prioritize:
+
+- independent canonicalization
+- independent hash verification
+- independent Ed25519 verification
+- exact vector compatibility
+- clear failure output
+
+### 4.4 Documentation and audit changes
+
+Documentation changes are encouraged, but must preserve the project’s conservative claim discipline.
+
+Audit updates should be internally consistent across all affected sections.
+
+If a P-item or residual changes state, update every affected reference in the audit, not only the primary follow-up section.
+
+### 4.5 External integration proposals
+
+External integrations are reviewed against the core OxDeAI boundary:
+
+```text
+routing proposes
+authorization decides
+PEP enforces
+````
+
+External metadata may explain, audit, or contextualize routing and agent behavior, but it must not define, expand, reduce, or modify execution authority.
+
+The non-authoritative metadata pattern established through external integration review is the preferred model for third-party routing or audit evidence.
+
+---
+
+## 5. Future Governance Evolution
+
+The current model may evolve as the project gains contributors, adopters, and independent reviewers.
+
+Possible future stages include:
+
+### Maintainer expansion
+
+If additional contributors demonstrate sustained technical judgment and alignment with the project’s discipline, they may be added as maintainers.
+
+Maintainer authority would be based on contribution quality, protocol understanding, and adherence to the documented process.
+
+### Core team
+
+If multiple maintainers become active, OxDeAI may move to a small core-team model.
+
+The core team would govern the canonical repository and approve protocol-level changes.
+
+### Advisory or review group
+
+If OxDeAI gains external adoption, an advisory group of independent technical reviewers, adopters, and security experts may be created.
+
+Such a group would advise on protocol direction, security posture, and standardization readiness.
+
+### Foundation or neutral stewardship
+
+If OxDeAI becomes broadly adopted, transfer to a neutral foundation may be considered.
+
+No foundation transfer is currently in place.
+
+Any such change would be proposed publicly and reflected in this document before taking effect.
+
+---
+
+## 6. Communication Channels
+
+Primary project communication happens through GitHub:
+
+* issues for bugs, proposals, and design discussion
+* pull requests for reviewable changes
+* discussions if enabled for broader topics
+
+General contact:
+
+```text
+contact@oxdeai.dev
+```
+
+Security contact:
+
+```text
+security@oxdeai.dev
+```
+
+Security issues should not be reported as public GitHub issues. See `SECURITY.md`.
+
+---
+
+## 7. Intellectual Property and Licensing
+
+### 7.1 License
+
+OxDeAI is licensed under the Apache License 2.0.
+
+The license applies to code, documentation, conformance vectors, and specifications unless a file states otherwise.
+
+### 7.2 Contributor rights
+
+Contributors retain copyright in their contributions.
+
+By contributing, they license their contributions under Apache 2.0.
+
+OxDeAI does not currently require copyright assignment.
+
+### 7.3 DCO
+
+OxDeAI uses Developer Certificate of Origin sign-off for contributions.
+
+The contribution process is described in `CONTRIBUTING.md`.
+
+### 7.4 IP discipline
+
+OxDeAI uses its own component names and protocol terminology, including:
+
+* `AuthorizationV1`
+* `DelegationV1`
+* `SignedKRLV1`
+* `OxDeAIGuard`
+* `canonicalization-v1`
+
+The project should avoid adopting names from external patent-encumbered systems as OxDeAI component names.
+
+External frameworks may be cited where relevant, with proper attribution and without implying affiliation or derivation.
+
+The independent-development statement in `docs/standardization/execution-time-authorization-alignment.md` should be preserved unless it becomes factually inaccurate.
+
+---
+
+## 8. Security Governance
+
+OxDeAI has not yet undergone independent security review.
+
+The current security posture is documented in:
+
+```text
+docs/audits/protocol-audit-post-interoperability.md
+```
+
+Known residuals include, but are not limited to:
+
+* RT-TRUST-1: state provider integrity, specified with residual deployment responsibility
+* RT-TRUST-2: KRL transport / migration-tracked revocation integrity posture
+* RT-TRUST-3: replay store bootstrapping and deployment residuals
+
+Security disclosures should be sent privately to:
+
+```text
+security@oxdeai.dev
+```
+
+The disclosure process is defined in `SECURITY.md`.
+
+---
+
+## 9. External Engagement
+
+OxDeAI welcomes external feedback, implementation experience, and integration proposals.
+
+External engagement may include:
+
+* issue discussions
+* pull requests
+* conformance vector proposals
+* independent implementation reports
+* security review feedback
+* academic or standards-oriented review
+* integration proposals from other systems
+
+External feedback is valued, especially when tied to concrete implementation or deployment experience.
+
+External feedback does not create formal voting rights under the current governance model.
+
+### External integrator engagement
+
+OxDeAI has engaged with external integrators on technical grounds during its development.
+
+The most substantial engagement to date has been with Sift / Walko Systems, which produced the `@oxdeai/sift` adapter package and surfaced several protocol-level alignment issues that were resolved at the specification layer.
+
+Issue #122 documents an ongoing engagement around non-authoritative routing/audit metadata patterns.
+
+These engagements are purely technical. OxDeAI has not received funding, sponsorship, advisory compensation, or other commercial benefit from any external integrator. No external integrator has decision authority over OxDeAI's protocol design.
+
+If a commercial relationship with any external integrator is established in the future, it will be disclosed in this document.
+
+---
+
+## 10. Integration Proposal Process
+
+External integration proposals should be opened as GitHub issues.
+
+A good integration proposal should describe:
+
+* the external system
+* the proposed integration point
+* whether the integration is authoritative or non-authoritative
+* what data is exchanged
+* how canonicalization is handled
+* how authorization boundaries are preserved
+* how failure modes behave
+* what test vectors or examples exist
+
+The default review rule is:
+
+```text
+external systems may propose or explain
+AuthorizationV1 decides
+PEP enforces
+```
+
+Integrations that attempt to influence `AuthorizationV1` verification or PEP enforcement without going through the documented authority path will not be accepted.
+The project may accept integration requests that produce protocol-level improvements applicable to all integrators, such as wire-format alignment, canonicalization clarification, or portable conformance coverage.
+
+The project will not accept integration requests that couple OxDeAI protocol semantics to a specific integrator's needs, even when the request is technically reasonable.
+
+---
+
+## 11. Conflict of Interest
+
+The lead maintainer may have roles in other companies or projects.
+
+OxDeAI is maintained as a separate open-source protocol project.
+
+If a future commercial relationship, sponsorship, paid support arrangement, shared infrastructure, or other material relationship could affect OxDeAI governance, it should be disclosed.
+
+Project decisions should be made in the interest of OxDeAI’s protocol integrity, not in the interest of another commercial entity.
+
+---
+
+## 12. Changing This Governance Document
+
+Changes to this document must be proposed through pull requests.
+
+Minor edits may include:
+
+* wording clarifications
+* contact updates
+* link updates
+* formatting fixes
+
+Substantive edits include changes to:
+
+* decision model
+* stewardship
+* licensing posture
+* IP discipline
+* security disclosure posture
+* external engagement process
+
+Substantive edits should be discussed publicly before merge.
+
+---
+
+## 13. Current Governance Summary
+
+Current state:
+
+* solo-maintained / lead-architect governed
+* Apache-2.0 licensed
+* BDFL with documented discipline
+* no foundation governance yet
+* no maintainer committee yet
+* no independent security review yet
+* external engagement beginning
+* protocol decisions constrained by specs, audit, vectors, and fail-closed invariants
+
+OxDeAI’s governance is intentionally conservative.
+
+The project should prefer being precise and externally reviewable over appearing more mature than it is.
+
+

--- a/README.md
+++ b/README.md
@@ -234,9 +234,12 @@ The gate can emit a **verifiable decision artifact** (integrity proof).
 
 ---
 
-## Quick Start (2 min)
+## Quick Start
 
-**Prereqs:** Node.js 20+, pnpm 9+
+Prerequisites:
+
+- Node.js 20+
+- pnpm 9+
 
 ```bash
 git clone https://github.com/oxdeai/oxdeai.git
@@ -244,24 +247,12 @@ cd oxdeai
 pnpm install
 pnpm build
 
-export OXDEAI_ENGINE_SECRET=test-secret-must-be-at-least-32-chars!!
-pnpm -C examples/execution-boundary-demo start
-```
-
-Open: [http://localhost:3001](http://localhost:3001)
+export OXDEAI_ENGINE_SECRET='test-secret-must-be-at-least-32-chars!!'
+pnpm -C examples/openclaw start
 
 ---
-
-## Additional Example
-
-```bash
-export OXDEAI_ENGINE_SECRET=test-secret-must-be-at-least-32-chars!!
-pnpm -C examples/openclaw start
-```
 
 Runs an OpenClaw agent with enforced execution authorization.
-
----
 
 ## Delegated Authorization
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,55 +1,83 @@
 # Roadmap
 
-**Last updated:** 2026-05-17
+**Last updated:** 2026-06-04
 
 ---
 
 ## Positioning
 
-OxDeAI is an **execution authorization boundary** for autonomous systems.
+OxDeAI is an **execution authorization boundary** for autonomous and AI-native systems.
 
 Core invariant:
 
 > **No valid authorization → no execution path**
 
+OxDeAI does not secure agents by trusting better agents. It secures execution by requiring verifiable authorization artifacts before side-effecting actions are allowed.
+
 ---
 
 ## Protocol Maturity
 
+```text
+implementation → interoperable protocol → executable interoperability → reviewer-ready protocol package
+````
+
+OxDeAI now specifies and validates:
+
+* deterministic canonicalization
+* `AuthorizationV1`
+* `DelegationV1`
+* `SignedKRLV1`
+* PEP gateway enforcement
+* external-provider interoperability profiles
+* state-provider trust boundary requirements
+* cross-language conformance across TypeScript, Go, and Python
+* audit and standardization alignment documentation
+
+Current maturity:
+
+```text
+interoperable protocol with executable cross-language conformance
 ```
-implementation → interoperable protocol → executable interoperability
-```
 
-OxDeAI now specifies:
+OxDeAI is **not yet standard-adoption-ready**.
 
-* accepted wire encodings for external provider interoperability (Encoding A, Encoding B)
-* an interoperability profile (Profile A / B / C) with executable conformance coverage
-* formal threat model, key lifecycle, and replay-store TTL alignment documentation
+Remaining standardization gates include:
 
-This reflects maturity at the **interoperable protocol** layer - not standard adoption.
+* independent security review
+* external feedback / co-author channel
+* release-policy decision for signed-required default migration
+* continued external integration review
 
 ---
 
 ## Version Snapshot
 
-### Protocol
+> Verify exact package versions against `package.json` before release publication.
 
-* `@oxdeai/core`: 1.7.0
-* `@oxdeai/sdk`: 1.3.2
-* `@oxdeai/conformance`: 1.5.0
+### Protocol / Core
 
-### Adapters
+- `@oxdeai/core`: 1.7.0
+- `@oxdeai/conformance`: 1.5.0
+- `@oxdeai/sdk`: 1.3.3
 
-* `@oxdeai/guard`: 1.0.2
-* `@oxdeai/langgraph`: 1.0.1
-* `@oxdeai/openai-agents`: 1.0.1
-* `@oxdeai/crewai`: 1.0.1
-* `@oxdeai/autogen`: 1.0.1
-* `@oxdeai/openclaw`: 1.0.1
+### Enforcement / Adapters
+
+- `@oxdeai/guard`: 1.0.3
+- `@oxdeai/sift`: 0.0.1
+- `@oxdeai/langgraph`: 1.0.1
+- `@oxdeai/openai-agents`: 1.0.1
+- `@oxdeai/crewai`: 1.0.1
+- `@oxdeai/autogen`: 1.0.1
+- `@oxdeai/openclaw`: 1.0.1
 
 ### Tooling
 
-* `@oxdeai/cli`: 0.2.4
+- `@oxdeai/cli`: 0.2.4
+
+### Compatibility
+
+- `@oxdeai/compat`: 0.0.1
 
 ---
 
@@ -57,25 +85,50 @@ This reflects maturity at the **interoperable protocol** layer - not standard ad
 
 ### Validation
 
+Current validation posture:
+
 * build: pass
 * tests: pass
-* conformance: pass (`161 assertions`)
-* adapters: pass (`6/6`)
-* vectors: pass (TS / Go / Python)
+* TypeScript conformance: 209 assertions
+* Go harness: 28 assertions
+* Python harness: 28 assertions
+* aggregate conformance posture: 265 assertions across TypeScript, Go, and Python
+* security gate: ALLOW
+* API fingerprint: unchanged where required
 
-### Deterministic scenario (all adapters)
+### Cross-language coverage
 
-```
-ALLOW → ALLOW → DENY → verifyEnvelope() => ok
-```
+Covered cross-language:
+
+* canonicalization vectors
+* SignedKRLV1 vectors
+* Profile C state verification vectors
+* Profile C Encoding B modes 006–008
+* independent Ed25519 verification in Go and Python
 
 ### Boundary proof
 
-```
+```text
 ALLOW
 DENY_HASH_MISMATCH
 REPLAY
 BYPASS → rejected
+```
+
+### Core execution invariant
+
+```text
+proposal
+→ authorization verification
+→ PEP enforcement
+→ execution only if allowed
+```
+
+If any verification step fails:
+
+```text
+DENY
+→ no execution
 ```
 
 ---
@@ -84,17 +137,24 @@ BYPASS → rejected
 
 ### Optimized for
 
-* deterministic authorization `(intent, state, policy)`
+* deterministic authorization: `(intent, state, policy) → ALLOW | DENY`
 * fail-closed execution
 * pre-execution enforcement
-* portable verification (offline-capable)
+* non-bypassable PEP boundary
+* portable offline verification
+* proof-carrying authorization artifacts
+* replay without re-reasoning
+* explicit trust boundaries
 
 ### Not
 
 * agent framework
 * runtime replacement
-* guardrail / output filtering
+* guardrail / output filtering system
+* model-alignment system
 * monitoring-only system
+* sandboxing system
+* policy-authoring product
 
 ---
 
@@ -106,9 +166,18 @@ BYPASS → rejected
 
 **Status:** Done
 
+Delivered:
+
 * `AuthorizationV1`
 * pre-execution gating semantics
 * PEP verification contract
+* fail-closed authorization model
+
+Invariant:
+
+```text
+Only valid ALLOW artifacts may reach execution.
+```
 
 ---
 
@@ -116,10 +185,13 @@ BYPASS → rejected
 
 **Status:** Done
 
-* Ed25519 signatures
-* `alg / kid / signature`
-* KeySet model
+Delivered:
+
+* Ed25519 verification
+* `alg` / `kid` / signature verification
+* trusted keyset model
 * signature failure conformance
+* strict issuer / audience / expiry / replay checks
 
 ---
 
@@ -127,24 +199,31 @@ BYPASS → rejected
 
 **Status:** Done
 
+Delivered:
+
 * SDK guard surface
 * multi-framework demos
 * deterministic envelope verification
+* initial adapter model
 
 ---
 
-## v1.4 - Ecosystem Adoption
+## v1.4 - Ecosystem Adapter Layer
 
 **Status:** Done
 
-* unified PEP (`@oxdeai/guard`)
-* adapter packages (LangGraph, OpenAI, CrewAI, AutoGen, OpenClaw)
+Delivered:
+
+* unified PEP guard package
+* adapter packages for major AI orchestration surfaces
 * cross-adapter validation
 * reproducible demo scenario
 
-**Invariant enforced across adapters:**
+Adapters remain non-authoritative. They may propose actions. They do not define execution authority.
 
-```
+Invariant:
+
+```text
 proposal → authorization → execution
 ```
 
@@ -154,14 +233,16 @@ proposal → authorization → execution
 
 **Status:** Done
 
+Delivered:
+
 * quickstarts
 * visual demos
 * architecture docs
 * reproducible integrations
 
-**Goal achieved:**
+Goal achieved:
 
-> Run a demo < 5 minutes
+> Run a demo in under 5 minutes.
 
 ---
 
@@ -169,166 +250,376 @@ proposal → authorization → execution
 
 **Status:** Done
 
+Delivered:
+
 * `DelegationV1`
-* scope narrowing (tools, amount, depth)
+* strict scope narrowing
 * single-hop enforcement
-* chain verification (local, no control-plane)
-* full conformance vectors
+* parent authorization binding
+* local chain verification
+* delegation replay protection
+* conformance vectors
 * cross-language verification
 
----
+Invariant:
 
-## v2.5 - ETA Core (Execution-Time Authorization)
-
-**Status:** In Progress
-
-### Goal
-
-Turn OxDeAI into a **deployable infra boundary**, not just a protocol.
+```text
+Delegation may narrow authority.
+Delegation may not expand authority.
+```
 
 ---
 
-### Delivered
+## v2.5 - ETA Core / Interoperable Protocol Hardening
+
+**Status:** Done
+
+Goal:
+
+> Turn OxDeAI from implementation into interoperable execution-time authorization protocol.
+
+Delivered:
 
 * canonicalization spec
 * authorization spec
+* delegation spec
 * PEP gateway spec
 * verification spec
 * conformance vectors
-* cross-language determinism
+* cross-language canonicalization
+* cross-language Profile C verification
+* cross-language SignedKRLV1 verification
 * non-bypassable execution demo
+* ETA alignment document
+* protocol audit cleanup
 
-#### Interoperability Hardening (completed)
+### Interoperability hardening
+
+Delivered:
 
 * external provider wire encoding specification
-  * Encoding A - Core-native (`"Ed25519"`, `expiry`, domain-prefixed preimage)
-  * Encoding B - external provider-compatible (`"ed25519"`, `expires_at`, base64url signature)
-* durable replay semantics with formal TTL alignment rules (`computeTtl = max(1, expiry − now)`)
-* pluggable `computeStateHash` in `OxDeAIGuard` (fail-closed on exception)
-* external provider interoperability profile
-  * Profile A - Core-native `AuthorizationV1`
-  * Profile B - external provider wire-compatible
-  * Profile C - full semantic state verification
-* Profile C executable conformance vectors (12 assertions; 161 total)
-* external provider threat model (12 threat scenarios, T-1 through T-12)
-* key custody and rotation guide (8 compromise scenarios, KC-1 through KC-8)
-* replay-store TTL alignment guide (10 failure scenarios, RT-1 through RT-10)
+
+  * Encoding A: Core-native
+  * Encoding B: external-provider compatible
+* external provider profiles
+
+  * Profile A: Core-native `AuthorizationV1`
+  * Profile B: external wire-compatible authorization
+  * Profile C: full semantic state verification
+* Profile C executable vectors
+* Profile C Go/Python coverage for all 8 modes
+* Encoding B modes 006–008 covered cross-language
+* external provider threat model
+* key custody and rotation guide
+* replay-store TTL alignment guide
+* state-provider trust boundary requirements
+
+### Revocation hardening
+
+Delivered:
+
+* SignedKRLV1 verification path
+* signed-required / signed-preferred / unsigned-legacy mode model
+* persistent KRL high-watermark support
+* last-known-good signed-KRL cache
+* fail-closed KRL watermark persistence behavior
+* migration warnings for unsigned legacy behavior
+
+### Audit posture
+
+Delivered:
+
+* post-interoperability protocol audit
+* ETA framework alignment
+* RT-TRUST-1 specified with residual
+* final audit readiness cleanup
+
+Current audit posture:
+
+```text
+reviewer-ready, not standard-adoption-ready
+```
 
 ---
 
-### In Progress
+## v2.6 - Project Readiness / External Engagement Surface
 
-* infra-native enforcement patterns
-* external-builder quickstarts (<10 min)
-* failure playbooks (real-world scenarios)
-* adapter stress testing
-* structured decision events
+**Status:** In Progress
+
+Goal:
+
+> Make OxDeAI evaluable by external contributors, reviewers, integrators, and security researchers.
+
+Scope:
+
+* `GOVERNANCE.md`
+* updated `CONTRIBUTING.md`
+* `SECURITY.md`
+* DCO contribution policy
+* optional DCO enforcement workflow
+* clear security disclosure path
+* external integration proposal process
+* no overclaiming of foundation, legal entity, or security-review status
+
+Completion criteria:
+
+* governance model reflects current project state
+* security disclosure path exists
+* contribution process is clear
+* DCO requirement documented
+* no unsupported legal or standardization claims
+* no protocol/runtime changes
 
 ---
 
-### Key Objective
-
-> Enforcement must live **outside the agent runtime**
-
----
-
-### Completion Criteria
-
-* deterministic outputs across environments
-* full conformance coverage
-* reproducible enforcement demos
-* ≥3 real-world failure scenarios documented
-* external adoption without reading core source
-
----
-
-## v2.6 - Infra Integrations
+## v2.7 - Independent Security Review Scoping
 
 **Status:** Planned
 
-### Scope
+Goal:
+
+> Prepare OxDeAI for independent security review.
+
+Scope:
+
+* define review surface
+* define out-of-scope areas
+* prepare reviewer package
+* map artifacts to audit sections
+* define threat model focus
+* define expected deliverables
+* define success criteria
+* identify reviewer profile
+
+Review surface should include:
+
+* `AuthorizationV1`
+* `DelegationV1`
+* `SignedKRLV1`
+* canonicalization-v1
+* PEP gateway boundary
+* OxDeAIGuard
+* Profile A/B/C
+* KRL high-watermark / LKG cache
+* state-provider trust boundary
+* conformance vectors and harnesses
+* audit and ETA alignment documents
+
+Completion criteria:
+
+* security review issue opened
+* review package defined
+* candidate reviewers identified
+* cost / timeline understood
+* funding or sponsor path clarified
+
+---
+
+## v2.8 - External Feedback / Co-author Channel
+
+**Status:** Planned
+
+Goal:
+
+> Create a structured path for external technical feedback.
+
+Scope:
+
+* external feedback process
+* integration proposal template
+* reviewer/adopter feedback template
+* possible RFC-lite process
+* public discussion conventions
+* issue labels and triage model
+
+Constraints:
+
+* do not create fake foundation governance
+* do not create formal standards-body claims
+* do not give external integrators protocol authority
+* preserve maintainer decision model until real contributor base exists
+
+Completion criteria:
+
+* external feedback path documented
+* integration proposal process stable
+* public contribution route clear
+* at least one external technical review or integration proposal processed under the model
+
+---
+
+## v3.0 - Release-Policy Gate for Signed-Required Default
+
+**Status:** Planned / Release-Gated
+
+Goal:
+
+> Decide when `signed_required` becomes the default KRL posture and when `unsigned_legacy` is removed.
+
+Scope:
+
+* semver / release policy
+* migration notice
+* changelog
+* deprecation timeline
+* pre-release or major-release decision
+* user migration guide
+* default flip to `signed_required`
+* eventual `unsigned_legacy` removal
+
+Constraints:
+
+* do not flip defaults without release-boundary decision
+* do not remove unsigned legacy without migration window
+* do not overstate signed-required coverage for deployments that do not configure it
+
+Related:
+
+* #116
+* SignedKRLV1
+* KRL high-watermark
+* LKG cache
+
+---
+
+## v3.x - Infra Integrations
+
+**Status:** Planned
+
+Goal:
+
+> Make OxDeAI a drop-in execution boundary for infrastructure systems.
+
+Scope:
 
 * HTTP PEP package
 * Express / Fastify middleware
 * route-level enforcement
+* service-to-service authorization examples
+* production deployment checklist
+* network isolation guidance
 
-### Example
+Example:
 
-```
+```text
 POST /payments/charge
 → verify AuthorizationV1
 → execute or deny
 ```
 
-### Goal
+Constraint:
 
-> Make OxDeAI a **drop-in execution boundary**
+```text
+PEP must remain outside the agent runtime.
+```
 
 ---
 
-## v3.x - Verifiable Execution
+## v4.x - Verifiable Execution Evidence
 
 **Status:** Planned
 
-### Scope
+Goal:
+
+> Extend OxDeAI from authorization enforcement to verifiable execution evidence.
+
+Scope:
 
 * execution receipts
 * `VerificationEnvelopeV1`
 * Merkle batching
 * proof-of-inclusion
 * optional on-chain anchoring
+* audit evidence export
 
-### Constraint
+Constraint:
 
-* authorization remains **off-chain-first**
+```text
+authorization remains off-chain-first
+```
 
 ---
 
-# Summary
+# Current Priorities
 
 ## Done
 
 * authorization artifacts
 * cryptographic verification
-* adapters + ecosystem
+* canonicalization-v1
+* PEP gateway specification
 * delegated authorization
-* conformance + proof
+* adapter surface
 * external provider interoperability hardening
-  * wire encoding specification (Encoding A, Encoding B)
-  * interoperability profiles (A / B / C) with executable conformance (161 assertions)
-  * threat model, key lifecycle, replay-store TTL alignment
+* Profile A/B/C specification
+* Profile C cross-language coverage
+* SignedKRLV1 coverage
+* persistent KRL watermark
+* last-known-good KRL cache
+* state-provider requirements spec
+* ETA alignment document
+* final protocol audit cleanup
 
 ## In Progress
 
-* ETA core
-* infra-native enforcement
-* failure playbooks
-* adoption path
+* governance / contribution / security disclosure docs
+* project-readiness surface for external reviewers
 
-## Planned
+## Next
 
-* HTTP integrations
-* verifiable execution infrastructure
+* independent security review scoping
+* external feedback / co-author channel
+* release-policy decision for signed-required default migration
+
+## Planned Later
+
+* HTTP PEP integrations
+* production deployment checklist
+* structured decision event schema
+* verifiable execution receipts
+* optional evidence anchoring
 
 ---
 
----
+# Documentation Map
 
-# Architecture Documentation
+## Core Specifications
 
-## Specification
+* `docs/spec/core/canonicalization-v1.md`
+* `docs/spec/core/authorization-v1.md`
+* `docs/spec/core/delegation-v1.md`
+* `docs/spec/artifacts/signed-krl-v1.md`
+* `docs/spec/enforcement/pep-gateway-v1.md`
+* `docs/spec/verification-v1.md`
 
-* [External Provider Interoperability Profile](docs/spec/interoperability/external-provider-profile.md) - Profile A / B / C, accepted wire encodings, interoperability matrix, fail-closed rules
+## Interoperability
 
-## Architecture Guides
+* `docs/spec/interoperability/external-provider-profile.md`
+* `docs/spec/state-provider-requirements.md`
 
-* [Threat Model: External Authorization Providers](docs/architecture/threat-model-external-providers.md) - trust boundaries, T-1 through T-12 threat scenarios
-* [Key Custody and Rotation](docs/architecture/key-custody-and-rotation.md) - key lifecycle, KC-1 through KC-8 compromise scenarios, operational checklist
-* [Replay-Store TTL Alignment](docs/architecture/replay-store-ttl-alignment.md) - formal TTL rules, RT-1 through RT-10 failure scenarios, store implementation guidance
+## Audit and Standardization
+
+* `docs/audits/protocol-audit-post-interoperability.md`
+* `docs/standardization/execution-time-authorization-alignment.md`
+
+## Operations and Security
+
+* `docs/spec/replay-store-ttl-alignment.md`
+* `docs/spec/threat-model-external-providers.md`
+* `docs/spec/key-custody-and-rotation.md`
+* `SECURITY.md`
+
+## Governance and Contribution
+
+* `GOVERNANCE.md`
+* `CONTRIBUTING.md`
 
 ---
 
 # Key Insight
 
-> Agents generate actions.
-> OxDeAI decides if they can happen.
+```text
+Agents generate actions.
+OxDeAI decides whether they are authorized.
+The PEP enforces the boundary.
+```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,258 @@
+# Security Policy
+
+**Status:** Working security disclosure policy for OxDeAI v1  
+**Last updated:** 2026-06-04
+
+This document explains how to report security issues in OxDeAI, what versions are supported, and how vulnerability disclosure is handled.
+
+OxDeAI is an open-source execution-time authorization protocol. Security reports should be handled privately and responsibly.
+
+---
+
+## 1. Security Review Status
+
+OxDeAI has not yet undergone independent security review.
+
+The current security posture is documented in:
+
+```text
+docs/audits/protocol-audit-post-interoperability.md
+````
+
+That audit tracks known residual risks, production-readiness gaps, and standardization-readiness blockers.
+
+Known residuals include, but are not limited to:
+
+* **RT-TRUST-1:** state provider integrity, specified with residual deployment responsibility
+* **RT-TRUST-2:** KRL transport / migration-tracked revocation integrity posture
+* **RT-TRUST-3:** replay store bootstrapping and deployment residuals
+
+Production adopters should review the audit before relying on OxDeAI in high-assurance environments.
+
+---
+
+## 2. Supported Versions
+
+OxDeAI is currently pre-1.0 / early v1 protocol work.
+
+Security fixes are handled on the active default branch and published through the normal release process.
+
+| Version / Branch              | Supported   |
+| ----------------------------- | ----------- |
+| `main`                        | Yes         |
+| Latest published npm packages | Best effort |
+| Older branches or tags        | Best effort |
+| Forks                         | No          |
+
+If a vulnerability affects a released package, the fix will be documented in the release notes.
+
+---
+
+## 3. Reporting a Vulnerability
+
+Do not report security vulnerabilities as public GitHub issues.
+
+Report suspected vulnerabilities privately by email:
+
+```text
+security@oxdeai.dev
+```
+
+For non-security contact:
+
+```text
+contact@oxdeai.dev
+```
+
+A good report should include:
+
+* affected component
+* affected version or commit
+* vulnerability description
+* reproduction steps, if available
+* expected impact
+* whether the issue is already public
+* any proposed fix or mitigation
+
+Do not include secrets, private keys, production credentials, or sensitive third-party data in the report.
+
+---
+
+## 4. Response Timeline
+
+OxDeAI is currently solo-maintained, so response times are best effort.
+
+Target response timeline:
+
+| Step                                              | Target                              |
+| ------------------------------------------------- | ----------------------------------- |
+| Initial acknowledgement                           | within 7 days                       |
+| Initial triage                                    | within 14 days                      |
+| Remediation plan for confirmed significant issues | within 30 days                      |
+| Public disclosure                                 | coordinated, usually within 90 days |
+
+Severe issues affecting active adopters may be handled faster.
+
+Low-impact or speculative issues may take longer.
+
+---
+
+## 5. Disclosure Process
+
+The default process is coordinated disclosure.
+
+1. Reporter emails `security@oxdeai.dev`.
+2. Maintainer acknowledges the report.
+3. Maintainer triages severity and affected components.
+4. If valid, a private fix plan is prepared.
+5. Fix is developed and validated.
+6. Release or patch is published.
+7. Public advisory or disclosure is issued when appropriate.
+
+Public disclosure may be accelerated if:
+
+* exploitation is active
+* the issue is already public
+* users need immediate mitigation guidance
+
+Reporter credit will be given unless anonymity is requested.
+
+---
+
+## 6. Bug Bounty
+
+OxDeAI does not currently operate a bug bounty program.
+
+Security researchers are welcome to report issues, but no monetary reward is promised unless a separate written agreement exists.
+
+---
+
+## 7. Security Scope
+
+Security reports are in scope if they affect OxDeAI’s authorization boundary, verification semantics, conformance guarantees, or security-relevant implementation behavior.
+
+Examples of in-scope issues:
+
+* bypassing `AuthorizationV1` verification
+* execution without valid authorization
+* fail-open behavior
+* replay protection failure
+* signature verification flaws
+* canonicalization inconsistencies
+* key lifecycle / revocation failures
+* `SignedKRLV1` verification failures
+* delegation scope widening
+* PEP bypass paths
+* state binding failures
+* audit-chain integrity failures
+* cross-language vector inconsistency
+* security-sensitive documentation errors that could cause unsafe deployment
+
+Examples of out-of-scope issues:
+
+* generic website styling issues
+* speculative reports without an actionable attack path
+* vulnerabilities only present in unsupported forks
+* social engineering
+* denial-of-service reports requiring unrealistic resource assumptions
+* reports based only on lack of independent security review
+* reports about risks already documented as residuals, unless a new exploit path is shown
+
+---
+
+## 8. Residual Risks
+
+Some risks are known and documented. Reporting them again is useful only if the report adds a new exploit path, evidence, or mitigation.
+
+Current known residuals include:
+
+### RT-TRUST-1 - State provider integrity
+
+OxDeAI verifies state binding at the PEP, but state-source compliance remains a deployment responsibility.
+
+The relevant specification is:
+
+```text
+docs/spec/state-provider-requirements.md
+```
+
+A non-compliant or compromised state provider remains a residual risk.
+
+### RT-TRUST-2 - KRL revocation integrity posture
+
+KRL integrity has been hardened through signed KRL verification paths, persistent high-watermark handling, and last-known-good cache behavior for configured deployments.
+
+Residual risk remains for deployments using weaker migration modes or incomplete configuration.
+
+### RT-TRUST-3 - Replay store bootstrapping
+
+Replay protection depends on correct deployment of the replay store.
+
+In-memory stores are suitable for development and single-process contexts, but production deployments should use durable replay infrastructure appropriate to their scaling model.
+
+---
+
+## 9. Safe Harbor
+
+Security research conducted in good faith is welcome.
+
+To remain within safe harbor:
+
+* act only against systems you own or are explicitly authorized to test
+* avoid privacy violations
+* avoid data destruction
+* avoid service disruption
+* do not attempt extortion
+* report findings promptly
+* give the project a reasonable opportunity to fix confirmed issues before public disclosure
+
+This safe harbor does not authorize testing against third-party deployments of OxDeAI without their permission.
+
+---
+
+## 10. Handling Public Issues
+
+If a security issue is accidentally opened publicly:
+
+* the issue may be closed or minimized
+* the reporter may be asked to continue by email
+* public details may be limited until a fix or advisory is ready
+
+Do not post exploit details, private keys, credentials, or active attack instructions in public issues.
+
+---
+
+## 11. Security Advisory Format
+
+When a public advisory is needed, it should include:
+
+* affected component
+* affected versions or commits
+* severity assessment
+* impact
+* fixed version or commit
+* mitigation steps
+* credit, if applicable
+* links to relevant audit/spec updates
+
+Advisories should avoid unnecessary exploit detail before users have had reasonable time to upgrade.
+
+---
+
+## 12. Security Contact
+
+Security reports:
+
+```text
+security@oxdeai.dev
+```
+
+General contact:
+
+```text
+contact@oxdeai.dev
+```
+
+GitHub issues are appropriate for non-sensitive bugs, documentation improvements, feature requests, and public design discussion.
+
+Security vulnerabilities should be reported privately.


### PR DESCRIPTION
Adds project-readiness documentation for governance, contribution process, security disclosure, README positioning, and roadmap alignment.

This is documentation/governance work only. It does not change protocol semantics, runtime behavior, conformance vectors, or package code.