### PR TITLE
docs: add LGF Frappe Helpdesk PoC boundary contract

### DIFF
--- a/docs/integrations/lgf-frappe-helpdesk-poc.md
+++ b/docs/integrations/lgf-frappe-helpdesk-poc.md
@@ -1,0 +1,302 @@
+# LGF-managed Frappe Helpdesk PoC
+
+Status: Draft  
+Related issue: #141  
+Scope: external interoperability PoC  
+Protected action: `frappe.helpdesk.create_ticket`
+
+## Purpose
+
+This PoC validates OxDeAI as a deployable execution authorization boundary inside an externally managed runtime.
+
+LGF manages the deployment environment. OxDeAI manages execution authorization.
+
+The invariant under test is:
+
+> No valid authorization -> no execution path.
+
+## Boundary Summary
+
+The PoC uses an LGF-managed Frappe / ERPNext bench with Helpdesk installed.
+
+The protected action is narrow by design:
+
+```text
+frappe.helpdesk.create_ticket
+```
+
+The goal is not to protect all of Frappe, all of ERPNext, or all OpenWebUI tool calls. The goal is to prove that one side-effecting business action cannot execute unless an OxDeAI AuthorizationV1 artifact is valid at the PEP boundary.
+
+## Responsibility Split
+
+### LGF responsibilities
+
+LGF owns:
+
+* host provisioning assumptions
+* bench lifecycle
+* reverse proxy routing
+* TLS termination
+* bench service topology
+* bench start, stop, repair, backup, and update operations
+* network ingress policy
+* Frappe / ERPNext / Helpdesk deployment
+
+### OxDeAI responsibilities
+
+OxDeAI owns:
+
+* action canonicalization
+* AuthorizationV1 issuance
+* AuthorizationV1 verification
+* replay protection
+* audience validation
+* expiry validation
+* intent hash binding
+* fail-closed execution enforcement
+* PEP decision logging
+* protected-action adapter rules
+
+### Frappe responsibilities
+
+Frappe owns:
+
+* Helpdesk application behavior
+* ticket persistence
+* Frappe REST API semantics
+* Frappe user and API credential model
+
+## Deployment Shape
+
+```text
+OpenWebUI / agent / caller
+        |
+        | HTTPS + declared caller identity
+        v
+OxDeAI PEP
+        |
+        | verifies AuthorizationV1
+        | checks replay / expiry / audience / intent hash
+        v
+Frappe adapter
+        |
+        | holds Frappe API credential
+        v
+LGF-managed Frappe Helpdesk
+```
+
+The Frappe API credential must be held only by the PEP or its trusted adapter.
+
+If the caller can create the Helpdesk ticket directly through the main Frappe route without passing through the PEP, the PoC fails.
+
+## Known LGF Bench State
+
+The initial external test environment used:
+
+```text
+LGF base domain: lgf.oxdeai.dev
+Frappe bench hostname: frappe.lgf.oxdeai.dev
+Helpdesk route: https://frappe.lgf.oxdeai.dev/helpdesk/dashboard
+```
+
+Helpdesk was confirmed installed and reachable.
+
+This environment is a private evaluation environment and is not part of the public protocol surface.
+
+## Two-phase Flow
+
+The PoC uses a two-phase flow.
+
+### Phase 1: authorize
+
+Endpoint:
+
+```text
+POST /authorize
+```
+
+The caller submits a proposed action envelope.
+
+The PEP/PDP evaluates:
+
+```text
+intent + state + policy
+```
+
+If the decision is `ALLOW`, it emits an AuthorizationV1 artifact.
+
+If the decision is `DENY`, it emits no executable authorization artifact.
+
+No Frappe action is executed during `/authorize`.
+
+### Phase 2: execute
+
+Endpoint:
+
+```text
+POST /execute
+```
+
+The caller submits the same action envelope plus the AuthorizationV1 artifact.
+
+The PEP verifies:
+
+* signature
+* trusted issuer / key
+* audience
+* expiry
+* replay status
+* intent hash
+* action binding
+* protected action name
+
+Only after verification succeeds may the adapter call Frappe.
+
+## Minimal Action Envelope
+
+```json
+{
+  "source_bench": "openwebui-dev",
+  "target_bench": "frappe",
+  "agent_or_tool_context": "erp-assistant",
+  "user_identity": "user@example.com",
+  "session_id": "example-session",
+  "action": {
+    "type": "EXECUTE",
+    "tool": "frappe.helpdesk.create_ticket",
+    "params": {
+      "subject": "OxDeAI PoC ticket",
+      "description": "Created through the OxDeAI execution boundary PoC.",
+      "priority": "Low"
+    }
+  }
+}
+```
+
+## Minimal Policy
+
+Initial policy for the PoC:
+
+```text
+ALLOW priority = Low
+ALLOW priority = Medium
+DENY  priority = Urgent
+```
+
+This is intentionally simple. The purpose is boundary validation, not business policy completeness.
+
+## Expected Decisions
+
+| Case                                      | Expected result |
+| ----------------------------------------- | --------------- |
+| Valid authorization                       | Ticket created  |
+| Missing authorization                     | DENY, no ticket |
+| Invalid signature                         | DENY, no ticket |
+| Expired authorization                     | DENY, no ticket |
+| Replayed authorization                    | DENY, no ticket |
+| Wrong audience                            | DENY, no ticket |
+| Modified payload after authorization      | DENY, no ticket |
+| Policy-denied priority                    | DENY, no ticket |
+| Direct Frappe call without PEP credential | No ticket       |
+
+## PEP Modes
+
+The PoC supports two modes.
+
+### Observe mode
+
+Observe mode may log what would have happened, but it is not a security boundary.
+
+Observe mode must not be described as protected execution.
+
+### Enforce mode
+
+Enforce mode is the boundary proof.
+
+Protected execution must fail closed if the authorization is missing, invalid, expired, replayed, wrong-audience, or intent-mismatched.
+
+## Credential Isolation Requirement
+
+The Frappe credential capable of creating Helpdesk tickets must not be available to:
+
+* OpenWebUI
+* the agent runtime
+* the browser client
+* the caller
+* unprotected scripts
+* public environment variables
+* committed repository files
+
+The credential belongs only to the PEP runtime or trusted adapter.
+
+## Logging Requirements
+
+Each decision should log:
+
+* correlation id
+* action name
+* expected audience
+* authorization id
+* intent hash
+* policy id
+* decision
+* reason code
+* execution result
+* Frappe ticket id if executed
+
+Logs must not expose secrets.
+
+## Non-goals
+
+This PoC does not claim:
+
+* production readiness
+* full Frappe protection
+* full ERPNext protection
+* full OpenWebUI governance
+* LGF protocol changes
+* OxDeAI protocol changes
+* general-purpose Frappe authorization
+* issuer/verifier separation
+* full live-state Profile C verification
+
+## Acceptance Criteria
+
+The PoC is complete when:
+
+* the LGF-managed Frappe bench is reachable
+* Helpdesk is installed
+* the PEP exposes `/authorize`, `/execute`, and `/healthz`
+* `/authorize` emits AuthorizationV1 only for allowed actions
+* `/execute` creates one Helpdesk ticket with valid authorization
+* invalid authorization creates no ticket
+* replayed authorization creates no ticket
+* expired authorization creates no ticket
+* wrong-audience authorization creates no ticket
+* modified payload creates no ticket
+* policy-denied action creates no ticket
+* no caller outside the PEP holds a Frappe ticket-creation credential
+* direct bypass attempts fail
+* observe mode is visibly marked as non-enforcing
+* enforce mode fails closed
+
+## Current PoC Status
+
+Initial LGF/Frappe environment validation is complete.
+
+Confirmed:
+
+* LGF installed
+* Frappe bench created
+* HTTPS bench route active
+* Helpdesk installed
+* Helpdesk dashboard reachable
+* Frappe backend, frontend, queues, scheduler, websocket, Redis, and MariaDB running
+
+Known LGF observations from setup:
+
+* `verify-operational` reported rendered `.env` hash drift after update and repair
+* after enabling bench HTTPS, generated host reverse proxy upstream used HTTPS toward the local Frappe backend even though Frappe listens internally over HTTP
+* manually changing the upstream from `https://127.0.0.1:8080` to `http://127.0.0.1:8080` made the HTTPS Helpdesk route return `200`
+
+These observations are LGF environment notes, not OxDeAI protocol changes.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
       "ws": ">=8.20.1",
       "uuid": "14.0.0",
       "basic-ftp": ">=5.3.0",
-      "fast-uri": "3.1.2"
+      "fast-uri": "3.1.2",
+      "form-data": "4.0.6",
+      "js-yaml": "4.2.0"
     }
   },
   "type": "module"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,8 @@ overrides:
   uuid: 14.0.0
   basic-ftp: '>=5.3.0'
   fast-uri: 3.1.2
+  form-data: 4.0.6
+  js-yaml: 4.2.0
 
 importers:
 
@@ -1011,8 +1013,8 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
   es-set-tostringtag@2.1.0:
@@ -1087,8 +1089,8 @@ packages:
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   formdata-node@4.4.1:
@@ -1155,8 +1157,8 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   http-proxy-agent@7.0.2:
@@ -1215,8 +1217,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   json-parse-even-better-errors@2.3.1:
@@ -1936,7 +1938,7 @@ snapshots:
   '@types/node-fetch@2.6.13':
     dependencies:
       '@types/node': 22.19.17
-      form-data: 4.0.5
+      form-data: 4.0.6
 
   '@types/node@18.19.130':
     dependencies:
@@ -2113,7 +2115,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -2170,7 +2172,7 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-object-atoms@1.1.1:
+  es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
 
@@ -2179,7 +2181,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -2266,12 +2268,12 @@ snapshots:
 
   form-data-encoder@1.7.2: {}
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   formdata-node@4.4.1:
@@ -2299,18 +2301,18 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       function-bind: 1.1.2
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   get-stream@5.2.0:
     dependencies:
@@ -2342,7 +2344,7 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hasown@2.0.2:
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -2383,7 +2385,7 @@ snapshots:
 
   is-core-module@2.16.1:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -2397,7 +2399,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
Adds the initial boundary contract for #141.

This PR documents the LGF-managed Frappe / Helpdesk PoC scope before implementing the OxDeAI PEP container.

The goal is to freeze the execution-boundary contract first, so implementation work can proceed against a clear infra/security model.

### Covered:

* protected action: `frappe.helpdesk.create_ticket`
* LGF / OxDeAI / Frappe responsibility split
* external deployment boundary assumptions
* two-phase `/authorize` and `/execute` flow
* AuthorizationV1 verification requirements
* credential isolation requirements
* observe vs enforce mode distinction
* expected ALLOW / DENY behavior
* replay, expiry, wrong-audience, and modified-payload denial cases
* direct-bypass failure expectations
* logging requirements
* acceptance criteria
* current LGF/Frappe environment validation notes

### Explicitly out of scope:

* protocol changes
* implementation changes
* production-readiness claims
* full Frappe / ERPNext protection
* LGF semantic changes
* secrets, credentials, license keys, or private infrastructure data

No protocol changes.
No implementation changes.
No secrets included.

#### Related: #141
