### PR TITLE
fix(types): reconcile AuthorizationV1 auth_id reads with legacy authorization_id (#186)

### DIFF
--- a/bench/cases/evaluate.ts
+++ b/bench/cases/evaluate.ts
@@ -38,7 +38,7 @@ export function create(seed: number): () => unknown {
   return () => {
     const out = engine.evaluatePure(fx.intent, cloneState(baseState), fx.intent.timestamp);
     if (out.decision === "ALLOW") {
-      return out.authorization.authorization_id;
+      return out.authorization.auth_id;
     }
     return out.decision;
   };

--- a/examples/delegation-demo/src/scenario.ts
+++ b/examples/delegation-demo/src/scenario.ts
@@ -61,7 +61,7 @@ export interface AuthDecision {
   authType: "engine" | "delegation";
   tool: string;
   args: Record<string, string | number>;
-  /** For engine auth: the authorization_id */
+  /** For engine auth: the auth_id */
   authId?: string;
   /** For delegation: the delegation_id */
   delegationId?: string;

--- a/examples/gpu-guard/demo.mjs
+++ b/examples/gpu-guard/demo.mjs
@@ -55,7 +55,7 @@ const out = engine.evaluatePure(intent, state, { mode: "fail-fast" });
 
 console.log("decision:", out.decision);
 if (out.decision === "ALLOW") {
-  console.log("authorization_id:", out.authorization.authorization_id);
+  console.log("auth_id:", out.authorization.auth_id);
   console.log("policyId:", engine.computePolicyId());
   console.log("stateHash:", engine.computeStateHash(out.nextState));
   console.log("auditHeadHash:", engine.audit.headHash());

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -507,7 +507,7 @@ const releaseIntent: Intent = {
   metadata_hash: "0".repeat(64),
   signature: "",
   type: "RELEASE",
-  authorization_id: out.authorization.authorization_id,
+  authorization_id: out.authorization.auth_id,
   nonce: 43n,
   amount: 0n,
   timestamp: now

--- a/packages/core/src/test/authorization-v1-boundary.compile.test.ts
+++ b/packages/core/src/test/authorization-v1-boundary.compile.test.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * authorization-v1-boundary.compile.test.ts
+ *
+ * Compile-time regression guard for the public AuthorizationV1 artifact
+ * boundary (P0-4, resolved in #102 / #103; reconciliation tracked in #186).
+ *
+ * The public engine surface — `AuthorizationV1` and the ALLOW branch of
+ * `EvaluateOutput` / `EvaluatePureOutput` — exposes the canonical `auth_id`
+ * identifier and MUST NOT statically expose the legacy `authorization_id`
+ * alias. Reading `.authorization_id` off any of these public types is exactly
+ * the TS2339 that motivated migrating the artifact-identifier reads to
+ * `auth_id`.
+ *
+ * The assertions below are conditional types. If a future change re-widens a
+ * public authorization back to the legacy-carrying `Authorization` type (or
+ * re-adds `authorization_id` to `AuthorizationV1`), the guarded type flips to
+ * "LEAK" and the corresponding `const` initializer stops type-checking, so
+ * `tsc` fails under both `pnpm --filter @oxdeai/core typecheck` and the build
+ * (`noEmitOnError`). This turns a silent boundary regression into a hard error.
+ *
+ * Scope note: legacy fields are still physically present on the runtime object
+ * by design; that is covered separately by public-artifact-boundary.test.ts,
+ * which proves `toPublicAuthorizationV1()` strips them from every signing/hash
+ * surface. This file guards the *static type* contract only.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { AuthorizationV1, EvaluateOutput, EvaluatePureOutput } from "@oxdeai/core";
+
+// The `authorization` payload carried by each public ALLOW result.
+type AllowEvaluateAuth = Extract<EvaluateOutput, { decision: "ALLOW" }>["authorization"];
+type AllowEvaluatePureAuth = Extract<EvaluatePureOutput, { decision: "ALLOW" }>["authorization"];
+
+test("AuthorizationV1 boundary: public types expose auth_id and hide authorization_id (compile-time guard)", () => {
+  // Positive: the canonical identifier is present and typed as string on the
+  // public type. Breaks if `auth_id` is removed or retyped.
+  const authIdIsString: AuthorizationV1["auth_id"] extends string ? true : never = true;
+
+  // Negative: the legacy alias must NOT be a key of any public authorization
+  // surface. Each of these is "ok" today; it becomes "LEAK" — and fails to
+  // compile — if `authorization_id` re-enters the public type.
+  const noLegacyOnV1: "authorization_id" extends keyof AuthorizationV1 ? "LEAK" : "ok" = "ok";
+  const noLegacyOnEvaluate: "authorization_id" extends keyof AllowEvaluateAuth ? "LEAK" : "ok" = "ok";
+  const noLegacyOnEvaluatePure: "authorization_id" extends keyof AllowEvaluatePureAuth ? "LEAK" : "ok" = "ok";
+
+  assert.equal(authIdIsString, true);
+  assert.equal(noLegacyOnV1, "ok");
+  assert.equal(noLegacyOnEvaluate, "ok");
+  assert.equal(noLegacyOnEvaluatePure, "ok");
+
+  // Runtime sanity: a well-typed public authorization identifies itself via
+  // `auth_id`, and the clean public shape carries no `authorization_id` key.
+  const auth: AuthorizationV1 = {
+    auth_id: "a".repeat(64),
+    issuer: "issuer-A",
+    audience: "rp-A",
+    intent_hash: "b".repeat(64),
+    state_hash: "c".repeat(64),
+    policy_id: "d".repeat(64),
+    decision: "ALLOW",
+    issued_at: 1_000_000,
+    expiry: 1_000_060,
+    alg: "Ed25519",
+    kid: "k1",
+    signature: "sig",
+  };
+
+  assert.equal(typeof auth.auth_id, "string");
+  assert.equal((auth as Record<string, unknown>)["authorization_id"], undefined);
+});


### PR DESCRIPTION
Closes #186.

Per your confirmation on the issue: **Option A, scoped strictly to role 1** (artifact-identifier reads). Patch-level internal consistency fix — no wire-format, canonicalization, serialization, or API change.

## What changed

The public engine surface — the `ALLOW` branch of `EvaluateOutput` / `EvaluatePureOutput`, and `AuthorizationV1` itself — exposes the canonical `auth_id` and not the legacy `authorization_id`, so reading `.authorization_id` off those public values is a `TS2339` (the exact error in the issue). Migrated the identified reads:

| Site | Change |
|------|--------|
| `bench/cases/evaluate.ts:41` | `out.authorization.authorization_id` → `auth_id` (the reported TS2339) |
| `examples/gpu-guard/demo.mjs:58` | read → `auth_id` (was `undefined` at runtime on the public output); console label updated to match |
| `packages/core/README.md:510` | RELEASE-intent example **value** read → `out.authorization.auth_id` |
| `examples/delegation-demo/src/scenario.ts:64` | doc-comment consistency only |

**Left unchanged, deliberately:**
- Protocol **reference** fields — `authorization_id` in RELEASE intents (including the README example's `authorization_id:` **key**), audit events, conformance vectors, canonicalization/hashing.
- CLI / output payload keys.

## Compile-time regression guard

Added `packages/core/src/test/authorization-v1-boundary.compile.test.ts`. It uses conditional-type assertions (`"authorization_id" extends keyof <public type> ? "LEAK" : "ok"`) that stop type-checking if `authorization_id` re-enters `AuthorizationV1` or a public `ALLOW` authorization is re-widened back to the legacy-carrying `Authorization` type. Because the core build runs with `noEmitOnError`, that regression fails both `pnpm --filter @oxdeai/core typecheck` and the build — turning a silent boundary drift into a hard error. The existing `public-artifact-boundary.test.ts` continues to cover the *runtime* stripping via `toPublicAuthorizationV1()`; this file guards the *static type* contract.

## Verification

- `pnpm --filter @oxdeai/core typecheck` — clean
- `pnpm --filter @oxdeai/core test` — **255/255 pass** (incl. the new guard)
- `bench` typecheck (against freshly-built core) — clean **except one pre-existing, unrelated error** (see below)

## Two things for your call (not fixed here, to respect the confirmed scope)

1. **`examples/delegation-demo/src/scenario.ts:64`** is a doc comment, not a read — I updated it for naming consistency since it sits directly on the `authId` field, but happy to drop it if you'd rather keep this PR to reads only.
2. **`bench/fixtures.ts:192`** has a pre-existing `AuthorizationV1` → `Authorization` widening error (the fixture's `auth` field is typed as the full `Authorization` but receives the public `out.authorization`). It's untouched by this PR and is the *inverse* direction of the role-1 reads, so I left it out. If you want, I can reconcile it in a follow-up (retype the fixture field to `AuthorizationV1`).

Signed-off-by is on the commit (DCO). Let me know if you'd like either scope tweak.
