### PR TITLE
Fix: harden Frappe PEP Docker runtime and upstream diagnostics

### DIFF
--- a/examples/lgf-frappe-pep/Dockerfile
+++ b/examples/lgf-frappe-pep/Dockerfile
@@ -36,8 +36,10 @@ RUN corepack enable && corepack prepare pnpm@9.12.2 --activate
 WORKDIR /app
 
 COPY --from=build /app/pnpm-lock.yaml /app/pnpm-workspace.yaml /app/package.json ./
-COPY --from=build /app/packages/core/package.json /app/packages/core/dist/ packages/core/
-COPY --from=build /app/packages/guard/package.json /app/packages/guard/dist/ packages/guard/
+COPY --from=build /app/packages/core/package.json packages/core/package.json
+COPY --from=build /app/packages/core/dist/ packages/core/dist/
+COPY --from=build /app/packages/guard/package.json packages/guard/package.json
+COPY --from=build /app/packages/guard/dist/ packages/guard/dist/
 COPY --from=build /app/examples/lgf-frappe-pep/package.json examples/lgf-frappe-pep/
 COPY --from=build /app/examples/lgf-frappe-pep/dist/ examples/lgf-frappe-pep/dist/
 COPY --from=build /app/node_modules/ node_modules/

--- a/examples/lgf-frappe-pep/LIVE_VALIDATION.md
+++ b/examples/lgf-frappe-pep/LIVE_VALIDATION.md
@@ -1,4 +1,4 @@
-# Live Validation Guide — LGF Frappe Helpdesk PEP
+# Live Validation Guide - LGF Frappe Helpdesk PEP
 
 Protected action: `frappe.helpdesk.create_ticket`
 
@@ -52,10 +52,10 @@ cp examples/lgf-frappe-pep/.env.live.example /tmp/.env.pep.live
 
 Edit `/tmp/.env.pep.live` and fill in:
 
-- `FRAPPE_API_KEY` — your real Frappe API key
-- `FRAPPE_API_SECRET` — your real Frappe API secret
+- `FRAPPE_API_KEY` - your real Frappe API key
+- `FRAPPE_API_SECRET` - your real Frappe API secret
 
-Remove the `SIGNING_PRIVATE_KEY_PEM` line from the env file — the signing key
+Remove the `SIGNING_PRIVATE_KEY_PEM` line from the env file - the signing key
 will be passed separately via `docker run -e` to preserve real newlines.
 
 **Never commit `/tmp/.env.pep.live` or any file containing real credentials.**
@@ -110,7 +110,7 @@ echo "$AUTH_RESPONSE" | jq '{ ok, decision, mode, auth_id, intent_hash, policy_i
 
 Expected: `decision: "ALLOW"`, `authorization` present in full response.
 
-Confirm no ticket was created — `/authorize` never calls Frappe.
+Confirm no ticket was created - `/authorize` never calls Frappe.
 
 ## 7. Execute with valid authorization
 
@@ -146,7 +146,7 @@ Expected: `decision: "ALLOW"`, `frappe_ticket_id` present (e.g., `"HD-TICKET-000
 
 **This is the only step that creates a Frappe ticket.**
 
-## 8. DENY — policy-denied priority (Urgent)
+## 8. DENY - policy-denied priority (Urgent)
 
 ```bash
 curl -s -X POST http://localhost:3000/authorize \
@@ -171,7 +171,7 @@ curl -s -X POST http://localhost:3000/authorize \
 
 Expected: HTTP 403, `decision: "DENY"`, `reason: "POLICY_DENIED_PRIORITY"`, no `authorization`.
 
-## 9. DENY — missing authorization
+## 9. DENY - missing authorization
 
 ```bash
 curl -s -X POST http://localhost:3000/execute \
@@ -198,7 +198,7 @@ curl -s -X POST http://localhost:3000/execute \
 
 Expected: HTTP 403, `decision: "DENY"`, `reason: "INVALID_REQUEST"`.
 
-## 10. DENY — replayed authorization
+## 10. DENY - replayed authorization
 
 Re-run the exact same `/execute` call from step 7 (same `$AUTHORIZATION`):
 
@@ -212,7 +212,7 @@ curl -s -X POST http://localhost:3000/execute \
 
 Expected: HTTP 403, `reason` contains `AUTH_REPLAY`.
 
-## 11. DENY — modified payload (intent hash mismatch)
+## 11. DENY - modified payload (intent hash mismatch)
 
 Get a fresh authorization, then modify the envelope before executing:
 
@@ -357,7 +357,7 @@ Safe to include:
 | `/authorize` summary | `{ "ok": true, "decision": "ALLOW", "auth_id": "...", "policy_id": "..." }` |
 | `/execute` summary | `{ "ok": true, "decision": "ALLOW", "frappe_ticket_id": "HD-TICKET-00001" }` |
 | DENY responses (full body) | `{ "ok": false, "decision": "DENY", "reason": "..." }` |
-| Container startup log | Redacted config — credentials shown as `***` |
+| Container startup log | Redacted config - credentials shown as `***` |
 | Decision log lines | No secrets by design |
 | Frappe ticket name/count | Ticket name is not a secret |
 | Final ticket count | Just a number |

--- a/examples/lgf-frappe-pep/src/execute.ts
+++ b/examples/lgf-frappe-pep/src/execute.ts
@@ -229,6 +229,7 @@ export function handleExecute(
         log,
       };
     } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
       const log: DecisionLog = {
         correlation_id: correlationId,
         action: envelope.action.tool,
@@ -238,7 +239,7 @@ export function handleExecute(
         policy_id: POLICY_ID,
         mode: "enforce",
         decision: "DENY",
-        reason: "FRAPPE_UPSTREAM_ERROR",
+        reason: `FRAPPE_UPSTREAM_ERROR: ${detail.slice(0, 300)}`,
         executed: false,
         frappe_ticket_id: null,
         timestamp: new Date(now * 1000).toISOString(),

--- a/examples/lgf-frappe-pep/src/frappe.ts
+++ b/examples/lgf-frappe-pep/src/frappe.ts
@@ -8,9 +8,11 @@ export type FrappeHttpAdapterOptions = {
 };
 
 export function createFrappeHttpAdapter(options: FrappeHttpAdapterOptions): FrappeAdapter {
+  const doctype = encodeURIComponent("HD Ticket");
+
   return {
     async createTicket(params: FrappeCreateTicketParams): Promise<FrappeCreateTicketResult> {
-      const url = `${options.baseUrl}/api/resource/HD Ticket`;
+      const url = `${options.baseUrl}/api/resource/${doctype}`;
       const response = await fetch(url, {
         method: "POST",
         headers: {
@@ -28,13 +30,20 @@ export function createFrappeHttpAdapter(options: FrappeHttpAdapterOptions): Frap
 
       if (!response.ok) {
         const text = await response.text().catch(() => "");
-        throw new Error(`Frappe API error: ${response.status} ${text}`);
+        throw new Error(`Frappe API error: status=${response.status} body=${text.slice(0, 200)}`);
       }
 
-      const result = await response.json() as { data?: { name?: string } };
-      const name = result?.data?.name;
+      const contentType = response.headers.get("content-type") ?? "";
+      if (!contentType.includes("application/json")) {
+        throw new Error(`Frappe API returned non-JSON content-type=${contentType} status=${response.status}`);
+      }
+
+      const result = await response.json() as Record<string, unknown>;
+      const data = result["data"] as Record<string, unknown> | undefined;
+      const name = data?.["name"];
       if (typeof name !== "string") {
-        throw new Error("Frappe API returned unexpected response shape");
+        const keys = Object.keys(result).join(",");
+        throw new Error(`Frappe API unexpected response shape: top-level keys=[${keys}]`);
       }
 
       return { ticket_id: name, name };

--- a/examples/lgf-frappe-pep/test/boundary.test.ts
+++ b/examples/lgf-frappe-pep/test/boundary.test.ts
@@ -515,3 +515,81 @@ describe("LGF Frappe PEP observe mode", () => {
     assert.equal(body["mode"], "observe");
   });
 });
+
+// ─── Frappe upstream error diagnostic suite ──────────────────────────────────
+
+describe("LGF Frappe PEP upstream error handling", () => {
+  let baseUrl: string;
+  let privateKeyPem: string;
+  let close: () => Promise<void>;
+
+  before(async () => {
+    const keyPair = generateKeyPairSync("ed25519");
+    privateKeyPem = keyPair.privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+    const publicKeyPem = keyPair.publicKey.export({ type: "spki", format: "pem" }) as string;
+
+    const failingFrappe: FrappeAdapter = {
+      async createTicket() {
+        throw new Error("Frappe API returned non-JSON content-type=text/html status=200");
+      },
+    };
+
+    const config: PepConfig = {
+      mode: "enforce",
+      expectedAudience: "PEP-frappe.lgf.oxdeai.dev",
+      frappeBaseUrl: "https://frappe.lgf.oxdeai.dev",
+      frappeApiKey: "test-key",
+      frappeApiSecret: "test-secret",
+      replayStore: "memory",
+      port: 0,
+      signingPrivateKey: keyPair.privateKey,
+      signingPublicKeyPem: publicKeyPem,
+      signingKid: "test-key-1",
+      issuer: "oxdeai.lgf-frappe-pep",
+      authorizationTtlSeconds: 60,
+    };
+
+    const server = createPepServer({
+      config,
+      replayStore: createInMemoryReplayStore(),
+      frappeAdapter: failingFrappe,
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("Unexpected address");
+
+    baseUrl = `http://127.0.0.1:${(addr as { port: number }).port}`;
+    close = () => {
+      server.closeAllConnections();
+      return new Promise((res, rej) => server.close((e) => (e ? rej(e) : res())));
+    };
+  });
+
+  after(async () => {
+    await close();
+  });
+
+  test("upstream error returns 502 DENY with FRAPPE_UPSTREAM_ERROR and does not leak error detail to caller", async () => {
+    const envelope = makeEnvelope({ priority: "Low" });
+    const authorization = issueAuthorization(envelope, privateKeyPem);
+
+    const result = await postJson(`${baseUrl}/execute`, { envelope, authorization });
+    assert.equal(result.status, 502, `Expected 502, got ${result.status}`);
+
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body["ok"], false);
+    assert.equal(body["decision"], "DENY");
+    assert.equal(body["reason"], "FRAPPE_UPSTREAM_ERROR");
+    // The HTTP response must NOT contain the internal error detail
+    assert.equal(
+      (body["reason"] as string).includes("content-type"),
+      false,
+      "Internal error detail must not leak to caller",
+    );
+  });
+});


### PR DESCRIPTION
Fixes live-validation blockers found while testing the OxDeAI PEP container against the LGF-managed Frappe Helpdesk bench.

### Changes:
- preserve workspace dist folders correctly in the Docker runtime image
- URL-encode the Frappe HD Ticket DocType path
- add content-type guard before parsing Frappe responses as JSON
- improve safe upstream diagnostics in decision logs
- keep HTTP caller response generic as FRAPPE_UPSTREAM_ERROR
- add upstream error handling coverage
- update live validation notes

### Security posture:
- no secrets added
- no Frappe credentials added
- no signing keys added
- no raw AuthorizationV1 artifacts added
- no protocol semantics changed
- no PEP enforcement weakened
- upstream failures still fail closed

### Validation:
- @oxdeai/example-lgf-frappe-pep: 20/20 passing
- @oxdeai/core: 177/177 passing
- @oxdeai/guard: 145/145 passing
- total: 342/342 passing
- security gate: ALLOW
- blocking findings: 0
- remaining finding: pre-existing low esbuild advisory

### Context:
During live validation, /authorize succeeded but /execute returned DENY with FRAPPE_UPSTREAM_ERROR. The new diagnostics make the Frappe-side failure class visible in logs without exposing credentials or internal artifacts.

### Related: 
#141 #142 #143 #144