### PR TITLE
fix(core): derive tool-call enforcement from trusted policy state

### DIFF
--- a/packages/core/src/policy/modules/ToolAmplificationModule.ts
+++ b/packages/core/src/policy/modules/ToolAmplificationModule.ts
@@ -9,6 +9,36 @@ function prune(events: Array<{ ts: number; tool?: string }>, cutoff: number): Ar
   return events.filter((e) => e.ts >= cutoff);
 }
 
+/**
+ * Trusted tool-call classifier.
+ *
+ * `intent.tool_call` is a self-declared, agent-controlled field and MUST NOT
+ * influence this decision (an agent can omit or falsify it to bypass
+ * enforcement). Classification instead follows the trusted action
+ * discriminator (`EXECUTE`) plus policy-controlled tool configuration in
+ * `state.tool_limits`, resolved via the agent-supplied `intent.tool` used
+ * only as a lookup key — the same pattern AllowlistModule uses to resolve
+ * `intent.action_type`/`intent.target` against `state.allowlists`. A bare
+ * non-empty `tool` string is never sufficient on its own; it must also
+ * resolve against trusted state.
+ *
+ * @public
+ */
+export function isRateLimitedToolCall(intent: Intent, state: State): boolean {
+  const t = intent.type ?? "EXECUTE";
+  if (t !== "EXECUTE") return false;
+
+  const tool = intent.tool;
+  if (typeof tool !== "string" || tool.length === 0) return false;
+
+  const tl = state.tool_limits;
+  if (!tl) return false;
+
+  const agent = intent.agent_id;
+  if (tl.max_calls_by_tool?.[agent]?.[tool] !== undefined) return true;
+  return tl.max_calls?.[agent] !== undefined;
+}
+
 /** @public */
 export function ToolAmplificationModule(intent: Intent, state: State): PolicyResult {
   const agent = intent.agent_id;
@@ -17,8 +47,9 @@ export function ToolAmplificationModule(intent: Intent, state: State): PolicyRes
   const t = intent.type ?? "EXECUTE";
   if (t === "RELEASE") return { decision: "ALLOW", reasons: [] };
 
-  // Explicit opt-in: only enforce for tool calls
-  if (intent.tool_call !== true) return { decision: "ALLOW", reasons: [] };
+  // Trusted classification only — intent.tool_call is descriptive/compat
+  // data and MUST NOT gate enforcement. See isRateLimitedToolCall above.
+  if (!isRateLimitedToolCall(intent, state)) return { decision: "ALLOW", reasons: [] };
 
   const tl = state.tool_limits;
   if (!tl || typeof tl.window_seconds !== "number" || !tl.max_calls || !tl.calls) {

--- a/packages/core/src/test/tool-amplification.trusted-classifier.test.ts
+++ b/packages/core/src/test/tool-amplification.trusted-classifier.test.ts
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Regression coverage for the trusted tool-call classifier
+ * (isRateLimitedToolCall in ToolAmplificationModule.ts).
+ *
+ * Prior to this fix, ToolAmplificationModule gated entirely on the
+ * self-declared, agent-controlled `intent.tool_call` boolean: an agent could
+ * omit or falsify it to bypass the tool-call limit while requesting the same
+ * executable action. Classification is now derived from the EXECUTE
+ * discriminator plus policy-controlled `state.tool_limits`, resolved via
+ * `intent.tool` used only as a lookup key. `intent.tool_call` must not
+ * influence the outcome at all.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { PolicyEngine } from "../policy/PolicyEngine.js";
+import { RECOMMENDED_TRUSTED_TIME_PROFILE } from "../policy/trustedTimeProfile.js";
+import type { State } from "../types/state.js";
+import type { Intent } from "../types/intent.js";
+
+const AGENT = "agent-1";
+const TOOL = "search";
+const BASE_TS = 1_800_000_000;
+
+function makeEngine(): PolicyEngine {
+  return new PolicyEngine({
+    policy_version: "v1-test",
+    engine_secret: "x".repeat(32),
+    ...RECOMMENDED_TRUSTED_TIME_PROFILE,
+  });
+}
+
+function makeState(overrides?: (s: State) => void): State {
+  const s: State = {
+    policy_version: "v1-test",
+    period_id: "p1",
+    kill_switch: { global: false, agents: {} },
+    allowlists: { action_types: ["PAYMENT"], assets: ["wallet", "tool"], targets: ["user_1", "tool_1"] },
+    budget: { budget_limit: { [AGENT]: 1_000_000_000n }, spent_in_period: { [AGENT]: 0n } },
+    max_amount_per_action: { [AGENT]: 1_000_000_000n },
+    velocity: { config: { window_seconds: 3600, max_actions: 1000 }, counters: {} },
+    replay: { window_seconds: 3600, max_nonces_per_agent: 256, nonces: {} },
+    concurrency: { max_concurrent: { [AGENT]: 1000 }, active: {}, active_auths: {} },
+    recursion: { max_depth: { [AGENT]: 1000 } },
+    tool_limits: { window_seconds: 60, max_calls: { [AGENT]: 1 }, calls: {} },
+  };
+  overrides?.(s);
+  return s;
+}
+
+function makeIntent(overrides?: Partial<Intent>): Intent {
+  return {
+    intent_id: `intent-${Math.random().toString(16).slice(2)}`,
+    agent_id: AGENT,
+    action_type: "PAYMENT",
+    amount: 100n,
+    asset: "wallet",
+    target: "user_1",
+    timestamp: BASE_TS,
+    metadata_hash: "00",
+    nonce: 1n,
+    signature: "placeholder",
+    depth: 0,
+    ...overrides,
+  } as Intent;
+}
+
+// 1-3: same tool, same limit, each self-declared tool_call variant must be
+// enforced identically (first ALLOW, second DENY with TOOL_CALL_LIMIT_EXCEEDED).
+for (const [label, tool_call] of [
+  ["true", true],
+  ["false", false],
+  ["omitted", undefined],
+] as const) {
+  test(`tool-call limit enforced identically when tool_call is ${label}`, () => {
+    const engine = makeEngine();
+    let state = makeState();
+
+    const first = engine.evaluatePure(
+      makeIntent({ tool: TOOL, tool_call, nonce: 1n, timestamp: BASE_TS }),
+      state,
+      BASE_TS,
+    );
+    assert.equal(first.decision, "ALLOW");
+    assert.ok(first.decision === "ALLOW" && first.nextState);
+    state = (first as Extract<typeof first, { decision: "ALLOW" }>).nextState;
+
+    const second = engine.evaluatePure(
+      makeIntent({ tool: TOOL, tool_call, nonce: 2n, timestamp: BASE_TS }),
+      state,
+      BASE_TS,
+    );
+    assert.equal(second.decision, "DENY");
+    assert.deepEqual(second.reasons, ["TOOL_CALL_LIMIT_EXCEEDED"]);
+  });
+}
+
+// 4: mixed sequence must consume ONE shared budget — not per-variant fixtures.
+test("mixed tool_call sequence (omitted -> false -> true) shares one budget", () => {
+  const engine = makeEngine();
+  let state = makeState();
+
+  const omitted = engine.evaluatePure(makeIntent({ tool: TOOL, nonce: 10n, timestamp: BASE_TS }), state, BASE_TS);
+  assert.equal(omitted.decision, "ALLOW");
+  assert.ok(omitted.decision === "ALLOW");
+  state = omitted.nextState;
+
+  const declaredFalse = engine.evaluatePure(
+    makeIntent({ tool: TOOL, tool_call: false, nonce: 11n, timestamp: BASE_TS }),
+    state,
+    BASE_TS,
+  );
+  assert.equal(declaredFalse.decision, "DENY");
+  assert.deepEqual(declaredFalse.reasons, ["TOOL_CALL_LIMIT_EXCEEDED"]);
+
+  const declaredTrue = engine.evaluatePure(
+    makeIntent({ tool: TOOL, tool_call: true, nonce: 12n, timestamp: BASE_TS }),
+    state,
+    BASE_TS,
+  );
+  assert.equal(declaredTrue.decision, "DENY");
+  assert.deepEqual(declaredTrue.reasons, ["TOOL_CALL_LIMIT_EXCEEDED"]);
+});
+
+// 5: exact configured limit boundary.
+test("exact configured limit boundary: N ALLOW then DENY on N+1", () => {
+  const engine = makeEngine();
+  let state = makeState((s) => {
+    s.tool_limits.max_calls[AGENT] = 3;
+  });
+
+  const outcomes: string[] = [];
+  for (let i = 0; i < 4; i++) {
+    const out = engine.evaluatePure(makeIntent({ tool: TOOL, nonce: BigInt(20 + i), timestamp: BASE_TS }), state, BASE_TS);
+    outcomes.push(out.decision);
+    if (out.decision === "ALLOW") state = out.nextState;
+  }
+  assert.deepEqual(outcomes, ["ALLOW", "ALLOW", "ALLOW", "DENY"]);
+});
+
+// 6: non-tool action (no `tool` field) is never charged against the tool budget.
+test("non-tool action is not charged against the tool-call budget", () => {
+  const engine = makeEngine();
+  let state = makeState((s) => {
+    s.tool_limits.max_calls[AGENT] = 1;
+  });
+
+  for (let i = 0; i < 5; i++) {
+    const out = engine.evaluatePure(makeIntent({ nonce: BigInt(30 + i), timestamp: BASE_TS }), state, BASE_TS);
+    assert.equal(out.decision, "ALLOW", `call ${i} should not be tool-limited`);
+    state = out.nextState;
+  }
+  assert.deepEqual(state.tool_limits.calls[AGENT] ?? [], []);
+});
+
+// 7: configured tool (explicit per-tool cap) vs unconfigured tool (no
+// per-tool entry, falls back to the agent's aggregate cap). `max_calls[agent]`
+// is a mandatory per-agent leaf (validateNumericLeaves) so every EXECUTE
+// intent naming a tool is still subject to *some* enforcement; the per-tool
+// registry only tightens the threshold for tools it explicitly names.
+test("configured tool gets its explicit per-tool cap; unconfigured tool falls back to the aggregate cap", () => {
+  const engine = makeEngine();
+  let state = makeState((s) => {
+    s.tool_limits.max_calls[AGENT] = 100;
+    s.tool_limits.max_calls_by_tool = { [AGENT]: { [TOOL]: 1 } };
+  });
+
+  const firstConfigured = engine.evaluatePure(makeIntent({ tool: TOOL, nonce: 40n, timestamp: BASE_TS }), state, BASE_TS);
+  assert.equal(firstConfigured.decision, "ALLOW");
+  assert.ok(firstConfigured.decision === "ALLOW");
+  state = firstConfigured.nextState;
+
+  const secondConfigured = engine.evaluatePure(makeIntent({ tool: TOOL, nonce: 41n, timestamp: BASE_TS }), state, BASE_TS);
+  assert.equal(secondConfigured.decision, "DENY", "per-tool cap of 1 should already be exhausted");
+  assert.deepEqual(secondConfigured.reasons, ["TOOL_CALL_LIMIT_EXCEEDED"]);
+
+  const unconfiguredTool = engine.evaluatePure(
+    makeIntent({ tool: "unlisted_tool", nonce: 42n, timestamp: BASE_TS }),
+    state,
+    BASE_TS,
+  );
+  assert.equal(unconfiguredTool.decision, "ALLOW", "no per-tool cap for this name, aggregate cap (100) not yet reached");
+});
+
+test("agent with a configured tool cap has calls enforced regardless of tool_call", () => {
+  const engine = makeEngine();
+  let state = makeState((s) => {
+    s.tool_limits.max_calls[AGENT] = 1;
+  });
+
+  const first = engine.evaluatePure(makeIntent({ tool: TOOL, tool_call: false, nonce: 41n, timestamp: BASE_TS }), state, BASE_TS);
+  assert.equal(first.decision, "ALLOW");
+  assert.ok(first.decision === "ALLOW");
+  state = first.nextState;
+
+  const second = engine.evaluatePure(makeIntent({ tool: TOOL, nonce: 42n, timestamp: BASE_TS }), state, BASE_TS);
+  assert.equal(second.decision, "DENY");
+  assert.deepEqual(second.reasons, ["TOOL_CALL_LIMIT_EXCEEDED"]);
+});
+
+// 8: malformed/ambiguous tool identifiers fail closed or are safely excluded.
+test("empty-string tool is not classified as a tool call (excluded, not charged)", () => {
+  const engine = makeEngine();
+  const state = makeState((s) => {
+    s.tool_limits.max_calls[AGENT] = 1;
+  });
+
+  const out = engine.evaluatePure(makeIntent({ tool: "", tool_call: true, nonce: 50n, timestamp: BASE_TS }), state, BASE_TS);
+  assert.equal(out.decision, "ALLOW");
+});
+
+test("classified tool call with malformed tool_limits state fails closed", () => {
+  const engine = makeEngine();
+  const state = makeState((s) => {
+    // Classification resolves true (max_calls[AGENT] configured), but the
+    // enforcement data itself is malformed -> must fail closed.
+    (s.tool_limits as unknown as { window_seconds: unknown }).window_seconds = "not-a-number";
+  });
+
+  const out = engine.evaluatePure(makeIntent({ tool: TOOL, nonce: 51n, timestamp: BASE_TS }), state, BASE_TS);
+  assert.equal(out.decision, "DENY");
+  assert.deepEqual(out.reasons, ["STATE_INVALID"]);
+});
+
+// 9: window reset keyed off intent.timestamp (pre-existing window semantics,
+// unchanged by this fix), with evaluationTime kept consistent to stay fresh.
+test("tool-call window resets once elapsed time exceeds window_seconds", () => {
+  const engine = makeEngine();
+  let state = makeState((s) => {
+    s.tool_limits.window_seconds = 60;
+    s.tool_limits.max_calls[AGENT] = 1;
+  });
+
+  const first = engine.evaluatePure(makeIntent({ tool: TOOL, nonce: 60n, timestamp: BASE_TS }), state, BASE_TS);
+  assert.equal(first.decision, "ALLOW");
+  assert.ok(first.decision === "ALLOW");
+  state = first.nextState;
+
+  const withinWindow = engine.evaluatePure(makeIntent({ tool: TOOL, nonce: 61n, timestamp: BASE_TS + 30 }), state, BASE_TS + 30);
+  assert.equal(withinWindow.decision, "DENY");
+
+  const afterWindow = engine.evaluatePure(makeIntent({ tool: TOOL, nonce: 62n, timestamp: BASE_TS + 61 }), state, BASE_TS + 61);
+  assert.equal(afterWindow.decision, "ALLOW");
+});
+
+// 10: deterministic repeated evaluation.
+test("classification and decision are deterministic for identical inputs", () => {
+  const state = makeState((s) => {
+    s.tool_limits.max_calls[AGENT] = 1;
+  });
+  const intent = makeIntent({ tool: TOOL, nonce: 70n, timestamp: BASE_TS });
+
+  const out1 = makeEngine().evaluatePure(intent, state, BASE_TS);
+  const out2 = makeEngine().evaluatePure(intent, state, BASE_TS);
+
+  assert.equal(out1.decision, out2.decision);
+  assert.deepEqual(out1.reasons, out2.reasons);
+});
+
+// 11: audit reason-code consistency — the audit trail reflects the trusted
+// classification outcome, not the agent's tool_call claim.
+test("audit trail records TOOL_CALL_LIMIT_EXCEEDED without referencing tool_call", () => {
+  const engine = makeEngine();
+  let state = makeState((s) => {
+    s.tool_limits.max_calls[AGENT] = 1;
+  });
+
+  const first = engine.evaluatePure(makeIntent({ tool: TOOL, nonce: 80n, timestamp: BASE_TS }), state, BASE_TS);
+  assert.ok(first.decision === "ALLOW");
+  state = first.nextState;
+
+  const second = engine.evaluatePure(makeIntent({ tool: TOOL, tool_call: false, nonce: 81n, timestamp: BASE_TS }), state, BASE_TS);
+  assert.equal(second.decision, "DENY");
+
+  const events = engine.audit.snapshot() as Array<{ type: string; reasons?: string[] }>;
+  const denyEvents = events.filter((e) => e.reasons?.includes("TOOL_CALL_LIMIT_EXCEEDED"));
+  assert.ok(denyEvents.length > 0, "expected an audit event carrying TOOL_CALL_LIMIT_EXCEEDED");
+});
+
+// 12: replay and velocity still run in their existing order/precedence,
+// unaffected by tool-call classification.
+test("replay detection still precedes tool-limit accounting for tool intents", () => {
+  const engine = makeEngine();
+  const state = makeState((s) => {
+    s.tool_limits.max_calls[AGENT] = 1000;
+  });
+
+  const intent = makeIntent({ tool: TOOL, nonce: 90n, timestamp: BASE_TS });
+  const first = engine.evaluatePure(intent, state, BASE_TS);
+  assert.equal(first.decision, "ALLOW");
+  assert.ok(first.decision === "ALLOW");
+
+  const replay = engine.evaluatePure(intent, first.nextState, BASE_TS);
+  assert.equal(replay.decision, "DENY");
+  assert.ok(
+    replay.reasons.includes("REPLAY_NONCE") || replay.reasons.includes("REPLAY_DETECTED"),
+    `expected a replay reason, got ${JSON.stringify(replay.reasons)}`,
+  );
+});
+
+test("velocity limit still enforced independently of tool-call classification", () => {
+  const engine = makeEngine();
+  const state = makeState((s) => {
+    s.velocity.config.max_actions = 1;
+    s.tool_limits.max_calls[AGENT] = 1000;
+  });
+
+  const first = engine.evaluatePure(makeIntent({ tool: TOOL, nonce: 91n, timestamp: BASE_TS }), state, BASE_TS);
+  assert.equal(first.decision, "ALLOW");
+  assert.ok(first.decision === "ALLOW");
+
+  const second = engine.evaluatePure(makeIntent({ tool: TOOL, nonce: 92n, timestamp: BASE_TS }), first.nextState, BASE_TS);
+  assert.equal(second.decision, "DENY");
+  assert.deepEqual(second.reasons, ["VELOCITY_EXCEEDED"]);
+});
+
+test("kill-switch still fail-fasts before tool-limit accounting runs", () => {
+  const engine = makeEngine();
+  const state = makeState((s) => {
+    s.kill_switch.agents[AGENT] = true;
+    s.tool_limits.max_calls[AGENT] = 1000;
+  });
+
+  const out = engine.evaluatePure(makeIntent({ tool: TOOL, nonce: 93n, timestamp: BASE_TS }), state, BASE_TS);
+  assert.equal(out.decision, "DENY");
+  assert.deepEqual(out.reasons, ["KILL_SWITCH"]);
+});

--- a/scripts/security/repro-policy-boundary-attacks.ts
+++ b/scripts/security/repro-policy-boundary-attacks.ts
@@ -93,6 +93,52 @@ function intent(overrides?: Partial<Intent>): Intent {
   } as Intent;
 }
 
+// ── Fixtures for identity/label-substitution attacks (L, M) ────────────────
+const LOW_AGENT = "agent-low";
+const HIGH_AGENT = "agent-high";
+const CAPPED_TOOL = "search";
+
+// Two configured agents: a restrictive one and a permissive one. L probes an
+// intent that self-declares HIGH_AGENT to inherit the permissive caps.
+function twoAgentState(): State {
+  const s = baseState();
+  s.budget.budget_limit = { [LOW_AGENT]: 100n, [HIGH_AGENT]: 1_000_000_000n };
+  s.budget.spent_in_period = { [LOW_AGENT]: 0n, [HIGH_AGENT]: 0n };
+  s.max_amount_per_action = { [LOW_AGENT]: 100n, [HIGH_AGENT]: 1_000_000_000n };
+  s.velocity.config.max_actions = 1000;
+  s.concurrency.max_concurrent = { [LOW_AGENT]: 1000, [HIGH_AGENT]: 1000 };
+  s.recursion.max_depth = { [LOW_AGENT]: 1, [HIGH_AGENT]: 1 };
+  s.tool_limits.max_calls = { [LOW_AGENT]: 1000, [HIGH_AGENT]: 1000 };
+  return s;
+}
+
+// Per-tool cap on CAPPED_TOOL only; every other gate relaxed so M isolates the
+// per-tool accounting path.
+function perToolCapState(): State {
+  const s = baseState();
+  s.budget.budget_limit = { [LOW_AGENT]: 1_000_000n };
+  s.budget.spent_in_period = { [LOW_AGENT]: 0n };
+  s.max_amount_per_action = { [LOW_AGENT]: 1_000_000n };
+  s.velocity.config.max_actions = 1000;
+  s.concurrency.max_concurrent = { [LOW_AGENT]: 1000 };
+  s.recursion.max_depth = { [LOW_AGENT]: 1000 };
+  s.tool_limits.max_calls = { [LOW_AGENT]: 100 };
+  s.tool_limits.max_calls_by_tool = { [LOW_AGENT]: { [CAPPED_TOOL]: 1 } };
+  return s;
+}
+
+function toolIntent(nonce: number): Partial<Intent> {
+  return {
+    intent_id: `tool-${nonce}`,
+    agent_id: LOW_AGENT,
+    asset: "tool",
+    target: "tool_1",
+    nonce: BigInt(nonce),
+    timestamp: BASE_TS,
+    tool_call: true,
+  };
+}
+
 function print(name: string, out: Outcome): void {
   console.log(`\n=== ${name} ===`);
   console.log("decision:", out.decision);
@@ -303,16 +349,30 @@ function attackI_toolWindowFutureDating(): void {
 /**
  * H — tool-amplification opt-in bypass.
  *
- * Expected vulnerable behavior:
+ * Classification is now derived from the trusted action discriminator
+ * (EXECUTE) plus a policy-configured tool in state.tool_limits, resolved via
+ * intent.tool as a lookup key — never from the self-declared intent.tool_call
+ * boolean (see isRateLimitedToolCall in ToolAmplificationModule.ts). All
+ * three intents below name the same policy-configured tool and therefore
+ * MUST receive identical tool-limit treatment regardless of tool_call.
+ *
+ * Originally vulnerable behavior:
  *   max_calls = 1
  *   tool_call omitted
  *   5 tool-like actions ALLOW
  *
- * Control:
+ * Control (always enforced, before and after the fix):
  *   tool_call = true
  *   only first ALLOW, rest DENY
+ *
+ * Fixed behavior additionally requires the omitted/false variants to be
+ * denied identically to the control, AND a mixed omitted -> false -> true
+ * sequence to consume one shared budget (limit = 1): only the first call
+ * ALLOWs, the rest DENY with TOOL_CALL_LIMIT_EXCEEDED.
  */
 function attackH_toolCallOptIn(): void {
+  const TOOL = "search";
+
   const e1 = engine();
   let s1 = baseState((st) => {
     st.velocity.config.max_actions = 1000;
@@ -327,6 +387,7 @@ function attackH_toolCallOptIn(): void {
         intent_id: `tool-omitted-${i}`,
         asset: "tool",
         target: "tool_1",
+        tool: TOOL,
         nonce: BigInt(300 + i),
         timestamp: BASE_TS,
         // tool_call intentionally omitted
@@ -352,6 +413,7 @@ function attackH_toolCallOptIn(): void {
         intent_id: `tool-explicit-${i}`,
         asset: "tool",
         target: "tool_1",
+        tool: TOOL,
         nonce: BigInt(400 + i),
         timestamp: BASE_TS,
         tool_call: true,
@@ -363,16 +425,48 @@ function attackH_toolCallOptIn(): void {
     if (out.decision === "ALLOW") s2 = out.nextState;
   }
 
+  const e3 = engine();
+  let s3 = baseState((st) => {
+    st.velocity.config.max_actions = 1000;
+    st.tool_limits.max_calls[AGENT] = 1;
+  });
+
+  const mixedVariants: Array<{ tool_call?: boolean }> = [{ tool_call: undefined }, { tool_call: false }, { tool_call: true }];
+  const mixed: Outcome[] = [];
+
+  for (let i = 0; i < mixedVariants.length; i++) {
+    const out = e3.evaluatePure(
+      intent({
+        intent_id: `tool-mixed-${i}`,
+        asset: "tool",
+        target: "tool_1",
+        tool: TOOL,
+        nonce: BigInt(800 + i),
+        timestamp: BASE_TS,
+        tool_call: mixedVariants[i]!.tool_call,
+      }),
+      s3,
+      EVAL_TIME,
+    );
+    mixed.push(out);
+    if (out.decision === "ALLOW") s3 = out.nextState;
+  }
+
   console.log("\n=== H: tool_call opt-in bypass ===");
   console.log("tool_call omitted:", omitted.map((o) => o.decision).join(", "));
   console.log("tool_call true   :", explicit.map((o) => o.decision).join(", "));
+  console.log("mixed omitted->false->true:", mixed.map((o) => o.decision).join(", "));
+
+  const omittedBypassed = omitted.every((o) => o.decision === "ALLOW");
+  const controlEnforced = explicit.filter((o) => o.decision === "ALLOW").length === 1;
+  const mixedSharesOneBudget =
+    mixed[0]!.decision === "ALLOW" && mixed[1]!.decision === "DENY" && mixed[2]!.decision === "DENY";
 
   assertSignal(
     "H",
-    omitted.every((o) => o.decision === "ALLOW") &&
-      explicit.filter((o) => o.decision === "ALLOW").length === 1,
-    "VULNERABLE: omitting self-declared tool_call bypasses tool limit",
-    "tool limit enforced even when tool_call is omitted",
+    omittedBypassed || !controlEnforced || !mixedSharesOneBudget,
+    "VULNERABLE: omitting or falsifying self-declared tool_call bypasses tool limit",
+    "tool limit enforced identically regardless of tool_call value or presence",
   );
 }
 
@@ -402,6 +496,111 @@ function attackG_depthSelfDeclared(): void {
   );
 }
 
+/**
+ * L — per-agent limit evasion by self-declared identity.
+ *
+ * agent_id is the trust anchor every per-agent gate keys off (budget,
+ * velocity, replay, concurrency, recursion, tool limits, kill-switch), yet it
+ * is an unauthenticated attacker-controlled intent field. An agent bound to a
+ * restrictive profile can inherit a more permissive agent's limits simply by
+ * naming it. Same family as G/H: a self-declared field gates a security
+ * decision without independent provenance.
+ *
+ * Note: substituting an *unconfigured* agent_id fails closed (STATE_INVALID),
+ * so this probes the more dangerous case — substituting a *known, more
+ * privileged* agent, which is indistinguishable from a legitimate request for
+ * that agent.
+ *
+ * Expected vulnerable behavior:
+ *   amount above the caller's own per-action cap => DENY as self
+ *   identical amount declared under a higher-limit agent => ALLOW
+ *
+ * Expected fixed behavior (design change, out of scope for trusted-time):
+ *   engine binds decisions to an authenticated principal, not intent.agent_id;
+ *   the substituted-identity request cannot inherit foreign limits.
+ */
+function attackL_agentIdentitySubstitution(): void {
+  const restrictedAmount = 1_000n;
+
+  const asSelf = engine().evaluatePure(
+    intent({ agent_id: LOW_AGENT, amount: restrictedAmount, nonce: 600n }),
+    twoAgentState(),
+    EVAL_TIME,
+  );
+  const asPrivileged = engine().evaluatePure(
+    intent({ agent_id: HIGH_AGENT, amount: restrictedAmount, nonce: 601n }),
+    twoAgentState(),
+    EVAL_TIME,
+  );
+
+  print(`L1: amount ${restrictedAmount} as '${LOW_AGENT}' (cap 100)`, asSelf);
+  print(`L2: amount ${restrictedAmount} as '${HIGH_AGENT}' (cap 1e9)`, asPrivileged);
+
+  assertSignal(
+    "L",
+    asSelf.decision === "DENY" && asPrivileged.decision === "ALLOW",
+    "VULNERABLE: per-agent limits inherited by self-declaring a more privileged agent_id",
+    "decisions bound to authenticated principal, not self-declared agent_id",
+  );
+}
+
+/**
+ * M — per-tool cap evasion by self-declared tool name.
+ *
+ * ToolAmplificationModule enforces a per-tool cap only when
+ * max_calls_by_tool[agent][intent.tool] is configured. intent.tool is
+ * attacker-controlled, so spreading calls across freshly-invented tool names
+ * falls through to the aggregate cap only, defeating any per-tool cap. Sibling
+ * of H (there the whole module is skipped by omitting tool_call; here one
+ * specific cap is dodged by renaming the tool).
+ *
+ * Setup isolates the per-tool cap: aggregate tool cap, budget, velocity and
+ * concurrency are all raised so only the per-tool "search" cap can bite.
+ *
+ * Expected vulnerable behavior:
+ *   second call to capped tool "search" => DENY TOOL_CALL_LIMIT_EXCEEDED
+ *   call to unlisted tool "search_v2"   => ALLOW
+ *
+ * Expected fixed behavior:
+ *   per-tool accounting cannot be escaped by an unconfigured tool name
+ *   (e.g. default-deny unknown tools, or an aggregate that ignores tool label).
+ */
+function attackM_toolNameSelfDeclared(): void {
+  const e = engine();
+  let s = perToolCapState();
+
+  const first = e.evaluatePure(
+    intent({ ...toolIntent(700), tool: CAPPED_TOOL }),
+    s,
+    EVAL_TIME,
+  );
+  if (first.decision === "ALLOW") s = first.nextState;
+
+  const sameTool = e.evaluatePure(
+    intent({ ...toolIntent(701), tool: CAPPED_TOOL }),
+    s,
+    EVAL_TIME,
+  );
+  const renamedTool = e.evaluatePure(
+    intent({ ...toolIntent(702), tool: `${CAPPED_TOOL}_v2` }),
+    s,
+    EVAL_TIME,
+  );
+
+  print(`M1: first '${CAPPED_TOOL}' (per-tool cap 1)`, first);
+  print(`M2: second '${CAPPED_TOOL}'`, sameTool);
+  print(`M3: renamed '${CAPPED_TOOL}_v2' (no per-tool cap)`, renamedTool);
+
+  assertSignal(
+    "M",
+    first.decision === "ALLOW" &&
+      sameTool.decision === "DENY" &&
+      renamedTool.decision === "ALLOW",
+    "VULNERABLE: per-tool cap bypassed by self-declaring an unlisted tool name",
+    "per-tool accounting resistant to attacker-chosen tool labels",
+  );
+}
+
 function main(): void {
   console.log("\nOxDeAI policy-boundary attack repro harness");
   console.log("Repo-local only. Do not run against production systems.\n");
@@ -413,6 +612,8 @@ function main(): void {
   attackI_toolWindowFutureDating();
   attackH_toolCallOptIn();
   attackG_depthSelfDeclared();
+  attackL_agentIdentitySubstitution();
+  attackM_toolNameSelfDeclared();
 
   console.log("\nDone.");
 }


### PR DESCRIPTION
## Summary

Fixes the tool-call limit opt-in bypass in `ToolAmplificationModule`.

Previously, enforcement depended on the optional, agent-controlled field:

```ts
intent.tool_call === true
````

An agent could omit `tool_call` or set it to `false` while submitting the same executable tool action, causing the module to skip tool-call accounting entirely.

This change derives tool-call enforcement from trusted policy state instead:

* the intent must be an `EXECUTE`;
* it must name a non-empty tool;
* the agent/tool must resolve against `state.tool_limits`;
* `intent.tool_call` is retained for compatibility but is no longer trusted for enforcement.

## Security impact

Before:

```text
tool_call omitted: ALLOW, ALLOW, ALLOW, ALLOW, ALLOW
tool_call true:    ALLOW, DENY, DENY, DENY, DENY
```

After:

```text
tool_call omitted: ALLOW, DENY, DENY, DENY, DENY
tool_call true:    ALLOW, DENY, DENY, DENY, DENY
mixed omitted -> false -> true: ALLOW, DENY, DENY
```

The mixed sequence confirms that omitted, false, and true variants consume the same shared tool-call budget.

## Changes

* Added `isRateLimitedToolCall(intent, state)` in `ToolAmplificationModule`.
* Removed enforcement dependence on `intent.tool_call`.
* Added comprehensive trusted-classifier regression tests.
* Updated security repro scenario H.
* Added diagnostic scenarios L and M to the repro harness for separate follow-up analysis.

## Invariants preserved

* Module ordering unchanged.
* `RELEASE` behavior unchanged.
* Existing fail-closed state validation preserved.
* No canonicalization, signature, hashing, or wire-format changes.
* No public package export changes.
* No ambient clock or I/O introduced.

## Validation

* Core build and typecheck: pass
* Core tests: 254/254 pass
* Guard tests: 145/145 pass
* SDK typecheck: pass
* SDK tests: 6/6 pass via scratch-build workaround
* Root typecheck: pass
* Root test suite: pass
* Conformance: 209/209 pass
* Vector suites: pass
* Security gate: ALLOW
* Security repro: scenario H reports `RESISTED / FIXED`
* `git diff --check`: clean

## Out of scope

The following pre-existing findings remain separate:

* recursion depth depends on self-declared `intent.depth`;
* agent-specific limits depend on `intent.agent_id` and require end-to-end identity-binding review;
* unconfigured tool names fall back to the aggregate tool cap;
* tool-call windows still use `intent.timestamp` as documented in the trusted-time deferral.

Closes #188 the tool-call opt-in bypass issue.