### PR TITLE
poc: add LGF Frappe Helpdesk PEP container

### DIFF
--- a/examples/lgf-frappe-pep/.dockerignore
+++ b/examples/lgf-frappe-pep/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.env
+.git
+*.md
+test

--- a/examples/lgf-frappe-pep/.env.example
+++ b/examples/lgf-frappe-pep/.env.example
@@ -1,0 +1,30 @@
+# OxDeAI PEP runtime configuration for LGF Frappe Helpdesk PoC
+#
+# Copy this file to .env and fill in the values.
+# NEVER commit .env or any file containing real credentials.
+
+# Mode: "enforce" or "observe"
+# enforce = full PEP boundary enforcement, calls Frappe on ALLOW
+# observe = dry-run only, never calls Frappe, logs would-ALLOW / would-DENY
+OXDEAI_MODE=enforce
+
+# Audience claim expected in AuthorizationV1 artifacts
+EXPECTED_AUDIENCE=PEP-frappe.lgf.oxdeai.dev
+
+# Frappe Helpdesk REST API base URL (no trailing slash)
+FRAPPE_BASE_URL=https://frappe.lgf.oxdeai.dev
+
+# Frappe API credentials — injected at runtime only
+FRAPPE_API_KEY=
+FRAPPE_API_SECRET=
+
+# Replay store backend: "memory" (PoC only — state lost on restart)
+REPLAY_STORE=memory
+
+# Ed25519 private key PEM for signing AuthorizationV1 artifacts
+# Generate with: node -e "const{generateKeyPairSync}=require('crypto');const{privateKey}=generateKeyPairSync('ed25519');console.log(privateKey.export({type:'pkcs8',format:'pem'}))"
+# Inject at runtime only — never commit.
+SIGNING_PRIVATE_KEY_PEM=
+
+# Server port
+PORT=3000

--- a/examples/lgf-frappe-pep/Dockerfile
+++ b/examples/lgf-frappe-pep/Dockerfile
@@ -1,0 +1,54 @@
+# OxDeAI PEP runtime for LGF Frappe Helpdesk PoC
+# No secrets baked in — all credentials injected at runtime.
+#
+# Build context must be the repo root:
+#   docker build -f examples/lgf-frappe-pep/Dockerfile .
+#
+# Place a .dockerignore at the repo root to exclude .env, .git, etc.
+# The .dockerignore at examples/lgf-frappe-pep/ is NOT used when the
+# build context is the repo root.
+
+# ── Stage 1: build ───────────────────────────────────────────────────────────
+FROM node:20-alpine AS build
+RUN corepack enable && corepack prepare pnpm@9.12.2 --activate
+WORKDIR /app
+
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY tsconfig.base.json ./
+COPY packages/core/package.json packages/core/
+COPY packages/guard/package.json packages/guard/
+COPY examples/lgf-frappe-pep/package.json examples/lgf-frappe-pep/
+
+RUN pnpm install --frozen-lockfile
+
+COPY packages/core/ packages/core/
+COPY packages/guard/ packages/guard/
+COPY examples/lgf-frappe-pep/src/ examples/lgf-frappe-pep/src/
+COPY examples/lgf-frappe-pep/tsconfig.json examples/lgf-frappe-pep/
+
+RUN pnpm --filter @oxdeai/core build && \
+    pnpm --filter @oxdeai/guard build && \
+    pnpm --filter @oxdeai/example-lgf-frappe-pep build
+
+# ── Stage 2: runtime ─────────────────────────────────────────────────────────
+FROM node:20-alpine
+RUN corepack enable && corepack prepare pnpm@9.12.2 --activate
+WORKDIR /app
+
+COPY --from=build /app/pnpm-lock.yaml /app/pnpm-workspace.yaml /app/package.json ./
+COPY --from=build /app/packages/core/package.json /app/packages/core/dist/ packages/core/
+COPY --from=build /app/packages/guard/package.json /app/packages/guard/dist/ packages/guard/
+COPY --from=build /app/examples/lgf-frappe-pep/package.json examples/lgf-frappe-pep/
+COPY --from=build /app/examples/lgf-frappe-pep/dist/ examples/lgf-frappe-pep/dist/
+COPY --from=build /app/node_modules/ node_modules/
+COPY --from=build /app/packages/core/node_modules/ packages/core/node_modules/
+COPY --from=build /app/packages/guard/node_modules/ packages/guard/node_modules/
+COPY --from=build /app/examples/lgf-frappe-pep/node_modules/ examples/lgf-frappe-pep/node_modules/
+
+ENV OXDEAI_MODE=enforce
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget -qO- http://localhost:3000/healthz || exit 1
+
+CMD ["node", "examples/lgf-frappe-pep/dist/src/server.js"]

--- a/examples/lgf-frappe-pep/package.json
+++ b/examples/lgf-frappe-pep/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@oxdeai/example-lgf-frappe-pep",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "OxDeAI PEP runtime for LGF-managed Frappe Helpdesk PoC",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "pnpm build && node dist/server.js",
+    "test": "pnpm build && node --test dist/test/boundary.test.js"
+  },
+  "dependencies": {
+    "@oxdeai/core": "workspace:*",
+    "@oxdeai/guard": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/lgf-frappe-pep/src/authorize.ts
+++ b/examples/lgf-frappe-pep/src/authorize.ts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+import { randomUUID } from "node:crypto";
+import { sha256HexFromJson, signAuthorizationEd25519 } from "@oxdeai/core";
+import type { AuthorizationV1 } from "@oxdeai/core";
+import type { PepConfig } from "./config.js";
+import type { ActionEnvelope, PepResponse, DecisionLog } from "./types.js";
+import { evaluatePolicy, POLICY_ID } from "./policy.js";
+
+function parseEnvelope(body: unknown): ActionEnvelope | null {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) return null;
+  const b = body as Record<string, unknown>;
+  if (typeof b["source_bench"] !== "string") return null;
+  if (typeof b["target_bench"] !== "string") return null;
+  if (typeof b["agent_or_tool_context"] !== "string") return null;
+  if (typeof b["user_identity"] !== "string") return null;
+  if (typeof b["session_id"] !== "string") return null;
+  const action = b["action"];
+  if (typeof action !== "object" || action === null) return null;
+  const a = action as Record<string, unknown>;
+  if (a["type"] !== "EXECUTE") return null;
+  if (typeof a["tool"] !== "string") return null;
+  const params = a["params"];
+  if (typeof params !== "object" || params === null) return null;
+  const p = params as Record<string, unknown>;
+  if (typeof p["subject"] !== "string") return null;
+  if (typeof p["description"] !== "string") return null;
+  if (typeof p["priority"] !== "string") return null;
+  return body as ActionEnvelope;
+}
+
+export function handleAuthorize(config: PepConfig) {
+  return (body: unknown): { status: number; body: PepResponse; log: DecisionLog } => {
+    const correlationId = randomUUID();
+    const now = Math.floor(Date.now() / 1000);
+
+    const envelope = parseEnvelope(body);
+    if (!envelope) {
+      const log: DecisionLog = {
+        correlation_id: correlationId,
+        action: "unknown",
+        expected_audience: config.expectedAudience,
+        auth_id: null,
+        intent_hash: null,
+        policy_id: POLICY_ID,
+        mode: config.mode,
+        decision: "DENY",
+        reason: "INVALID_ENVELOPE",
+        executed: false,
+        frappe_ticket_id: null,
+        timestamp: new Date(now * 1000).toISOString(),
+      };
+      return {
+        status: 400,
+        body: { ok: false, decision: "DENY", mode: config.mode, reason: "INVALID_ENVELOPE" },
+        log,
+      };
+    }
+
+    const intentHash = sha256HexFromJson(envelope.action);
+    const policyResult = evaluatePolicy(envelope);
+
+    if (policyResult.decision === "DENY") {
+      const log: DecisionLog = {
+        correlation_id: correlationId,
+        action: envelope.action.tool,
+        expected_audience: config.expectedAudience,
+        auth_id: null,
+        intent_hash: intentHash,
+        policy_id: POLICY_ID,
+        mode: config.mode,
+        decision: "DENY",
+        reason: policyResult.reason,
+        executed: false,
+        frappe_ticket_id: null,
+        timestamp: new Date(now * 1000).toISOString(),
+      };
+      return {
+        status: 403,
+        body: { ok: false, decision: "DENY", mode: config.mode, reason: policyResult.reason },
+        log,
+      };
+    }
+
+    const stateHash = sha256HexFromJson({});
+    const authId = randomUUID();
+    const expiry = now + config.authorizationTtlSeconds;
+    const privateKeyPem = config.signingPrivateKey.export({ type: "pkcs8", format: "pem" }) as string;
+
+    const authorization: AuthorizationV1 = signAuthorizationEd25519(
+      {
+        auth_id: authId,
+        issuer: config.issuer,
+        audience: config.expectedAudience,
+        intent_hash: intentHash,
+        state_hash: stateHash,
+        policy_id: POLICY_ID,
+        decision: "ALLOW",
+        issued_at: now,
+        expiry,
+        kid: config.signingKid,
+        nonce: randomUUID(),
+      },
+      privateKeyPem,
+    );
+
+    const log: DecisionLog = {
+      correlation_id: correlationId,
+      action: envelope.action.tool,
+      expected_audience: config.expectedAudience,
+      auth_id: authId,
+      intent_hash: intentHash,
+      policy_id: POLICY_ID,
+      mode: config.mode,
+      decision: "ALLOW",
+      reason: "POLICY_ALLOWED",
+      executed: false,
+      frappe_ticket_id: null,
+      timestamp: new Date(now * 1000).toISOString(),
+    };
+
+    return {
+      status: 200,
+      body: {
+        ok: true,
+        decision: "ALLOW",
+        mode: config.mode,
+        auth_id: authId,
+        intent_hash: intentHash,
+        policy_id: POLICY_ID,
+        authorization,
+      },
+      log,
+    };
+  };
+}

--- a/examples/lgf-frappe-pep/src/config.ts
+++ b/examples/lgf-frappe-pep/src/config.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+import { createPrivateKey, createPublicKey } from "node:crypto";
+import type { KeyObject } from "node:crypto";
+
+export type PepMode = "enforce" | "observe";
+
+export type PepConfig = {
+  mode: PepMode;
+  expectedAudience: string;
+  frappeBaseUrl: string;
+  frappeApiKey: string;
+  frappeApiSecret: string;
+  replayStore: "memory";
+  port: number;
+  signingPrivateKey: KeyObject;
+  signingPublicKeyPem: string;
+  signingKid: string;
+  issuer: string;
+  authorizationTtlSeconds: number;
+};
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value.length === 0) {
+    throw new Error(`Required environment variable ${name} is missing or empty`);
+  }
+  return value;
+}
+
+export function loadConfig(): PepConfig {
+  const rawMode = requireEnv("OXDEAI_MODE");
+  if (rawMode !== "enforce" && rawMode !== "observe") {
+    throw new Error(`OXDEAI_MODE must be "enforce" or "observe", got "${rawMode}"`);
+  }
+
+  const expectedAudience = requireEnv("EXPECTED_AUDIENCE");
+  const frappeBaseUrl = requireEnv("FRAPPE_BASE_URL");
+
+  const mode: PepMode = rawMode;
+  let frappeApiKey = "";
+  let frappeApiSecret = "";
+  if (mode === "enforce") {
+    frappeApiKey = requireEnv("FRAPPE_API_KEY");
+    frappeApiSecret = requireEnv("FRAPPE_API_SECRET");
+  } else {
+    frappeApiKey = process.env["FRAPPE_API_KEY"] ?? "";
+    frappeApiSecret = process.env["FRAPPE_API_SECRET"] ?? "";
+  }
+
+  const replayStoreType = process.env["REPLAY_STORE"] ?? "memory";
+  if (replayStoreType !== "memory") {
+    throw new Error(`Unsupported REPLAY_STORE: "${replayStoreType}". Only "memory" is supported in this PoC.`);
+  }
+
+  const privateKeyPem = requireEnv("SIGNING_PRIVATE_KEY_PEM");
+  const signingPrivateKey = createPrivateKey(privateKeyPem);
+  const signingPublicKeyPem = createPublicKey(signingPrivateKey)
+    .export({ type: "spki", format: "pem" }) as string;
+
+  const signingKid = process.env["SIGNING_KID"] ?? "lgf-frappe-pep-key-1";
+  const issuer = process.env["ISSUER"] ?? "oxdeai.lgf-frappe-pep";
+
+  const authorizationTtlSeconds = Number(process.env["AUTHORIZATION_TTL_SECONDS"] ?? "60");
+  if (!Number.isFinite(authorizationTtlSeconds) || authorizationTtlSeconds < 1) {
+    throw new Error(`AUTHORIZATION_TTL_SECONDS must be a positive integer, got "${process.env["AUTHORIZATION_TTL_SECONDS"]}"`);
+  }
+
+  const port = Number(process.env["PORT"] ?? "3000");
+  if (!Number.isFinite(port) || port < 0 || port > 65535) {
+    throw new Error(`PORT must be 0-65535, got "${process.env["PORT"]}"`);
+  }
+
+  return {
+    mode,
+    expectedAudience,
+    frappeBaseUrl,
+    frappeApiKey,
+    frappeApiSecret,
+    replayStore: "memory",
+    port,
+    signingPrivateKey,
+    signingPublicKeyPem,
+    signingKid,
+    issuer,
+    authorizationTtlSeconds,
+  };
+}
+
+export function redactedConfigSummary(config: PepConfig): Record<string, unknown> {
+  return {
+    mode: config.mode,
+    expectedAudience: config.expectedAudience,
+    frappeBaseUrl: config.frappeBaseUrl,
+    frappeApiKey: config.frappeApiKey ? "***" : "(not set)",
+    frappeApiSecret: config.frappeApiSecret ? "***" : "(not set)",
+    replayStore: config.replayStore,
+    port: config.port,
+    signingKid: config.signingKid,
+    issuer: config.issuer,
+    authorizationTtlSeconds: config.authorizationTtlSeconds,
+  };
+}

--- a/examples/lgf-frappe-pep/src/execute.ts
+++ b/examples/lgf-frappe-pep/src/execute.ts
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: Apache-2.0
+import { randomUUID } from "node:crypto";
+import { sha256HexFromJson, verifyAuthorization } from "@oxdeai/core";
+import type { AuthorizationV1, KeySet } from "@oxdeai/core";
+import type { ReplayStore } from "@oxdeai/guard";
+import type { PepConfig } from "./config.js";
+import type { ActionEnvelope, FrappeAdapter, PepResponse, DecisionLog } from "./types.js";
+import { PROTECTED_ACTION, POLICY_ID } from "./policy.js";
+
+function parseExecuteRequest(
+  body: unknown,
+): { envelope: ActionEnvelope; authorization: AuthorizationV1 } | null {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) return null;
+  const b = body as Record<string, unknown>;
+  const envelope = b["envelope"];
+  const authorization = b["authorization"];
+  if (typeof envelope !== "object" || envelope === null) return null;
+  if (typeof authorization !== "object" || authorization === null) return null;
+
+  const e = envelope as Record<string, unknown>;
+  if (typeof e["source_bench"] !== "string") return null;
+  if (typeof e["target_bench"] !== "string") return null;
+  if (typeof e["agent_or_tool_context"] !== "string") return null;
+  if (typeof e["user_identity"] !== "string") return null;
+  if (typeof e["session_id"] !== "string") return null;
+  const action = e["action"];
+  if (typeof action !== "object" || action === null) return null;
+  const a = action as Record<string, unknown>;
+  if (a["type"] !== "EXECUTE") return null;
+  if (typeof a["tool"] !== "string") return null;
+  const params = a["params"];
+  if (typeof params !== "object" || params === null) return null;
+  const p = params as Record<string, unknown>;
+  if (typeof p["subject"] !== "string") return null;
+  if (typeof p["description"] !== "string") return null;
+  if (typeof p["priority"] !== "string") return null;
+
+  return {
+    envelope: envelope as ActionEnvelope,
+    authorization: authorization as AuthorizationV1,
+  };
+}
+
+function denyResult(
+  correlationId: string,
+  reason: string,
+  config: PepConfig,
+  action: string,
+  intentHash: string | null,
+  authId: string | null,
+  now: number,
+): { status: number; body: PepResponse; log: DecisionLog } {
+  return {
+    status: 403,
+    body: { ok: false, decision: "DENY", mode: config.mode, reason },
+    log: {
+      correlation_id: correlationId,
+      action,
+      expected_audience: config.expectedAudience,
+      auth_id: authId,
+      intent_hash: intentHash,
+      policy_id: POLICY_ID,
+      mode: config.mode,
+      decision: "DENY",
+      reason,
+      executed: false,
+      frappe_ticket_id: null,
+      timestamp: new Date(now * 1000).toISOString(),
+    },
+  };
+}
+
+export function handleExecute(
+  config: PepConfig,
+  replayStore: ReplayStore,
+  frappeAdapter: FrappeAdapter,
+) {
+  const trustedKeySets: KeySet[] = [
+    {
+      issuer: config.issuer,
+      version: "1",
+      keys: [
+        {
+          kid: config.signingKid,
+          alg: "Ed25519",
+          public_key: config.signingPublicKeyPem,
+          status: "active",
+        },
+      ],
+    },
+  ];
+
+  return async (body: unknown): Promise<{ status: number; body: PepResponse; log: DecisionLog }> => {
+    const correlationId = randomUUID();
+    const now = Math.floor(Date.now() / 1000);
+
+    // 1. Parse
+    const parsed = parseExecuteRequest(body);
+    if (!parsed) {
+      return denyResult(correlationId, "INVALID_REQUEST", config, "unknown", null, null, now);
+    }
+
+    const { envelope, authorization } = parsed;
+
+    // 2. Verify protected action name
+    if (envelope.action.tool !== PROTECTED_ACTION) {
+      return denyResult(
+        correlationId, "UNSUPPORTED_ACTION", config,
+        envelope.action.tool, null, authorization.auth_id ?? null, now,
+      );
+    }
+
+    // 3. Canonicalize + compute intent hash
+    let intentHash: string;
+    try {
+      intentHash = sha256HexFromJson(envelope.action);
+    } catch {
+      return denyResult(
+        correlationId, "CANONICALIZATION_FAILED", config,
+        envelope.action.tool, null, authorization.auth_id ?? null, now,
+      );
+    }
+
+    // 4. Verify AuthorizationV1 (signature, issuer, audience, expiry, decision, structural)
+    const verification = verifyAuthorization(authorization, {
+      now,
+      mode: "strict",
+      trustedKeySets,
+      requireSignatureVerification: true,
+      expectedAudience: config.expectedAudience,
+    });
+
+    if (verification.status !== "ok") {
+      const reason = verification.violations.map((v) => v.code).join(",") || "AUTHORIZATION_INVALID";
+      return denyResult(
+        correlationId, reason, config,
+        envelope.action.tool, intentHash, authorization.auth_id ?? null, now,
+      );
+    }
+
+    // 5. Verify intent hash binding
+    if (authorization.intent_hash !== intentHash) {
+      return denyResult(
+        correlationId, "INTENT_HASH_MISMATCH", config,
+        envelope.action.tool, intentHash, authorization.auth_id, now,
+      );
+    }
+
+    // 6. Replay protection (last verification step before execution)
+    let consumed: boolean;
+    try {
+      consumed = await replayStore.consumeAuthId(authorization.auth_id, { expiry: authorization.expiry });
+    } catch {
+      return denyResult(
+        correlationId, "REPLAY_STORE_UNAVAILABLE", config,
+        envelope.action.tool, intentHash, authorization.auth_id, now,
+      );
+    }
+    if (!consumed) {
+      return denyResult(
+        correlationId, "AUTH_REPLAY", config,
+        envelope.action.tool, intentHash, authorization.auth_id, now,
+      );
+    }
+
+    // 7. Mode check — observe mode stops here
+    if (config.mode === "observe") {
+      const log: DecisionLog = {
+        correlation_id: correlationId,
+        action: envelope.action.tool,
+        expected_audience: config.expectedAudience,
+        auth_id: authorization.auth_id,
+        intent_hash: intentHash,
+        policy_id: POLICY_ID,
+        mode: "observe",
+        decision: "ALLOW",
+        reason: "OBSERVE_DRY_RUN",
+        executed: false,
+        frappe_ticket_id: null,
+        timestamp: new Date(now * 1000).toISOString(),
+      };
+      return {
+        status: 200,
+        body: {
+          ok: true,
+          decision: "ALLOW",
+          mode: "observe",
+          auth_id: authorization.auth_id,
+          intent_hash: intentHash,
+          policy_id: POLICY_ID,
+        },
+        log,
+      };
+    }
+
+    // 8. Enforce mode — call Frappe
+    try {
+      const result = await frappeAdapter.createTicket({
+        subject: envelope.action.params.subject,
+        description: envelope.action.params.description,
+        priority: envelope.action.params.priority,
+      });
+
+      const log: DecisionLog = {
+        correlation_id: correlationId,
+        action: envelope.action.tool,
+        expected_audience: config.expectedAudience,
+        auth_id: authorization.auth_id,
+        intent_hash: intentHash,
+        policy_id: POLICY_ID,
+        mode: "enforce",
+        decision: "ALLOW",
+        reason: "AUTHORIZED",
+        executed: true,
+        frappe_ticket_id: result.ticket_id,
+        timestamp: new Date(now * 1000).toISOString(),
+      };
+      return {
+        status: 200,
+        body: {
+          ok: true,
+          decision: "ALLOW",
+          mode: "enforce",
+          auth_id: authorization.auth_id,
+          intent_hash: intentHash,
+          policy_id: POLICY_ID,
+          frappe_ticket_id: result.ticket_id,
+        },
+        log,
+      };
+    } catch (err) {
+      const log: DecisionLog = {
+        correlation_id: correlationId,
+        action: envelope.action.tool,
+        expected_audience: config.expectedAudience,
+        auth_id: authorization.auth_id,
+        intent_hash: intentHash,
+        policy_id: POLICY_ID,
+        mode: "enforce",
+        decision: "DENY",
+        reason: "FRAPPE_UPSTREAM_ERROR",
+        executed: false,
+        frappe_ticket_id: null,
+        timestamp: new Date(now * 1000).toISOString(),
+      };
+      return {
+        status: 502,
+        body: { ok: false, decision: "DENY", mode: "enforce", reason: "FRAPPE_UPSTREAM_ERROR" },
+        log,
+      };
+    }
+  };
+}

--- a/examples/lgf-frappe-pep/src/frappe.ts
+++ b/examples/lgf-frappe-pep/src/frappe.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { FrappeAdapter, FrappeCreateTicketParams, FrappeCreateTicketResult } from "./types.js";
+
+export type FrappeHttpAdapterOptions = {
+  baseUrl: string;
+  apiKey: string;
+  apiSecret: string;
+};
+
+export function createFrappeHttpAdapter(options: FrappeHttpAdapterOptions): FrappeAdapter {
+  return {
+    async createTicket(params: FrappeCreateTicketParams): Promise<FrappeCreateTicketResult> {
+      const url = `${options.baseUrl}/api/resource/HD Ticket`;
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `token ${options.apiKey}:${options.apiSecret}`,
+        },
+        body: JSON.stringify({
+          data: {
+            subject: params.subject,
+            description: params.description,
+            priority: params.priority,
+          },
+        }),
+      });
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        throw new Error(`Frappe API error: ${response.status} ${text}`);
+      }
+
+      const result = await response.json() as { data?: { name?: string } };
+      const name = result?.data?.name;
+      if (typeof name !== "string") {
+        throw new Error("Frappe API returned unexpected response shape");
+      }
+
+      return { ticket_id: name, name };
+    },
+  };
+}

--- a/examples/lgf-frappe-pep/src/policy.ts
+++ b/examples/lgf-frappe-pep/src/policy.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+import { sha256HexFromJson } from "@oxdeai/core";
+import type { ActionEnvelope } from "./types.js";
+
+export const PROTECTED_ACTION = "frappe.helpdesk.create_ticket";
+
+const ALLOWED_PRIORITIES = new Set(["Low", "Medium"]);
+const DENIED_PRIORITIES = new Set(["Urgent"]);
+
+const POLICY_DESCRIPTOR = {
+  name: "lgf-frappe-helpdesk-poc-v1",
+  protected_action: PROTECTED_ACTION,
+  allowed_priorities: [...ALLOWED_PRIORITIES].sort(),
+  denied_priorities: [...DENIED_PRIORITIES].sort(),
+};
+
+export const POLICY_ID = sha256HexFromJson(POLICY_DESCRIPTOR);
+
+export type PolicyResult =
+  | { decision: "ALLOW"; reason: string }
+  | { decision: "DENY"; reason: string };
+
+export function evaluatePolicy(envelope: ActionEnvelope): PolicyResult {
+  if (envelope.action.tool !== PROTECTED_ACTION) {
+    return { decision: "DENY", reason: "UNSUPPORTED_ACTION" };
+  }
+
+  const priority = envelope.action.params.priority;
+
+  if (DENIED_PRIORITIES.has(priority)) {
+    return { decision: "DENY", reason: "POLICY_DENIED_PRIORITY" };
+  }
+
+  if (ALLOWED_PRIORITIES.has(priority)) {
+    return { decision: "ALLOW", reason: "POLICY_ALLOWED" };
+  }
+
+  return { decision: "DENY", reason: "UNKNOWN_PRIORITY" };
+}

--- a/examples/lgf-frappe-pep/src/server.ts
+++ b/examples/lgf-frappe-pep/src/server.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+import { createServer } from "node:http";
+import type { IncomingMessage, ServerResponse, Server } from "node:http";
+import { createInMemoryReplayStore } from "@oxdeai/guard";
+import type { ReplayStore } from "@oxdeai/guard";
+import { loadConfig, redactedConfigSummary } from "./config.js";
+import type { PepConfig } from "./config.js";
+import type { FrappeAdapter, DecisionLog } from "./types.js";
+import { handleAuthorize } from "./authorize.js";
+import { handleExecute } from "./execute.js";
+import { createFrappeHttpAdapter } from "./frappe.js";
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  const data = JSON.stringify(body);
+  res.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "content-length": Buffer.byteLength(data),
+  });
+  res.end(data);
+}
+
+const MAX_BODY_BYTES = 1_048_576; // 1 MiB
+
+async function readJson(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  for await (const chunk of req) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += buf.length;
+    if (totalBytes > MAX_BODY_BYTES) {
+      req.resume();
+      throw Object.assign(new Error("BODY_TOO_LARGE"), { statusCode: 413 });
+    }
+    chunks.push(buf);
+  }
+  const raw = Buffer.concat(chunks).toString("utf8");
+  return raw.trim() ? JSON.parse(raw) : {};
+}
+
+function emitDecisionLog(log: DecisionLog): void {
+  console.log(JSON.stringify(log));
+}
+
+export type PepServerOptions = {
+  config: PepConfig;
+  replayStore?: ReplayStore;
+  frappeAdapter?: FrappeAdapter;
+};
+
+export function createPepServer(options: PepServerOptions): Server {
+  const { config } = options;
+  const replayStore = options.replayStore ?? createInMemoryReplayStore();
+  const frappeAdapter =
+    options.frappeAdapter ??
+    createFrappeHttpAdapter({
+      baseUrl: config.frappeBaseUrl,
+      apiKey: config.frappeApiKey,
+      apiSecret: config.frappeApiSecret,
+    });
+
+  const authorize = handleAuthorize(config);
+  const execute = handleExecute(config, replayStore, frappeAdapter);
+
+  return createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    if (req.method === "GET" && req.url === "/healthz") {
+      return sendJson(res, 200, { ok: true, status: "healthy", mode: config.mode });
+    }
+
+    if (req.method === "POST" && req.url === "/authorize") {
+      try {
+        const body = await readJson(req);
+        const result = authorize(body);
+        emitDecisionLog(result.log);
+        return sendJson(res, result.status, result.body);
+      } catch (err) {
+        const status = (err as { statusCode?: number }).statusCode === 413 ? 413
+          : err instanceof SyntaxError ? 400 : 500;
+        const reason = status === 413 ? "BODY_TOO_LARGE"
+          : err instanceof SyntaxError ? "INVALID_JSON" : "INTERNAL_ERROR";
+        return sendJson(res, status, {
+          ok: false, decision: "DENY", mode: config.mode, reason,
+        });
+      }
+    }
+
+    if (req.method === "POST" && req.url === "/execute") {
+      try {
+        const body = await readJson(req);
+        const result = await execute(body);
+        emitDecisionLog(result.log);
+        return sendJson(res, result.status, result.body);
+      } catch (err) {
+        const status = (err as { statusCode?: number }).statusCode === 413 ? 413
+          : err instanceof SyntaxError ? 400 : 500;
+        const reason = status === 413 ? "BODY_TOO_LARGE"
+          : err instanceof SyntaxError ? "INVALID_JSON" : "INTERNAL_ERROR";
+        return sendJson(res, status, {
+          ok: false, decision: "DENY", mode: config.mode, reason,
+        });
+      }
+    }
+
+    return sendJson(res, 404, { ok: false, error: "not found" });
+  });
+}
+
+// Main entry point — only runs when executed directly
+const isMain = process.argv[1]?.endsWith("server.js") || process.argv[1]?.endsWith("server.ts");
+if (isMain) {
+  const config = loadConfig();
+  console.log("OxDeAI PEP starting", JSON.stringify(redactedConfigSummary(config)));
+  const server = createPepServer({ config });
+  server.listen(config.port, () => {
+    console.log(`OxDeAI PEP listening on :${config.port} [mode=${config.mode}]`);
+  });
+}

--- a/examples/lgf-frappe-pep/src/types.ts
+++ b/examples/lgf-frappe-pep/src/types.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { AuthorizationV1 } from "@oxdeai/core";
+
+export type ActionEnvelope = {
+  source_bench: string;
+  target_bench: string;
+  agent_or_tool_context: string;
+  user_identity: string;
+  session_id: string;
+  action: {
+    type: "EXECUTE";
+    tool: string;
+    params: {
+      subject: string;
+      description: string;
+      priority: string;
+      [key: string]: unknown;
+    };
+  };
+};
+
+export type AuthorizeRequest = ActionEnvelope;
+
+export type ExecuteRequest = {
+  envelope: ActionEnvelope;
+  authorization: AuthorizationV1;
+};
+
+export type PepResponse =
+  | {
+      ok: true;
+      decision: "ALLOW";
+      mode: "enforce" | "observe";
+      auth_id: string;
+      intent_hash: string;
+      policy_id: string;
+      authorization?: AuthorizationV1;
+      frappe_ticket_id?: string;
+    }
+  | {
+      ok: false;
+      decision: "DENY";
+      mode: "enforce" | "observe";
+      reason: string;
+    };
+
+export type FrappeCreateTicketParams = {
+  subject: string;
+  description: string;
+  priority: string;
+};
+
+export type FrappeCreateTicketResult = {
+  ticket_id: string;
+  name: string;
+};
+
+export interface FrappeAdapter {
+  createTicket(params: FrappeCreateTicketParams): Promise<FrappeCreateTicketResult>;
+}
+
+export type DecisionLog = {
+  correlation_id: string;
+  action: string;
+  expected_audience: string;
+  auth_id: string | null;
+  intent_hash: string | null;
+  policy_id: string;
+  mode: "enforce" | "observe";
+  decision: "ALLOW" | "DENY";
+  reason: string;
+  executed: boolean;
+  frappe_ticket_id: string | null;
+  timestamp: string;
+};

--- a/examples/lgf-frappe-pep/test/boundary.test.ts
+++ b/examples/lgf-frappe-pep/test/boundary.test.ts
@@ -1,0 +1,517 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Boundary test matrix — 11 adversarial scenarios.
+ *
+ * Invariant under test: No valid AuthorizationV1 → no execution.
+ *
+ * Every DENY scenario asserts:
+ *   - HTTP 403 from the enforcement boundary
+ *   - Frappe adapter never called
+ *
+ * Test matrix:
+ *   1.  ALLOW (enforce, Low)       — happy path, Frappe called
+ *   2.  ALLOW (enforce, Medium)    — second allowed priority, Frappe called
+ *   3.  ALLOW (observe)            — would-ALLOW, Frappe NOT called
+ *   4.  DENY (policy, Urgent)      — policy-denied priority
+ *   5.  DENY (missing auth)        — no authorization on /execute
+ *   6.  DENY (invalid signature)   — tampered signature
+ *   7.  DENY (expired)             — expired authorization
+ *   8.  DENY (replay)              — auth_id reused
+ *   9.  DENY (wrong audience)      — audience mismatch
+ *   10. DENY (modified payload)    — intent hash mismatch
+ *   11. DENY (unsupported action)  — wrong tool name
+ */
+
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync, randomUUID } from "node:crypto";
+import type { KeyObject } from "node:crypto";
+import { sha256HexFromJson, signAuthorizationEd25519 } from "@oxdeai/core";
+import type { AuthorizationV1 } from "@oxdeai/core";
+import { createInMemoryReplayStore } from "@oxdeai/guard";
+import type { PepConfig } from "../src/config.js";
+import type { FrappeAdapter, FrappeCreateTicketParams, ActionEnvelope } from "../src/types.js";
+import { createPepServer } from "../src/server.js";
+import { POLICY_ID } from "../src/policy.js";
+
+// ─── Test infrastructure ────────────────────────────────────────────────────
+
+type TestHarness = {
+  baseUrl: string;
+  config: PepConfig;
+  frappeCallCount: () => number;
+  frappeLastCall: () => FrappeCreateTicketParams | null;
+  resetFrappe: () => void;
+  privateKeyPem: string;
+  close: () => Promise<void>;
+};
+
+function makeEnvelope(overrides?: {
+  tool?: string;
+  priority?: string;
+  subject?: string;
+}): ActionEnvelope {
+  return {
+    source_bench: "openwebui-dev",
+    target_bench: "frappe",
+    agent_or_tool_context: "erp-assistant",
+    user_identity: "user@example.com",
+    session_id: "test-session",
+    action: {
+      type: "EXECUTE",
+      tool: overrides?.tool ?? "frappe.helpdesk.create_ticket",
+      params: {
+        subject: overrides?.subject ?? "Test ticket",
+        description: "Created by boundary test",
+        priority: overrides?.priority ?? "Low",
+      },
+    },
+  };
+}
+
+async function startHarness(modeOverride?: "enforce" | "observe"): Promise<TestHarness> {
+  const keyPair = generateKeyPairSync("ed25519");
+  const privateKeyPem = keyPair.privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+  const publicKeyPem = keyPair.publicKey.export({ type: "spki", format: "pem" }) as string;
+
+  let callCount = 0;
+  let lastCall: FrappeCreateTicketParams | null = null;
+
+  const mockFrappe: FrappeAdapter = {
+    async createTicket(params) {
+      callCount++;
+      lastCall = params;
+      return { ticket_id: `HD-TICKET-${callCount}`, name: `HD-TICKET-${callCount}` };
+    },
+  };
+
+  const config: PepConfig = {
+    mode: modeOverride ?? "enforce",
+    expectedAudience: "PEP-frappe.lgf.oxdeai.dev",
+    frappeBaseUrl: "https://frappe.lgf.oxdeai.dev",
+    frappeApiKey: "test-key",
+    frappeApiSecret: "test-secret",
+    replayStore: "memory",
+    port: 0,
+    signingPrivateKey: keyPair.privateKey,
+    signingPublicKeyPem: publicKeyPem,
+    signingKid: "test-key-1",
+    issuer: "oxdeai.lgf-frappe-pep",
+    authorizationTtlSeconds: 60,
+  };
+
+  const server = createPepServer({
+    config,
+    replayStore: createInMemoryReplayStore(),
+    frappeAdapter: mockFrappe,
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const addr = server.address();
+  if (!addr || typeof addr === "string") throw new Error("Unexpected server address");
+
+  return {
+    baseUrl: `http://127.0.0.1:${addr.port}`,
+    config,
+    frappeCallCount: () => callCount,
+    frappeLastCall: () => lastCall,
+    resetFrappe: () => { callCount = 0; lastCall = null; },
+    privateKeyPem,
+    close: () => {
+      server.closeAllConnections();
+      return new Promise((res, rej) => server.close((e) => (e ? rej(e) : res())));
+    },
+  };
+}
+
+async function postJson(url: string, body: unknown): Promise<{ status: number; body: unknown }> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: await res.json() };
+}
+
+function issueAuthorization(
+  envelope: ActionEnvelope,
+  privateKeyPem: string,
+  overrides?: Partial<{
+    audience: string;
+    expiry: number;
+    issued_at: number;
+    intent_hash: string;
+    kid: string;
+    issuer: string;
+  }>,
+): AuthorizationV1 {
+  const now = Math.floor(Date.now() / 1000);
+  const intentHash = overrides?.intent_hash ?? sha256HexFromJson(envelope.action);
+  const stateHash = sha256HexFromJson({});
+
+  return signAuthorizationEd25519(
+    {
+      auth_id: randomUUID(),
+      issuer: overrides?.issuer ?? "oxdeai.lgf-frappe-pep",
+      audience: overrides?.audience ?? "PEP-frappe.lgf.oxdeai.dev",
+      intent_hash: intentHash,
+      state_hash: stateHash,
+      policy_id: POLICY_ID,
+      decision: "ALLOW",
+      issued_at: overrides?.issued_at ?? now,
+      expiry: overrides?.expiry ?? now + 60,
+      kid: overrides?.kid ?? "test-key-1",
+      nonce: randomUUID(),
+    },
+    privateKeyPem,
+  );
+}
+
+// ─── Test suite ──────────────────────────────────────────────────────────────
+
+describe("LGF Frappe PEP boundary", () => {
+  let h: TestHarness;
+
+  before(async () => {
+    h = await startHarness("enforce");
+  });
+
+  after(async () => {
+    await h.close();
+  });
+
+  // ── 1. ALLOW (enforce, Low) ────────────────────────────────────────────────
+
+  test("ALLOW: valid authorization in enforce mode creates ticket (priority=Low)", async () => {
+    h.resetFrappe();
+    const envelope = makeEnvelope({ priority: "Low" });
+    const authorization = issueAuthorization(envelope, h.privateKeyPem);
+
+    const result = await postJson(`${h.baseUrl}/execute`, { envelope, authorization });
+    assert.equal(result.status, 200, `Expected 200, got ${result.status}`);
+
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body["ok"], true);
+    assert.equal(body["decision"], "ALLOW");
+    assert.equal(body["mode"], "enforce");
+    assert.equal(typeof body["frappe_ticket_id"], "string");
+    assert.equal(h.frappeCallCount(), 1, "Frappe adapter must be called exactly once");
+  });
+
+  // ── 2. ALLOW (enforce, Medium) ─────────────────────────────────────────────
+
+  test("ALLOW: valid authorization in enforce mode creates ticket (priority=Medium)", async () => {
+    h.resetFrappe();
+    const envelope = makeEnvelope({ priority: "Medium" });
+    const authorization = issueAuthorization(envelope, h.privateKeyPem);
+
+    const result = await postJson(`${h.baseUrl}/execute`, { envelope, authorization });
+    assert.equal(result.status, 200, `Expected 200, got ${result.status}`);
+
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body["ok"], true);
+    assert.equal(body["decision"], "ALLOW");
+    assert.equal(h.frappeCallCount(), 1, "Frappe adapter must be called exactly once");
+  });
+
+  // ── 3. DENY: policy-denied priority ────────────────────────────────────────
+
+  test("DENY: policy-denied priority (Urgent) returns no AuthorizationV1", async () => {
+    h.resetFrappe();
+    const envelope = makeEnvelope({ priority: "Urgent" });
+
+    const result = await postJson(`${h.baseUrl}/authorize`, envelope);
+    assert.equal(result.status, 403, `Expected 403, got ${result.status}`);
+
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body["ok"], false);
+    assert.equal(body["decision"], "DENY");
+    assert.equal(body["reason"], "POLICY_DENIED_PRIORITY");
+    assert.equal(body["authorization"], undefined, "No authorization artifact on DENY");
+    assert.equal(h.frappeCallCount(), 0, "Frappe must not be called on policy DENY");
+  });
+
+  // ── 4. DENY: missing authorization ─────────────────────────────────────────
+
+  test("DENY: missing authorization on /execute", async () => {
+    h.resetFrappe();
+    const envelope = makeEnvelope();
+
+    const result = await postJson(`${h.baseUrl}/execute`, { envelope });
+    assert.equal(result.status, 403, `Expected 403, got ${result.status}`);
+
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body["ok"], false);
+    assert.equal(body["decision"], "DENY");
+    assert.equal(h.frappeCallCount(), 0, "Frappe must not be called without authorization");
+  });
+
+  // ── 5. DENY: invalid signature ─────────────────────────────────────────────
+
+  test("DENY: tampered signature is rejected", async () => {
+    h.resetFrappe();
+    const envelope = makeEnvelope();
+    const authorization = issueAuthorization(envelope, h.privateKeyPem);
+
+    const tampered: AuthorizationV1 = {
+      ...authorization,
+      signature: "AAAA" + (typeof authorization.signature === "string"
+        ? authorization.signature.slice(4)
+        : "invalid"),
+    };
+
+    const result = await postJson(`${h.baseUrl}/execute`, { envelope, authorization: tampered });
+    assert.equal(result.status, 403, `Expected 403, got ${result.status}`);
+
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body["ok"], false);
+    assert.equal(body["decision"], "DENY");
+    assert.equal(h.frappeCallCount(), 0, "Frappe must not be called with invalid signature");
+  });
+
+  // ── 6. DENY: expired authorization ─────────────────────────────────────────
+
+  test("DENY: expired authorization is rejected", async () => {
+    h.resetFrappe();
+    const envelope = makeEnvelope();
+    const pastNow = Math.floor(Date.now() / 1000) - 120;
+    const authorization = issueAuthorization(envelope, h.privateKeyPem, {
+      issued_at: pastNow,
+      expiry: pastNow + 30,
+    });
+
+    const result = await postJson(`${h.baseUrl}/execute`, { envelope, authorization });
+    assert.equal(result.status, 403, `Expected 403, got ${result.status}`);
+
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body["ok"], false);
+    assert.equal(body["decision"], "DENY");
+    assert.equal(h.frappeCallCount(), 0, "Frappe must not be called with expired authorization");
+  });
+
+  // ── 7. DENY: replayed authorization ────────────────────────────────────────
+
+  test("DENY: replayed authorization is rejected on second use", async () => {
+    h.resetFrappe();
+    const envelope = makeEnvelope({ subject: "replay-test" });
+    const authorization = issueAuthorization(envelope, h.privateKeyPem);
+
+    const first = await postJson(`${h.baseUrl}/execute`, { envelope, authorization });
+    assert.equal(first.status, 200, `First use must succeed — got ${first.status}`);
+    assert.equal(h.frappeCallCount(), 1, "First use must call Frappe");
+
+    h.resetFrappe();
+    const second = await postJson(`${h.baseUrl}/execute`, { envelope, authorization });
+    assert.equal(second.status, 403, `Replay must return 403 — got ${second.status}`);
+
+    const body = second.body as Record<string, unknown>;
+    assert.equal(body["ok"], false);
+    assert.equal(body["decision"], "DENY");
+    assert.match(body["reason"] as string, /REPLAY/);
+    assert.equal(h.frappeCallCount(), 0, "Frappe must not be called on replay");
+  });
+
+  // ── 8. DENY: wrong audience ────────────────────────────────────────────────
+
+  test("DENY: wrong audience is rejected", async () => {
+    h.resetFrappe();
+    const envelope = makeEnvelope();
+    const authorization = issueAuthorization(envelope, h.privateKeyPem, {
+      audience: "PEP-wrong-audience",
+    });
+
+    const result = await postJson(`${h.baseUrl}/execute`, { envelope, authorization });
+    assert.equal(result.status, 403, `Expected 403, got ${result.status}`);
+
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body["ok"], false);
+    assert.equal(body["decision"], "DENY");
+    assert.equal(h.frappeCallCount(), 0, "Frappe must not be called with wrong audience");
+  });
+
+  // ── 9. DENY: modified payload (intent hash mismatch) ──────────────────────
+
+  test("DENY: modified payload after authorization is rejected", async () => {
+    h.resetFrappe();
+    const envelope = makeEnvelope({ priority: "Low" });
+    const authorization = issueAuthorization(envelope, h.privateKeyPem);
+
+    const tampered = makeEnvelope({ priority: "Low", subject: "Tampered subject" });
+
+    const result = await postJson(`${h.baseUrl}/execute`, {
+      envelope: tampered,
+      authorization,
+    });
+    assert.equal(result.status, 403, `Expected 403, got ${result.status}`);
+
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body["ok"], false);
+    assert.equal(body["decision"], "DENY");
+    assert.equal(h.frappeCallCount(), 0, "Frappe must not be called with tampered payload");
+  });
+
+  // ── 10. DENY: unsupported protected action ─────────────────────────────────
+
+  test("DENY: unsupported action name is rejected", async () => {
+    h.resetFrappe();
+    const envelope = makeEnvelope({ tool: "frappe.helpdesk.delete_ticket" });
+    const authorization = issueAuthorization(envelope, h.privateKeyPem);
+
+    const result = await postJson(`${h.baseUrl}/execute`, { envelope, authorization });
+    assert.equal(result.status, 403, `Expected 403, got ${result.status}`);
+
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body["ok"], false);
+    assert.equal(body["decision"], "DENY");
+    assert.equal(body["reason"], "UNSUPPORTED_ACTION");
+    assert.equal(h.frappeCallCount(), 0, "Frappe must not be called for unsupported action");
+  });
+
+  // ── 11. /authorize emits AuthorizationV1 for allowed action ────────────────
+
+  test("ALLOW: /authorize emits AuthorizationV1 for allowed action (Low)", async () => {
+    const envelope = makeEnvelope({ priority: "Low" });
+    const result = await postJson(`${h.baseUrl}/authorize`, envelope);
+    assert.equal(result.status, 200, `Expected 200, got ${result.status}`);
+
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body["ok"], true);
+    assert.equal(body["decision"], "ALLOW");
+    assert.notEqual(body["authorization"], undefined, "Must include authorization artifact");
+
+    const auth = body["authorization"] as AuthorizationV1;
+    assert.equal(auth.decision, "ALLOW");
+    assert.equal(auth.audience, "PEP-frappe.lgf.oxdeai.dev");
+    assert.equal(auth.alg, "Ed25519");
+    assert.equal(typeof auth.signature, "string");
+    assert.equal(typeof auth.intent_hash, "string");
+  });
+
+  // ── 12. /healthz returns healthy ───────────────────────────────────────────
+
+  test("healthz returns healthy status", async () => {
+    const res = await fetch(`${h.baseUrl}/healthz`);
+    assert.equal(res.status, 200);
+    const body = await res.json() as Record<string, unknown>;
+    assert.equal(body["ok"], true);
+    assert.equal(body["status"], "healthy");
+    assert.equal(body["mode"], "enforce");
+  });
+
+  // ── 13. DENY: oversized request body ──────────────────────────────────────
+
+  test("DENY: oversized request body is rejected", async () => {
+    h.resetFrappe();
+    const oversized = JSON.stringify({ junk: "x".repeat(2 * 1024 * 1024) });
+    const res = await fetch(`${h.baseUrl}/execute`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: oversized,
+    });
+    assert.equal(res.status, 413, `Expected 413, got ${res.status}`);
+    const body = await res.json() as Record<string, unknown>;
+    assert.equal(body["ok"], false);
+    assert.equal(body["decision"], "DENY");
+    assert.equal(body["reason"], "BODY_TOO_LARGE");
+    assert.equal(h.frappeCallCount(), 0, "Frappe must not be called on oversized body");
+  });
+});
+
+// ─── Observe mode suite ──────────────────────────────────────────────────────
+
+describe("LGF Frappe PEP observe mode", () => {
+  let h: TestHarness;
+
+  before(async () => {
+    h = await startHarness("observe");
+  });
+
+  after(async () => {
+    await h.close();
+  });
+
+  test("OBSERVE: valid authorization returns would-ALLOW without calling Frappe", async () => {
+    h.resetFrappe();
+    const envelope = makeEnvelope({ priority: "Low" });
+    const authorization = issueAuthorization(envelope, h.privateKeyPem);
+
+    const result = await postJson(`${h.baseUrl}/execute`, { envelope, authorization });
+    assert.equal(result.status, 200, `Expected 200, got ${result.status}`);
+
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body["ok"], true);
+    assert.equal(body["decision"], "ALLOW");
+    assert.equal(body["mode"], "observe");
+    assert.equal(body["frappe_ticket_id"], undefined, "Observe mode must not produce ticket");
+    assert.equal(h.frappeCallCount(), 0, "Frappe must NOT be called in observe mode");
+  });
+
+  test("OBSERVE: /authorize returns would-ALLOW with authorization artifact", async () => {
+    const envelope = makeEnvelope({ priority: "Medium" });
+    const result = await postJson(`${h.baseUrl}/authorize`, envelope);
+    assert.equal(result.status, 200);
+
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body["ok"], true);
+    assert.equal(body["decision"], "ALLOW");
+    assert.equal(body["mode"], "observe");
+    assert.notEqual(body["authorization"], undefined);
+  });
+
+  test("OBSERVE: /authorize returns would-DENY for Urgent priority", async () => {
+    const envelope = makeEnvelope({ priority: "Urgent" });
+    const result = await postJson(`${h.baseUrl}/authorize`, envelope);
+    assert.equal(result.status, 403);
+
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body["ok"], false);
+    assert.equal(body["decision"], "DENY");
+    assert.equal(body["mode"], "observe");
+  });
+
+  test("OBSERVE: expired authorization on /execute returns DENY without calling Frappe", async () => {
+    h.resetFrappe();
+    const envelope = makeEnvelope({ priority: "Low" });
+    const pastNow = Math.floor(Date.now() / 1000) - 120;
+    const authorization = issueAuthorization(envelope, h.privateKeyPem, {
+      issued_at: pastNow,
+      expiry: pastNow + 30,
+    });
+
+    const result = await postJson(`${h.baseUrl}/execute`, { envelope, authorization });
+    assert.equal(result.status, 403, `Expected 403, got ${result.status}`);
+
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body["ok"], false);
+    assert.equal(body["decision"], "DENY");
+    assert.equal(body["mode"], "observe");
+    assert.equal(h.frappeCallCount(), 0, "Frappe must NOT be called on observe-mode DENY");
+  });
+
+  test("OBSERVE: wrong audience on /execute returns DENY without calling Frappe", async () => {
+    h.resetFrappe();
+    const envelope = makeEnvelope();
+    const authorization = issueAuthorization(envelope, h.privateKeyPem, {
+      audience: "PEP-wrong-audience",
+    });
+
+    const result = await postJson(`${h.baseUrl}/execute`, { envelope, authorization });
+    assert.equal(result.status, 403, `Expected 403, got ${result.status}`);
+
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body["ok"], false);
+    assert.equal(body["decision"], "DENY");
+    assert.equal(body["mode"], "observe");
+    assert.equal(h.frappeCallCount(), 0, "Frappe must NOT be called on observe-mode audience mismatch");
+  });
+
+  test("OBSERVE: healthz shows observe mode", async () => {
+    const res = await fetch(`${h.baseUrl}/healthz`);
+    const body = await res.json() as Record<string, unknown>;
+    assert.equal(body["mode"], "observe");
+  });
+});

--- a/examples/lgf-frappe-pep/tsconfig.json
+++ b/examples/lgf-frappe-pep/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src", "test"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,22 @@ importers:
         specifier: ^5.0.0
         version: 5.9.3
 
+  examples/lgf-frappe-pep:
+    dependencies:
+      '@oxdeai/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@oxdeai/guard':
+        specifier: workspace:*
+        version: link:../../packages/guard
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
   examples/non-bypassable-demo: {}
 
   examples/non-bypassable-openclaw:


### PR DESCRIPTION
## Summary

Adds a minimal OxDeAI PEP runtime for the LGF-managed Frappe Helpdesk PoC defined in #141 and documented by #142.

The PoC protects one action:

`frappe.helpdesk.create_ticket`

Core invariant:

`No valid authorization -> no execution path.`

## Implemented

- `GET /healthz`
- `POST /authorize`
- `POST /execute`
- AuthorizationV1 issuance for allowed actions
- AuthorizationV1 verification before execution
- expected audience validation
- expiry validation
- replay protection
- intent hash binding
- observe / enforce mode
- dry-run-only observe mode
- Frappe Helpdesk adapter
- runtime-only Frappe credentials
- structured ALLOW / DENY logs
- Dockerfile
- `.env.example`
- boundary tests

## Security hardening

The implementation was reviewed as an execution-boundary PoC and patched for:

- request body size cap: 1 MiB
- fail-closed TTL and port validation
- correct DENY logging on Frappe upstream errors
- observe-mode DENY coverage
- Docker build-context documentation

Verified:

- no path calls Frappe before verification completes
- no observe-mode path calls Frappe
- no DENY path calls Frappe
- malformed JSON returns DENY
- oversized body returns 413 DENY
- no secrets in logs, Dockerfile, tests, `.env.example`, or fixtures

## Test results

- `@oxdeai/example-lgf-frappe-pep`: 19/19 passing
- `@oxdeai/core`: 177/177 passing
- `@oxdeai/guard`: 145/145 passing

Total:

`341/341 passing`

## Security gate

Security gate result:

`Decision: ALLOW`

Remaining finding:

- 1 pre-existing low-severity `esbuild` advisory
- 0 blocking findings

## Limitations

This is a PoC, not production-ready.

Known limitations:

- in-memory replay store
- combined PDP/PEP container
- static empty state hash
- no GHCR publishing yet
- Frappe adapter tested with mock only
- no live LGF/Frappe validation yet
- no rate limiting beyond body-size cap
- logs go to stdout only

## Follow-ups

Recommended follow-up issues:

- live LGF/Frappe validation
- GHCR publishing workflow
- Redis replay store
- Docker-based e2e test
- request rate limiting
- structured logging sink

## Non-goals

- no protocol changes
- no LGF semantic changes
- no production-readiness claim
- no full Frappe / ERPNext protection
- no full live-state Profile C verification

Related: #141, #142