### PR TITLE
fix(demo): add Ed25519 signing and trustedKeySets to execution-bounda…

### DIFF
--- a/examples/execution-boundary-demo/src/policy.ts
+++ b/examples/execution-boundary-demo/src/policy.ts
@@ -7,13 +7,36 @@
  * on the allowlist — only the execution state changes between evaluations.
  */
 
+import { generateKeyPairSync } from "node:crypto";
 import { PolicyEngine } from "@oxdeai/core";
-import type { Intent, State } from "@oxdeai/core";
+import type { Intent, KeySet, State } from "@oxdeai/core";
 
 export const POLICY_ID =
   "demo-execution-boundary-0000000000000000000000000000000000000000000000";
 
 export const AGENT_ID = "payment-agent-1";
+
+export const AUTH_ISSUER = "execution-boundary-demo-issuer";
+export const AUTH_KID = "execution-boundary-demo-k1";
+
+const DEMO_AUTH_KEYPAIR = generateKeyPairSync("ed25519", {
+  privateKeyEncoding: { format: "pem", type: "pkcs8" },
+  publicKeyEncoding: { format: "pem", type: "spki" },
+});
+
+export const TRUSTED_KEYSETS: KeySet[] = [
+  {
+    issuer: AUTH_ISSUER,
+    version: "1",
+    keys: [
+      {
+        kid: AUTH_KID,
+        alg: "Ed25519",
+        public_key: DEMO_AUTH_KEYPAIR.publicKey.toString(),
+      },
+    ],
+  },
+];
 
 // Fixed nonce - same value across both calls, making the intent structurally identical.
 export const CHARGE_NONCE = 42n;
@@ -37,6 +60,10 @@ export const engine = new PolicyEngine({
   engine_secret: _engineSecret,
   authorization_ttl_seconds: 60,
   authorization_audience: AGENT_ID,
+  authorization_issuer: AUTH_ISSUER,
+  authorization_signing_alg: "Ed25519",
+  authorization_signing_kid: AUTH_KID,
+  authorization_private_key_pem: DEMO_AUTH_KEYPAIR.privateKey.toString(),
   policyId: POLICY_ID,
 });
 

--- a/examples/execution-boundary-demo/src/scenario.ts
+++ b/examples/execution-boundary-demo/src/scenario.ts
@@ -23,7 +23,7 @@
 
 import type { AuthorizationV1, State } from "@oxdeai/core";
 import { OxDeAIGuard, OxDeAIDenyError } from "@oxdeai/guard";
-import { engine, makeState, buildChargeIntent, AGENT_ID, WALLET_START } from "./policy.js";
+import { engine, makeState, buildChargeIntent, AGENT_ID, TRUSTED_KEYSETS, WALLET_START } from "./policy.js";
 
 // ── Step types ────────────────────────────────────────────────────────────────
 
@@ -90,6 +90,7 @@ export async function runScenario(): Promise<ScenarioStep[]> {
     getState: () => ({ state, version: 0 }),
     setState: (s) => { state = s; return true; },
     expectedAudience: AGENT_ID,
+    trustedKeySets: TRUSTED_KEYSETS,
     // chargeIntent is identical for both calls — only state differs
     mapActionToIntent: () => chargeIntent,
     beforeExecute(_action: unknown, authorization: AuthorizationV1) {
@@ -171,6 +172,7 @@ export async function runScenario(): Promise<ScenarioStep[]> {
     getState: () => ({ state, version: 0 }),
     setState: (s) => { state = s; return true; },
     expectedAudience: AGENT_ID,
+    trustedKeySets: TRUSTED_KEYSETS,
     mapActionToIntent: () => chargeIntent,
     beforeExecute() {
       secondDecision = "ALLOW"; // should not be reached


### PR DESCRIPTION
## Summary

Fixes `examples/execution-boundary-demo` after strict `trustedKeySets` enforcement.

The demo now emits Ed25519-signed `AuthorizationV1` artifacts and verifies them through `OxDeAIGuard` using matching `trustedKeySets`.

## Root cause

`OxDeAIGuard` now requires non-empty `trustedKeySets` for authorization verification.

The demo still used the deprecated HMAC-SHA256 default and constructed two guard instances without `trustedKeySets`, causing:

```text
OxDeAIGuardConfigurationError: trustedKeySets are required for authorization verification and must not be empty.
````

## What changed

Updated:

* `examples/execution-boundary-demo/src/policy.ts`
* `examples/execution-boundary-demo/src/scenario.ts`

## Implementation

`policy.ts` now:

* generates a demo Ed25519 keypair at module initialization
* configures `PolicyEngine` with Ed25519 authorization signing
* exports `TRUSTED_KEYSETS` containing the matching public key

`scenario.ts` now:

* imports `TRUSTED_KEYSETS`
* passes `trustedKeySets` into both `OxDeAIGuard` instances

## Boundary guarantees

This PR does not change protocol semantics.

No changes were made to:

* `packages/core/**`
* `packages/guard/**`
* conformance vectors
* protocol artifact formats
* `packages/core/API_FINGERPRINT`

`OxDeAIGuard` strict trust-boundary enforcement is preserved and exercised, not bypassed.

## Validation

* `pnpm -C examples/execution-boundary-demo build`: passing
* `pnpm -C examples/execution-boundary-demo terminal`: passing
* `pnpm test`: passing
* `pnpm security:gate`: ALLOW
* `git diff --check`: clean
* `packages/core/API_FINGERPRINT`: unchanged
