### PR TITLE
build: prepare generic PEP sidecar image

### DIFF
--- a/examples/lgf-frappe-pep/Dockerfile
+++ b/examples/lgf-frappe-pep/Dockerfile
@@ -1,5 +1,6 @@
-# OxDeAI PEP runtime for LGF Frappe Helpdesk PoC
-# No secrets baked in — all credentials injected at runtime.
+# Generic OxDeAI PEP sidecar OCI image
+# Implementation source currently comes from the LGF/Frappe example package,
+# but all runtime credentials and deployment-specific settings remain external.
 #
 # Build context must be the repo root:
 #   docker build -f examples/lgf-frappe-pep/Dockerfile .
@@ -8,7 +9,6 @@
 # The .dockerignore at examples/lgf-frappe-pep/ is NOT used when the
 # build context is the repo root.
 
-# ── Stage 1: build ───────────────────────────────────────────────────────────
 FROM node:20-alpine AS build
 RUN corepack enable && corepack prepare pnpm@9.12.2 --activate
 WORKDIR /app
@@ -30,10 +30,13 @@ RUN pnpm --filter @oxdeai/core build && \
     pnpm --filter @oxdeai/guard build && \
     pnpm --filter @oxdeai/example-lgf-frappe-pep build
 
-# ── Stage 2: runtime ─────────────────────────────────────────────────────────
 FROM node:20-alpine
 RUN corepack enable && corepack prepare pnpm@9.12.2 --activate
 WORKDIR /app
+
+LABEL org.opencontainers.image.title="OxDeAI PEP Sidecar"
+LABEL org.opencontainers.image.description="Generic OxDeAI PEP sidecar OCI image built from the LGF/Frappe example runtime with runtime-injected configuration."
+LABEL org.opencontainers.image.source="https://github.com/oxdeai/oxdeai"
 
 COPY --from=build /app/pnpm-lock.yaml /app/pnpm-workspace.yaml /app/package.json ./
 COPY --from=build /app/packages/core/package.json packages/core/package.json
@@ -48,9 +51,12 @@ COPY --from=build /app/packages/guard/node_modules/ packages/guard/node_modules/
 COPY --from=build /app/examples/lgf-frappe-pep/node_modules/ examples/lgf-frappe-pep/node_modules/
 
 ENV OXDEAI_MODE=enforce
+ENV PORT=3000
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD wget -qO- http://localhost:3000/healthz || exit 1
+
+USER node
 
 CMD ["node", "examples/lgf-frappe-pep/dist/src/server.js"]

--- a/examples/lgf-frappe-pep/LGF_DEPLOYMENT.md
+++ b/examples/lgf-frappe-pep/LGF_DEPLOYMENT.md
@@ -66,7 +66,21 @@ The PEP does not know the target platform's internal semantics. Platform-specifi
 
 The long-term image is a generic OxDeAI PEP OCI artifact. It accepts platform-specific configuration through mounted files and environment variables. It does not embed platform-specific adapter code or credentials.
 
-The generic image is not yet published. Its design is informed by the Frappe PoC validation.
+The current packaging target is:
+
+```text
+ghcr.io/oxdeai/oxdeai-pep-sidecar:lgf-sidecar-poc
+```
+
+Local build:
+
+```bash
+docker build -t oxdeai-pep-sidecar:local -f examples/lgf-frappe-pep/Dockerfile .
+```
+
+The image is suitable for GHCR publishing, but GHCR push remains a manual release step.
+
+Current limitation: this is the first generic-sidecar packaging step. The implementation source still lives in `examples/lgf-frappe-pep`, and the runtime still expects Frappe-oriented adapter configuration such as `FRAPPE_BASE_URL`. That means the packaging is generic and secret-free, but full adapter extraction is still future work.
 
 ### Frappe-specific PoC image
 
@@ -88,6 +102,35 @@ The Frappe PoC image is not the required long-term image shape. It demonstrates:
 * structured decision logging
 
 Future LGF deployments should use the generic PEP image with LGF-injected platform adapters, unless a Frappe-specific deployment is required.
+
+### Generic sidecar runtime behavior
+
+The packaged sidecar image:
+
+* exposes the PEP HTTP listener on port `3000`
+* provides `/healthz`
+* supports `REPLAY_STORE=memory`
+* supports `REPLAY_STORE=redis` with runtime `REDIS_URL`
+* preserves graceful `SIGTERM` / `SIGINT` shutdown
+* does not bake in Frappe credentials, LGF credentials, signing private keys, Redis credentials, or local `/tmp` secret files
+
+Example local run:
+
+```bash
+docker run --rm -p 8080:3000 \
+  -e OXDEAI_MODE=observe \
+  -e EXPECTED_AUDIENCE=pep-sidecar.local \
+  -e FRAPPE_BASE_URL=https://example.invalid \
+  -e REPLAY_STORE=memory \
+  -e SIGNING_PRIVATE_KEY_PEM="<runtime-injected-private-key-pem>" \
+  oxdeai-pep-sidecar:local
+```
+
+Health check:
+
+```bash
+curl -fsS http://127.0.0.1:8080/healthz
+```
 
 ## Runtime Configuration Contract
 

--- a/examples/lgf-frappe-pep/README.md
+++ b/examples/lgf-frappe-pep/README.md
@@ -30,6 +30,64 @@ This is operational hardening for the sidecar runtime. It does not change author
 
 See [LIVE_VALIDATION.md](LIVE_VALIDATION.md) for local build, run, and validation instructions.
 
+## Generic sidecar image
+
+This repository now packages the runtime as a generic-sidecar OCI image using:
+
+```text
+ghcr.io/oxdeai/oxdeai-pep-sidecar:lgf-sidecar-poc
+```
+
+Local build:
+
+```bash
+docker build -t oxdeai-pep-sidecar:local -f examples/lgf-frappe-pep/Dockerfile .
+```
+
+Local run in memory replay mode:
+
+```bash
+SIGNING_PRIVATE_KEY_PEM="$(node -e "const { generateKeyPairSync } = require('node:crypto'); const { privateKey } = generateKeyPairSync('ed25519'); process.stdout.write(privateKey.export({ type: 'pkcs8', format: 'pem' }));")"
+
+docker run --rm -p 8080:3000 \
+  -e OXDEAI_MODE=observe \
+  -e EXPECTED_AUDIENCE=pep-sidecar.local \
+  -e FRAPPE_BASE_URL=https://example.invalid \
+  -e REPLAY_STORE=memory \
+  -e SIGNING_PRIVATE_KEY_PEM="$SIGNING_PRIVATE_KEY_PEM" \
+  -e PORT=3000 \
+  oxdeai-pep-sidecar:local
+```
+
+Health check:
+
+```bash
+curl -fsS http://127.0.0.1:8080/healthz
+```
+
+Redis replay mode is also runtime-configured:
+
+```bash
+docker run --rm -p 8080:3000 \
+  -e OXDEAI_MODE=observe \
+  -e EXPECTED_AUDIENCE=pep-sidecar.local \
+  -e FRAPPE_BASE_URL=https://example.invalid \
+  -e REPLAY_STORE=redis \
+  -e REDIS_URL=redis://host.docker.internal:6379 \
+  -e SIGNING_PRIVATE_KEY_PEM="$SIGNING_PRIVATE_KEY_PEM" \
+  oxdeai-pep-sidecar:local
+```
+
+GHCR publish commands are prepared but not run automatically:
+
+```bash
+docker tag oxdeai-pep-sidecar:local ghcr.io/oxdeai/oxdeai-pep-sidecar:lgf-sidecar-poc
+docker push ghcr.io/oxdeai/oxdeai-pep-sidecar:lgf-sidecar-poc
+docker pull ghcr.io/oxdeai/oxdeai-pep-sidecar:lgf-sidecar-poc
+```
+
+Current limitation: this is the first generic-sidecar packaging step. The packaged runtime still comes from the `examples/lgf-frappe-pep` implementation source and still expects Frappe-oriented adapter configuration such as `FRAPPE_BASE_URL`. No live Frappe credentials are baked into the image, but a fuller extraction of platform adapter configuration remains future work.
+
 ## Live Redis replay integration test
 
 This example includes a live Redis integration test for the PEP replay persistence path.


### PR DESCRIPTION
## Summary

Prepares the generic OxDeAI PEP sidecar OCI image path.

This reframes the existing LGF/Frappe PEP image as the first generic-sidecar packaging step while keeping runtime configuration external.

The image is intended for future publishing as:

```text
ghcr.io/oxdeai/oxdeai-pep-sidecar:lgf-sidecar-poc
```

## What changed

* Updated `examples/lgf-frappe-pep/Dockerfile`

  * clarified generic-sidecar image purpose
  * added OCI labels
  * keeps runtime config external
  * switches final runtime to `USER node`

* Updated documentation

  * generic image name
  * initial tag
  * local build command
  * local run command
  * `/healthz` check
  * memory replay mode
  * Redis replay mode
  * LGF sidecar deployment shape
  * honest limitation that the implementation source is still the LGF/Frappe example runtime

## Validation

Local image build:

```bash
docker build -t oxdeai-pep-sidecar:local -f examples/lgf-frappe-pep/Dockerfile .
```

Local image ID:

```text
sha256:84a1715cb447531c3a30616d9da6e737038b2ffcd59488e6828528d0397dd71b
```

Local run command:

```bash
docker run -d -p 8080:3000 \
  -e OXDEAI_MODE=observe \
  -e EXPECTED_AUDIENCE=pep-sidecar.local \
  -e FRAPPE_BASE_URL=https://example.invalid \
  -e REPLAY_STORE=memory \
  -e PORT=3000 \
  -e SIGNING_PRIVATE_KEY_PEM="<runtime-injected-ed25519-private-key-pem>" \
  --name oxdeai-pep-sidecar-test \
  oxdeai-pep-sidecar:local
```

Health check:

```bash
curl -fsS http://127.0.0.1:8080/healthz
```

Result:

```json
{"ok":true,"status":"healthy","mode":"observe"}
```

Graceful shutdown:

```bash
docker stop oxdeai-pep-sidecar-test
```

Result:

```text
exit code: 0
shutdown_status: requested
shutdown_status: completed
```

Package tests:

```text
42/42 passing
```

Live Redis replay integration:

```text
3/3 passing
```

Security gate:

```text
Decision: ALLOW
Blocking findings: 0
```

## Image hygiene

Confirmed the runtime image does not include:

* `README.md`
* `LIVE_VALIDATION.md`
* `.env.live.example`

Secret/path grep found no real secrets, private keys, GitHub tokens, or credential-bearing Redis URLs.

Remaining matches are acceptable placeholder docs, live-validation instructions, or shutdown negative assertions.

## Honest limitation

This is the first generic-sidecar packaging step.

The packaged runtime is still sourced from `examples/lgf-frappe-pep` and still expects Frappe-oriented adapter config such as `FRAPPE_BASE_URL`.

This PR does not fully extract the adapter interface into a platform-neutral runtime package.

## Not done in this PR

GHCR push was not performed in this branch.

Prepared publishing commands:

```bash
docker tag oxdeai-pep-sidecar:local ghcr.io/oxdeai/oxdeai-pep-sidecar:lgf-sidecar-poc
docker push ghcr.io/oxdeai/oxdeai-pep-sidecar:lgf-sidecar-poc
docker pull ghcr.io/oxdeai/oxdeai-pep-sidecar:lgf-sidecar-poc
```

The issue should remain open until GHCR push, pull-test, and digest documentation are completed.
