### PR TITLE
fix: add graceful shutdown handling for PEP runtime

### DIFF
--- a/examples/lgf-frappe-pep/LGF_DEPLOYMENT.md
+++ b/examples/lgf-frappe-pep/LGF_DEPLOYMENT.md
@@ -58,6 +58,7 @@ The PEP does not know the target platform's internal semantics. Platform-specifi
 * Enforce / observe mode behavior
 * Fail-closed execution guarantees
 * Decision logging (structured, secret-free)
+* Graceful runtime shutdown on `SIGTERM` / `SIGINT`
 
 ## Image Strategy
 
@@ -240,6 +241,23 @@ It proves:
 It does **not** require live Frappe, LGF-managed infrastructure, or deployment secrets.
 
 Current CI note: this repository keeps the live Redis test runnable locally first. CI service-container wiring is a follow-up and does not change the runtime or replay contract being tested.
+
+## Graceful Shutdown
+
+The PEP runtime registers `SIGTERM` and `SIGINT` handlers in the main process entrypoint.
+
+On shutdown request it:
+
+* logs a structured shutdown event with mode, replay store type, port, signal, and shutdown status
+* stops accepting new HTTP connections
+* closes active connections through the existing server shutdown path
+* disconnects owned Redis clients on the Redis replay path
+* exits `0` on successful shutdown
+* exits non-zero if shutdown fails unexpectedly
+
+Shutdown is idempotent. Multiple signals do not double-run cleanup or double-disconnect Redis.
+
+This is operational hardening for sidecar deployment. It does not change authorization, replay, or policy semantics.
 
 ### Configuration
 

--- a/examples/lgf-frappe-pep/LIVE_VALIDATION.md
+++ b/examples/lgf-frappe-pep/LIVE_VALIDATION.md
@@ -10,6 +10,8 @@ REDIS_URL=redis://127.0.0.1:6379 pnpm -C examples/lgf-frappe-pep test:redis
 docker compose -f examples/lgf-frappe-pep/docker-compose.redis.yml down
 ```
 
+The runtime also handles `SIGTERM` and `SIGINT` gracefully during local runs, closing the HTTP server and disconnecting owned Redis clients before exit.
+
 Protected action: `frappe.helpdesk.create_ticket`
 
 Core invariant: **No valid authorization → no execution path.**

--- a/examples/lgf-frappe-pep/README.md
+++ b/examples/lgf-frappe-pep/README.md
@@ -12,6 +12,20 @@ Core invariant: **No valid authorization → no execution path.**
 * `POST /authorize` - evaluate policy, issue AuthorizationV1 for allowed actions
 * `POST /execute` - verify AuthorizationV1, call Frappe if valid (enforce mode only)
 
+## Graceful shutdown
+
+The runtime now installs explicit `SIGTERM` and `SIGINT` handlers.
+
+On shutdown request it:
+
+* logs a structured, non-secret shutdown event
+* stops accepting new HTTP connections
+* closes active HTTP connections through the existing `server.shutdown()` path
+* disconnects an owned Redis replay client when `REPLAY_STORE=redis`
+* exits cleanly on successful shutdown
+
+This is operational hardening for the sidecar runtime. It does not change authorization semantics.
+
 ## Quick start
 
 See [LIVE_VALIDATION.md](LIVE_VALIDATION.md) for local build, run, and validation instructions.

--- a/examples/lgf-frappe-pep/package.json
+++ b/examples/lgf-frappe-pep/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "pnpm build && node dist/server.js",
-    "test": "pnpm build && node --test dist/test/boundary.test.js",
+    "test": "pnpm build && node --test dist/test/boundary.test.js dist/test/shutdown.test.js",
     "test:redis": "pnpm build && OXDEAI_LIVE_REDIS_TEST=1 node --test dist/test/live-redis.test.js"
   },
   "dependencies": {

--- a/examples/lgf-frappe-pep/src/server.ts
+++ b/examples/lgf-frappe-pep/src/server.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { createServer } from "node:http";
-import type { IncomingMessage, ServerResponse, Server } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import type { ReplayStore } from "@oxdeai/guard";
 import { loadConfig, redactedConfigSummary } from "./config.js";
 import type { PepConfig } from "./config.js";
@@ -41,20 +41,110 @@ function emitDecisionLog(log: DecisionLog): void {
   console.log(JSON.stringify(log));
 }
 
+type ShutdownSignal = "SIGTERM" | "SIGINT";
+
+export type ShutdownLog = {
+  mode: PepConfig["mode"];
+  replay_store_type: PepConfig["replayStore"]["type"];
+  port: number;
+  signal: ShutdownSignal;
+  shutdown_status: "requested" | "completed" | "failed";
+};
+
+export type ShutdownHandlerOptions = {
+  config: Pick<PepConfig, "mode" | "replayStore" | "port">;
+  server: { shutdown: () => Promise<void> };
+  logger?: (entry: ShutdownLog) => void;
+  exit?: (code: number) => void;
+  on?: (signal: ShutdownSignal, handler: () => void) => void;
+};
+
+function emitShutdownLog(entry: ShutdownLog): void {
+  console.log(JSON.stringify(entry));
+}
+
+export function installShutdownHandlers(options: ShutdownHandlerOptions): {
+  requestShutdown: (signal: ShutdownSignal) => Promise<void>;
+} {
+  const {
+    config,
+    server,
+    logger = emitShutdownLog,
+    exit = (code: number) => process.exit(code),
+    on = (signal, handler) => {
+      process.on(signal, handler);
+    },
+  } = options;
+
+  let shutdownPromise: Promise<void> | null = null;
+
+  const requestShutdown = (signal: ShutdownSignal): Promise<void> => {
+    if (shutdownPromise) {
+      return shutdownPromise;
+    }
+
+    logger({
+      mode: config.mode,
+      replay_store_type: config.replayStore.type,
+      port: config.port,
+      signal,
+      shutdown_status: "requested",
+    });
+
+    shutdownPromise = (async () => {
+      try {
+        await server.shutdown();
+        logger({
+          mode: config.mode,
+          replay_store_type: config.replayStore.type,
+          port: config.port,
+          signal,
+          shutdown_status: "completed",
+        });
+        exit(0);
+      } catch {
+        logger({
+          mode: config.mode,
+          replay_store_type: config.replayStore.type,
+          port: config.port,
+          signal,
+          shutdown_status: "failed",
+        });
+        exit(1);
+      }
+    })();
+
+    return shutdownPromise;
+  };
+
+  on("SIGTERM", () => {
+    void requestShutdown("SIGTERM");
+  });
+  on("SIGINT", () => {
+    void requestShutdown("SIGINT");
+  });
+
+  return { requestShutdown };
+}
+
 export type PepServerOptions = {
   config: PepConfig;
   replayStore?: ReplayStore;
   frappeAdapter?: FrappeAdapter;
+  replayStoreHandleFactory?: typeof createReplayStoreHandle;
 };
 
-export function createPepServer(options: PepServerOptions): Server & { shutdown: () => Promise<void> } {
+type PepHttpServer = ReturnType<typeof createServer> & { shutdown: () => Promise<void> };
+
+export function createPepServer(options: PepServerOptions): PepHttpServer {
   const { config } = options;
   let replayDisconnect: () => Promise<void> = async () => {};
   let replayStore: import("@oxdeai/guard").ReplayStore;
+  let shutdownPromise: Promise<void> | null = null;
   if (options.replayStore) {
     replayStore = options.replayStore;
   } else {
-    const handle = createReplayStoreHandle({
+    const handle = (options.replayStoreHandleFactory ?? createReplayStoreHandle)({
       config: config.replayStore,
       issuer: config.issuer,
       audience: config.expectedAudience,
@@ -114,12 +204,28 @@ export function createPepServer(options: PepServerOptions): Server & { shutdown:
     }
 
     return sendJson(res, 404, { ok: false, error: "not found" });
-  }) as Server & { shutdown: () => Promise<void> };
+  }) as PepHttpServer;
 
   server.shutdown = async () => {
-    await replayDisconnect();
-    server.closeAllConnections();
-    await new Promise<void>((res, rej) => server.close((e) => (e ? rej(e) : res())));
+    if (shutdownPromise) {
+      return shutdownPromise;
+    }
+
+    shutdownPromise = (async () => {
+      if (!server.listening) {
+        await replayDisconnect();
+        return;
+      }
+
+      const closePromise = new Promise<void>((resolve, reject) => {
+        server.close((error?: Error) => (error ? reject(error) : resolve()));
+      });
+      server.closeAllConnections();
+      await closePromise;
+      await replayDisconnect();
+    })();
+
+    return shutdownPromise;
   };
 
   return server;
@@ -131,6 +237,7 @@ if (isMain) {
   const config = loadConfig();
   console.log("OxDeAI PEP starting", JSON.stringify(redactedConfigSummary(config)));
   const server = createPepServer({ config });
+  installShutdownHandlers({ config, server });
   server.listen(config.port, () => {
     console.log(`OxDeAI PEP listening on :${config.port} [mode=${config.mode}]`);
   });

--- a/examples/lgf-frappe-pep/test/shutdown.test.ts
+++ b/examples/lgf-frappe-pep/test/shutdown.test.ts
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import type { PepConfig } from "../src/config.js";
+import { createPepServer, installShutdownHandlers } from "../src/server.js";
+import type { ReplayStoreHandle } from "../src/replay.js";
+
+function makeConfig(replayStore: PepConfig["replayStore"]): Pick<PepConfig, "mode" | "replayStore" | "port"> {
+  return {
+    mode: "enforce",
+    replayStore,
+    port: 3000,
+  };
+}
+
+describe("PEP runtime shutdown hardening", () => {
+  test("shutdown request invokes server cleanup and exits 0", async () => {
+    const logs: unknown[] = [];
+    const exits: number[] = [];
+    const registered = new Map<string, () => void>();
+    let shutdownCalls = 0;
+
+    const { requestShutdown } = installShutdownHandlers({
+      config: makeConfig({ type: "memory" }),
+      server: {
+        shutdown: async () => {
+          shutdownCalls += 1;
+        },
+      },
+      logger: (entry) => logs.push(entry),
+      exit: (code) => {
+        exits.push(code);
+      },
+      on: (signal, handler) => {
+        registered.set(signal, handler);
+      },
+    });
+
+    assert.ok(registered.has("SIGTERM"));
+    assert.ok(registered.has("SIGINT"));
+
+    await requestShutdown("SIGTERM");
+
+    assert.equal(shutdownCalls, 1);
+    assert.deepEqual(exits, [0]);
+    assert.deepEqual(logs, [
+      {
+        mode: "enforce",
+        replay_store_type: "memory",
+        port: 3000,
+        signal: "SIGTERM",
+        shutdown_status: "requested",
+      },
+      {
+        mode: "enforce",
+        replay_store_type: "memory",
+        port: 3000,
+        signal: "SIGTERM",
+        shutdown_status: "completed",
+      },
+    ]);
+  });
+
+  test("multiple shutdown requests are idempotent", async () => {
+    const exits: number[] = [];
+    let shutdownCalls = 0;
+    let resolveShutdown: (() => void) | undefined;
+
+    const { requestShutdown } = installShutdownHandlers({
+      config: makeConfig({ type: "memory" }),
+      server: {
+        shutdown: async () => {
+          shutdownCalls += 1;
+          await new Promise<void>((resolve) => {
+            resolveShutdown = resolve;
+          });
+        },
+      },
+      exit: (code) => {
+        exits.push(code);
+      },
+      on: () => {},
+      logger: () => {},
+    });
+
+    const first = requestShutdown("SIGTERM");
+    const second = requestShutdown("SIGINT");
+    assert.equal(shutdownCalls, 1, "shutdown must not run concurrently");
+
+    resolveShutdown?.();
+    await Promise.all([first, second]);
+
+    assert.equal(shutdownCalls, 1, "shutdown must only run once");
+    assert.deepEqual(exits, [0], "successful idempotent shutdown exits once with 0");
+  });
+
+  test("shutdown failure exits non-zero", async () => {
+    const exits: number[] = [];
+    const logs: unknown[] = [];
+
+    const { requestShutdown } = installShutdownHandlers({
+      config: makeConfig({ type: "memory" }),
+      server: {
+        shutdown: async () => {
+          throw new Error("boom");
+        },
+      },
+      logger: (entry) => logs.push(entry),
+      exit: (code) => {
+        exits.push(code);
+      },
+      on: () => {},
+    });
+
+    await requestShutdown("SIGINT");
+
+    assert.deepEqual(exits, [1]);
+    assert.deepEqual(logs, [
+      {
+        mode: "enforce",
+        replay_store_type: "memory",
+        port: 3000,
+        signal: "SIGINT",
+        shutdown_status: "requested",
+      },
+      {
+        mode: "enforce",
+        replay_store_type: "memory",
+        port: 3000,
+        signal: "SIGINT",
+        shutdown_status: "failed",
+      },
+    ]);
+  });
+
+  test("shutdown logs do not leak secrets", async () => {
+    const logs: string[] = [];
+
+    const { requestShutdown } = installShutdownHandlers({
+      config: makeConfig({
+        type: "redis",
+        redisUrl: "redis://user:secret-password@redis.internal:6379/0",
+        keyPrefix: "oxdeai:test:replay",
+        ttlSkewSeconds: 60,
+      }),
+      server: { shutdown: async () => {} },
+      logger: (entry) => logs.push(JSON.stringify(entry)),
+      exit: () => {},
+      on: () => {},
+    });
+
+    await requestShutdown("SIGTERM");
+
+    const joined = logs.join("\n");
+    assert.ok(joined.includes("\"replay_store_type\":\"redis\""));
+    assert.ok(!joined.includes("redis.internal"));
+    assert.ok(!joined.includes("secret-password"));
+    assert.ok(!joined.includes("FRAPPE_API_SECRET"));
+    assert.ok(!joined.includes("SIGNING_PRIVATE_KEY_PEM"));
+    assert.ok(!joined.includes("/tmp/.env.pep.live"));
+    assert.ok(!joined.includes("/tmp/pep-signing-key.pem"));
+  });
+
+  test("server shutdown disconnects owned Redis client through existing shutdown path", async () => {
+    let disconnectCalls = 0;
+
+    const server = createPepServer({
+      config: {
+        mode: "enforce",
+        expectedAudience: "PEP-frappe.lgf.oxdeai.dev",
+        frappeBaseUrl: "https://frappe.example.invalid",
+        frappeApiKey: "test-key",
+        frappeApiSecret: "test-secret",
+        replayStore: {
+          type: "redis",
+          redisUrl: "redis://127.0.0.1:6379",
+          keyPrefix: "oxdeai:test:replay",
+          ttlSkewSeconds: 60,
+        },
+        port: 0,
+        signingPrivateKey: {} as PepConfig["signingPrivateKey"],
+        signingPublicKeyPem: "test-public-key",
+        signingKid: "test-key-1",
+        issuer: "oxdeai.lgf-frappe-pep",
+        authorizationTtlSeconds: 60,
+      },
+      replayStoreHandleFactory: (): ReplayStoreHandle => ({
+        store: {
+          consumeAuthId: async () => true,
+        },
+        disconnect: async () => {
+          disconnectCalls += 1;
+        },
+      }),
+      frappeAdapter: {
+        createTicket: async () => ({ ticket_id: "T1", name: "T1" }),
+      },
+    });
+
+    await server.shutdown();
+    await server.shutdown();
+
+    assert.equal(disconnectCalls, 1, "owned Redis disconnect must run exactly once");
+  });
+});


### PR DESCRIPTION
## Summary

Adds graceful shutdown handling for the OxDeAI PEP runtime.

The PEP runtime now registers `SIGTERM` and `SIGINT` handlers and routes process shutdown through the existing server cleanup path.

This is operational hardening for Docker, Compose, LGF-managed runtime, and future sidecar deployments.

## What changed

* Added shutdown handler installation for:

  * `SIGTERM`
  * `SIGINT`

* Hardened server shutdown behavior:

  * idempotent shutdown
  * stops accepting new HTTP connections
  * closes active HTTP connections
  * disconnects owned Redis replay clients
  * handles the “server never started listening” case cleanly

* Added structured shutdown logging with non-secret fields only:

  * mode
  * replay store type
  * port
  * signal
  * shutdown status

* Added shutdown tests covering:

  * cleanup invocation
  * signal handler registration
  * idempotent repeated shutdown
  * failure exit behavior
  * Redis disconnect through the server shutdown path
  * no secret leakage in shutdown logs

* Updated documentation:

  * README
  * LGF deployment notes
  * live validation notes

## Scope

Operational hardening only.

No changes to:

* authorization semantics
* replay semantics
* policy enforcement
* AuthorizationV1 behavior
* intent hash validation
* Frappe adapter behavior

## Validation

* LGF/Frappe PEP package tests: 42 passing / 0 failing
* Live Redis replay integration: 3 passing / 0 failing
* Security gate: ALLOW
* Blocking findings: 0

Secret/path grep:

* no new real secrets
* no GitHub tokens
* no private keys
* no credential-bearing Redis URLs
* remaining matches are existing placeholders, live-validation instructions, or negative assertions in tests

## Notes

CI wiring for the live Redis test remains a separate follow-up.

Closes #154
