### PR TITLE
docs: document published generic PEP sidecar image

### DIFF
--- a/examples/lgf-frappe-pep/LGF_DEPLOYMENT.md
+++ b/examples/lgf-frappe-pep/LGF_DEPLOYMENT.md
@@ -72,6 +72,12 @@ The current packaging target is:
 ghcr.io/oxdeai/oxdeai-pep-sidecar:lgf-sidecar-poc
 ```
 
+Published digest:
+
+```text
+ghcr.io/oxdeai/oxdeai-pep-sidecar@sha256:19086e7972484852efe998f8a3f0982125a16e3911ea068af52829b8ee746e53
+```
+
 Local build:
 
 ```bash
@@ -79,6 +85,12 @@ docker build -t oxdeai-pep-sidecar:local -f examples/lgf-frappe-pep/Dockerfile .
 ```
 
 The image is suitable for GHCR publishing, but GHCR push remains a manual release step.
+
+Published image pull command:
+
+```bash
+docker pull ghcr.io/oxdeai/oxdeai-pep-sidecar:lgf-sidecar-poc
+```
 
 Current limitation: this is the first generic-sidecar packaging step. The implementation source still lives in `examples/lgf-frappe-pep`, and the runtime still expects Frappe-oriented adapter configuration such as `FRAPPE_BASE_URL`. That means the packaging is generic and secret-free, but full adapter extraction is still future work.
 
@@ -130,6 +142,12 @@ Health check:
 
 ```bash
 curl -fsS http://127.0.0.1:8080/healthz
+```
+
+Observed result from the pulled GHCR image:
+
+```json
+{"ok":true,"status":"healthy","mode":"observe"}
 ```
 
 ## Runtime Configuration Contract

--- a/examples/lgf-frappe-pep/README.md
+++ b/examples/lgf-frappe-pep/README.md
@@ -38,6 +38,12 @@ This repository now packages the runtime as a generic-sidecar OCI image using:
 ghcr.io/oxdeai/oxdeai-pep-sidecar:lgf-sidecar-poc
 ```
 
+Published digest:
+
+```text
+ghcr.io/oxdeai/oxdeai-pep-sidecar@sha256:19086e7972484852efe998f8a3f0982125a16e3911ea068af52829b8ee746e53
+```
+
 Local build:
 
 ```bash
@@ -84,6 +90,18 @@ GHCR publish commands are prepared but not run automatically:
 docker tag oxdeai-pep-sidecar:local ghcr.io/oxdeai/oxdeai-pep-sidecar:lgf-sidecar-poc
 docker push ghcr.io/oxdeai/oxdeai-pep-sidecar:lgf-sidecar-poc
 docker pull ghcr.io/oxdeai/oxdeai-pep-sidecar:lgf-sidecar-poc
+```
+
+Published image pull-test command:
+
+```bash
+docker pull ghcr.io/oxdeai/oxdeai-pep-sidecar:lgf-sidecar-poc
+```
+
+Published image health result:
+
+```json
+{"ok":true,"status":"healthy","mode":"observe"}
 ```
 
 Current limitation: this is the first generic-sidecar packaging step. The packaged runtime still comes from the `examples/lgf-frappe-pep` implementation source and still expects Frappe-oriented adapter configuration such as `FRAPPE_BASE_URL`. No live Frappe credentials are baked into the image, but a fuller extraction of platform adapter configuration remains future work.


### PR DESCRIPTION
## Summary

Documents the published generic OxDeAI PEP sidecar OCI image.

This completes the publish and pull-test step for:

```text
ghcr.io/oxdeai/oxdeai-pep-sidecar:lgf-sidecar-poc
```

Closes #[ISSUE_NUMBER].

## Published image

Image:

```text
ghcr.io/oxdeai/oxdeai-pep-sidecar:lgf-sidecar-poc
```

Digest:

```text
sha256:19086e7972484852efe998f8a3f0982125a16e3911ea068af52829b8ee746e53
```

## Validation

Local image ID:

```text
sha256:19086e7972484852efe998f8a3f0982125a16e3911ea068af52829b8ee746e53
```

Pull-tested image ID:

```text
sha256:19086e7972484852efe998f8a3f0982125a16e3911ea068af52829b8ee746e53
```

Pulled image `/healthz` result:

```json
{"ok":true,"status":"healthy","mode":"observe"}
```

Graceful shutdown:

```text
docker stop oxdeai-pep-sidecar-ghcr-test
exit code: 0
shutdown_status: requested
shutdown_status: completed
```

Runtime image hygiene:

```text
runtime-image-clean
```

Confirmed the runtime image does not include:

* `.env.live.example`
* `LIVE_VALIDATION.md`
* `README.md`

## Tests

Package tests:

```text
42/42 passing
```

Live Redis replay integration:

```text
3/3 passing
```

Redis replay behavior validated:

* first execution succeeds
* replay denied with `AUTH_REPLAY`
* outage denied with `REPLAY_STORE_UNAVAILABLE`

Security gate:

```text
Decision: ALLOW
Blocking findings: 0
```

## Secret / path safety

Secret/path grep found no new real secrets, GitHub tokens, Frappe credentials, signing keys, or credential-bearing Redis URLs.

Remaining matches are acceptable placeholder docs, live-validation instructions, or shutdown test negative assertions.

## Scope

This PR documents the completed GHCR publish and pull-test.

It does not change runtime semantics.

## Remaining limitation

The image is published and working, but the implementation source is still the LGF/Frappe example runtime.

The runtime still expects adapter-oriented config such as `FRAPPE_BASE_URL`.

Full adapter extraction remains future work.
