### PR TITLE
fix(core): validate runtime state numeric leaves

### DIFF
--- a/packages/core/src/policy/PolicyEngine.ts
+++ b/packages/core/src/policy/PolicyEngine.ts
@@ -14,6 +14,7 @@ import { runDecisionModules } from "./decision/index.js";
 
 import { HashChainedLog } from "../audit/HashChainedLog.js";
 import type { AuditEvent } from "../audit/AuditLog.js";
+import { isRuntimeState, validateNumericLeaves } from "./stateGuards.js";
 import { KillSwitchModule } from "./modules/KillSwitchModule.js";
 import { AllowlistModule } from "./modules/AllowlistModule.js";
 import { BudgetModule } from "./modules/BudgetModule.js";
@@ -77,10 +78,6 @@ export type EngineOptions = {
   auditSink?: AuditSink;
   autoPersist?: boolean;
 };
-
-function isObject(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null;
-}
 
 // Keep canonical snapshot hashes stable across host package managers/runners.
 const ENGINE_VERSION = "unknown";
@@ -155,82 +152,12 @@ export class PolicyEngine {
    * Note: per-agent configuration is validated for the current intent.agent_id only.
    */
   private validateStateForIntent(state: unknown, intent: Intent): { ok: true } | { ok: false; reason: ReasonCode } {
-    if (!isObject(state)) return { ok: false, reason: "STATE_INVALID" };
+    if (!isRuntimeState(state)) return { ok: false, reason: "STATE_INVALID" };
 
-    // policy_version check is handled separately to keep reason specific
-    if (!("policy_version" in state) || typeof (state as any).policy_version !== "string") {
-      return { ok: false, reason: "STATE_INVALID" };
-    }
-
-
-    // Required top-level keys
-    const requiredTop = [
-      "period_id",
-      "kill_switch",
-      "allowlists",
-      "budget",
-      "max_amount_per_action",
-      "velocity",
-      "replay",
-      "concurrency",
-      "recursion",
-      "tool_limits"
-    ];
-    for (const k of requiredTop) {
-      if (!(k in state)) return { ok: false, reason: "STATE_INVALID" };
-    }
-
-    const ks = (state as any).kill_switch;
-    if (!isObject(ks) || typeof ks.global !== "boolean" || !isObject(ks.agents)) {
-      return { ok: false, reason: "STATE_INVALID" };
-    }
-
-    const al = (state as any).allowlists;
-    if (!isObject(al)) return { ok: false, reason: "STATE_INVALID" };
-
-    const budget = (state as any).budget;
-    if (!isObject(budget) || !isObject(budget.budget_limit) || !isObject(budget.spent_in_period)) {
-      return { ok: false, reason: "STATE_INVALID" };
-    }
-
-    const caps = (state as any).max_amount_per_action;
-    if (!isObject(caps)) return { ok: false, reason: "STATE_INVALID" };
-
-    const vel = (state as any).velocity;
-    if (!isObject(vel) || !isObject(vel.config) || !isObject(vel.counters)) return { ok: false, reason: "STATE_INVALID" };
-    if (typeof (vel.config as any).window_seconds !== "number" || typeof (vel.config as any).max_actions !== "number") {
-      return { ok: false, reason: "STATE_INVALID" };
-    }
-
-    const rp = (state as any).replay;
-    if (!isObject(rp) || typeof rp.window_seconds !== "number" || typeof rp.max_nonces_per_agent !== "number" || !isObject(rp.nonces)) {
-      return { ok: false, reason: "STATE_INVALID" };
-    }
-
-    const cc = (state as any).concurrency;
-    if (!isObject(cc) || !isObject(cc.max_concurrent) || !isObject(cc.active) || !isObject(cc.active_auths)) {
-      return { ok: false, reason: "STATE_INVALID" };
-    }
-
-    const rc = (state as any).recursion;
-    if (!isObject(rc) || !isObject(rc.max_depth)) return { ok: false, reason: "STATE_INVALID" };
-
-    const tl = (state as any).tool_limits;
-    if (!isObject(tl) || typeof tl.window_seconds !== "number" || !isObject(tl.max_calls) || !isObject(tl.calls)) {
-      return { ok: false, reason: "STATE_INVALID" };
-    }
-
-    // Per-agent minimal config for this intent
-    const agent = intent.agent_id;
-    if (budget.budget_limit[agent] === undefined) return { ok: false, reason: "STATE_INVALID" };
-    if (caps[agent] === undefined) return { ok: false, reason: "STATE_INVALID" };
-    if (cc.max_concurrent[agent] === undefined) return { ok: false, reason: "STATE_INVALID" };
-    if (rc.max_depth[agent] === undefined) return { ok: false, reason: "STATE_INVALID" };
-    if (tl.max_calls[agent] === undefined) return { ok: false, reason: "STATE_INVALID" };
+    const leaves = validateNumericLeaves(state, intent.agent_id);
+    if (!leaves.ok) return { ok: false, reason: "STATE_INVALID" };
 
     return { ok: true };
-
-    
   }
 
   private validateIntent(intent: Intent): { ok: true } | { ok: false; reason: ReasonCode } {

--- a/packages/core/src/policy/stateGuards.ts
+++ b/packages/core/src/policy/stateGuards.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { State } from "../types/state.js";
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+/**
+ * isRuntimeState(): structural validation for the runtime `State` shape.
+ * Validates presence of required containers and that fixed numeric config
+ * leaves are finite numbers (not merely `typeof === "number"`, which would
+ * still accept NaN). Per-agent leaves are validated separately by
+ * validateNumericLeaves() since they depend on the evaluated agent_id.
+ */
+export function isRuntimeState(state: unknown): state is State {
+  if (!isObject(state)) return false;
+
+  if (typeof state.policy_version !== "string") return false;
+  if (typeof state.period_id !== "string") return false;
+
+  const requiredTop = [
+    "period_id",
+    "kill_switch",
+    "allowlists",
+    "budget",
+    "max_amount_per_action",
+    "velocity",
+    "replay",
+    "concurrency",
+    "recursion",
+    "tool_limits"
+  ];
+  for (const k of requiredTop) {
+    if (!(k in state)) return false;
+  }
+
+  const ks = state.kill_switch;
+  if (!isObject(ks) || typeof ks.global !== "boolean" || !isObject(ks.agents)) return false;
+
+  const al = state.allowlists;
+  if (!isObject(al)) return false;
+
+  const budget = state.budget;
+  if (!isObject(budget) || !isObject(budget.budget_limit) || !isObject(budget.spent_in_period)) {
+    return false;
+  }
+
+  const caps = state.max_amount_per_action;
+  if (!isObject(caps)) return false;
+
+  const vel = state.velocity;
+  if (!isObject(vel) || !isObject(vel.config) || !isObject(vel.counters)) return false;
+  if (!Number.isFinite(vel.config.window_seconds) || !Number.isFinite(vel.config.max_actions)) {
+    return false;
+  }
+
+  const rp = state.replay;
+  if (!isObject(rp) || !isObject(rp.nonces)) return false;
+  if (!Number.isFinite(rp.window_seconds) || !Number.isFinite(rp.max_nonces_per_agent)) {
+    return false;
+  }
+
+  const cc = state.concurrency;
+  if (!isObject(cc) || !isObject(cc.max_concurrent) || !isObject(cc.active) || !isObject(cc.active_auths)) {
+    return false;
+  }
+
+  const rc = state.recursion;
+  if (!isObject(rc) || !isObject(rc.max_depth)) return false;
+
+  const tl = state.tool_limits;
+  if (!isObject(tl) || !isObject(tl.max_calls) || !isObject(tl.calls)) return false;
+  if (!Number.isFinite(tl.window_seconds)) return false;
+
+  return true;
+}
+
+/**
+ * validateNumericLeaves(): per-agent leaf validation for the evaluated
+ * agentId. Runs after isRuntimeState() has confirmed containers exist.
+ * bigint leaves are checked with `typeof === "bigint"` (Number.isFinite does
+ * not apply to bigint); numeric leaves are checked with Number.isFinite so a
+ * corrupted NaN or non-numeric value fails closed instead of silently
+ * comparing incorrectly.
+ */
+export function validateNumericLeaves(
+  state: State,
+  agentId: string
+): { ok: true } | { ok: false; field: string } {
+  const budgetLimit = state.budget.budget_limit[agentId];
+  if (budgetLimit === undefined || typeof budgetLimit !== "bigint") {
+    return { ok: false, field: "budget.budget_limit" };
+  }
+
+  const spent = state.budget.spent_in_period[agentId];
+  if (spent !== undefined && typeof spent !== "bigint") {
+    return { ok: false, field: "budget.spent_in_period" };
+  }
+
+  const cap = state.max_amount_per_action[agentId];
+  if (cap === undefined || typeof cap !== "bigint") {
+    return { ok: false, field: "max_amount_per_action" };
+  }
+
+  const maxConcurrent = state.concurrency.max_concurrent[agentId];
+  if (maxConcurrent === undefined || !Number.isFinite(maxConcurrent)) {
+    return { ok: false, field: "concurrency.max_concurrent" };
+  }
+
+  const maxDepth = state.recursion.max_depth[agentId];
+  if (maxDepth === undefined || !Number.isFinite(maxDepth)) {
+    return { ok: false, field: "recursion.max_depth" };
+  }
+
+  const maxCalls = state.tool_limits.max_calls[agentId];
+  if (maxCalls === undefined || !Number.isFinite(maxCalls)) {
+    return { ok: false, field: "tool_limits.max_calls" };
+  }
+
+  return { ok: true };
+}

--- a/packages/core/src/test/state.leaf-validation.test.ts
+++ b/packages/core/src/test/state.leaf-validation.test.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * state.leaf-validation.test.ts
+ *
+ * Regression coverage for stateGuards.ts: corrupted per-agent or config
+ * numeric leaves (wrong type, or NaN passing a bare `typeof === "number"`
+ * check) must fail closed with STATE_INVALID rather than silently
+ * mis-evaluating a budget/velocity/replay comparison.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { PolicyEngine } from "../policy/PolicyEngine.js";
+import type { State } from "../types/state.js";
+import type { Intent } from "../types/intent.js";
+
+function validState(overrides?: Partial<State>): State {
+  return {
+    policy_version: "v1-test",
+    period_id: "p1",
+    kill_switch: { global: false, agents: {} },
+    allowlists: { action_types: ["PAYMENT"], assets: ["wallet"], targets: ["user_1"] },
+    budget: { budget_limit: { "agent-1": 1_000_000_000n }, spent_in_period: { "agent-1": 0n } },
+    max_amount_per_action: { "agent-1": 100_000_000n },
+    velocity: { config: { window_seconds: 3600, max_actions: 1000 }, counters: {} },
+    replay: { window_seconds: 3600, max_nonces_per_agent: 256, nonces: {} },
+    concurrency: { max_concurrent: { "agent-1": 10 }, active: {}, active_auths: {} },
+    recursion: { max_depth: { "agent-1": 5 } },
+    tool_limits: { window_seconds: 3600, max_calls: { "agent-1": 1000 }, calls: {} },
+    ...overrides,
+  } as State;
+}
+
+function validIntent(overrides?: Partial<Intent>): Intent {
+  return {
+    intent_id: "test-intent-1",
+    agent_id: "agent-1",
+    action_type: "PAYMENT",
+    amount: 1_000_000n,
+    asset: "wallet",
+    target: "user_1",
+    timestamp: 1_000_000,
+    metadata_hash: "0".repeat(64),
+    nonce: 1n,
+    signature: "sig",
+    tool: "pay",
+    tool_call: true,
+    depth: 0,
+    ...overrides,
+  } as Intent;
+}
+
+function makeEngine(): PolicyEngine {
+  return new PolicyEngine({
+    policy_version: "v1-test",
+    engine_secret: "test-secret-32-bytes-long-enough!!",
+    authorization_ttl_seconds: 60,
+    deny_mode: "fail-fast",
+  });
+}
+
+test("control: sound state returns ALLOW", () => {
+  const engine = makeEngine();
+  const out = engine.evaluatePure(validIntent(), validState());
+  assert.equal(out.decision, "ALLOW");
+});
+
+test("corrupted budget.budget_limit as string returns DENY STATE_INVALID", () => {
+  const engine = makeEngine();
+  const state = validState();
+  (state.budget.budget_limit as unknown as Record<string, unknown>)["agent-1"] = "1000";
+  const out = engine.evaluatePure(validIntent(), state);
+  assert.equal(out.decision, "DENY");
+  assert.deepEqual(out.reasons, ["STATE_INVALID"]);
+});
+
+test("corrupted budget.budget_limit / max_amount_per_action as NaN returns DENY STATE_INVALID", () => {
+  const engine = makeEngine();
+
+  const state1 = validState();
+  (state1.budget.budget_limit as unknown as Record<string, unknown>)["agent-1"] = NaN;
+  const out1 = engine.evaluatePure(validIntent(), state1);
+  assert.equal(out1.decision, "DENY");
+  assert.deepEqual(out1.reasons, ["STATE_INVALID"]);
+
+  const state2 = validState();
+  (state2.max_amount_per_action as unknown as Record<string, unknown>)["agent-1"] = NaN;
+  const out2 = engine.evaluatePure(validIntent(), state2);
+  assert.equal(out2.decision, "DENY");
+  assert.deepEqual(out2.reasons, ["STATE_INVALID"]);
+});
+
+test("corrupted budget.spent_in_period as plain number returns DENY STATE_INVALID", () => {
+  const engine = makeEngine();
+  const state = validState();
+  (state.budget.spent_in_period as unknown as Record<string, unknown>)["agent-1"] = 0;
+  const out = engine.evaluatePure(validIntent(), state);
+  assert.equal(out.decision, "DENY");
+  assert.deepEqual(out.reasons, ["STATE_INVALID"]);
+});
+
+test("corrupted velocity.config.window_seconds as NaN returns DENY STATE_INVALID", () => {
+  const engine = makeEngine();
+  const state = validState();
+  state.velocity.config.window_seconds = NaN;
+  const out = engine.evaluatePure(validIntent(), state);
+  assert.equal(out.decision, "DENY");
+  assert.deepEqual(out.reasons, ["STATE_INVALID"]);
+});
+
+test("corrupted replay.window_seconds as NaN returns DENY STATE_INVALID", () => {
+  const engine = makeEngine();
+  const state = validState();
+  state.replay.window_seconds = NaN;
+  const out = engine.evaluatePure(validIntent(), state);
+  assert.equal(out.decision, "DENY");
+  assert.deepEqual(out.reasons, ["STATE_INVALID"]);
+});


### PR DESCRIPTION
## Summary

This PR fixes a state-validation fail-open in `PolicyEngine`.

The previous validation path checked that per-agent state leaves existed, but did not verify that they had the correct numeric type before module evaluation.

A corrupted state provider could set:

```ts
budget.budget_limit[agent] = "1000"
````

Because the value was present, the old validation accepted it. The downstream budget comparison then evaluated incorrectly and returned `ALLOW` instead of rejecting the corrupted state.

This PR moves that rejection to the engine boundary.

## Changes

* Adds `packages/core/src/policy/stateGuards.ts`
* Adds `isRuntimeState(state): state is State`
* Adds `validateNumericLeaves(state, agentId)`
* Replaces the old inline `PolicyEngine.ts` state-validation block with typed guards
* Removes unsafe casts from the targeted state-validation path
* Adds regression tests for corrupted numeric state leaves

## Security impact

This closes a fail-open caused by malformed state-provider input.

Security repro:

```text
Corrupted state:
budget.budget_limit[agent] = "1000"
```

Result on `main`:

```text
Decision: ALLOW
Reasons: []

VULNERABLE: corrupted string budget limit produced ALLOW
```

Result after this fix:

```text
Decision: DENY
Reasons: ["STATE_INVALID"]

FIXED: corrupted string budget limit rejected as STATE_INVALID
```

## Validation strategy

The new guard layer validates:

* runtime state structure
* required state containers
* fixed numeric config leaves using `Number.isFinite`
* per-agent bigint leaves
* per-agent finite-number leaves

Malformed or corrupted state is now rejected before module arithmetic.

## Tests added

Adds regression tests for:

* valid state still returns `ALLOW`
* string `budget_limit` returns `DENY / STATE_INVALID`
* `NaN` per-agent limits return `DENY / STATE_INVALID`
* mixed `bigint` / `number` budget leaves return `DENY / STATE_INVALID`
* `velocity.config.window_seconds = NaN` returns `DENY / STATE_INVALID`
* `replay.window_seconds = NaN` returns `DENY / STATE_INVALID`

## Scope

This PR does not:

* change protocol semantics
* change `AuthorizationV1`
* change `DelegationV1`
* change `SignedKRLV1`
* change canonicalization
* change conformance vectors
* change README/docs
* change api-extractor temp files
* change `packages/core/API_FINGERPRINT`

## Validation

* [x] `git diff --check`
* [x] `pnpm typecheck`
* [x] `pnpm test`
* [x] `pnpm -C packages/conformance validate`
* [x] `pnpm test:vectors:all`
* [x] `pnpm security:gate`
* [x] `git diff -- packages/core/API_FINGERPRINT`

## Closes

Closes #168