### PR TITLE
feat: add pluggable replay persistence for PEP sidecar

### DIFF
--- a/examples/lgf-frappe-pep/LGF_DEPLOYMENT.md
+++ b/examples/lgf-frappe-pep/LGF_DEPLOYMENT.md
@@ -213,20 +213,60 @@ Replay protection prevents a consumed AuthorizationV1 from being used a second t
 |---------|-------|-------------|---------------|----------|
 | `memory` | single process | no | no | local dev, single-process PoC |
 | `redis` | shared | yes | yes | multi-replica or restart-safe deployment |
-| `mounted` | single node | yes | no | single-node LGF bench without Redis |
+| `mounted` | single node | yes | no | single-node LGF bench without Redis (not yet implemented) |
 
 The replay backend is an implementation detail behind the PEP. It does not affect the authorization protocol or the decision semantics.
+
+### Configuration
+
+Memory (default):
+
+```env
+REPLAY_STORE=memory
+```
+
+Redis:
+
+```env
+REPLAY_STORE=redis
+REDIS_URL=redis://redis:6379
+REPLAY_KEY_PREFIX=oxdeai:pep:replay
+REPLAY_TTL_SKEW_SECONDS=60
+```
+
+When `REPLAY_STORE=redis`, `REDIS_URL` is required. The PEP will fail to start without it.
+
+The PEP creates an ioredis client from `REDIS_URL` on startup and disconnects it on shutdown. The Redis URL may contain credentials (`redis://user:password@host:port`); these are redacted in startup logs.
+
+### Key format
+
+Redis keys use a stable namespaced format:
+
+```text
+<REPLAY_KEY_PREFIX>:<issuer>:<audience>:<auth_id>
+```
+
+Stored values contain only non-secret metadata (`claimed_at`, `issuer`, `audience`). No signing keys, API credentials, or raw AuthorizationV1 artifacts are stored.
+
+### TTL
+
+Replay keys expire after the authorization validity window plus a configurable safety buffer:
+
+```text
+ttl = (expiry - now) + REPLAY_TTL_SKEW_SECONDS
+```
+
+Default skew: 60 seconds. Replay entries do not persist forever.
 
 ### Constraints
 
 * The PEP must fail closed if a required replay backend is unavailable.
 * The replay backend must support atomic check-and-consume to prevent race conditions.
+* Redis uses `SET key value NX EX ttl` for atomic single-use claiming.
 * The in-memory backend is acceptable only for local dev and single-process PoC scenarios. It loses state on restart.
-* Redis or mounted persistence is required for deployments where replay protection must survive restarts or span multiple replicas.
+* Redis or equivalent shared persistence is required for deployments where replay protection must survive restarts or span multiple replicas.
 
 The replay backend choice must not force platform-specific images. All backends are injected through configuration, not compiled into the image.
-
-See #148 for the pluggable replay persistence follow-up.
 
 ## Enforce vs Observe Mode
 
@@ -344,7 +384,7 @@ This documentation covers the sidecar deployment model validated by the LGF/Frap
 * One protected action: `frappe.helpdesk.create_ticket`
 * AuthorizationV1 issuance and verification
 * Intent hash binding
-* Replay protection (in-memory)
+* Replay protection (in-memory and Redis backends)
 * Enforce and observe modes
 * Fail-closed behavior on upstream errors
 * Frappe numeric ticket ID normalization
@@ -354,7 +394,7 @@ This documentation covers the sidecar deployment model validated by the LGF/Frap
 * Full Frappe governance
 * Full ERPNext governance
 * Production readiness
-* Redis or mounted replay persistence (#148)
+* Mounted-volume replay persistence
 * Kubernetes manifests or Helm charts
 * LGF production automation
 * Multi-action policy evaluation

--- a/examples/lgf-frappe-pep/package.json
+++ b/examples/lgf-frappe-pep/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@oxdeai/core": "workspace:*",
-    "@oxdeai/guard": "workspace:*"
+    "@oxdeai/guard": "workspace:*",
+    "ioredis": "^5.4.0"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/examples/lgf-frappe-pep/src/config.ts
+++ b/examples/lgf-frappe-pep/src/config.ts
@@ -4,13 +4,24 @@ import type { KeyObject } from "node:crypto";
 
 export type PepMode = "enforce" | "observe";
 
+export type ReplayStoreType = "memory" | "redis";
+
+export type ReplayStoreConfig =
+  | { type: "memory" }
+  | {
+      type: "redis";
+      redisUrl: string;
+      keyPrefix: string;
+      ttlSkewSeconds: number;
+    };
+
 export type PepConfig = {
   mode: PepMode;
   expectedAudience: string;
   frappeBaseUrl: string;
   frappeApiKey: string;
   frappeApiSecret: string;
-  replayStore: "memory";
+  replayStore: ReplayStoreConfig;
   port: number;
   signingPrivateKey: KeyObject;
   signingPublicKeyPem: string;
@@ -47,9 +58,20 @@ export function loadConfig(): PepConfig {
     frappeApiSecret = process.env["FRAPPE_API_SECRET"] ?? "";
   }
 
-  const replayStoreType = process.env["REPLAY_STORE"] ?? "memory";
-  if (replayStoreType !== "memory") {
-    throw new Error(`Unsupported REPLAY_STORE: "${replayStoreType}". Only "memory" is supported in this PoC.`);
+  const rawReplayStore = process.env["REPLAY_STORE"] ?? "memory";
+  let replayStore: ReplayStoreConfig;
+  if (rawReplayStore === "memory") {
+    replayStore = { type: "memory" };
+  } else if (rawReplayStore === "redis") {
+    const redisUrl = requireEnv("REDIS_URL");
+    const keyPrefix = process.env["REPLAY_KEY_PREFIX"] ?? "oxdeai:pep:replay";
+    const ttlSkewSeconds = Number(process.env["REPLAY_TTL_SKEW_SECONDS"] ?? "60");
+    if (!Number.isFinite(ttlSkewSeconds) || ttlSkewSeconds < 0) {
+      throw new Error(`REPLAY_TTL_SKEW_SECONDS must be a non-negative integer, got "${process.env["REPLAY_TTL_SKEW_SECONDS"]}"`);
+    }
+    replayStore = { type: "redis", redisUrl, keyPrefix, ttlSkewSeconds };
+  } else {
+    throw new Error(`REPLAY_STORE must be "memory" or "redis", got "${rawReplayStore}"`);
   }
 
   const rawPem = requireEnv("SIGNING_PRIVATE_KEY_PEM");
@@ -79,7 +101,7 @@ export function loadConfig(): PepConfig {
     frappeBaseUrl,
     frappeApiKey,
     frappeApiSecret,
-    replayStore: "memory",
+    replayStore,
     port,
     signingPrivateKey,
     signingPublicKeyPem,
@@ -96,7 +118,8 @@ export function redactedConfigSummary(config: PepConfig): Record<string, unknown
     frappeBaseUrl: config.frappeBaseUrl,
     frappeApiKey: config.frappeApiKey ? "***" : "(not set)",
     frappeApiSecret: config.frappeApiSecret ? "***" : "(not set)",
-    replayStore: config.replayStore,
+    replayStore: config.replayStore.type,
+    redisUrl: config.replayStore.type === "redis" ? config.replayStore.redisUrl.replace(/:\/\/.*@/, "://***@") : undefined,
     port: config.port,
     signingKid: config.signingKid,
     issuer: config.issuer,

--- a/examples/lgf-frappe-pep/src/replay.ts
+++ b/examples/lgf-frappe-pep/src/replay.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Redis } from "ioredis";
+import { createInMemoryReplayStore } from "@oxdeai/guard";
+import type { ReplayStore } from "@oxdeai/guard";
+import type { ReplayStoreConfig } from "./config.js";
+
+export type RedisClientLike = {
+  set(
+    key: string,
+    value: string,
+    nx: "NX",
+    ex: "EX",
+    seconds: number,
+  ): Promise<"OK" | null>;
+};
+
+export type CreateReplayStoreOptions = {
+  config: ReplayStoreConfig;
+  issuer: string;
+  audience: string;
+  authorizationTtlSeconds: number;
+  redisClient?: RedisClientLike;
+};
+
+export type ReplayStoreHandle = {
+  store: ReplayStore;
+  disconnect: () => Promise<void>;
+};
+
+export function createReplayStoreHandle(options: CreateReplayStoreOptions): ReplayStoreHandle {
+  const { config } = options;
+
+  if (config.type === "memory") {
+    return { store: createInMemoryReplayStore(), disconnect: async () => {} };
+  }
+
+  if (config.type === "redis") {
+    let client: RedisClientLike;
+    let ownedRedis: Redis | undefined;
+
+    if (options.redisClient) {
+      client = options.redisClient;
+    } else {
+      ownedRedis = new Redis(config.redisUrl, {
+        lazyConnect: true,
+        maxRetriesPerRequest: 1,
+        enableOfflineQueue: false,
+      });
+      client = ownedRedis as unknown as RedisClientLike;
+    }
+
+    const { keyPrefix, ttlSkewSeconds } = config;
+    const issuer = options.issuer;
+    const audience = options.audience;
+
+    const store: ReplayStore = {
+      async consumeAuthId(authId: string, opts: { expiry: number }): Promise<boolean> {
+        const key = `${keyPrefix}:${issuer}:${audience}:${authId}`;
+        const now = Math.floor(Date.now() / 1000);
+        const ttl = Math.max(1, opts.expiry - now + ttlSkewSeconds);
+        const value = JSON.stringify({
+          claimed_at: new Date(now * 1000).toISOString(),
+          issuer,
+          audience,
+        });
+        const result = await client.set(key, value, "NX", "EX", ttl);
+        return result === "OK";
+      },
+    };
+
+    const disconnect = async () => {
+      if (ownedRedis) {
+        ownedRedis.disconnect();
+      }
+    };
+
+    return { store, disconnect };
+  }
+
+  throw new Error(`Unsupported replay store type: "${(config as { type: string }).type}"`);
+}
+
+export function createReplayStore(options: CreateReplayStoreOptions): ReplayStore {
+  return createReplayStoreHandle(options).store;
+}

--- a/examples/lgf-frappe-pep/src/server.ts
+++ b/examples/lgf-frappe-pep/src/server.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { createServer } from "node:http";
 import type { IncomingMessage, ServerResponse, Server } from "node:http";
-import { createInMemoryReplayStore } from "@oxdeai/guard";
 import type { ReplayStore } from "@oxdeai/guard";
 import { loadConfig, redactedConfigSummary } from "./config.js";
 import type { PepConfig } from "./config.js";
@@ -9,6 +8,7 @@ import type { FrappeAdapter, DecisionLog } from "./types.js";
 import { handleAuthorize } from "./authorize.js";
 import { handleExecute } from "./execute.js";
 import { createFrappeHttpAdapter } from "./frappe.js";
+import { createReplayStoreHandle } from "./replay.js";
 
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
   const data = JSON.stringify(body);
@@ -47,9 +47,22 @@ export type PepServerOptions = {
   frappeAdapter?: FrappeAdapter;
 };
 
-export function createPepServer(options: PepServerOptions): Server {
+export function createPepServer(options: PepServerOptions): Server & { shutdown: () => Promise<void> } {
   const { config } = options;
-  const replayStore = options.replayStore ?? createInMemoryReplayStore();
+  let replayDisconnect: () => Promise<void> = async () => {};
+  let replayStore: import("@oxdeai/guard").ReplayStore;
+  if (options.replayStore) {
+    replayStore = options.replayStore;
+  } else {
+    const handle = createReplayStoreHandle({
+      config: config.replayStore,
+      issuer: config.issuer,
+      audience: config.expectedAudience,
+      authorizationTtlSeconds: config.authorizationTtlSeconds,
+    });
+    replayStore = handle.store;
+    replayDisconnect = handle.disconnect;
+  }
   const frappeAdapter =
     options.frappeAdapter ??
     createFrappeHttpAdapter({
@@ -61,7 +74,7 @@ export function createPepServer(options: PepServerOptions): Server {
   const authorize = handleAuthorize(config);
   const execute = handleExecute(config, replayStore, frappeAdapter);
 
-  return createServer(async (req: IncomingMessage, res: ServerResponse) => {
+  const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
     if (req.method === "GET" && req.url === "/healthz") {
       return sendJson(res, 200, { ok: true, status: "healthy", mode: config.mode });
     }
@@ -101,7 +114,15 @@ export function createPepServer(options: PepServerOptions): Server {
     }
 
     return sendJson(res, 404, { ok: false, error: "not found" });
-  });
+  }) as Server & { shutdown: () => Promise<void> };
+
+  server.shutdown = async () => {
+    await replayDisconnect();
+    server.closeAllConnections();
+    await new Promise<void>((res, rej) => server.close((e) => (e ? rej(e) : res())));
+  };
+
+  return server;
 }
 
 // Main entry point — only runs when executed directly

--- a/examples/lgf-frappe-pep/test/boundary.test.ts
+++ b/examples/lgf-frappe-pep/test/boundary.test.ts
@@ -31,10 +31,14 @@ import type { KeyObject } from "node:crypto";
 import { sha256HexFromJson, signAuthorizationEd25519 } from "@oxdeai/core";
 import type { AuthorizationV1 } from "@oxdeai/core";
 import { createInMemoryReplayStore } from "@oxdeai/guard";
+import type { ReplayStore } from "@oxdeai/guard";
 import type { PepConfig } from "../src/config.js";
+import { redactedConfigSummary } from "../src/config.js";
 import type { FrappeAdapter, FrappeCreateTicketParams, ActionEnvelope } from "../src/types.js";
 import { createPepServer } from "../src/server.js";
 import { createFrappeHttpAdapter } from "../src/frappe.js";
+import { createReplayStore, createReplayStoreHandle } from "../src/replay.js";
+import type { RedisClientLike } from "../src/replay.js";
 import { POLICY_ID } from "../src/policy.js";
 
 // ─── Test infrastructure ────────────────────────────────────────────────────
@@ -94,7 +98,7 @@ async function startHarness(modeOverride?: "enforce" | "observe"): Promise<TestH
     frappeBaseUrl: "https://frappe.lgf.oxdeai.dev",
     frappeApiKey: "test-key",
     frappeApiSecret: "test-secret",
-    replayStore: "memory",
+    replayStore: { type: "memory" },
     port: 0,
     signingPrivateKey: keyPair.privateKey,
     signingPublicKeyPem: publicKeyPem,
@@ -543,7 +547,7 @@ describe("LGF Frappe PEP upstream error handling", () => {
       frappeBaseUrl: "https://frappe.lgf.oxdeai.dev",
       frappeApiKey: "test-key",
       frappeApiSecret: "test-secret",
-      replayStore: "memory",
+      replayStore: { type: "memory" },
       port: 0,
       signingPrivateKey: keyPair.privateKey,
       signingPublicKeyPem: publicKeyPem,
@@ -721,5 +725,369 @@ describe("Frappe adapter response parsing", () => {
         return true;
       },
     );
+  });
+});
+
+// ─── Replay persistence backend tests ────────────────────────────────────────
+
+function createMockRedisClient(): RedisClientLike & {
+  store: Map<string, { value: string; ttl: number }>;
+  lastKey: () => string | undefined;
+  lastTtl: () => number | undefined;
+} {
+  const store = new Map<string, { value: string; ttl: number }>();
+  let _lastKey: string | undefined;
+  let _lastTtl: number | undefined;
+
+  return {
+    store,
+    lastKey: () => _lastKey,
+    lastTtl: () => _lastTtl,
+    async set(key: string, value: string, _nx: "NX", _ex: "EX", seconds: number) {
+      _lastKey = key;
+      _lastTtl = seconds;
+      if (store.has(key)) return null;
+      store.set(key, { value, ttl: seconds });
+      return "OK" as const;
+    },
+  };
+}
+
+function createFailingRedisClient(): RedisClientLike {
+  return {
+    async set() {
+      throw new Error("REDIS_CONNECTION_REFUSED");
+    },
+  };
+}
+
+describe("Replay persistence backends", () => {
+  test("memory store: first claim succeeds, second claim denies", async () => {
+    const store = createReplayStore({
+      config: { type: "memory" },
+      issuer: "test-issuer",
+      audience: "test-audience",
+      authorizationTtlSeconds: 60,
+    });
+
+    const expiry = Math.floor(Date.now() / 1000) + 60;
+    const first = await store.consumeAuthId("auth-1", { expiry });
+    assert.equal(first, true, "First claim must succeed");
+
+    const second = await store.consumeAuthId("auth-1", { expiry });
+    assert.equal(second, false, "Second claim must fail (replay)");
+  });
+
+  test("redis store: first claim succeeds via SET NX EX", async () => {
+    const redis = createMockRedisClient();
+    const store = createReplayStore({
+      config: { type: "redis", redisUrl: "redis://localhost:6379", keyPrefix: "oxdeai:pep:replay", ttlSkewSeconds: 60 },
+      issuer: "test-issuer",
+      audience: "test-audience",
+      authorizationTtlSeconds: 60,
+      redisClient: redis,
+    });
+
+    const expiry = Math.floor(Date.now() / 1000) + 60;
+    const result = await store.consumeAuthId("auth-redis-1", { expiry });
+    assert.equal(result, true, "First claim must succeed");
+    assert.ok(redis.lastKey()?.startsWith("oxdeai:pep:replay:test-issuer:test-audience:auth-redis-1"));
+    assert.ok((redis.lastTtl() ?? 0) > 60, "TTL must include skew");
+  });
+
+  test("redis store: second claim denies with replay", async () => {
+    const redis = createMockRedisClient();
+    const store = createReplayStore({
+      config: { type: "redis", redisUrl: "redis://localhost:6379", keyPrefix: "oxdeai:pep:replay", ttlSkewSeconds: 60 },
+      issuer: "test-issuer",
+      audience: "test-audience",
+      authorizationTtlSeconds: 60,
+      redisClient: redis,
+    });
+
+    const expiry = Math.floor(Date.now() / 1000) + 60;
+    await store.consumeAuthId("auth-redis-2", { expiry });
+    const second = await store.consumeAuthId("auth-redis-2", { expiry });
+    assert.equal(second, false, "Replay must be denied");
+  });
+
+  test("redis store: TTL includes skew", async () => {
+    const redis = createMockRedisClient();
+    const store = createReplayStore({
+      config: { type: "redis", redisUrl: "redis://localhost:6379", keyPrefix: "test", ttlSkewSeconds: 30 },
+      issuer: "i",
+      audience: "a",
+      authorizationTtlSeconds: 60,
+      redisClient: redis,
+    });
+
+    const now = Math.floor(Date.now() / 1000);
+    await store.consumeAuthId("ttl-test", { expiry: now + 60 });
+    const ttl = redis.lastTtl() ?? 0;
+    assert.ok(ttl >= 60 && ttl <= 95, `TTL must be ~90 (60 remaining + 30 skew), got ${ttl}`);
+  });
+
+  test("redis store: key uses namespaced format", async () => {
+    const redis = createMockRedisClient();
+    const store = createReplayStore({
+      config: { type: "redis", redisUrl: "redis://localhost:6379", keyPrefix: "myprefix", ttlSkewSeconds: 0 },
+      issuer: "my-issuer",
+      audience: "my-audience",
+      authorizationTtlSeconds: 60,
+      redisClient: redis,
+    });
+
+    await store.consumeAuthId("key-format-test", { expiry: Math.floor(Date.now() / 1000) + 60 });
+    assert.equal(redis.lastKey(), "myprefix:my-issuer:my-audience:key-format-test");
+  });
+
+  test("redis store: stored value contains only non-secret metadata", async () => {
+    const redis = createMockRedisClient();
+    const store = createReplayStore({
+      config: { type: "redis", redisUrl: "redis://localhost:6379", keyPrefix: "p", ttlSkewSeconds: 0 },
+      issuer: "safe-issuer",
+      audience: "safe-audience",
+      authorizationTtlSeconds: 60,
+      redisClient: redis,
+    });
+
+    await store.consumeAuthId("value-test", { expiry: Math.floor(Date.now() / 1000) + 60 });
+    const entry = redis.store.get("p:safe-issuer:safe-audience:value-test");
+    assert.ok(entry, "Entry must exist");
+    const parsed = JSON.parse(entry.value);
+    assert.equal(typeof parsed.claimed_at, "string");
+    assert.equal(parsed.issuer, "safe-issuer");
+    assert.equal(parsed.audience, "safe-audience");
+    assert.equal(parsed.signing_key, undefined, "Must not store signing key");
+    assert.equal(parsed.api_key, undefined, "Must not store API key");
+    assert.equal(parsed.api_secret, undefined, "Must not store API secret");
+  });
+
+  test("redis unavailable: consumeAuthId throws (fail-closed)", async () => {
+    const store = createReplayStore({
+      config: { type: "redis", redisUrl: "redis://localhost:6379", keyPrefix: "p", ttlSkewSeconds: 0 },
+      issuer: "i",
+      audience: "a",
+      authorizationTtlSeconds: 60,
+      redisClient: createFailingRedisClient(),
+    });
+
+    await assert.rejects(
+      () => store.consumeAuthId("fail-test", { expiry: Math.floor(Date.now() / 1000) + 60 }),
+      (err: Error) => {
+        assert.match(err.message, /REDIS_CONNECTION_REFUSED/);
+        return true;
+      },
+    );
+  });
+});
+
+describe("Redis unavailable PEP integration", () => {
+  let baseUrl: string;
+  let privateKeyPem: string;
+  let frappeCallCount: number;
+  let close: () => Promise<void>;
+
+  before(async () => {
+    const keyPair = generateKeyPairSync("ed25519");
+    privateKeyPem = keyPair.privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+    const publicKeyPem = keyPair.publicKey.export({ type: "spki", format: "pem" }) as string;
+
+    frappeCallCount = 0;
+    const mockFrappe: FrappeAdapter = {
+      async createTicket() {
+        frappeCallCount++;
+        return { ticket_id: "should-not-reach", name: "should-not-reach" };
+      },
+    };
+
+    const failingStore: ReplayStore = {
+      async consumeAuthId() {
+        throw new Error("REDIS_CONNECTION_REFUSED");
+      },
+    };
+
+    const config: PepConfig = {
+      mode: "enforce",
+      expectedAudience: "PEP-frappe.lgf.oxdeai.dev",
+      frappeBaseUrl: "https://frappe.lgf.oxdeai.dev",
+      frappeApiKey: "test-key",
+      frappeApiSecret: "test-secret",
+      replayStore: { type: "memory" },
+      port: 0,
+      signingPrivateKey: keyPair.privateKey,
+      signingPublicKeyPem: publicKeyPem,
+      signingKid: "test-key-1",
+      issuer: "oxdeai.lgf-frappe-pep",
+      authorizationTtlSeconds: 60,
+    };
+
+    const server = createPepServer({
+      config,
+      replayStore: failingStore,
+      frappeAdapter: mockFrappe,
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("Unexpected address");
+    baseUrl = `http://127.0.0.1:${(addr as { port: number }).port}`;
+    close = () => {
+      server.closeAllConnections();
+      return new Promise((res, rej) => server.close((e) => (e ? rej(e) : res())));
+    };
+  });
+
+  after(async () => {
+    await close();
+  });
+
+  test("replay store unavailable denies execution and never calls Frappe", async () => {
+    frappeCallCount = 0;
+    const envelope = makeEnvelope({ priority: "Low" });
+    const authorization = issueAuthorization(envelope, privateKeyPem);
+
+    const result = await postJson(`${baseUrl}/execute`, { envelope, authorization });
+    assert.equal(result.status, 403, `Expected 403, got ${result.status}`);
+
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body["ok"], false);
+    assert.equal(body["decision"], "DENY");
+    assert.match(body["reason"] as string, /REPLAY_STORE_UNAVAILABLE/);
+    assert.equal(frappeCallCount, 0, "Frappe must NOT be called when replay store is unavailable");
+  });
+});
+
+// ─── Redis runtime wiring tests ──────────────────────────────────────────────
+
+describe("Redis runtime wiring", () => {
+  test("createReplayStoreHandle creates a handle with disconnect for redis config", () => {
+    const mockClient: RedisClientLike = {
+      async set() { return "OK"; },
+    };
+    const handle = createReplayStoreHandle({
+      config: { type: "redis", redisUrl: "redis://localhost:6379", keyPrefix: "test", ttlSkewSeconds: 0 },
+      issuer: "i",
+      audience: "a",
+      authorizationTtlSeconds: 60,
+      redisClient: mockClient,
+    });
+    assert.ok(handle.store, "Must return a store");
+    assert.equal(typeof handle.disconnect, "function", "Must return a disconnect function");
+  });
+
+  test("createReplayStoreHandle returns no-op disconnect for memory config", async () => {
+    const handle = createReplayStoreHandle({
+      config: { type: "memory" },
+      issuer: "i",
+      audience: "a",
+      authorizationTtlSeconds: 60,
+    });
+    assert.ok(handle.store, "Must return a store");
+    await handle.disconnect();
+  });
+
+  test("redacted config summary masks Redis URL credentials", () => {
+    const keyPair = generateKeyPairSync("ed25519");
+    const config: PepConfig = {
+      mode: "enforce",
+      expectedAudience: "test",
+      frappeBaseUrl: "https://frappe.example.com",
+      frappeApiKey: "k",
+      frappeApiSecret: "s",
+      replayStore: { type: "redis", redisUrl: "redis://user:secret-password@redis.internal:6379/0", keyPrefix: "p", ttlSkewSeconds: 0 },
+      port: 3000,
+      signingPrivateKey: keyPair.privateKey,
+      signingPublicKeyPem: keyPair.publicKey.export({ type: "spki", format: "pem" }) as string,
+      signingKid: "k1",
+      issuer: "i",
+      authorizationTtlSeconds: 60,
+    };
+    const summary = redactedConfigSummary(config);
+    assert.equal(summary["replayStore"], "redis");
+    const redisUrl = summary["redisUrl"] as string;
+    assert.ok(redisUrl.includes("***"), "Redis URL credentials must be redacted");
+    assert.ok(!redisUrl.includes("secret-password"), "Password must not appear in redacted URL");
+  });
+
+  test("redacted config summary omits Redis URL for memory config", () => {
+    const keyPair = generateKeyPairSync("ed25519");
+    const config: PepConfig = {
+      mode: "enforce",
+      expectedAudience: "test",
+      frappeBaseUrl: "https://frappe.example.com",
+      frappeApiKey: "k",
+      frappeApiSecret: "s",
+      replayStore: { type: "memory" },
+      port: 3000,
+      signingPrivateKey: keyPair.privateKey,
+      signingPublicKeyPem: keyPair.publicKey.export({ type: "spki", format: "pem" }) as string,
+      signingKid: "k1",
+      issuer: "i",
+      authorizationTtlSeconds: 60,
+    };
+    const summary = redactedConfigSummary(config);
+    assert.equal(summary["replayStore"], "memory");
+    assert.equal(summary["redisUrl"], undefined);
+  });
+
+  test("server factory path uses replay store from config (not only injected)", async () => {
+    const keyPair = generateKeyPairSync("ed25519");
+    const publicKeyPem = keyPair.publicKey.export({ type: "spki", format: "pem" }) as string;
+
+    let frappeCallCount = 0;
+    const mockFrappe: FrappeAdapter = {
+      async createTicket() {
+        frappeCallCount++;
+        return { ticket_id: "T1", name: "T1" };
+      },
+    };
+
+    const config: PepConfig = {
+      mode: "enforce",
+      expectedAudience: "PEP-frappe.lgf.oxdeai.dev",
+      frappeBaseUrl: "https://frappe.lgf.oxdeai.dev",
+      frappeApiKey: "test-key",
+      frappeApiSecret: "test-secret",
+      replayStore: { type: "memory" },
+      port: 0,
+      signingPrivateKey: keyPair.privateKey,
+      signingPublicKeyPem: publicKeyPem,
+      signingKid: "test-key-1",
+      issuer: "oxdeai.lgf-frappe-pep",
+      authorizationTtlSeconds: 60,
+    };
+
+    // Do NOT pass replayStore — force the factory path
+    const server = createPepServer({ config, frappeAdapter: mockFrappe });
+    await new Promise<void>((resolve, reject) => {
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("Unexpected address");
+    const baseUrl = `http://127.0.0.1:${(addr as { port: number }).port}`;
+
+    try {
+      const envelope = makeEnvelope({ priority: "Low" });
+      const privateKeyPem = keyPair.privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+      const authorization = issueAuthorization(envelope, privateKeyPem);
+
+      const result = await postJson(`${baseUrl}/execute`, { envelope, authorization });
+      assert.equal(result.status, 200, `Expected 200 from factory-path server, got ${result.status}`);
+      assert.equal(frappeCallCount, 1, "Frappe must be called via factory-path replay store");
+
+      // Replay must be denied (same auth, same factory-created store)
+      frappeCallCount = 0;
+      const replay = await postJson(`${baseUrl}/execute`, { envelope, authorization });
+      assert.equal(replay.status, 403, `Replay must return 403, got ${replay.status}`);
+      assert.equal(frappeCallCount, 0, "Frappe must not be called on replay via factory-path store");
+    } finally {
+      await server.shutdown();
+    }
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       '@oxdeai/guard':
         specifier: workspace:*
         version: link:../../packages/guard
+      ioredis:
+        specifier: ^5.4.0
+        version: 5.11.1
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
@@ -622,6 +625,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@ioredis/commands@1.10.0':
+    resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -937,6 +943,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  cluster-key-slot@1.1.1:
+    resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
+    engines: {node: '>=0.10.0'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -988,6 +998,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1204,6 +1218,10 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ioredis@5.11.1:
+    resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
+    engines: {node: '>=12.22.0'}
 
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
@@ -1456,6 +1474,14 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -1508,6 +1534,9 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
@@ -1772,6 +1801,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.3':
     optional: true
+
+  '@ioredis/commands@1.10.0': {}
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -2117,6 +2148,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  cluster-key-slot@1.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -2157,6 +2190,8 @@ snapshots:
       esprima: 4.0.1
 
   delayed-stream@1.0.0: {}
+
+  denque@2.1.0: {}
 
   detect-libc@2.1.2: {}
 
@@ -2394,6 +2429,18 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  ioredis@5.11.1:
+    dependencies:
+      '@ioredis/commands': 1.10.0
+      cluster-key-slot: 1.1.1
+      debug: 4.4.3
+      denque: 2.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   ip-address@10.2.0: {}
 
@@ -2650,6 +2697,12 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -2694,6 +2747,8 @@ snapshots:
   source-map@0.6.1: {}
 
   sprintf-js@1.0.3: {}
+
+  standard-as-callback@2.1.0: {}
 
   streamx@2.25.0:
     dependencies:


### PR DESCRIPTION
## Summary

Adds pluggable replay persistence for the generic OxDeAI PEP sidecar.

This moves replay handling behind a dedicated runtime abstraction and adds Redis as the first shared/durable replay backend while preserving the existing in-memory mode for local development and single-process PoC use.

Closes #148.

## What changed

* Added replay store configuration:

  * `REPLAY_STORE=memory`
  * `REPLAY_STORE=redis`
  * `REDIS_URL`
  * `REPLAY_KEY_PREFIX`
  * `REPLAY_TTL_SKEW_SECONDS`

* Added replay store factory:

  * memory-backed replay store
  * Redis-backed replay store
  * runtime handle with optional disconnect lifecycle

* Added Redis runtime wiring:

  * creates an `ioredis` client from `REDIS_URL`
  * uses `SET NX EX` for atomic replay claims
  * uses namespaced replay keys
  * stores only minimal non-secret metadata
  * fails closed with `REPLAY_STORE_UNAVAILABLE` when Redis is unavailable

* Updated server wiring:

  * production path now uses the replay store factory
  * tests can still inject replay stores directly
  * server exposes shutdown behavior for Redis disconnect

* Updated documentation:

  * replay persistence is documented as a PEP implementation detail
  * Redis is documented as one backend option, not the LGF deployment model
  * memory mode is documented as local/dev/single-process only
  * mounted persistence remains a future option

## Runtime behavior

When `REPLAY_STORE=memory`:

* current PoC behavior is preserved
* replay state is process-local
* not restart-safe
* not multi-replica safe

When `REPLAY_STORE=redis`:

* `REDIS_URL` is required
* replay claims are made through Redis using atomic `SET NX EX`
* replay keys use the configured namespace prefix
* replay TTL includes authorization validity plus skew
* Redis outage causes `/execute` to deny before any target-platform side effect occurs

## Validation

* PEP boundary enforce tests: 13 passing
* PEP observe mode tests: 6 passing
* PEP upstream error handling tests: 1 passing
* Frappe adapter response parsing tests: 4 passing
* Replay persistence backend tests: 7 passing
* Redis unavailable PEP integration test: 1 passing
* Redis runtime wiring tests: 5 passing
* `@oxdeai/core`: 177 passing
* `@oxdeai/guard`: 145 passing
* Total: 359 passing

Security gate:

* Decision: ALLOW
* Blocking findings: 0
* Remaining finding: pre-existing low-severity `esbuild` advisory

Secret/path grep:

* No real secrets found
* No GitHub tokens found
* No private key material found
* No Redis URLs with embedded credentials found
* Matches are limited to pre-existing instructional references or placeholders

## Notes / follow-ups

Not included in this PR:

* live Redis integration test using Docker Compose or CI Redis service
* SIGTERM handler in the main entry point
* eager Redis startup validation
* mounted-volume replay backend
* production Redis cluster provisioning
