### PR TITLE
fix(core): validate per-agent kill-switch state leaves

### DIFF
--- a/packages/core/src/policy/stateGuards.ts
+++ b/packages/core/src/policy/stateGuards.ts
@@ -36,6 +36,9 @@ export function isRuntimeState(state: unknown): state is State {
 
   const ks = state.kill_switch;
   if (!isObject(ks) || typeof ks.global !== "boolean" || !isObject(ks.agents)) return false;
+  for (const v of Object.values(ks.agents)) {
+    if (typeof v !== "boolean") return false;
+  }
 
   const al = state.allowlists;
   if (!isObject(al)) return false;

--- a/packages/core/src/test/state.leaf-validation.test.ts
+++ b/packages/core/src/test/state.leaf-validation.test.ts
@@ -117,3 +117,56 @@ test("corrupted replay.window_seconds as NaN returns DENY STATE_INVALID", () => 
   assert.equal(out.decision, "DENY");
   assert.deepEqual(out.reasons, ["STATE_INVALID"]);
 });
+
+test("control: kill_switch.agents[agent] = true returns DENY KILL_SWITCH", () => {
+  const engine = makeEngine();
+  const state = validState();
+  state.kill_switch.agents["agent-1"] = true;
+  const out = engine.evaluatePure(validIntent(), state);
+  assert.equal(out.decision, "DENY");
+  assert.deepEqual(out.reasons, ["KILL_SWITCH"]);
+});
+
+test("control: kill_switch.agents[agent] = false allows evaluation to continue", () => {
+  const engine = makeEngine();
+  const state = validState();
+  state.kill_switch.agents["agent-1"] = false;
+  const out = engine.evaluatePure(validIntent(), state);
+  assert.equal(out.decision, "ALLOW");
+});
+
+test("corrupted kill_switch.agents[agent] = 1 returns DENY STATE_INVALID", () => {
+  const engine = makeEngine();
+  const state = validState();
+  (state.kill_switch.agents as unknown as Record<string, unknown>)["agent-1"] = 1;
+  const out = engine.evaluatePure(validIntent(), state);
+  assert.equal(out.decision, "DENY");
+  assert.deepEqual(out.reasons, ["STATE_INVALID"]);
+});
+
+test("corrupted kill_switch.agents[agent] = \"true\" returns DENY STATE_INVALID", () => {
+  const engine = makeEngine();
+  const state = validState();
+  (state.kill_switch.agents as unknown as Record<string, unknown>)["agent-1"] = "true";
+  const out = engine.evaluatePure(validIntent(), state);
+  assert.equal(out.decision, "DENY");
+  assert.deepEqual(out.reasons, ["STATE_INVALID"]);
+});
+
+test("corrupted kill_switch.agents[agent] = {} returns DENY STATE_INVALID", () => {
+  const engine = makeEngine();
+  const state = validState();
+  (state.kill_switch.agents as unknown as Record<string, unknown>)["agent-1"] = {};
+  const out = engine.evaluatePure(validIntent(), state);
+  assert.equal(out.decision, "DENY");
+  assert.deepEqual(out.reasons, ["STATE_INVALID"]);
+});
+
+test("corrupted kill_switch.agents container with a non-boolean element returns DENY STATE_INVALID", () => {
+  const engine = makeEngine();
+  const state = validState();
+  (state.kill_switch as unknown as Record<string, unknown>)["agents"] = { "agent-1": true, "agent-2": null };
+  const out = engine.evaluatePure(validIntent(), state);
+  assert.equal(out.decision, "DENY");
+  assert.deepEqual(out.reasons, ["STATE_INVALID"]);
+});


### PR DESCRIPTION
## Summary

Hardens runtime state validation for per-agent kill-switch flags.

Previously, `kill_switch.agents` was validated only as an object. Individual leaf values were not required to be booleans, allowing malformed state such as:

```ts
kill_switch.agents["agent-1"] = 1
````

to pass structural validation.

This PR now requires every per-agent kill-switch value to be a strict boolean. Malformed values fail closed with `DENY / STATE_INVALID` before policy modules execute.

## Changes

* validates every `kill_switch.agents[*]` value as boolean
* preserves valid-state behavior:

  * `true` → `DENY / KILL_SWITCH`
  * `false` → evaluation continues
* adds regression coverage for:

  * numeric value
  * string value
  * object value
  * mixed container with a non-boolean leaf

## Scope

* no change to `KillSwitchModule`
* no change to protocol semantics for valid boolean states
* no changes to AuthorizationV1, DelegationV1, SignedKRLV1, or canonicalization
* no conformance vector changes
* no API fingerprint change
* no unrelated refactor

## Validation

* typecheck passed
* core test suite passed
* conformance validation passed
* all vectors passed
* security gate passed
* API fingerprint unchanged

Refs #170