### PR TITLE
ci: add Redis replay integration test for PEP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,63 @@ jobs:
         env:
           OXDEAI_ENGINE_SECRET: ci-adapter-validation-secret-testing!!
 
+  pep-redis-replay:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Wait for Redis
+        run: |
+          node -e '
+            const net = require("node:net");
+            const deadline = Date.now() + 30_000;
+            const tryConnect = () => {
+              const socket = net.connect({ host: "127.0.0.1", port: 6379 });
+              socket.once("connect", () => { socket.end(); process.exit(0); });
+              socket.once("error", () => {
+                socket.destroy();
+                if (Date.now() >= deadline) {
+                  console.error("Redis did not become ready on 127.0.0.1:6379");
+                  process.exit(1);
+                }
+                setTimeout(tryConnect, 500);
+              });
+            };
+            tryConnect();
+          '
+
+      - name: PEP live Redis replay integration
+        run: pnpm --filter @oxdeai/example-lgf-frappe-pep test:redis
+        env:
+          REDIS_URL: redis://127.0.0.1:6379
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,11 @@ jobs:
             tryConnect();
           '
 
+      - name: Build workspace dependencies
+        run: |
+          pnpm --filter @oxdeai/core build
+          pnpm --filter @oxdeai/guard build
+
       - name: PEP live Redis replay integration
         run: pnpm --filter @oxdeai/example-lgf-frappe-pep test:redis
         env:

--- a/examples/lgf-frappe-pep/LGF_DEPLOYMENT.md
+++ b/examples/lgf-frappe-pep/LGF_DEPLOYMENT.md
@@ -240,7 +240,15 @@ It proves:
 
 It does **not** require live Frappe, LGF-managed infrastructure, or deployment secrets.
 
-Current CI note: this repository keeps the live Redis test runnable locally first. CI service-container wiring is a follow-up and does not change the runtime or replay contract being tested.
+This same replay integration test now also runs in CI in the `pep-redis-replay` job in [.github/workflows/ci.yml](/home/ange/OxDeAI-core/.github/workflows/ci.yml:93) against a real `redis:7-alpine` service.
+
+The CI job keeps the same contract as the local Docker Compose flow:
+
+* no live Frappe dependency
+* no LGF infrastructure dependency
+* no secrets required
+* replay denial remains validated with `AUTH_REPLAY`
+* outage denial remains validated with `REPLAY_STORE_UNAVAILABLE`
 
 ## Graceful Shutdown
 

--- a/examples/lgf-frappe-pep/README.md
+++ b/examples/lgf-frappe-pep/README.md
@@ -62,7 +62,15 @@ docker compose -f examples/lgf-frappe-pep/docker-compose.redis.yml down
 
 The replay backend is one implementation detail behind the PEP boundary. Redis here is used only to validate replay persistence behavior.
 
-Current CI note: this live Redis test is designed to run locally today. Service-container or CI Compose wiring can be added later without changing the test contract.
+CI now runs this same test in the `pep-redis-replay` job in [.github/workflows/ci.yml](/home/ange/OxDeAI-core/.github/workflows/ci.yml:93) against a real `redis:7-alpine` service.
+
+That CI job:
+
+* uses a real Redis service, not mocks
+* runs the existing `pnpm --filter @oxdeai/example-lgf-frappe-pep test:redis` command
+* does not require live Frappe
+* does not require LGF infrastructure
+* does not require secrets
 
 ## LGF deployment
 


### PR DESCRIPTION
## Summary

Adds CI coverage for the OxDeAI PEP Redis replay integration test.

This wires the existing live Redis replay test into GitHub Actions using a real `redis:7-alpine` service container.

Closes #156.

## What changed

* Added CI job: `pep-redis-replay`
* Starts Redis as a GitHub Actions service container
* Uses `redis:7-alpine`
* Adds Redis health check with `redis-cli ping`
* Adds explicit Node-based Redis readiness wait against `127.0.0.1:6379`
* Runs the existing Redis replay integration test:

```bash
pnpm --filter @oxdeai/example-lgf-frappe-pep test:redis
```

with:

```bash
REDIS_URL=redis://127.0.0.1:6379
```

## What the CI job validates

The existing live Redis test proves:

* first execution succeeds
* replayed `AuthorizationV1` is denied with `AUTH_REPLAY`
* no second target-platform side effect occurs
* Redis replay key is created with the expected prefix
* Redis replay key has a positive bounded TTL
* Redis outage fails closed with `REPLAY_STORE_UNAVAILABLE`

## Scope

CI validation only.

No changes to:

* authorization semantics
* replay semantics
* policy enforcement
* PEP runtime behavior
* Frappe adapter behavior
* LGF deployment behavior

## Validation

Local package suite:

```bash
timeout 90s pnpm --filter @oxdeai/example-lgf-frappe-pep test
```

Result:

```text
42/42 passing
```

Local live Redis validation:

```bash
docker compose -f examples/lgf-frappe-pep/docker-compose.redis.yml up -d redis
REDIS_URL=redis://127.0.0.1:6379 timeout 90s pnpm --filter @oxdeai/example-lgf-frappe-pep test:redis
docker compose -f examples/lgf-frappe-pep/docker-compose.redis.yml down
```

Result:

```text
3/3 passing
```

Security gate:

```text
Decision: ALLOW
Blocking findings: 0
```

## Secret / path safety

Secret/path grep was run.

No new real secret material was introduced.

No GitHub tokens, private keys, embedded Redis credentials, Frappe credentials, or signing key material were added.

Remaining matches are acceptable existing placeholder docs, live-validation instructions, or shutdown test negative assertions.

## Notes

This does not publish a generic PEP OCI image.

That remains a later follow-up after CI replay coverage is merged and stable.
