### PR TITLE
test(core): harden trusted-time verifier boundary invariants (#183)

### DIFF
--- a/packages/core/src/test/verify.trusted-time.test.ts
+++ b/packages/core/src/test/verify.trusted-time.test.ts
@@ -169,3 +169,83 @@ test("verifyTrustedTime: input object remains unchanged after verification", () 
   assert.deepEqual(input, snapshot);
   assert.equal(out.decision, "DENY");
 });
+
+// ── Maximum-magnitude arithmetic (overflow-safe freshness, issue #183) ───────
+//
+// Freshness is evaluated in DIFFERENCE form (`delta = intentTimestamp -
+// evaluationTime`, compared to the tolerances), not the literal spec SUM form
+// (`intentTimestamp > evaluationTime + maxClockSkewSeconds`). Because
+// `isProtocolSeconds` bounds every operand to `[0, MAX_SAFE_INTEGER]`, `delta`
+// is always an exact safe integer, whereas `evaluationTime +
+// maxClockSkewSeconds` can exceed 2^53 and lose integer precision. These cases
+// pin correct behavior at the safe-integer domain edge and exercise the path
+// where a naive sum would form an unsafe intermediate.
+
+const MAX = Number.MAX_SAFE_INTEGER;
+
+test("verifyTrustedTime: intent exactly at the future boundary with evaluationTime near MAX_SAFE_INTEGER → ALLOW", () => {
+  // Future boundary = evaluationTime + skew = MAX (exactly representable); inclusive → ALLOW.
+  const out = verifyTrustedTime(
+    baseInput({ intentTimestamp: MAX, evaluationTime: MAX - 300, maxClockSkewSeconds: 300 })
+  );
+  assert.deepEqual(out, { decision: "ALLOW", reasons: [] });
+});
+
+test("verifyTrustedTime: intent one second beyond the future boundary near MAX_SAFE_INTEGER → INTENT_FRESHNESS_FUTURE", () => {
+  // delta = 300, skew = 299 → strictly beyond → deny; all operands are valid safe integers.
+  const out = verifyTrustedTime(
+    baseInput({ intentTimestamp: MAX, evaluationTime: MAX - 300, maxClockSkewSeconds: 299 })
+  );
+  assert.deepEqual(out, { decision: "DENY", reasons: ["INTENT_FRESHNESS_FUTURE"] });
+});
+
+test("verifyTrustedTime: fresh intent when evaluationTime + maxClockSkewSeconds would exceed MAX_SAFE_INTEGER → ALLOW (no unsafe addition)", () => {
+  // evaluationTime + maxClockSkewSeconds = MAX + 999 (beyond the safe range), yet the difference
+  // form keeps delta exact, so the intent is correctly within skew. A sum-form implementation that
+  // guarded or threw on the unsafe intermediate would regress this case.
+  const out = verifyTrustedTime(
+    baseInput({ intentTimestamp: MAX, evaluationTime: 1000, maxClockSkewSeconds: MAX - 1 })
+  );
+  assert.deepEqual(out, { decision: "ALLOW", reasons: [] });
+});
+
+test("verifyTrustedTime: stale boundary is exact at maximum magnitude → ALLOW at the boundary, INTENT_STALE beyond", () => {
+  const atBoundary = verifyTrustedTime(
+    baseInput({ intentTimestamp: MAX - 300, evaluationTime: MAX, maxIntentAgeSeconds: 300 })
+  );
+  assert.deepEqual(atBoundary, { decision: "ALLOW", reasons: [] });
+  const beyond = verifyTrustedTime(
+    baseInput({ intentTimestamp: MAX - 301, evaluationTime: MAX, maxIntentAgeSeconds: 300 })
+  );
+  assert.deepEqual(beyond, { decision: "DENY", reasons: ["INTENT_STALE"] });
+});
+
+test("verifyTrustedTime: intent one past MAX_SAFE_INTEGER is out of domain → DENY STATE_INVALID (not a freshness code)", () => {
+  // MAX + 1 (= 2^53) is not a safe integer, so it is rejected as malformed data, never evaluated for freshness.
+  const out = verifyTrustedTime(
+    baseInput({ intentTimestamp: MAX + 1, evaluationTime: MAX - 300, maxClockSkewSeconds: 300 })
+  );
+  assert.deepEqual(out, { decision: "DENY", reasons: ["STATE_INVALID"] });
+});
+
+// ── Validation ordering: trusted preconditions before attacker input (issue #183) ──
+//
+// Trusted inputs (evaluationTime, config bounds) are validated BEFORE the
+// attacker-controlled intentTimestamp. When BOTH a trusted input and the
+// intent are malformed, the trusted-precondition failure must surface as a
+// throw — never be masked as a data-driven DENY / STATE_INVALID. This pins the
+// order: trusted inputs → intent timestamp → freshness.
+
+test("verifyTrustedTime: malformed evaluationTime AND malformed intentTimestamp → throws (trusted precondition precedes STATE_INVALID)", () => {
+  assert.throws(
+    () => verifyTrustedTime(baseInput({ evaluationTime: NaN, intentTimestamp: NaN })),
+    /evaluationTime/
+  );
+});
+
+test("verifyTrustedTime: malformed config AND malformed intentTimestamp → throws (config precondition precedes STATE_INVALID)", () => {
+  assert.throws(
+    () => verifyTrustedTime(baseInput({ maxClockSkewSeconds: NaN, intentTimestamp: Infinity })),
+    /maxClockSkewSeconds/
+  );
+});


### PR DESCRIPTION
## Summary

Adds focused, test-only regression coverage for two security-relevant invariants already implemented by `verifyTrustedTime`, per #183:

1. **Overflow-safe freshness comparison** near `Number.MAX_SAFE_INTEGER` (difference form, no unsafe addition).
2. **Trusted-input validation ordering** — trusted preconditions are validated before the attacker-controlled `intentTimestamp`.

Only `packages/core/src/test/verify.trusted-time.test.ts` changes. No production code, no public API, no behavior change.

## Why

`verifyTrustedTime` evaluates freshness as `delta = intentTimestamp - evaluationTime` and compares `delta` to the tolerances, rather than the literal spec sum form `intentTimestamp > evaluationTime + maxClockSkewSeconds`. Since `isProtocolSeconds` bounds every operand to `[0, MAX_SAFE_INTEGER]`, `delta` is always an exact safe integer, while `evaluationTime + maxClockSkewSeconds` can exceed 2^53 and lose integer precision. It also validates the trusted caller inputs (`evaluationTime`, config bounds) before the attacker-controlled `intentTimestamp`, so a broken trusted clock or invalid configuration surfaces as a thrown precondition failure rather than being masked as `DENY / STATE_INVALID`. Both properties are currently implicit; these tests pin them before the verifier is wired into `PolicyEngine`.

## Boundary (non-goals honored)

No change to `verifyTrustedTime` behavior, `PolicyEngine`, public exports, replay/velocity logic, PEP clock capture, issuance/expiry, conformance-vector activation, or the Trusted-Time Core Profile. No unrelated refactor. Test file only.

## Tests added (7; core suite 212 → 219)

**Maximum-magnitude arithmetic** (`MAX = Number.MAX_SAFE_INTEGER = 9007199254740991`):
- `evaluationTime = MAX - 300`, `skew = 300`, `intent = MAX` → **ALLOW** (future boundary at exactly `MAX`, inclusive).
- `evaluationTime = MAX - 300`, `skew = 299`, `intent = MAX` → **INTENT_FRESHNESS_FUTURE** (`delta = 300 > 299`, all valid safe integers).
- `evaluationTime = 1000`, `skew = MAX - 1`, `intent = MAX` → **ALLOW**. Here `evaluationTime + maxClockSkewSeconds = MAX + 999` (beyond the safe range), yet the difference form keeps `delta` exact and correctly sees the intent as within skew.
- `evaluationTime = MAX`, `maxIntentAge = 300`: `intent = MAX - 300` → **ALLOW** (stale boundary), `intent = MAX - 301` → **INTENT_STALE**.
- `intent = MAX + 1` (= 2^53, not a safe integer) → **DENY STATE_INVALID** (out-of-domain data, never evaluated for freshness).

**Validation ordering**:
- malformed `evaluationTime` (`NaN`) **and** malformed `intentTimestamp` (`NaN`) → **throws** `/evaluationTime/` (trusted precondition precedes the `STATE_INVALID` data path).
- malformed config (`maxClockSkewSeconds = NaN`) **and** malformed `intentTimestamp` (`Infinity`) → **throws** `/maxClockSkewSeconds/`.

The ordering tests are the strong pins: if validation were reordered to check `intentTimestamp` first, both would return `DENY / STATE_INVALID` instead of throwing, and the assertions would fail.

## Honest scope note on "sum-form regression detectable"

Worth stating precisely, because it bears on acceptance criterion 2. Given the `isProtocolSeconds` domain guard (both operands ≤ `MAX_SAFE_INTEGER`), the difference form and the plain sum form are **behaviorally equivalent on every valid input**: wherever `evaluationTime + maxClockSkewSeconds` would overflow the safe range, no valid `intentTimestamp` (≤ `MAX_SAFE_INTEGER`) can reach that boundary, so both forms `ALLOW`; wherever the sum is within range it is exact. So a black-box test cannot distinguish a plain sum-form rewrite from the difference form on valid inputs — the difference form's benefit is the **absence of an unsafe intermediate**, not a divergent valid-input result.

What these max-magnitude tests concretely guarantee: correct behavior at the safe-integer domain edge (future/stale boundaries and out-of-domain rejection), and — via the `evaluationTime = 1000, skew = MAX - 1` case — that a sum-form rewrite which *guards or throws* on the unsafe `evaluationTime + maxClockSkewSeconds` intermediate would regress and be caught. If you'd like a stronger guarantee against the plain-sum rewrite specifically, that needs a source-level assertion rather than a black-box test (out of this issue's "test file only" scope) — happy to follow up if you want it.

## Protocol / security

- **Invariants preserved:** deterministic ALLOW/DENY, inclusive boundaries via strict `>`, fail-closed on malformed data (`STATE_INVALID`) vs throw on malformed trusted precondition, purity/immutability. All unchanged — this PR only adds assertions over them.
- **Residual risks:** none introduced (test-only). The sum-form-detectability limit above is documented, not newly created.
- **Audit-spec updates:** none. No Core Profile or vector changes.

## Validation

```
git diff --check                          → clean
pnpm --filter @oxdeai/core typecheck      → PASS (tsc --noEmit, exit 0)
pnpm --filter @oxdeai/core test           → PASS (build + node --test: 219 pass / 0 fail)
git diff -- packages/core/API_FINGERPRINT → no change (test-only)
git status --short                        → only packages/core/src/test/verify.trusted-time.test.ts
```

Full `pnpm typecheck` / `pnpm test` / `pnpm -C packages/conformance validate` / `pnpm test:vectors:all` / `pnpm security:gate` run in CI (the vector harnesses need the Go/Python toolchains); this change touches no production or vector surface.

## Final report

- **Files changed:** `packages/core/src/test/verify.trusted-time.test.ts` (only).
- **Tests added:** 7 — 5 maximum-magnitude arithmetic (one asserts both the stale boundary and one-second-beyond in a single case) + 2 validation-ordering. Core suite 212 → 219.
- **Exact maximum-magnitude values used:** `MAX = 9007199254740991`; `MAX - 300 = 9007199254740691`; `MAX - 301`; `MAX - 1 = 9007199254740990`; `MAX + 1 = 9007199254740992` (= 2^53, unsafe); `evaluationTime = 1000` with `skew = MAX - 1` (sum `= MAX + 999`, beyond safe range).
- **Validation-order case added:** malformed-`evaluationTime` + malformed-`intentTimestamp` → throws `/evaluationTime/`; malformed-config + malformed-`intentTimestamp` → throws `/maxClockSkewSeconds/`.
- **Production code unchanged:** yes — test file only.
- **API fingerprint impact:** none.
- **Validation results:** typecheck PASS (exit 0); `@oxdeai/core` test 219 pass / 0 fail; whitespace clean; API fingerprint unchanged; only the test file modified (see Validation section above).

Refs #171, #181. Closes #183.
