### PR TITLE
test: add live Redis replay integration for PEP

### DIFF
--- a/examples/lgf-frappe-pep/LGF_DEPLOYMENT.md
+++ b/examples/lgf-frappe-pep/LGF_DEPLOYMENT.md
@@ -217,6 +217,30 @@ Replay protection prevents a consumed AuthorizationV1 from being used a second t
 
 The replay backend is an implementation detail behind the PEP. It does not affect the authorization protocol or the decision semantics.
 
+### Live Redis test coverage
+
+This repository includes a live Redis integration test for the replay backend:
+
+```bash
+docker compose -f examples/lgf-frappe-pep/docker-compose.redis.yml up -d redis
+REDIS_URL=redis://127.0.0.1:6379 pnpm -C examples/lgf-frappe-pep test:redis
+docker compose -f examples/lgf-frappe-pep/docker-compose.redis.yml down
+```
+
+This test runs the real PEP server against a real Redis service and a fake target-platform adapter.
+
+It proves:
+
+* first execution claims the replay key and executes once
+* second submission of the same `AuthorizationV1` is denied with `AUTH_REPLAY`
+* replay keys use the configured prefix
+* replay keys have positive TTL
+* Redis outage fails closed with `REPLAY_STORE_UNAVAILABLE`
+
+It does **not** require live Frappe, LGF-managed infrastructure, or deployment secrets.
+
+Current CI note: this repository keeps the live Redis test runnable locally first. CI service-container wiring is a follow-up and does not change the runtime or replay contract being tested.
+
 ### Configuration
 
 Memory (default):

--- a/examples/lgf-frappe-pep/LIVE_VALIDATION.md
+++ b/examples/lgf-frappe-pep/LIVE_VALIDATION.md
@@ -1,5 +1,15 @@
 # Live Validation Guide - LGF Frappe Helpdesk PEP
 
+Note: this guide is for live Frappe validation. It is separate from the local live Redis replay integration test, which does **not** require Frappe, LGF infrastructure, or secrets.
+
+For the Redis replay persistence test, use:
+
+```bash
+docker compose -f examples/lgf-frappe-pep/docker-compose.redis.yml up -d redis
+REDIS_URL=redis://127.0.0.1:6379 pnpm -C examples/lgf-frappe-pep test:redis
+docker compose -f examples/lgf-frappe-pep/docker-compose.redis.yml down
+```
+
 Protected action: `frappe.helpdesk.create_ticket`
 
 Core invariant: **No valid authorization → no execution path.**

--- a/examples/lgf-frappe-pep/README.md
+++ b/examples/lgf-frappe-pep/README.md
@@ -16,6 +16,40 @@ Core invariant: **No valid authorization → no execution path.**
 
 See [LIVE_VALIDATION.md](LIVE_VALIDATION.md) for local build, run, and validation instructions.
 
+## Live Redis replay integration test
+
+This example includes a live Redis integration test for the PEP replay persistence path.
+
+What it proves:
+
+* first execution succeeds once with `REPLAY_STORE=redis`
+* replayed `AuthorizationV1` is denied with `AUTH_REPLAY`
+* the target-platform adapter is not called on replay
+* the Redis replay key uses the configured prefix
+* the Redis replay key has a positive bounded TTL
+* Redis outage fails closed with `REPLAY_STORE_UNAVAILABLE`
+
+What it does **not** require:
+
+* live Frappe
+* LGF infrastructure
+* API keys or secrets
+* signing-key files on disk
+
+The test uses the real PEP server plus a fake Frappe adapter that counts side effects.
+
+Run locally:
+
+```bash
+docker compose -f examples/lgf-frappe-pep/docker-compose.redis.yml up -d redis
+REDIS_URL=redis://127.0.0.1:6379 pnpm -C examples/lgf-frappe-pep test:redis
+docker compose -f examples/lgf-frappe-pep/docker-compose.redis.yml down
+```
+
+The replay backend is one implementation detail behind the PEP boundary. Redis here is used only to validate replay persistence behavior.
+
+Current CI note: this live Redis test is designed to run locally today. Service-container or CI Compose wiring can be added later without changing the test contract.
+
 ## LGF deployment
 
 See [LGF_DEPLOYMENT.md](LGF_DEPLOYMENT.md) for the LGF Platform Layer sidecar deployment model, responsibility boundaries, runtime configuration contract, and failure behavior.

--- a/examples/lgf-frappe-pep/docker-compose.redis.yml
+++ b/examples/lgf-frappe-pep/docker-compose.redis.yml
@@ -1,0 +1,5 @@
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"

--- a/examples/lgf-frappe-pep/package.json
+++ b/examples/lgf-frappe-pep/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "pnpm build && node dist/server.js",
-    "test": "pnpm build && node --test dist/test/boundary.test.js"
+    "test": "pnpm build && node --test dist/test/boundary.test.js",
+    "test:redis": "pnpm build && OXDEAI_LIVE_REDIS_TEST=1 node --test dist/test/live-redis.test.js"
   },
   "dependencies": {
     "@oxdeai/core": "workspace:*",

--- a/examples/lgf-frappe-pep/src/replay.ts
+++ b/examples/lgf-frappe-pep/src/replay.ts
@@ -37,6 +37,7 @@ export function createReplayStoreHandle(options: CreateReplayStoreOptions): Repl
   if (config.type === "redis") {
     let client: RedisClientLike;
     let ownedRedis: Redis | undefined;
+    let connectPromise: Promise<void> | null = null;
 
     if (options.redisClient) {
       client = options.redisClient;
@@ -46,8 +47,20 @@ export function createReplayStoreHandle(options: CreateReplayStoreOptions): Repl
         maxRetriesPerRequest: 1,
         enableOfflineQueue: false,
       });
+      ownedRedis.on("error", () => {});
       client = ownedRedis as unknown as RedisClientLike;
     }
+
+    const ensureConnected = async (): Promise<void> => {
+      if (!ownedRedis) return;
+      if (ownedRedis.status === "ready") return;
+      if (!connectPromise) {
+        connectPromise = ownedRedis.connect().finally(() => {
+          connectPromise = null;
+        });
+      }
+      await connectPromise;
+    };
 
     const { keyPrefix, ttlSkewSeconds } = config;
     const issuer = options.issuer;
@@ -63,6 +76,7 @@ export function createReplayStoreHandle(options: CreateReplayStoreOptions): Repl
           issuer,
           audience,
         });
+        await ensureConnected();
         const result = await client.set(key, value, "NX", "EX", ttl);
         return result === "OK";
       },

--- a/examples/lgf-frappe-pep/test/live-redis.test.ts
+++ b/examples/lgf-frappe-pep/test/live-redis.test.ts
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: Apache-2.0
+import { after, before, describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { createServer as createHttpServer } from "node:http";
+import type { Server as HttpServer } from "node:http";
+import { generateKeyPairSync, randomUUID } from "node:crypto";
+import { Redis } from "ioredis";
+import { sha256HexFromJson, signAuthorizationEd25519 } from "@oxdeai/core";
+import type { AuthorizationV1 } from "@oxdeai/core";
+import type { PepConfig } from "../src/config.js";
+import { createPepServer } from "../src/server.js";
+import type { ActionEnvelope, FrappeAdapter, FrappeCreateTicketParams } from "../src/types.js";
+import { POLICY_ID } from "../src/policy.js";
+
+const LIVE_REDIS_URL = process.env["REDIS_URL"] ?? "redis://127.0.0.1:6379";
+const LIVE_REDIS_ENABLED = process.env["OXDEAI_LIVE_REDIS_TEST"] === "1";
+const LIVE_REDIS_TIMEOUT_MS = 8_000;
+const AUTH_TTL_SECONDS = 60;
+const REPLAY_TTL_SKEW_SECONDS = 45;
+const TTL_BUFFER_SECONDS = 5;
+
+type LiveHarness = {
+  baseUrl: string;
+  config: PepConfig;
+  privateKeyPem: string;
+  frappeCallCount: () => number;
+  resetFrappe: () => void;
+  close: () => Promise<void>;
+};
+
+function makeEnvelope(subject = "Live Redis replay test"): ActionEnvelope {
+  return {
+    source_bench: "openwebui-dev",
+    target_bench: "frappe",
+    agent_or_tool_context: "erp-assistant",
+    user_identity: "redis-live-test@oxdeai.dev",
+    session_id: "redis-live-test-session",
+    action: {
+      type: "EXECUTE",
+      tool: "frappe.helpdesk.create_ticket",
+      params: {
+        subject,
+        description: "Live Redis replay integration test",
+        priority: "Low",
+      },
+    },
+  };
+}
+
+function issueAuthorization(
+  envelope: ActionEnvelope,
+  privateKeyPem: string,
+  config: PepConfig,
+  authId = randomUUID(),
+): AuthorizationV1 {
+  const now = Math.floor(Date.now() / 1000);
+  return signAuthorizationEd25519(
+    {
+      auth_id: authId,
+      issuer: config.issuer,
+      audience: config.expectedAudience,
+      intent_hash: sha256HexFromJson(envelope.action),
+      state_hash: sha256HexFromJson({}),
+      policy_id: POLICY_ID,
+      decision: "ALLOW",
+      issued_at: now,
+      expiry: now + config.authorizationTtlSeconds,
+      kid: config.signingKid,
+      nonce: randomUUID(),
+    },
+    privateKeyPem,
+  );
+}
+
+async function postJson(url: string, body: unknown): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return {
+    status: res.status,
+    body: await res.json() as Record<string, unknown>,
+  };
+}
+
+async function waitForRedis(url: string): Promise<void> {
+  const redis = new Redis(url, {
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+    enableOfflineQueue: false,
+    connectTimeout: LIVE_REDIS_TIMEOUT_MS,
+  });
+
+  try {
+    await redis.connect();
+    const pong = await redis.ping();
+    assert.equal(pong, "PONG", "Redis must respond to PING");
+  } finally {
+    redis.disconnect();
+  }
+}
+
+async function deleteKeysByPrefix(redis: Redis, prefix: string): Promise<void> {
+  const keys = await redis.keys(`${prefix}:*`);
+  if (keys.length > 0) {
+    await redis.del(...keys);
+  }
+}
+
+async function startHarness(replayKeyPrefix: string, redisUrl = LIVE_REDIS_URL): Promise<LiveHarness> {
+  const keyPair = generateKeyPairSync("ed25519");
+  const privateKeyPem = keyPair.privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+  const publicKeyPem = keyPair.publicKey.export({ type: "spki", format: "pem" }) as string;
+
+  let callCount = 0;
+  const mockFrappe: FrappeAdapter = {
+    async createTicket(_params: FrappeCreateTicketParams) {
+      callCount += 1;
+      return { ticket_id: `HD-TICKET-${callCount}`, name: `HD-TICKET-${callCount}` };
+    },
+  };
+
+  const config: PepConfig = {
+    mode: "enforce",
+    expectedAudience: "PEP-frappe.lgf.oxdeai.dev",
+    frappeBaseUrl: "https://frappe.example.invalid",
+    frappeApiKey: "test-key",
+    frappeApiSecret: "test-secret",
+    replayStore: {
+      type: "redis",
+      redisUrl,
+      keyPrefix: replayKeyPrefix,
+      ttlSkewSeconds: REPLAY_TTL_SKEW_SECONDS,
+    },
+    port: 0,
+    signingPrivateKey: keyPair.privateKey,
+    signingPublicKeyPem: publicKeyPem,
+    signingKid: "redis-live-test-key-1",
+    issuer: "oxdeai.lgf-frappe-pep",
+    authorizationTtlSeconds: AUTH_TTL_SECONDS,
+  };
+
+  const server = createPepServer({ config, frappeAdapter: mockFrappe });
+  await new Promise<void>((resolve, reject) => {
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const addr = server.address();
+  if (!addr || typeof addr === "string") {
+    throw new Error("Unexpected server address");
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${addr.port}`,
+    config,
+    privateKeyPem,
+    frappeCallCount: () => callCount,
+    resetFrappe: () => {
+      callCount = 0;
+    },
+    close: () => server.shutdown(),
+  };
+}
+
+describe("LGF Frappe PEP live Redis replay integration", { skip: !LIVE_REDIS_ENABLED }, () => {
+  const replayKeyPrefix = `oxdeai:test:replay:${Date.now()}:${randomUUID()}`;
+  const redis = new Redis(LIVE_REDIS_URL, {
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+    enableOfflineQueue: false,
+    connectTimeout: LIVE_REDIS_TIMEOUT_MS,
+  });
+
+  let harness: LiveHarness;
+
+  before(async () => {
+    await waitForRedis(LIVE_REDIS_URL);
+    await redis.connect();
+    await deleteKeysByPrefix(redis, replayKeyPrefix);
+    harness = await startHarness(replayKeyPrefix);
+  });
+
+  after(async () => {
+    if (harness) {
+      await harness.close();
+    }
+    await deleteKeysByPrefix(redis, replayKeyPrefix);
+    redis.disconnect();
+  });
+
+  test("first execution succeeds, replay key is created with expected prefix and positive TTL", async () => {
+    harness.resetFrappe();
+    const envelope = makeEnvelope("Live Redis first execution");
+    const authorization = issueAuthorization(envelope, harness.privateKeyPem, harness.config);
+
+    const result = await postJson(`${harness.baseUrl}/execute`, { envelope, authorization });
+    assert.equal(result.status, 200);
+    assert.equal(result.body["decision"], "ALLOW");
+    assert.equal(harness.frappeCallCount(), 1, "First execution must call target adapter exactly once");
+
+    const replayKey = `${replayKeyPrefix}:${harness.config.issuer}:${harness.config.expectedAudience}:${authorization.auth_id}`;
+    const exists = await redis.exists(replayKey);
+    assert.equal(exists, 1, "Replay key must exist after first execution");
+
+    const ttl = await redis.ttl(replayKey);
+    assert.ok(ttl > AUTH_TTL_SECONDS, `TTL must exceed authorization TTL (${ttl})`);
+    assert.ok(
+      ttl <= AUTH_TTL_SECONDS + REPLAY_TTL_SKEW_SECONDS + TTL_BUFFER_SECONDS,
+      `TTL must stay within auth TTL + skew buffer (${ttl})`
+    );
+  });
+
+  test("replay is denied and no second side effect occurs", async () => {
+    harness.resetFrappe();
+    const envelope = makeEnvelope("Live Redis replay denial");
+    const authorization = issueAuthorization(envelope, harness.privateKeyPem, harness.config);
+
+    const first = await postJson(`${harness.baseUrl}/execute`, { envelope, authorization });
+    assert.equal(first.status, 200);
+    assert.equal(first.body["decision"], "ALLOW");
+    assert.equal(harness.frappeCallCount(), 1, "First execution must call target adapter exactly once");
+
+    const second = await postJson(`${harness.baseUrl}/execute`, { envelope, authorization });
+    assert.equal(second.status, 403);
+    assert.equal(second.body["decision"], "DENY");
+    assert.equal(second.body["reason"], "AUTH_REPLAY");
+    assert.equal(harness.frappeCallCount(), 1, "Replay must not trigger a second side effect");
+  });
+
+  test("Redis outage fails closed with REPLAY_STORE_UNAVAILABLE", async () => {
+    const outagePrefix = `${replayKeyPrefix}:outage`;
+    const outageHarness = await startHarness(outagePrefix, "redis://127.0.0.1:6399");
+    try {
+      outageHarness.resetFrappe();
+      const envelope = makeEnvelope("Live Redis outage");
+      const authorization = issueAuthorization(envelope, outageHarness.privateKeyPem, outageHarness.config);
+
+      const result = await postJson(`${outageHarness.baseUrl}/execute`, { envelope, authorization });
+      assert.equal(result.status, 403);
+      assert.equal(result.body["decision"], "DENY");
+      assert.equal(result.body["reason"], "REPLAY_STORE_UNAVAILABLE");
+      assert.equal(outageHarness.frappeCallCount(), 0, "Unavailable Redis must block target adapter calls");
+    } finally {
+      await outageHarness.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a live Redis integration test for OxDeAI PEP replay persistence.

This validates the Redis-backed replay path against a real `redis:7-alpine` service instead of relying only on mocks/fakes.

Closes #152.

## What changed

* Added live Redis integration test:

  * real PEP server via `createPepServer`
  * real Redis via Docker Compose
  * fake Frappe adapter counting side effects
  * unique per-run replay key prefix
  * scoped Redis cleanup by prefix

* Added Docker Compose Redis service:

  * `examples/lgf-frappe-pep/docker-compose.redis.yml`
  * uses `redis:7-alpine`

* Added package script:

  * `pnpm -C examples/lgf-frappe-pep test:redis`

* Updated Redis replay runtime:

  * fixed lazy `ioredis` connection path
  * ensures owned Redis client connects before first replay claim
  * attaches a no-op error listener for fail-closed outage tests

* Updated documentation:

  * README local Redis test instructions
  * LGF deployment Redis integration test notes
  * LIVE_VALIDATION Redis replay validation references

## What the live Redis test proves

The integration test validates:

* first execution succeeds with Redis replay persistence
* replayed AuthorizationV1 is denied with `AUTH_REPLAY`
* target-platform side effect is not executed twice
* Redis replay key is created with the expected configured prefix
* Redis replay key has a positive bounded TTL
* Redis outage fails closed with `REPLAY_STORE_UNAVAILABLE`
* no live Frappe or LGF infrastructure is required
* no secrets are required

## Validation

Normal LGF/Frappe PEP tests:

```bash
pnpm --filter @oxdeai/example-lgf-frappe-pep test
```

Live Redis integration test:

```bash
docker compose -f examples/lgf-frappe-pep/docker-compose.redis.yml up -d redis
REDIS_URL=redis://127.0.0.1:6379 pnpm -C examples/lgf-frappe-pep test:redis
docker compose -f examples/lgf-frappe-pep/docker-compose.redis.yml down
```

Results:

* normal package tests: passing
* live Redis integration tests: 3 passing / 0 failing
* security gate: ALLOW
* blocking findings: 0
* remaining warning: pre-existing low-severity `esbuild` advisory

## Secret / path safety

Secret/path grep was run.

No new secret material was introduced.

No GitHub tokens, private keys, Redis credential URLs, or real API credentials were found.

Remaining grep matches are pre-existing instructional references in `LIVE_VALIDATION.md` and `.env.live.example`, or placeholder values in docs.

## Notes / follow-ups

Not included in this PR:

* CI wiring for Redis service container
* production Redis provisioning
* Redis HA / clustering
* LGF-managed Redis lifecycle
* live Frappe validation
* mounted-volume replay backend
