### PR TITLE
feat(core): add deterministic trusted-time freshness verifier

### DIFF
--- a/packages/core/src/policy/verifyTrustedTime.ts
+++ b/packages/core/src/policy/verifyTrustedTime.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { PolicyResult } from "../types/policy.js";
+
+/**
+ * Inputs to {@link verifyTrustedTime}.
+ *
+ * `evaluationTime` MUST be supplied by a trusted caller — the PEP's own
+ * clock, sampled once per evaluation (docs/spec/core/trusted-time-v1.md
+ * §2.1). This module never reads an ambient clock; passing an untrusted or
+ * attacker-influenced `evaluationTime` defeats the entire trusted-time
+ * model. `intentTimestamp` is the opposite trust class: an agent-supplied,
+ * attacker-controllable freshness claim, admissible for this bounded check
+ * only (spec §2, §6).
+ *
+ * @public
+ */
+export type VerifyTrustedTimeInput = {
+  /** Agent-supplied `Intent.timestamp` (unix seconds). Untrusted freshness claim. */
+  intentTimestamp: number;
+  /** Trusted PEP clock (unix seconds), sampled once per evaluation by the caller. */
+  evaluationTime: number;
+  /** Max seconds `intentTimestamp` may lead `evaluationTime` and still be fresh (spec §5). */
+  maxClockSkewSeconds: number;
+  /** Max seconds `intentTimestamp` may lag `evaluationTime` and still be fresh (spec §5). */
+  maxIntentAgeSeconds: number;
+};
+
+/**
+ * Protocol numeric domain (spec §5.1): finite, non-negative, safe-integer
+ * unix-seconds / duration-seconds values only. NaN, Infinity, non-integers,
+ * negatives, and unsafe magnitudes are all rejected — never coerced.
+ */
+function isProtocolSeconds(value: number): boolean {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+/**
+ * Pure, deterministic freshness gate for the trusted-time profile
+ * (docs/spec/core/trusted-time-v1.md §6).
+ *
+ * Compares the untrusted `intentTimestamp` freshness claim against the
+ * trusted `evaluationTime` and the two bounded tolerances. Both boundaries
+ * are inclusive — a delta exactly equal to a tolerance is fresh; only a
+ * delta strictly beyond it denies (spec §6).
+ *
+ * This function is side-effect-free: it performs no I/O, reads no ambient
+ * clock (`Date.now()` or otherwise), derives no trust from
+ * `intentTimestamp`, and does not mutate its input or any external state.
+ * It returns the standard `PolicyResult` shape (spec §3) — `ALLOW` with
+ * empty reasons, or `DENY` with one `ReasonCode` — introducing no parallel
+ * result format.
+ *
+ * This function is standalone: it is not wired into `PolicyEngine`, does
+ * not read or write `State`, and does not evaluate replay, velocity, or any
+ * other gate. Wiring it into the evaluation pipeline is a separate,
+ * independently reviewed change (spec §9).
+ *
+ * A malformed `intentTimestamp` (NaN, Infinity, non-integer, negative, or
+ * unsafe magnitude) is the one attacker-reachable invalid input; it fails
+ * closed with `STATE_INVALID` per spec §5.1/§6, without being compared
+ * against the boundaries.
+ *
+ * `evaluationTime`, `maxClockSkewSeconds`, and `maxIntentAgeSeconds` are
+ * trusted-caller / configuration inputs, not attacker-reachable data. A
+ * malformed value among them is a caller precondition violation — per spec
+ * §5.1 ("malformed configuration MUST cause the implementation to refuse to
+ * evaluate") this function throws rather than returning a policy decision,
+ * so the failure cannot be mistaken for a data-driven `DENY`.
+ *
+ * @public
+ */
+export function verifyTrustedTime(input: VerifyTrustedTimeInput): PolicyResult {
+  const { intentTimestamp, evaluationTime, maxClockSkewSeconds, maxIntentAgeSeconds } = input;
+
+  if (!isProtocolSeconds(evaluationTime)) {
+    throw new Error(
+      "verifyTrustedTime: evaluationTime must be a finite, non-negative safe integer (unix seconds)"
+    );
+  }
+  if (!isProtocolSeconds(maxClockSkewSeconds)) {
+    throw new Error(
+      "verifyTrustedTime: maxClockSkewSeconds must be a finite, non-negative safe integer"
+    );
+  }
+  if (!isProtocolSeconds(maxIntentAgeSeconds)) {
+    throw new Error(
+      "verifyTrustedTime: maxIntentAgeSeconds must be a finite, non-negative safe integer"
+    );
+  }
+
+  if (!isProtocolSeconds(intentTimestamp)) {
+    return { decision: "DENY", reasons: ["STATE_INVALID"] };
+  }
+
+  const delta = intentTimestamp - evaluationTime;
+
+  if (delta > maxClockSkewSeconds) {
+    return { decision: "DENY", reasons: ["INTENT_FRESHNESS_FUTURE"] };
+  }
+  if (-delta > maxIntentAgeSeconds) {
+    return { decision: "DENY", reasons: ["INTENT_STALE"] };
+  }
+
+  return { decision: "ALLOW", reasons: [] };
+}

--- a/packages/core/src/test/verify.trusted-time.test.ts
+++ b/packages/core/src/test/verify.trusted-time.test.ts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * verifyTrustedTime — pure freshness-gate tests (docs/spec/core/trusted-time-v1.md §6).
+ *
+ * These tests exercise only the standalone verifier. They intentionally do
+ * NOT cover replay, velocity, nonce, issuance, expiry, PEP, or engine
+ * evaluation order — that is out of scope for this function and is deferred
+ * to the integration PR referenced in the spec (§9).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { verifyTrustedTime } from "../policy/verifyTrustedTime.js";
+import type { VerifyTrustedTimeInput } from "../policy/verifyTrustedTime.js";
+
+const T0 = 1_730_000_000;
+
+function baseInput(overrides?: Partial<VerifyTrustedTimeInput>): VerifyTrustedTimeInput {
+  return {
+    intentTimestamp: T0,
+    evaluationTime: T0,
+    maxClockSkewSeconds: 300,
+    maxIntentAgeSeconds: 300,
+    ...overrides,
+  };
+}
+
+// ── Freshness interval ──────────────────────────────────────────────────────
+
+test("verifyTrustedTime: timestamp inside the accepted freshness interval → ALLOW", () => {
+  const out = verifyTrustedTime(baseInput({ intentTimestamp: T0 + 30, evaluationTime: T0 }));
+  assert.deepEqual(out, { decision: "ALLOW", reasons: [] });
+});
+
+test("verifyTrustedTime: timestamp exactly at evaluationTime → ALLOW", () => {
+  const out = verifyTrustedTime(baseInput({ intentTimestamp: T0, evaluationTime: T0 }));
+  assert.deepEqual(out, { decision: "ALLOW", reasons: [] });
+});
+
+// ── Future boundary (inclusive) ─────────────────────────────────────────────
+
+test("verifyTrustedTime: timestamp exactly at evaluationTime + maxClockSkewSeconds → ALLOW (inclusive boundary)", () => {
+  const out = verifyTrustedTime(
+    baseInput({ evaluationTime: T0, maxClockSkewSeconds: 300, intentTimestamp: T0 + 300 })
+  );
+  assert.deepEqual(out, { decision: "ALLOW", reasons: [] });
+});
+
+test("verifyTrustedTime: timestamp one second beyond the future boundary → INTENT_FRESHNESS_FUTURE", () => {
+  const out = verifyTrustedTime(
+    baseInput({ evaluationTime: T0, maxClockSkewSeconds: 300, intentTimestamp: T0 + 301 })
+  );
+  assert.deepEqual(out, { decision: "DENY", reasons: ["INTENT_FRESHNESS_FUTURE"] });
+});
+
+// ── Stale boundary (inclusive) ──────────────────────────────────────────────
+
+test("verifyTrustedTime: timestamp exactly at evaluationTime - maxIntentAgeSeconds → ALLOW (inclusive boundary)", () => {
+  const out = verifyTrustedTime(
+    baseInput({ evaluationTime: T0, maxIntentAgeSeconds: 300, intentTimestamp: T0 - 300 })
+  );
+  assert.deepEqual(out, { decision: "ALLOW", reasons: [] });
+});
+
+test("verifyTrustedTime: timestamp one second before the stale boundary → INTENT_STALE", () => {
+  const out = verifyTrustedTime(
+    baseInput({ evaluationTime: T0, maxIntentAgeSeconds: 300, intentTimestamp: T0 - 301 })
+  );
+  assert.deepEqual(out, { decision: "DENY", reasons: ["INTENT_STALE"] });
+});
+
+// ── Determinism ──────────────────────────────────────────────────────────────
+
+test("verifyTrustedTime: repeated calls with identical inputs produce deeply identical outputs", () => {
+  const input = baseInput({ intentTimestamp: T0 + 301 });
+  const first = verifyTrustedTime(input);
+  const second = verifyTrustedTime(input);
+  const third = verifyTrustedTime(baseInput({ intentTimestamp: T0 + 301 }));
+  assert.deepEqual(first, second);
+  assert.deepEqual(first, third);
+});
+
+// ── Malformed configuration (trusted-caller preconditions) ─────────────────
+
+test("verifyTrustedTime: negative maxClockSkewSeconds throws (config-invalid, refuses to evaluate)", () => {
+  assert.throws(
+    () => verifyTrustedTime(baseInput({ maxClockSkewSeconds: -1 })),
+    /maxClockSkewSeconds/
+  );
+});
+
+test("verifyTrustedTime: negative maxIntentAgeSeconds throws (config-invalid, refuses to evaluate)", () => {
+  assert.throws(
+    () => verifyTrustedTime(baseInput({ maxIntentAgeSeconds: -1 })),
+    /maxIntentAgeSeconds/
+  );
+});
+
+test("verifyTrustedTime: NaN maxClockSkewSeconds throws", () => {
+  assert.throws(() => verifyTrustedTime(baseInput({ maxClockSkewSeconds: NaN })), /maxClockSkewSeconds/);
+});
+
+test("verifyTrustedTime: Infinity maxIntentAgeSeconds throws", () => {
+  assert.throws(
+    () => verifyTrustedTime(baseInput({ maxIntentAgeSeconds: Infinity })),
+    /maxIntentAgeSeconds/
+  );
+});
+
+test("verifyTrustedTime: non-integer maxClockSkewSeconds throws", () => {
+  assert.throws(() => verifyTrustedTime(baseInput({ maxClockSkewSeconds: 1.5 })), /maxClockSkewSeconds/);
+});
+
+test("verifyTrustedTime: negative evaluationTime throws", () => {
+  assert.throws(() => verifyTrustedTime(baseInput({ evaluationTime: -1 })), /evaluationTime/);
+});
+
+test("verifyTrustedTime: NaN evaluationTime throws", () => {
+  assert.throws(() => verifyTrustedTime(baseInput({ evaluationTime: NaN })), /evaluationTime/);
+});
+
+test("verifyTrustedTime: unsafe-magnitude evaluationTime throws", () => {
+  assert.throws(
+    () => verifyTrustedTime(baseInput({ evaluationTime: Number.MAX_SAFE_INTEGER + 10 })),
+    /evaluationTime/
+  );
+});
+
+// ── Malformed intentTimestamp (attacker-reachable data) ─────────────────────
+
+test("verifyTrustedTime: NaN intentTimestamp → DENY STATE_INVALID (not a freshness code)", () => {
+  const out = verifyTrustedTime(baseInput({ intentTimestamp: NaN }));
+  assert.deepEqual(out, { decision: "DENY", reasons: ["STATE_INVALID"] });
+});
+
+test("verifyTrustedTime: Infinity intentTimestamp → DENY STATE_INVALID", () => {
+  const out = verifyTrustedTime(baseInput({ intentTimestamp: Infinity }));
+  assert.deepEqual(out, { decision: "DENY", reasons: ["STATE_INVALID"] });
+});
+
+test("verifyTrustedTime: -Infinity intentTimestamp → DENY STATE_INVALID", () => {
+  const out = verifyTrustedTime(baseInput({ intentTimestamp: -Infinity }));
+  assert.deepEqual(out, { decision: "DENY", reasons: ["STATE_INVALID"] });
+});
+
+test("verifyTrustedTime: non-integer intentTimestamp → DENY STATE_INVALID", () => {
+  const out = verifyTrustedTime(baseInput({ intentTimestamp: T0 + 0.5 }));
+  assert.deepEqual(out, { decision: "DENY", reasons: ["STATE_INVALID"] });
+});
+
+test("verifyTrustedTime: negative intentTimestamp → DENY STATE_INVALID", () => {
+  const out = verifyTrustedTime(baseInput({ intentTimestamp: -1 }));
+  assert.deepEqual(out, { decision: "DENY", reasons: ["STATE_INVALID"] });
+});
+
+test("verifyTrustedTime: unsafe-magnitude intentTimestamp → DENY STATE_INVALID", () => {
+  const out = verifyTrustedTime(baseInput({ intentTimestamp: Number.MAX_SAFE_INTEGER + 10 }));
+  assert.deepEqual(out, { decision: "DENY", reasons: ["STATE_INVALID"] });
+});
+
+// ── Input immutability ───────────────────────────────────────────────────────
+
+test("verifyTrustedTime: input object remains unchanged after verification", () => {
+  const input = Object.freeze(
+    baseInput({ intentTimestamp: T0 + 301, evaluationTime: T0, maxClockSkewSeconds: 300, maxIntentAgeSeconds: 300 })
+  );
+  const snapshot = { ...input };
+  const out = verifyTrustedTime(input);
+  assert.deepEqual(input, snapshot);
+  assert.equal(out.decision, "DENY");
+});


### PR DESCRIPTION
## Summary

Adds a standalone deterministic trusted-time intent freshness verifier implementing the issuance-time freshness gate defined by the Trusted-Time Authorization Core Profile.

The verifier compares attacker-controlled `intent.timestamp` against an explicitly supplied trusted `evaluation_time`.

## What changed

Added:

- `packages/core/src/policy/verifyTrustedTime.ts`
- `packages/core/src/test/verify.trusted-time.test.ts`

The new `verifyTrustedTime` function accepts:

- `intentTimestamp`
- `evaluationTime`
- `maxClockSkewSeconds`
- `maxIntentAgeSeconds`

and returns the existing `PolicyResult` shape.

Implemented outcomes:

- fresh intent:
  - `ALLOW`
- future-dated intent:
  - `DENY / INTENT_FRESHNESS_FUTURE`
- stale intent:
  - `DENY / INTENT_STALE`
- malformed `intentTimestamp`:
  - `DENY / STATE_INVALID`

Both freshness boundaries are inclusive.

## Why

`intent.timestamp` is attacker-controlled and cannot be treated as the trusted clock.

The protocol requires freshness to be evaluated against an explicitly supplied trusted `evaluation_time`, without hidden wall-clock access or dependence on mutable process state.

This change provides the smallest deterministic freshness boundary required before later PolicyEngine and PEP integration.

## Implementation approach

`verifyTrustedTime` is implemented as a standalone pure function under:

`packages/core/src/policy/`

It is intentionally not implemented as a `PolicyModule`, because it requires explicit trusted `evaluationTime` input rather than reading time from policy state.

This avoids prejudging how `evaluation_time` will later be threaded into the engine, which remains a separate reviewable integration step.

The function reuses the existing `PolicyResult` type and does not introduce a parallel verification result model.

## Boundary

This PR implements only the pure trusted-time freshness verifier.

It does not:

- modify `PolicyEngine`
- modify global evaluation ordering
- modify replay logic
- modify velocity logic
- modify PEP clock capture
- modify authorization issuance
- modify authorization expiry
- modify replay retention
- modify velocity windows
- activate trusted-time conformance vectors
- modify `AuthorizationV1`
- modify canonicalization
- modify existing artifact verifier behavior
- export the verifier from the package barrel

## Invalid-input behavior

Malformed `intentTimestamp` returns:

```text
DENY / STATE_INVALID
````

Malformed configuration values refuse evaluation by throwing.

Malformed `evaluationTime` is currently treated as a trusted-caller precondition failure and also throws.

The specification explicitly classifies malformed `intent.timestamp` and malformed configuration, but does not explicitly classify malformed `evaluation_time`. Maintainer confirmation is requested before merge to ensure this interpretation is correct.

## Tests

Adds 22 focused tests covering:

* timestamp inside the accepted freshness band
* exact future-skew boundary
* one second beyond the future-skew boundary
* exact maximum-age boundary
* one second older than the maximum-age boundary
* deterministic repeated evaluation
* malformed `intentTimestamp`
* malformed `evaluationTime`
* malformed tolerance configuration
* non-finite values
* non-integer values
* negative values
* unsafe integer magnitudes

No replay, velocity, issuance, expiry, PEP, engine-ordering, or conformance activation tests are included.

## Validation

```bash
git diff --check
pnpm --filter @oxdeai/core build
pnpm --filter @oxdeai/core typecheck
pnpm --filter @oxdeai/core test
pnpm typecheck
pnpm test
pnpm -C packages/conformance validate
pnpm test:vectors:all
pnpm security:gate
git diff -- packages/core/API_FINGERPRINT
```

Results:

* core build passed
* core typecheck passed
* core tests: 212/212 passed
* full monorepo typecheck passed
* full monorepo tests passed
* conformance: 209 assertions passed
* all vector suites passed
* security gate: `ALLOW`
* `git diff --check`: clean
* API fingerprint unchanged

## Invariants preserved

* attacker-controlled `intent.timestamp` is never used as the trusted clock
* trusted time is supplied explicitly
* no ambient clock access is introduced
* identical inputs produce identical results
* both freshness boundaries remain inclusive
* no authorization is issued by this function
* existing replay and velocity behavior is unchanged
* existing PolicyEngine behavior is unchanged

## Residual risks

This PR does not yet enforce freshness in the runtime evaluation path.

Until a later integration PR wires the verifier before replay and velocity, the new function remains an isolated protocol primitive.

The behavior for malformed `evaluationTime` requires maintainer confirmation before the integration contract is finalized.

## Audit/spec updates

Implements only the §6 intent freshness gate from:

`docs/spec/core/trusted-time-v1.md`

No specification text is modified.

Refs #181
Refs #171