### PR TITLE
refactor: extract PEP platform adapter boundary

### DIFF
--- a/examples/lgf-frappe-pep/LGF_DEPLOYMENT.md
+++ b/examples/lgf-frappe-pep/LGF_DEPLOYMENT.md
@@ -32,6 +32,36 @@ The PEP enforces a single invariant:
 
 The PEP does not know the target platform's internal semantics. Platform-specific adapter logic, credentials, and routing are injected by LGF at deployment time.
 
+## Adapter Boundary
+
+The runtime now exposes an explicit platform adapter boundary.
+
+PEP owns:
+
+* AuthorizationV1 verification
+* intent hash binding
+* replay protection
+* policy enforcement
+* fail-closed execution gating
+* observe/enforce mode behavior
+* health and graceful shutdown
+
+Adapter owns:
+
+* target-platform API invocation
+* target-platform request formatting
+* target-platform response parsing
+* target-platform-specific side effects
+* target-platform runtime configuration
+
+Current adapter:
+
+```text
+Frappe Helpdesk
+```
+
+Current limitation: this is a first adapter-boundary extraction. The packaged sidecar still uses the current example runtime and still expects Frappe-oriented adapter configuration such as `FRAPPE_BASE_URL`. Full dynamic adapter loading and additional platform adapters remain future work.
+
 ## Responsibility Boundary
 
 ### LGF owns

--- a/examples/lgf-frappe-pep/README.md
+++ b/examples/lgf-frappe-pep/README.md
@@ -6,6 +6,36 @@ Protected action: `frappe.helpdesk.create_ticket`
 
 Core invariant: **No valid authorization → no execution path.**
 
+## PEP vs adapter boundary
+
+The runtime now has an explicit platform adapter boundary.
+
+PEP owns:
+
+* authorization verification
+* intent hash binding
+* replay protection
+* policy enforcement
+* fail-closed execution gating
+* observe/enforce behavior
+* health and graceful shutdown behavior
+
+Adapter owns:
+
+* target-platform API call
+* target-platform request formatting
+* target-platform response parsing
+* target-platform-specific side effects
+* target-platform runtime configuration
+
+Current adapter:
+
+```text
+Frappe Helpdesk
+```
+
+Current limitation: this is a first adapter-boundary extraction. It is not yet a dynamic adapter registry or plugin system. The generic sidecar image still packages the current example runtime, and additional platform adapters remain future work.
+
 ## Endpoints
 
 * `GET /healthz` - container health

--- a/examples/lgf-frappe-pep/package.json
+++ b/examples/lgf-frappe-pep/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "pnpm build && node dist/server.js",
-    "test": "pnpm build && node --test dist/test/boundary.test.js dist/test/shutdown.test.js",
+    "test": "pnpm build && node --test dist/test/boundary.test.js dist/test/adapter-boundary.test.js dist/test/shutdown.test.js",
     "test:redis": "pnpm build && OXDEAI_LIVE_REDIS_TEST=1 node --test dist/test/live-redis.test.js"
   },
   "dependencies": {

--- a/examples/lgf-frappe-pep/src/adapters/frappe.ts
+++ b/examples/lgf-frappe-pep/src/adapters/frappe.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+import type {
+  PlatformAdapter,
+  PlatformExecutionContext,
+  PlatformExecutionResult,
+} from "./platform.js";
+
+export type FrappeHttpAdapterOptions = {
+  baseUrl: string;
+  apiKey: string;
+  apiSecret: string;
+};
+
+export type FrappeCreateTicketParams = {
+  subject: string;
+  description: string;
+  priority: string;
+};
+
+export const FRAPPE_CREATE_TICKET_ACTION = "frappe.helpdesk.create_ticket";
+
+function isFrappeCreateTicketParams(payload: unknown): payload is FrappeCreateTicketParams {
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return false;
+  const p = payload as Record<string, unknown>;
+  return typeof p["subject"] === "string"
+    && typeof p["description"] === "string"
+    && typeof p["priority"] === "string";
+}
+
+export function createFrappePlatformAdapter(options: FrappeHttpAdapterOptions): PlatformAdapter {
+  const doctype = encodeURIComponent("HD Ticket");
+
+  return {
+    name: "frappe",
+    async execute(
+      action: string,
+      payload: unknown,
+      _context: PlatformExecutionContext,
+    ): Promise<PlatformExecutionResult> {
+      if (action !== FRAPPE_CREATE_TICKET_ACTION) {
+        throw new Error(`Unsupported Frappe adapter action: ${action}`);
+      }
+      if (!isFrappeCreateTicketParams(payload)) {
+        throw new Error("Invalid Frappe create-ticket payload");
+      }
+
+      const url = `${options.baseUrl}/api/resource/${doctype}`;
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `token ${options.apiKey}:${options.apiSecret}`,
+        },
+        body: JSON.stringify({
+          data: {
+            subject: payload.subject,
+            description: payload.description,
+            priority: payload.priority,
+          },
+        }),
+      });
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        throw new Error(`Frappe API error: status=${response.status} body=${text.slice(0, 200)}`);
+      }
+
+      const contentType = response.headers.get("content-type") ?? "";
+      if (!contentType.includes("application/json")) {
+        throw new Error(`Frappe API returned non-JSON content-type=${contentType} status=${response.status}`);
+      }
+
+      const result = await response.json() as Record<string, unknown>;
+      const data = result["data"] as Record<string, unknown> | undefined;
+      const rawName = data?.["name"];
+
+      if (typeof rawName !== "string" && typeof rawName !== "number") {
+        const keys = Object.keys(result).join(",");
+        throw new Error(`Frappe API unexpected response shape: top-level keys=[${keys}]`);
+      }
+
+      const name = String(rawName);
+      return {
+        resource_id: name,
+        details: { ticket_id: name, name },
+      };
+    },
+  };
+}

--- a/examples/lgf-frappe-pep/src/adapters/platform.ts
+++ b/examples/lgf-frappe-pep/src/adapters/platform.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { PepMode } from "../config.js";
+
+export type PlatformExecutionContext = {
+  correlationId: string;
+  mode: PepMode;
+  authId: string;
+  expectedAudience: string;
+};
+
+export type PlatformExecutionResult = {
+  resource_id: string;
+  details?: Record<string, unknown>;
+};
+
+export interface PlatformAdapter {
+  readonly name: string;
+  execute(
+    action: string,
+    payload: unknown,
+    context: PlatformExecutionContext,
+  ): Promise<PlatformExecutionResult>;
+}

--- a/examples/lgf-frappe-pep/src/execute.ts
+++ b/examples/lgf-frappe-pep/src/execute.ts
@@ -4,7 +4,8 @@ import { sha256HexFromJson, verifyAuthorization } from "@oxdeai/core";
 import type { AuthorizationV1, KeySet } from "@oxdeai/core";
 import type { ReplayStore } from "@oxdeai/guard";
 import type { PepConfig } from "./config.js";
-import type { ActionEnvelope, FrappeAdapter, PepResponse, DecisionLog } from "./types.js";
+import type { ActionEnvelope, PepResponse, DecisionLog } from "./types.js";
+import type { PlatformAdapter } from "./adapters/platform.js";
 import { PROTECTED_ACTION, POLICY_ID } from "./policy.js";
 
 function parseExecuteRequest(
@@ -73,7 +74,7 @@ function denyResult(
 export function handleExecute(
   config: PepConfig,
   replayStore: ReplayStore,
-  frappeAdapter: FrappeAdapter,
+  platformAdapter: PlatformAdapter,
 ) {
   const trustedKeySets: KeySet[] = [
     {
@@ -195,11 +196,16 @@ export function handleExecute(
 
     // 8. Enforce mode — call Frappe
     try {
-      const result = await frappeAdapter.createTicket({
-        subject: envelope.action.params.subject,
-        description: envelope.action.params.description,
-        priority: envelope.action.params.priority,
-      });
+      const result = await platformAdapter.execute(
+        envelope.action.tool,
+        envelope.action.params,
+        {
+          correlationId,
+          mode: config.mode,
+          authId: authorization.auth_id,
+          expectedAudience: config.expectedAudience,
+        },
+      );
 
       const log: DecisionLog = {
         correlation_id: correlationId,
@@ -212,7 +218,7 @@ export function handleExecute(
         decision: "ALLOW",
         reason: "AUTHORIZED",
         executed: true,
-        frappe_ticket_id: result.ticket_id,
+        frappe_ticket_id: result.resource_id,
         timestamp: new Date(now * 1000).toISOString(),
       };
       return {
@@ -224,7 +230,7 @@ export function handleExecute(
           auth_id: authorization.auth_id,
           intent_hash: intentHash,
           policy_id: POLICY_ID,
-          frappe_ticket_id: result.ticket_id,
+          frappe_ticket_id: result.resource_id,
         },
         log,
       };

--- a/examples/lgf-frappe-pep/src/frappe.ts
+++ b/examples/lgf-frappe-pep/src/frappe.ts
@@ -1,54 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-import type { FrappeAdapter, FrappeCreateTicketParams, FrappeCreateTicketResult } from "./types.js";
-
-export type FrappeHttpAdapterOptions = {
-  baseUrl: string;
-  apiKey: string;
-  apiSecret: string;
-};
-
-export function createFrappeHttpAdapter(options: FrappeHttpAdapterOptions): FrappeAdapter {
-  const doctype = encodeURIComponent("HD Ticket");
-
-  return {
-    async createTicket(params: FrappeCreateTicketParams): Promise<FrappeCreateTicketResult> {
-      const url = `${options.baseUrl}/api/resource/${doctype}`;
-      const response = await fetch(url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Authorization": `token ${options.apiKey}:${options.apiSecret}`,
-        },
-        body: JSON.stringify({
-          data: {
-            subject: params.subject,
-            description: params.description,
-            priority: params.priority,
-          },
-        }),
-      });
-
-      if (!response.ok) {
-        const text = await response.text().catch(() => "");
-        throw new Error(`Frappe API error: status=${response.status} body=${text.slice(0, 200)}`);
-      }
-
-      const contentType = response.headers.get("content-type") ?? "";
-      if (!contentType.includes("application/json")) {
-        throw new Error(`Frappe API returned non-JSON content-type=${contentType} status=${response.status}`);
-      }
-
-      const result = await response.json() as Record<string, unknown>;
-      const data = result["data"] as Record<string, unknown> | undefined;
-      const rawName = data?.["name"];
-
-      if (typeof rawName !== "string" && typeof rawName !== "number") {
-        const keys = Object.keys(result).join(",");
-        throw new Error(`Frappe API unexpected response shape: top-level keys=[${keys}]`);
-      }
-
-      const name = String(rawName);
-      return { ticket_id: name, name };
-    },
-  };
-}
+export {
+  createFrappePlatformAdapter as createFrappeHttpAdapter,
+  FRAPPE_CREATE_TICKET_ACTION,
+} from "./adapters/frappe.js";
+export type {
+  FrappeCreateTicketParams,
+  FrappeHttpAdapterOptions,
+} from "./adapters/frappe.js";

--- a/examples/lgf-frappe-pep/src/server.ts
+++ b/examples/lgf-frappe-pep/src/server.ts
@@ -4,10 +4,11 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { ReplayStore } from "@oxdeai/guard";
 import { loadConfig, redactedConfigSummary } from "./config.js";
 import type { PepConfig } from "./config.js";
-import type { FrappeAdapter, DecisionLog } from "./types.js";
+import type { DecisionLog } from "./types.js";
+import type { PlatformAdapter } from "./adapters/platform.js";
 import { handleAuthorize } from "./authorize.js";
 import { handleExecute } from "./execute.js";
-import { createFrappeHttpAdapter } from "./frappe.js";
+import { createFrappePlatformAdapter } from "./adapters/frappe.js";
 import { createReplayStoreHandle } from "./replay.js";
 
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
@@ -130,7 +131,7 @@ export function installShutdownHandlers(options: ShutdownHandlerOptions): {
 export type PepServerOptions = {
   config: PepConfig;
   replayStore?: ReplayStore;
-  frappeAdapter?: FrappeAdapter;
+  platformAdapter?: PlatformAdapter;
   replayStoreHandleFactory?: typeof createReplayStoreHandle;
 };
 
@@ -153,16 +154,16 @@ export function createPepServer(options: PepServerOptions): PepHttpServer {
     replayStore = handle.store;
     replayDisconnect = handle.disconnect;
   }
-  const frappeAdapter =
-    options.frappeAdapter ??
-    createFrappeHttpAdapter({
+  const platformAdapter =
+    options.platformAdapter ??
+    createFrappePlatformAdapter({
       baseUrl: config.frappeBaseUrl,
       apiKey: config.frappeApiKey,
       apiSecret: config.frappeApiSecret,
     });
 
   const authorize = handleAuthorize(config);
-  const execute = handleExecute(config, replayStore, frappeAdapter);
+  const execute = handleExecute(config, replayStore, platformAdapter);
 
   const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
     if (req.method === "GET" && req.url === "/healthz") {

--- a/examples/lgf-frappe-pep/src/types.ts
+++ b/examples/lgf-frappe-pep/src/types.ts
@@ -44,21 +44,6 @@ export type PepResponse =
       reason: string;
     };
 
-export type FrappeCreateTicketParams = {
-  subject: string;
-  description: string;
-  priority: string;
-};
-
-export type FrappeCreateTicketResult = {
-  ticket_id: string;
-  name: string;
-};
-
-export interface FrappeAdapter {
-  createTicket(params: FrappeCreateTicketParams): Promise<FrappeCreateTicketResult>;
-}
-
 export type DecisionLog = {
   correlation_id: string;
   action: string;

--- a/examples/lgf-frappe-pep/test/adapter-boundary.test.ts
+++ b/examples/lgf-frappe-pep/test/adapter-boundary.test.ts
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+import { after, before, describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync, randomUUID } from "node:crypto";
+import { sha256HexFromJson, signAuthorizationEd25519 } from "@oxdeai/core";
+import type { AuthorizationV1 } from "@oxdeai/core";
+import { createInMemoryReplayStore } from "@oxdeai/guard";
+import type { PepConfig } from "../src/config.js";
+import { createPepServer } from "../src/server.js";
+import type { ActionEnvelope } from "../src/types.js";
+import type { PlatformAdapter, PlatformExecutionContext } from "../src/adapters/platform.js";
+import { POLICY_ID } from "../src/policy.js";
+
+function makeEnvelope(): ActionEnvelope {
+  return {
+    source_bench: "openwebui-dev",
+    target_bench: "frappe",
+    agent_or_tool_context: "erp-assistant",
+    user_identity: "adapter-boundary@oxdeai.dev",
+    session_id: "adapter-boundary-session",
+    action: {
+      type: "EXECUTE",
+      tool: "frappe.helpdesk.create_ticket",
+      params: {
+        subject: "Adapter boundary ticket",
+        description: "Adapter boundary test",
+        priority: "Low",
+      },
+    },
+  };
+}
+
+function issueAuthorization(envelope: ActionEnvelope, privateKeyPem: string): AuthorizationV1 {
+  const now = Math.floor(Date.now() / 1000);
+  return signAuthorizationEd25519(
+    {
+      auth_id: randomUUID(),
+      issuer: "oxdeai.lgf-frappe-pep",
+      audience: "PEP-frappe.lgf.oxdeai.dev",
+      intent_hash: sha256HexFromJson(envelope.action),
+      state_hash: sha256HexFromJson({}),
+      policy_id: POLICY_ID,
+      decision: "ALLOW",
+      issued_at: now,
+      expiry: now + 60,
+      kid: "test-key-1",
+      nonce: randomUUID(),
+    },
+    privateKeyPem,
+  );
+}
+
+async function postJson(url: string, body: unknown): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: await res.json() as Record<string, unknown> };
+}
+
+describe("Platform adapter boundary", () => {
+  let baseUrl: string;
+  let privateKeyPem: string;
+  let adapterCalls: number;
+  let lastAction: string | null;
+  let lastPayload: unknown;
+  let lastContext: PlatformExecutionContext | null;
+  let close: () => Promise<void>;
+
+  before(async () => {
+    const keyPair = generateKeyPairSync("ed25519");
+    privateKeyPem = keyPair.privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+    const publicKeyPem = keyPair.publicKey.export({ type: "spki", format: "pem" }) as string;
+
+    adapterCalls = 0;
+    lastAction = null;
+    lastPayload = null;
+    lastContext = null;
+
+    const adapter: PlatformAdapter = {
+      name: "frappe",
+      async execute(action, payload, context) {
+        adapterCalls += 1;
+        lastAction = action;
+        lastPayload = payload;
+        lastContext = context;
+        return { resource_id: "HD-TICKET-BOUNDARY-1" };
+      },
+    };
+
+    const config: PepConfig = {
+      mode: "enforce",
+      expectedAudience: "PEP-frappe.lgf.oxdeai.dev",
+      frappeBaseUrl: "https://frappe.example.invalid",
+      frappeApiKey: "test-key",
+      frappeApiSecret: "test-secret",
+      replayStore: { type: "memory" },
+      port: 0,
+      signingPrivateKey: keyPair.privateKey,
+      signingPublicKeyPem: publicKeyPem,
+      signingKid: "test-key-1",
+      issuer: "oxdeai.lgf-frappe-pep",
+      authorizationTtlSeconds: 60,
+    };
+
+    const server = createPepServer({
+      config,
+      replayStore: createInMemoryReplayStore(),
+      platformAdapter: adapter,
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("Unexpected address");
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+    close = () => server.shutdown();
+  });
+
+  after(async () => {
+    await close();
+  });
+
+  test("PEP uses injected adapter and returns its execution result", async () => {
+    adapterCalls = 0;
+    lastAction = null;
+    lastPayload = null;
+    lastContext = null;
+
+    const envelope = makeEnvelope();
+    const authorization = issueAuthorization(envelope, privateKeyPem);
+    const result = await postJson(`${baseUrl}/execute`, { envelope, authorization });
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body["decision"], "ALLOW");
+    assert.equal(result.body["frappe_ticket_id"], "HD-TICKET-BOUNDARY-1");
+    assert.equal(adapterCalls, 1);
+    assert.equal(lastAction, "frappe.helpdesk.create_ticket");
+    assert.deepEqual(lastPayload, envelope.action.params);
+    const ctx = lastContext as PlatformExecutionContext | null;
+    assert.ok(ctx, "adapter context must be provided");
+    assert.equal(ctx.authId, authorization.auth_id);
+    assert.equal(ctx.mode, "enforce");
+  });
+});

--- a/examples/lgf-frappe-pep/test/boundary.test.ts
+++ b/examples/lgf-frappe-pep/test/boundary.test.ts
@@ -34,9 +34,11 @@ import { createInMemoryReplayStore } from "@oxdeai/guard";
 import type { ReplayStore } from "@oxdeai/guard";
 import type { PepConfig } from "../src/config.js";
 import { redactedConfigSummary } from "../src/config.js";
-import type { FrappeAdapter, FrappeCreateTicketParams, ActionEnvelope } from "../src/types.js";
+import type { ActionEnvelope } from "../src/types.js";
+import type { PlatformAdapter, PlatformExecutionContext } from "../src/adapters/platform.js";
+import type { FrappeCreateTicketParams } from "../src/adapters/frappe.js";
 import { createPepServer } from "../src/server.js";
-import { createFrappeHttpAdapter } from "../src/frappe.js";
+import { createFrappePlatformAdapter } from "../src/adapters/frappe.js";
 import { createReplayStore, createReplayStoreHandle } from "../src/replay.js";
 import type { RedisClientLike } from "../src/replay.js";
 import { POLICY_ID } from "../src/policy.js";
@@ -48,6 +50,7 @@ type TestHarness = {
   config: PepConfig;
   frappeCallCount: () => number;
   frappeLastCall: () => FrappeCreateTicketParams | null;
+  lastAdapterContext: () => PlatformExecutionContext | null;
   resetFrappe: () => void;
   privateKeyPem: string;
   close: () => Promise<void>;
@@ -83,12 +86,17 @@ async function startHarness(modeOverride?: "enforce" | "observe"): Promise<TestH
 
   let callCount = 0;
   let lastCall: FrappeCreateTicketParams | null = null;
+  let lastContext: PlatformExecutionContext | null = null;
 
-  const mockFrappe: FrappeAdapter = {
-    async createTicket(params) {
+  const mockFrappe: PlatformAdapter = {
+    name: "frappe",
+    async execute(action, payload, context) {
+      assert.equal(action, "frappe.helpdesk.create_ticket");
+      assert.ok(typeof payload === "object" && payload !== null);
       callCount++;
-      lastCall = params;
-      return { ticket_id: `HD-TICKET-${callCount}`, name: `HD-TICKET-${callCount}` };
+      lastCall = payload as FrappeCreateTicketParams;
+      lastContext = context;
+      return { resource_id: `HD-TICKET-${callCount}`, details: { ticket_id: `HD-TICKET-${callCount}`, name: `HD-TICKET-${callCount}` } };
     },
   };
 
@@ -110,7 +118,7 @@ async function startHarness(modeOverride?: "enforce" | "observe"): Promise<TestH
   const server = createPepServer({
     config,
     replayStore: createInMemoryReplayStore(),
-    frappeAdapter: mockFrappe,
+    platformAdapter: mockFrappe,
   });
 
   await new Promise<void>((resolve, reject) => {
@@ -126,7 +134,8 @@ async function startHarness(modeOverride?: "enforce" | "observe"): Promise<TestH
     config,
     frappeCallCount: () => callCount,
     frappeLastCall: () => lastCall,
-    resetFrappe: () => { callCount = 0; lastCall = null; },
+    lastAdapterContext: () => lastContext,
+    resetFrappe: () => { callCount = 0; lastCall = null; lastContext = null; },
     privateKeyPem,
     close: () => {
       server.closeAllConnections();
@@ -207,6 +216,8 @@ describe("LGF Frappe PEP boundary", () => {
     assert.equal(body["mode"], "enforce");
     assert.equal(typeof body["frappe_ticket_id"], "string");
     assert.equal(h.frappeCallCount(), 1, "Frappe adapter must be called exactly once");
+    assert.equal(h.frappeLastCall()?.subject, envelope.action.params.subject);
+    assert.equal(h.lastAdapterContext()?.mode, "enforce");
   });
 
   // ── 2. ALLOW (enforce, Medium) ─────────────────────────────────────────────
@@ -535,8 +546,9 @@ describe("LGF Frappe PEP upstream error handling", () => {
     privateKeyPem = keyPair.privateKey.export({ type: "pkcs8", format: "pem" }) as string;
     const publicKeyPem = keyPair.publicKey.export({ type: "spki", format: "pem" }) as string;
 
-    const failingFrappe: FrappeAdapter = {
-      async createTicket() {
+    const failingFrappe: PlatformAdapter = {
+      name: "frappe",
+      async execute() {
         throw new Error("Frappe API returned non-JSON content-type=text/html status=200");
       },
     };
@@ -559,7 +571,7 @@ describe("LGF Frappe PEP upstream error handling", () => {
     const server = createPepServer({
       config,
       replayStore: createInMemoryReplayStore(),
-      frappeAdapter: failingFrappe,
+      platformAdapter: failingFrappe,
     });
 
     await new Promise<void>((resolve, reject) => {
@@ -640,20 +652,26 @@ describe("Frappe adapter response parsing", () => {
       }),
     };
 
-    const adapter = createFrappeHttpAdapter({
+    const adapter = createFrappePlatformAdapter({
       baseUrl: mockFrappeUrl,
       apiKey: "test-key",
       apiSecret: "test-secret",
     });
 
-    const result = await adapter.createTicket({
-      subject: "test",
-      description: "test",
-      priority: "Low",
-    });
+    const result = await adapter.execute(
+      "frappe.helpdesk.create_ticket",
+      { subject: "test", description: "test", priority: "Low" },
+      {
+        correlationId: "c1",
+        mode: "enforce",
+        authId: "a1",
+        expectedAudience: "PEP-frappe.lgf.oxdeai.dev",
+      },
+    );
 
-    assert.equal(result.ticket_id, "3");
-    assert.equal(result.name, "3");
+    assert.equal(result.resource_id, "3");
+    assert.equal(result.details?.["ticket_id"], "3");
+    assert.equal(result.details?.["name"], "3");
   });
 
   test("string data.name is returned as-is", async () => {
@@ -665,20 +683,26 @@ describe("Frappe adapter response parsing", () => {
       }),
     };
 
-    const adapter = createFrappeHttpAdapter({
+    const adapter = createFrappePlatformAdapter({
       baseUrl: mockFrappeUrl,
       apiKey: "test-key",
       apiSecret: "test-secret",
     });
 
-    const result = await adapter.createTicket({
-      subject: "test",
-      description: "test",
-      priority: "Low",
-    });
+    const result = await adapter.execute(
+      "frappe.helpdesk.create_ticket",
+      { subject: "test", description: "test", priority: "Low" },
+      {
+        correlationId: "c2",
+        mode: "enforce",
+        authId: "a2",
+        expectedAudience: "PEP-frappe.lgf.oxdeai.dev",
+      },
+    );
 
-    assert.equal(result.ticket_id, "HD-TICKET-00042");
-    assert.equal(result.name, "HD-TICKET-00042");
+    assert.equal(result.resource_id, "HD-TICKET-00042");
+    assert.equal(result.details?.["ticket_id"], "HD-TICKET-00042");
+    assert.equal(result.details?.["name"], "HD-TICKET-00042");
   });
 
   test("non-JSON response throws with content-type detail", async () => {
@@ -688,14 +712,18 @@ describe("Frappe adapter response parsing", () => {
       body: "<html><body>Login</body></html>",
     };
 
-    const adapter = createFrappeHttpAdapter({
+    const adapter = createFrappePlatformAdapter({
       baseUrl: mockFrappeUrl,
       apiKey: "test-key",
       apiSecret: "test-secret",
     });
 
     await assert.rejects(
-      () => adapter.createTicket({ subject: "t", description: "t", priority: "Low" }),
+      () => adapter.execute(
+        "frappe.helpdesk.create_ticket",
+        { subject: "t", description: "t", priority: "Low" },
+        { correlationId: "c3", mode: "enforce", authId: "a3", expectedAudience: "PEP-frappe.lgf.oxdeai.dev" },
+      ),
       (err: Error) => {
         assert.match(err.message, /non-JSON/);
         assert.match(err.message, /text\/html/);
@@ -711,14 +739,18 @@ describe("Frappe adapter response parsing", () => {
       body: JSON.stringify({ message: "ok" }),
     };
 
-    const adapter = createFrappeHttpAdapter({
+    const adapter = createFrappePlatformAdapter({
       baseUrl: mockFrappeUrl,
       apiKey: "test-key",
       apiSecret: "test-secret",
     });
 
     await assert.rejects(
-      () => adapter.createTicket({ subject: "t", description: "t", priority: "Low" }),
+      () => adapter.execute(
+        "frappe.helpdesk.create_ticket",
+        { subject: "t", description: "t", priority: "Low" },
+        { correlationId: "c4", mode: "enforce", authId: "a4", expectedAudience: "PEP-frappe.lgf.oxdeai.dev" },
+      ),
       (err: Error) => {
         assert.match(err.message, /unexpected response shape/);
         assert.match(err.message, /message/);
@@ -894,10 +926,11 @@ describe("Redis unavailable PEP integration", () => {
     const publicKeyPem = keyPair.publicKey.export({ type: "spki", format: "pem" }) as string;
 
     frappeCallCount = 0;
-    const mockFrappe: FrappeAdapter = {
-      async createTicket() {
+    const mockFrappe: PlatformAdapter = {
+      name: "frappe",
+      async execute() {
         frappeCallCount++;
-        return { ticket_id: "should-not-reach", name: "should-not-reach" };
+        return { resource_id: "should-not-reach" };
       },
     };
 
@@ -925,7 +958,7 @@ describe("Redis unavailable PEP integration", () => {
     const server = createPepServer({
       config,
       replayStore: failingStore,
-      frappeAdapter: mockFrappe,
+      platformAdapter: mockFrappe,
     });
 
     await new Promise<void>((resolve, reject) => {
@@ -1040,10 +1073,11 @@ describe("Redis runtime wiring", () => {
     const publicKeyPem = keyPair.publicKey.export({ type: "spki", format: "pem" }) as string;
 
     let frappeCallCount = 0;
-    const mockFrappe: FrappeAdapter = {
-      async createTicket() {
+    const mockFrappe: PlatformAdapter = {
+      name: "frappe",
+      async execute() {
         frappeCallCount++;
-        return { ticket_id: "T1", name: "T1" };
+        return { resource_id: "T1", details: { ticket_id: "T1", name: "T1" } };
       },
     };
 
@@ -1063,7 +1097,7 @@ describe("Redis runtime wiring", () => {
     };
 
     // Do NOT pass replayStore — force the factory path
-    const server = createPepServer({ config, frappeAdapter: mockFrappe });
+    const server = createPepServer({ config, platformAdapter: mockFrappe });
     await new Promise<void>((resolve, reject) => {
       server.on("error", reject);
       server.listen(0, "127.0.0.1", () => resolve());

--- a/examples/lgf-frappe-pep/test/live-redis.test.ts
+++ b/examples/lgf-frappe-pep/test/live-redis.test.ts
@@ -9,7 +9,8 @@ import { sha256HexFromJson, signAuthorizationEd25519 } from "@oxdeai/core";
 import type { AuthorizationV1 } from "@oxdeai/core";
 import type { PepConfig } from "../src/config.js";
 import { createPepServer } from "../src/server.js";
-import type { ActionEnvelope, FrappeAdapter, FrappeCreateTicketParams } from "../src/types.js";
+import type { ActionEnvelope } from "../src/types.js";
+import type { PlatformAdapter } from "../src/adapters/platform.js";
 import { POLICY_ID } from "../src/policy.js";
 
 const LIVE_REDIS_URL = process.env["REDIS_URL"] ?? "redis://127.0.0.1:6379";
@@ -114,10 +115,11 @@ async function startHarness(replayKeyPrefix: string, redisUrl = LIVE_REDIS_URL):
   const publicKeyPem = keyPair.publicKey.export({ type: "spki", format: "pem" }) as string;
 
   let callCount = 0;
-  const mockFrappe: FrappeAdapter = {
-    async createTicket(_params: FrappeCreateTicketParams) {
+  const mockFrappe: PlatformAdapter = {
+    name: "frappe",
+    async execute() {
       callCount += 1;
-      return { ticket_id: `HD-TICKET-${callCount}`, name: `HD-TICKET-${callCount}` };
+      return { resource_id: `HD-TICKET-${callCount}` };
     },
   };
 
@@ -141,7 +143,7 @@ async function startHarness(replayKeyPrefix: string, redisUrl = LIVE_REDIS_URL):
     authorizationTtlSeconds: AUTH_TTL_SECONDS,
   };
 
-  const server = createPepServer({ config, frappeAdapter: mockFrappe });
+  const server = createPepServer({ config, platformAdapter: mockFrappe });
   await new Promise<void>((resolve, reject) => {
     server.on("error", reject);
     server.listen(0, "127.0.0.1", () => resolve());

--- a/examples/lgf-frappe-pep/test/shutdown.test.ts
+++ b/examples/lgf-frappe-pep/test/shutdown.test.ts
@@ -192,8 +192,9 @@ describe("PEP runtime shutdown hardening", () => {
           disconnectCalls += 1;
         },
       }),
-      frappeAdapter: {
-        createTicket: async () => ({ ticket_id: "T1", name: "T1" }),
+      platformAdapter: {
+        name: "frappe",
+        execute: async () => ({ resource_id: "T1", details: { ticket_id: "T1", name: "T1" } }),
       },
     });
 


### PR DESCRIPTION
## Summary

Extracts an explicit platform adapter boundary from the LGF/Frappe PEP runtime.

The PEP runtime now routes target-platform execution through a `PlatformAdapter` interface, while authorization, replay, policy, observe/enforce, and fail-closed behavior remain inside the PEP boundary.

This is the next cleanup step after publishing the generic PEP sidecar image.

## What changed

Added explicit adapter contract:

* `PlatformExecutionContext`
* `PlatformExecutionResult`
* `PlatformAdapter`

Added Frappe adapter implementation:

* moves Frappe-specific execution behind `createFrappePlatformAdapter`
* preserves `frappe.helpdesk.create_ticket`
* preserves request formatting
* preserves numeric `data.name` normalization
* preserves string `data.name` passthrough
* preserves non-JSON upstream error handling
* preserves missing `data.name` handling

Kept `src/frappe.ts` as a compatibility shim.

Updated server integration:

* `createPepServer` now accepts an optional `platformAdapter`
* default adapter remains Frappe for the current example package
* `handleExecute` calls the adapter only after the PEP passes:

  * request parsing
  * protected action check
  * authorization verification
  * intent hash verification
  * replay check
  * observe-mode gate

## Boundary preserved

The adapter cannot:

* verify `AuthorizationV1`
* perform replay checks
* override DENY decisions
* force execution before the PEP allows it
* change policy outcomes

The core invariant remains:

```text id="v1hiza"
No valid authorization -> no execution path.
```

## Tests

Added adapter-boundary coverage proving:

* injected adapter is used
* payload/context handoff is correct

Updated existing tests to prove:

* valid execution calls adapter once
* replay blocks adapter call
* observe mode blocks adapter call
* wrong audience blocks adapter call
* expired authorization blocks adapter call
* intent hash mismatch blocks adapter call
* unsupported action blocks adapter call
* replay-store outage blocks adapter call
* adapter failure fails closed
* Frappe parsing behavior is preserved

Updated live Redis and shutdown tests to use the new adapter seam.

## Validation

LGF/Frappe PEP package tests:

```text id="ysr1lu"
43/43 passing
```

Live Redis replay integration:

```text id="xlf8o5"
3/3 passing
```

Live Redis behavior validated:

* first execution succeeds
* replay denied with `AUTH_REPLAY`
* outage denied with `REPLAY_STORE_UNAVAILABLE`

Security gate:

```text id="xo34f6"
Decision: ALLOW
Blocking findings: 0
```

Secret/path grep found no new real secrets, tokens, Frappe credentials, signing keys, or credential-bearing Redis URLs.

Remaining matches are acceptable placeholder docs, live-validation instructions, or shutdown negative assertions.

## Scope

This PR is a first adapter-boundary extraction.

It does not implement:

* dynamic adapter registry
* ERPNext adapter
* Nextcloud adapter
* OpenProject adapter
* production adapter plugin loading
* protocol changes

## Remaining limitation

The packaged runtime still comes from the current example package.

The default adapter is still Frappe-oriented and still expects config such as `FRAPPE_BASE_URL`.

Additional platform adapters remain future work.

Closes #161.
