### PR TITLE
feat(verification): expose signature verification status and coverage on authorization results (#172)

### DIFF
--- a/packages/core/src/test/verify.authorization.surface.test.ts
+++ b/packages/core/src/test/verify.authorization.surface.test.ts
@@ -74,8 +74,10 @@ test("missing trusted key set does not silently produce a fully verified result"
   // verification occurred.
   const out = verifyAuthorization(makeAuth(), { now: 1010 });
   assert.equal(out.ok, true);
+  // Configured posture is permissive (best-effort default); the *absence* of a
+  // signature check is conveyed by signatureVerified/coverage, not the mode.
   assert.equal(out.signatureVerified, false);
-  assert.equal(out.verificationMode, "structure-only");
+  assert.equal(out.verificationMode, "permissive");
   assert.equal(out.verificationCoverage, "none");
 });
 
@@ -101,13 +103,15 @@ test("forged signature rejected in strict mode and not marked verified", () => {
   assert.ok(out.violations.some((v) => v.code === "AUTH_SIGNATURE_INVALID"));
 });
 
-test("explicit non-crypto (structure-only) result is distinguishable from strict verification", () => {
+test("permissive-without-crypto is distinguishable from strict verification", () => {
   const structural = verifyAuthorization(makeAuth(), { now: 1010 });
   const strict = verifyAuthorization(makeAuth(), { now: 1010, mode: "strict", trustedKeySets: KEYSET });
+  // Distinguished by posture (mode) AND by whether a signature was checked.
   assert.notEqual(structural.verificationMode, strict.verificationMode);
-  assert.equal(structural.verificationMode, "structure-only");
+  assert.equal(structural.verificationMode, "permissive");
   assert.equal(strict.verificationMode, "strict");
   assert.equal(structural.signatureVerified, false);
+  assert.equal(structural.verificationCoverage, "none");
   assert.equal(strict.signatureVerified, true);
 });
 
@@ -139,9 +143,10 @@ test("unknown kid engages no cryptographic check and is not marked verified", ()
   });
   assert.equal(out.ok, false);
   assert.equal(out.signatureVerified, false);
-  // No verify function ran (trust could not be resolved), so posture is
-  // structure-only rather than permissive.
-  assert.equal(out.verificationMode, "structure-only");
+  // Trust could not be resolved so no signature was checked; the posture is
+  // still the configured "permissive" — the missing check shows in
+  // signatureVerified/coverage, not the mode.
+  assert.equal(out.verificationMode, "permissive");
   assert.equal(out.verificationCoverage, "none");
   assert.ok(out.violations.some((v) => v.code === "AUTH_KID_UNKNOWN"));
 });

--- a/packages/core/src/test/verify.authorization.surface.test.ts
+++ b/packages/core/src/test/verify.authorization.surface.test.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * verify.authorization.surface.test.ts
+ *
+ * Verification-surface descriptors (#172): a verification result must make it
+ * impossible to mistake a merely-structural check for a cryptographically
+ * verified authorization. These tests pin the contract that
+ * `signatureVerified` is true ONLY when a cryptographic check actually ran and
+ * succeeded, and that `verificationMode` / `verificationCoverage` describe the
+ * posture and covered surface honestly.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+import { signAuthorizationEd25519, verifyAuthorization } from "../verification/index.js";
+import type { KeySet } from "../types/keyset.js";
+
+const KEYPAIR = generateKeyPairSync("ed25519", {
+  privateKeyEncoding: { format: "pem", type: "pkcs8" },
+  publicKeyEncoding: { format: "pem", type: "spki" },
+});
+
+const KEYSET: KeySet = {
+  issuer: "issuer-A",
+  version: "1",
+  keys: [{ kid: "2026-01", alg: "Ed25519", public_key: KEYPAIR.publicKey }],
+};
+
+function makeAuth(overrides?: { issued_at?: number; expiry?: number }) {
+  return signAuthorizationEd25519(
+    {
+      auth_id: "f".repeat(64),
+      issuer: "issuer-A",
+      audience: "rp-A",
+      intent_hash: "a".repeat(64),
+      state_hash: "b".repeat(64),
+      policy_id: "c".repeat(64),
+      decision: "ALLOW",
+      issued_at: overrides?.issued_at ?? 1000,
+      expiry: overrides?.expiry ?? 1060,
+      kid: "2026-01",
+    },
+    KEYPAIR.privateKey
+  );
+}
+
+test("signatureVerified === true only when cryptographic verification actually ran and succeeded", () => {
+  const out = verifyAuthorization(makeAuth(), {
+    now: 1010,
+    trustedKeySets: KEYSET,
+    requireSignatureVerification: true,
+  });
+  assert.equal(out.ok, true);
+  assert.equal(out.signatureVerified, true);
+  assert.equal(out.verificationMode, "permissive");
+  assert.equal(out.verificationCoverage, "authorization-v1-full");
+});
+
+test("strict mode with trustedKeySets reports strict posture and full coverage", () => {
+  const out = verifyAuthorization(makeAuth(), {
+    now: 1010,
+    mode: "strict",
+    trustedKeySets: KEYSET,
+  });
+  assert.equal(out.ok, true);
+  assert.equal(out.signatureVerified, true);
+  assert.equal(out.verificationMode, "strict");
+  assert.equal(out.verificationCoverage, "authorization-v1-full");
+});
+
+test("missing trusted key set does not silently produce a fully verified result", () => {
+  // Structurally valid, non-expired, but no trustedKeySets: the result is
+  // `ok: true` for backward compatibility, yet must NOT claim signature
+  // verification occurred.
+  const out = verifyAuthorization(makeAuth(), { now: 1010 });
+  assert.equal(out.ok, true);
+  assert.equal(out.signatureVerified, false);
+  assert.equal(out.verificationMode, "structure-only");
+  assert.equal(out.verificationCoverage, "none");
+});
+
+test("forged signature not reported as fully verified in default/permissive mode", () => {
+  // Tamper a signed field so the Ed25519 signature no longer matches, then
+  // verify in best-effort mode WITH a trusted key set (so a crypto check runs).
+  const forged = { ...makeAuth(), state_hash: "d".repeat(64) };
+  const out = verifyAuthorization(forged, { now: 1010, trustedKeySets: KEYSET });
+  assert.equal(out.ok, false);
+  assert.equal(out.signatureVerified, false);
+  assert.equal(out.verificationMode, "permissive");
+  assert.equal(out.verificationCoverage, "none");
+  assert.ok(out.violations.some((v) => v.code === "AUTH_SIGNATURE_INVALID"));
+});
+
+test("forged signature rejected in strict mode and not marked verified", () => {
+  const forged = { ...makeAuth(), audience: "rp-EVIL" };
+  const out = verifyAuthorization(forged, { now: 1010, mode: "strict", trustedKeySets: KEYSET });
+  assert.equal(out.ok, false);
+  assert.equal(out.signatureVerified, false);
+  assert.equal(out.verificationMode, "strict");
+  assert.equal(out.verificationCoverage, "none");
+  assert.ok(out.violations.some((v) => v.code === "AUTH_SIGNATURE_INVALID"));
+});
+
+test("explicit non-crypto (structure-only) result is distinguishable from strict verification", () => {
+  const structural = verifyAuthorization(makeAuth(), { now: 1010 });
+  const strict = verifyAuthorization(makeAuth(), { now: 1010, mode: "strict", trustedKeySets: KEYSET });
+  assert.notEqual(structural.verificationMode, strict.verificationMode);
+  assert.equal(structural.verificationMode, "structure-only");
+  assert.equal(strict.verificationMode, "strict");
+  assert.equal(structural.signatureVerified, false);
+  assert.equal(strict.signatureVerified, true);
+});
+
+test("signatureVerified is orthogonal to ok: validly-signed but expired is verified yet not ok", () => {
+  const out = verifyAuthorization(makeAuth({ issued_at: 1000, expiry: 1060 }), {
+    now: 2000, // past expiry
+    trustedKeySets: KEYSET,
+  });
+  assert.equal(out.ok, false);
+  assert.equal(out.signatureVerified, true);
+  assert.equal(out.verificationCoverage, "authorization-v1-full");
+  assert.ok(out.violations.some((v) => v.code === "AUTH_EXPIRED"));
+});
+
+test("strict mode without trustedKeySets reports strict posture, no signature verified", () => {
+  const out = verifyAuthorization(makeAuth(), { now: 1010, mode: "strict" });
+  assert.equal(out.ok, false);
+  assert.equal(out.signatureVerified, false);
+  assert.equal(out.verificationMode, "strict");
+  assert.equal(out.verificationCoverage, "none");
+  assert.ok(out.violations.some((v) => v.code === "TRUSTED_KEYSETS_REQUIRED"));
+});
+
+test("unknown kid engages no cryptographic check and is not marked verified", () => {
+  const out = verifyAuthorization({ ...makeAuth(), kid: "missing" }, {
+    now: 1010,
+    trustedKeySets: KEYSET,
+    requireSignatureVerification: true,
+  });
+  assert.equal(out.ok, false);
+  assert.equal(out.signatureVerified, false);
+  // No verify function ran (trust could not be resolved), so posture is
+  // structure-only rather than permissive.
+  assert.equal(out.verificationMode, "structure-only");
+  assert.equal(out.verificationCoverage, "none");
+  assert.ok(out.violations.some((v) => v.code === "AUTH_KID_UNKNOWN"));
+});

--- a/packages/core/src/test/verify.authorization.surface.test.ts
+++ b/packages/core/src/test/verify.authorization.surface.test.ts
@@ -81,25 +81,28 @@ test("missing trusted key set does not silently produce a fully verified result"
   assert.equal(out.verificationCoverage, "none");
 });
 
-test("forged signature not reported as fully verified in default/permissive mode", () => {
+test("forged signature not reported as verified, but coverage reflects the surface that was checked", () => {
   // Tamper a signed field so the Ed25519 signature no longer matches, then
   // verify in best-effort mode WITH a trusted key set (so a crypto check runs).
+  // The check DID execute against the full AuthorizationV1 payload, so coverage
+  // is "authorization-v1-full" even though authentication failed — the failure
+  // is conveyed by signatureVerified, keeping the two descriptors orthogonal.
   const forged = { ...makeAuth(), state_hash: "d".repeat(64) };
   const out = verifyAuthorization(forged, { now: 1010, trustedKeySets: KEYSET });
   assert.equal(out.ok, false);
   assert.equal(out.signatureVerified, false);
   assert.equal(out.verificationMode, "permissive");
-  assert.equal(out.verificationCoverage, "none");
+  assert.equal(out.verificationCoverage, "authorization-v1-full");
   assert.ok(out.violations.some((v) => v.code === "AUTH_SIGNATURE_INVALID"));
 });
 
-test("forged signature rejected in strict mode and not marked verified", () => {
+test("forged signature rejected in strict mode: not verified, full coverage (a check ran)", () => {
   const forged = { ...makeAuth(), audience: "rp-EVIL" };
   const out = verifyAuthorization(forged, { now: 1010, mode: "strict", trustedKeySets: KEYSET });
   assert.equal(out.ok, false);
   assert.equal(out.signatureVerified, false);
   assert.equal(out.verificationMode, "strict");
-  assert.equal(out.verificationCoverage, "none");
+  assert.equal(out.verificationCoverage, "authorization-v1-full");
   assert.ok(out.violations.some((v) => v.code === "AUTH_SIGNATURE_INVALID"));
 });
 
@@ -149,4 +152,29 @@ test("unknown kid engages no cryptographic check and is not marked verified", ()
   assert.equal(out.verificationMode, "permissive");
   assert.equal(out.verificationCoverage, "none");
   assert.ok(out.violations.some((v) => v.code === "AUTH_KID_UNKNOWN"));
+});
+
+test("strict + ok invariant: a passing strict verification always ran and passed full cryptographic coverage", () => {
+  const out = verifyAuthorization(makeAuth(), { now: 1010, mode: "strict", trustedKeySets: KEYSET });
+  assert.equal(out.verificationMode, "strict");
+  assert.equal(out.ok, true);
+  // The invariant: verificationMode === "strict" && ok === true ALWAYS implies
+  // signatureVerified === true && verificationCoverage === "authorization-v1-full".
+  assert.equal(out.signatureVerified, true);
+  assert.equal(out.verificationCoverage, "authorization-v1-full");
+});
+
+test("strict mode cannot pass an HMAC authorization without a shared secret (no silent crypto bypass)", () => {
+  // mode:strict + non-empty trustedKeySets + HMAC-SHA256 alg + no legacyHmacSecret
+  // must NOT yield ok:true. Strict now implies signature verification is required,
+  // so the missing HMAC secret surfaces as AUTH_TRUST_MISSING rather than an
+  // unauthenticated ALLOW. This is the precise gap the requireSig fix closes.
+  const hmacAuth = { ...makeAuth(), alg: "HMAC-SHA256" as const };
+  const out = verifyAuthorization(hmacAuth, { now: 1010, mode: "strict", trustedKeySets: KEYSET });
+  assert.equal(out.ok, false);
+  assert.equal(out.signatureVerified, false);
+  assert.equal(out.verificationMode, "strict");
+  // No cryptographic verifier ran (no secret to check against), so coverage is "none".
+  assert.equal(out.verificationCoverage, "none");
+  assert.ok(out.violations.some((v) => v.code === "AUTH_TRUST_MISSING"));
 });

--- a/packages/core/src/verification/types.ts
+++ b/packages/core/src/verification/types.ts
@@ -138,7 +138,7 @@ export type VerificationResult = {
    */
   signatureVerified?: boolean;
 
-  /** How verification was performed. See {@link VerificationMode}. */
+  /** Configured verification posture. See {@link VerificationMode}. */
   verificationMode?: VerificationMode;
 
   /** Which authorization surface the signature check covered. See {@link VerificationCoverage}. */

--- a/packages/core/src/verification/types.ts
+++ b/packages/core/src/verification/types.ts
@@ -2,6 +2,45 @@
 /** @public */
 export type VerificationStatus = "ok" | "invalid" | "inconclusive";
 
+/**
+ * How signature verification was performed, independent of the outcome.
+ *
+ * This describes the verification *posture* actually applied, and is distinct
+ * from the `mode` request option (`"strict" | "best-effort"`) passed into a
+ * verifier:
+ *
+ * - `"strict"`          — strict verification was requested (a trusted key set
+ *                         is mandatory and full cryptographic verification is
+ *                         enforced).
+ * - `"permissive"`      — best-effort verification in which a cryptographic
+ *                         signature check was actually engaged.
+ * - `"structure-only"`  — no cryptographic signature verification was engaged;
+ *                         only structural / semantic checks ran.
+ *
+ * A `"structure-only"` result must never be mistaken for a cryptographically
+ * verified one — inspect {@link VerificationResult.signatureVerified}.
+ *
+ * @public
+ */
+export type VerificationMode = "strict" | "permissive" | "structure-only";
+
+/**
+ * Which authorization surface a signature check actually covered.
+ *
+ * - `"authorization-v1-full"` — the full normative AuthorizationV1 signing
+ *                               payload was cryptographically verified.
+ * - `"engine-hmac-subset"`    — only the engine-HMAC field subset was
+ *                               authenticated (see `PolicyEngine.verifyAuthorization`);
+ *                               this is NOT full authorization verification.
+ * - `"none"`                  — no cryptographic coverage.
+ *
+ * @public
+ */
+export type VerificationCoverage =
+  | "authorization-v1-full"
+  | "engine-hmac-subset"
+  | "none";
+
 /** @public */
 export type VerificationViolationCode =
   | "MALFORMED_EVENT"
@@ -74,6 +113,43 @@ export type VerificationResult = {
   policyId?: string;
   stateHash?: string;
   auditHeadHash?: string;
+
+  /**
+   * Whether a cryptographic signature verification actually ran AND succeeded.
+   *
+   * This is `true` only when a real cryptographic check executed and passed —
+   * never for a result that was merely structurally or semantically validated.
+   * It is orthogonal to `ok`: a validly-signed but expired authorization has
+   * `signatureVerified: true` and `ok: false`.
+   *
+   * Optional on the shared result type so verifiers that do not perform a
+   * signature check can omit it; verifiers that expose a signature surface
+   * (e.g. {@link AuthorizationVerificationResult}) always populate it.
+   */
+  signatureVerified?: boolean;
+
+  /** How verification was performed. See {@link VerificationMode}. */
+  verificationMode?: VerificationMode;
+
+  /** Which authorization surface the signature check covered. See {@link VerificationCoverage}. */
+  verificationCoverage?: VerificationCoverage;
+};
+
+/**
+ * Result of {@link verifyAuthorization}.
+ *
+ * A specialization of {@link VerificationResult} in which the
+ * verification-surface descriptors are ALWAYS populated, so a caller can never
+ * mistake a structurally-checked authorization for a cryptographically verified
+ * one. To decide whether to rely on an authorization, check `signatureVerified`
+ * (and `verificationCoverage`), not merely `ok`.
+ *
+ * @public
+ */
+export type AuthorizationVerificationResult = VerificationResult & {
+  signatureVerified: boolean;
+  verificationMode: VerificationMode;
+  verificationCoverage: VerificationCoverage;
 };
 
 /** @public */

--- a/packages/core/src/verification/types.ts
+++ b/packages/core/src/verification/types.ts
@@ -3,26 +3,27 @@
 export type VerificationStatus = "ok" | "invalid" | "inconclusive";
 
 /**
- * How signature verification was performed, independent of the outcome.
+ * How the verifier was *configured* — its posture, independent of the outcome.
  *
- * This describes the verification *posture* actually applied, and is distinct
- * from the `mode` request option (`"strict" | "best-effort"`) passed into a
- * verifier:
+ * This deliberately describes configuration only, not whether cryptography
+ * actually ran. It maps from the `mode` request option (`"strict" |
+ * "best-effort"`, where `"best-effort"` reports as `"permissive"`):
  *
- * - `"strict"`          — strict verification was requested (a trusted key set
- *                         is mandatory and full cryptographic verification is
- *                         enforced).
- * - `"permissive"`      — best-effort verification in which a cryptographic
- *                         signature check was actually engaged.
- * - `"structure-only"`  — no cryptographic signature verification was engaged;
- *                         only structural / semantic checks ran.
+ * - `"strict"`     — strict verification was requested (a trusted key set is
+ *                    mandatory and full cryptographic verification is enforced).
+ * - `"permissive"` — best-effort verification was requested.
  *
- * A `"structure-only"` result must never be mistaken for a cryptographically
- * verified one — inspect {@link VerificationResult.signatureVerified}.
+ * Whether a signature was actually checked is a separate, orthogonal fact:
+ * inspect {@link VerificationResult.signatureVerified} and
+ * {@link VerificationResult.verificationCoverage}. A permissive verification
+ * that skipped signature verification (e.g. no trust anchor was available)
+ * reports `verificationMode: "permissive"`, `signatureVerified: false`,
+ * `verificationCoverage: "none"` — the absence of cryptography is conveyed by
+ * those fields, not by the mode.
  *
  * @public
  */
-export type VerificationMode = "strict" | "permissive" | "structure-only";
+export type VerificationMode = "strict" | "permissive";
 
 /**
  * Which authorization surface a signature check actually covered.
@@ -143,6 +144,12 @@ export type VerificationResult = {
  * mistake a structurally-checked authorization for a cryptographically verified
  * one. To decide whether to rely on an authorization, check `signatureVerified`
  * (and `verificationCoverage`), not merely `ok`.
+ *
+ * This verifier only ever emits `verificationCoverage` of
+ * `"authorization-v1-full"` (a full AuthorizationV1 signature was checked) or
+ * `"none"`. It never emits `"engine-hmac-subset"` — that value is reserved for
+ * the engine HMAC helper (`PolicyEngine.verifyAuthorization`). Consumers must
+ * not assume every verifier can produce every coverage level.
  *
  * @public
  */

--- a/packages/core/src/verification/types.ts
+++ b/packages/core/src/verification/types.ts
@@ -26,14 +26,23 @@ export type VerificationStatus = "ok" | "invalid" | "inconclusive";
 export type VerificationMode = "strict" | "permissive";
 
 /**
- * Which authorization surface a signature check actually covered.
+ * Which authorization surface a cryptographic check was run against.
  *
- * - `"authorization-v1-full"` — the full normative AuthorizationV1 signing
- *                               payload was cryptographically verified.
+ * This reports the surface that was cryptographically *evaluated*, independent
+ * of whether authentication succeeded — a forged signature that was checked
+ * against the full payload still reports `"authorization-v1-full"` (with
+ * `signatureVerified: false`). Whether the check passed is the separate,
+ * orthogonal fact on {@link VerificationResult.signatureVerified}.
+ *
+ * - `"authorization-v1-full"` — a cryptographic check ran against the full
+ *                               normative AuthorizationV1 signing payload
+ *                               (verified or rejected).
  * - `"engine-hmac-subset"`    — only the engine-HMAC field subset was
- *                               authenticated (see `PolicyEngine.verifyAuthorization`);
+ *                               evaluated (see `PolicyEngine.verifyAuthorization`);
  *                               this is NOT full authorization verification.
- * - `"none"`                  — no cryptographic coverage.
+ * - `"none"`                  — no cryptographic verifier ran at all (e.g.
+ *                               missing trust material, unknown/inactive kid,
+ *                               or absent HMAC secret).
  *
  * @public
  */
@@ -146,8 +155,9 @@ export type VerificationResult = {
  * (and `verificationCoverage`), not merely `ok`.
  *
  * This verifier only ever emits `verificationCoverage` of
- * `"authorization-v1-full"` (a full AuthorizationV1 signature was checked) or
- * `"none"`. It never emits `"engine-hmac-subset"` — that value is reserved for
+ * `"authorization-v1-full"` (a cryptographic check ran against the full
+ * AuthorizationV1 payload, whether it passed or was rejected) or `"none"`. It
+ * never emits `"engine-hmac-subset"` — that value is reserved for
  * the engine HMAC helper (`PolicyEngine.verifyAuthorization`). Consumers must
  * not assume every verifier can produce every coverage level.
  *

--- a/packages/core/src/verification/verifyAuthorization.ts
+++ b/packages/core/src/verification/verifyAuthorization.ts
@@ -248,15 +248,20 @@ export function verifyAuthorization(
   const violations: VerificationViolation[] = [];
   const now = nowOrThrow(opts?.now);
   // Verification-surface descriptors (#172). These make it impossible to
-  // mistake a merely-structural result for a cryptographically verified one:
-  //   - `signatureVerified` flips true ONLY at the point a cryptographic check
-  //     actually runs and succeeds;
-  //   - `verificationCoverage` records which surface that check covered.
+  // mistake a merely-structural result for a cryptographically verified one,
+  // and they are fully orthogonal:
+  //   - `signatureVerified` reports the OUTCOME of authentication: it flips true
+  //     ONLY when a cryptographic check actually runs AND succeeds;
+  //   - `verificationCoverage` reports which surface a cryptographic check was
+  //     run AGAINST, independent of that outcome. It becomes
+  //     "authorization-v1-full" the moment the check is engaged — so a forged
+  //     signature reports full coverage with `signatureVerified: false` — and
+  //     stays "none" only when no cryptographic verifier ran at all (missing
+  //     trust material, unknown/inactive kid, or absent HMAC secret).
   // `verificationMode` is derived purely from the requested posture (below),
-  // independent of whether cryptography ran — the absence of a signature check
-  // is conveyed by `signatureVerified: false` / `verificationCoverage: "none"`,
-  // not by the mode. The default/permissive path never sets `signatureVerified`,
-  // so a caller that only inspects `ok` cannot be silently misled.
+  // independent of whether cryptography ran. A permissive result sets
+  // `signatureVerified` only when a cryptographic check was available, executed,
+  // and succeeded, so a caller that only inspects `ok` cannot be silently misled.
   let signatureVerified = false;
   let verificationCoverage: VerificationCoverage = "none";
   const maxFutureIssuedAtSkewSeconds = resolveMaxFutureIssuedAtSkewSeconds(opts?.maxFutureIssuedAtSkewSeconds);
@@ -356,7 +361,15 @@ export function verifyAuthorization(
     };
   }
 
-  const requireSig = opts?.requireSignatureVerification ?? false;
+  // Strict mode implies signature verification is mandatory: a strict result
+  // must never be able to pass without a cryptographic check having actually
+  // run and succeeded (pinned by the strict + ok invariant test). Without this,
+  // an HMAC authorization under `mode: "strict"` with a non-empty trusted key
+  // set but no `legacyHmacSecret` would slip through with `ok: true` and
+  // `signatureVerified: false`.
+  const requireSig =
+    opts?.mode === "strict" ||
+    (opts?.requireSignatureVerification ?? false);
   const hasSigMaterial = hasText(sig.alg) && hasText(sig.kid) && hasText(sig.sig);
 
   if (hasSigMaterial) {
@@ -376,6 +389,10 @@ export function verifyAuthorization(
           violations.push({ code: "AUTH_KEY_INACTIVE", message: "key is not active at verification time" });
         } else {
           // A cryptographic check is actually performed here (pass or fail).
+          // Coverage records the surface evaluated and is set the moment the
+          // check is engaged, independent of the outcome; `signatureVerified`
+          // flips true only if it succeeds.
+          verificationCoverage = "authorization-v1-full";
           if (
             !verifyEd25519(SIGNING_DOMAINS.AUTH_V1, payload, sigValue, key.public_key) &&
             !verifyEd25519Raw(payload, sigValue, key.public_key)
@@ -383,19 +400,19 @@ export function verifyAuthorization(
             violations.push({ code: "AUTH_SIGNATURE_INVALID", message: "signature verification failed" });
           } else {
             signatureVerified = true;
-            verificationCoverage = "authorization-v1-full";
           }
         }
       }
     } else if (sigAlg === "HMAC-SHA256") {
       if (opts?.legacyHmacSecret) {
         // Legacy HMAC covers the full AuthorizationV1 signing payload (not the
-        // narrower engine-HMAC subset), so successful coverage is "full".
+        // narrower engine-HMAC subset). Coverage reflects the surface evaluated
+        // and is set once the check is engaged, independent of the outcome.
+        verificationCoverage = "authorization-v1-full";
         if (!verifyHmacDomain(SIGNING_DOMAINS.AUTH_V1, payload, sigValue, opts.legacyHmacSecret)) {
           violations.push({ code: "AUTH_SIGNATURE_INVALID", message: "legacy HMAC signature verification failed" });
         } else {
           signatureVerified = true;
-          verificationCoverage = "authorization-v1-full";
         }
       } else if (requireSig) {
         violations.push({ code: "AUTH_TRUST_MISSING", message: "legacyHmacSecret required for HMAC verification" });

--- a/packages/core/src/verification/verifyAuthorization.ts
+++ b/packages/core/src/verification/verifyAuthorization.ts
@@ -2,7 +2,12 @@
 import { verify as nodeVerify } from "node:crypto";
 import type { AuthorizationV1 } from "../types/authorization.js";
 import type { KeySet } from "../types/keyset.js";
-import type { VerificationResult, VerificationViolation } from "./types.js";
+import type {
+  AuthorizationVerificationResult,
+  VerificationCoverage,
+  VerificationMode,
+  VerificationViolation
+} from "./types.js";
 import { canonicalJson } from "../crypto/hashes.js";
 import {
   SIGNING_DOMAINS,
@@ -239,9 +244,21 @@ export function signAuthorizationEd25519(
 export function verifyAuthorization(
   auth: AuthorizationV1,
   opts?: VerifyAuthorizationOptions
-): VerificationResult {
+): AuthorizationVerificationResult {
   const violations: VerificationViolation[] = [];
   const now = nowOrThrow(opts?.now);
+  // Verification-surface descriptors (#172). These make it impossible to
+  // mistake a merely-structural result for a cryptographically verified one:
+  //   - `signatureVerified` flips true ONLY at the point a cryptographic check
+  //     actually runs and succeeds;
+  //   - `cryptoEngaged` records that a verify function was invoked at all
+  //     (pass or fail), which distinguishes "permissive" from "structure-only";
+  //   - `verificationCoverage` records which surface that check covered.
+  // The default/permissive path never sets `signatureVerified`, so a caller
+  // that only inspects `ok` cannot be silently misled.
+  let signatureVerified = false;
+  let cryptoEngaged = false;
+  let verificationCoverage: VerificationCoverage = "none";
   const maxFutureIssuedAtSkewSeconds = resolveMaxFutureIssuedAtSkewSeconds(opts?.maxFutureIssuedAtSkewSeconds);
   const consumed = new Set(opts?.consumedAuthIds ?? []);
 
@@ -327,10 +344,15 @@ export function verifyAuthorization(
     : [];
 
   if (opts?.mode === "strict" && trusted.length === 0) {
+    // Strict was requested but cannot run: report the requested posture
+    // ("strict") while making clear no signature was verified.
     return {
       ok: false,
       status: "invalid",
-      violations: [{ code: "TRUSTED_KEYSETS_REQUIRED", message: "strict mode requires trustedKeySets to be provided" }]
+      violations: [{ code: "TRUSTED_KEYSETS_REQUIRED", message: "strict mode requires trustedKeySets to be provided" }],
+      signatureVerified: false,
+      verificationMode: "strict",
+      verificationCoverage: "none"
     };
   }
 
@@ -352,17 +374,30 @@ export function verifyAuthorization(
           violations.push({ code: "AUTH_KID_UNKNOWN", message: "kid not found for issuer/alg" });
         } else if (!keyIsActiveAt(key, now)) {
           violations.push({ code: "AUTH_KEY_INACTIVE", message: "key is not active at verification time" });
-        } else if (
-          !verifyEd25519(SIGNING_DOMAINS.AUTH_V1, payload, sigValue, key.public_key) &&
-          !verifyEd25519Raw(payload, sigValue, key.public_key)
-        ) {
-          violations.push({ code: "AUTH_SIGNATURE_INVALID", message: "signature verification failed" });
+        } else {
+          // A cryptographic check is actually performed here (pass or fail).
+          cryptoEngaged = true;
+          if (
+            !verifyEd25519(SIGNING_DOMAINS.AUTH_V1, payload, sigValue, key.public_key) &&
+            !verifyEd25519Raw(payload, sigValue, key.public_key)
+          ) {
+            violations.push({ code: "AUTH_SIGNATURE_INVALID", message: "signature verification failed" });
+          } else {
+            signatureVerified = true;
+            verificationCoverage = "authorization-v1-full";
+          }
         }
       }
     } else if (sigAlg === "HMAC-SHA256") {
       if (opts?.legacyHmacSecret) {
+        // Legacy HMAC covers the full AuthorizationV1 signing payload (not the
+        // narrower engine-HMAC subset), so successful coverage is "full".
+        cryptoEngaged = true;
         if (!verifyHmacDomain(SIGNING_DOMAINS.AUTH_V1, payload, sigValue, opts.legacyHmacSecret)) {
           violations.push({ code: "AUTH_SIGNATURE_INVALID", message: "legacy HMAC signature verification failed" });
+        } else {
+          signatureVerified = true;
+          verificationCoverage = "authorization-v1-full";
         }
       } else if (requireSig) {
         violations.push({ code: "AUTH_TRUST_MISSING", message: "legacyHmacSecret required for HMAC verification" });
@@ -372,13 +407,21 @@ export function verifyAuthorization(
     }
   }
 
+  // Posture actually applied: "strict" when requested; otherwise "permissive"
+  // if a cryptographic check was engaged, else "structure-only".
+  const verificationMode: VerificationMode =
+    opts?.mode === "strict" ? "strict" : cryptoEngaged ? "permissive" : "structure-only";
+
   if (violations.length > 0) {
     return {
       ok: false,
       status: "invalid",
       violations: sortViolations(violations),
       policyId: hasText(auth.policy_id) ? auth.policy_id : undefined,
-      stateHash: hasText(auth.state_hash) ? auth.state_hash : undefined
+      stateHash: hasText(auth.state_hash) ? auth.state_hash : undefined,
+      signatureVerified,
+      verificationMode,
+      verificationCoverage
     };
   }
 
@@ -387,6 +430,9 @@ export function verifyAuthorization(
     status: "ok",
     violations: [],
     policyId: auth.policy_id,
-    stateHash: auth.state_hash
+    stateHash: auth.state_hash,
+    signatureVerified,
+    verificationMode,
+    verificationCoverage
   };
 }

--- a/packages/core/src/verification/verifyAuthorization.ts
+++ b/packages/core/src/verification/verifyAuthorization.ts
@@ -251,13 +251,13 @@ export function verifyAuthorization(
   // mistake a merely-structural result for a cryptographically verified one:
   //   - `signatureVerified` flips true ONLY at the point a cryptographic check
   //     actually runs and succeeds;
-  //   - `cryptoEngaged` records that a verify function was invoked at all
-  //     (pass or fail), which distinguishes "permissive" from "structure-only";
   //   - `verificationCoverage` records which surface that check covered.
-  // The default/permissive path never sets `signatureVerified`, so a caller
-  // that only inspects `ok` cannot be silently misled.
+  // `verificationMode` is derived purely from the requested posture (below),
+  // independent of whether cryptography ran — the absence of a signature check
+  // is conveyed by `signatureVerified: false` / `verificationCoverage: "none"`,
+  // not by the mode. The default/permissive path never sets `signatureVerified`,
+  // so a caller that only inspects `ok` cannot be silently misled.
   let signatureVerified = false;
-  let cryptoEngaged = false;
   let verificationCoverage: VerificationCoverage = "none";
   const maxFutureIssuedAtSkewSeconds = resolveMaxFutureIssuedAtSkewSeconds(opts?.maxFutureIssuedAtSkewSeconds);
   const consumed = new Set(opts?.consumedAuthIds ?? []);
@@ -376,7 +376,6 @@ export function verifyAuthorization(
           violations.push({ code: "AUTH_KEY_INACTIVE", message: "key is not active at verification time" });
         } else {
           // A cryptographic check is actually performed here (pass or fail).
-          cryptoEngaged = true;
           if (
             !verifyEd25519(SIGNING_DOMAINS.AUTH_V1, payload, sigValue, key.public_key) &&
             !verifyEd25519Raw(payload, sigValue, key.public_key)
@@ -392,7 +391,6 @@ export function verifyAuthorization(
       if (opts?.legacyHmacSecret) {
         // Legacy HMAC covers the full AuthorizationV1 signing payload (not the
         // narrower engine-HMAC subset), so successful coverage is "full".
-        cryptoEngaged = true;
         if (!verifyHmacDomain(SIGNING_DOMAINS.AUTH_V1, payload, sigValue, opts.legacyHmacSecret)) {
           violations.push({ code: "AUTH_SIGNATURE_INVALID", message: "legacy HMAC signature verification failed" });
         } else {
@@ -407,10 +405,11 @@ export function verifyAuthorization(
     }
   }
 
-  // Posture actually applied: "strict" when requested; otherwise "permissive"
-  // if a cryptographic check was engaged, else "structure-only".
-  const verificationMode: VerificationMode =
-    opts?.mode === "strict" ? "strict" : cryptoEngaged ? "permissive" : "structure-only";
+  // Configured posture only (independent of whether cryptography ran):
+  // "strict" when requested, otherwise "permissive" (the best-effort default).
+  // Whether a signature was actually checked is reported separately via
+  // `signatureVerified` / `verificationCoverage`.
+  const verificationMode: VerificationMode = opts?.mode === "strict" ? "strict" : "permissive";
 
   if (violations.length > 0) {
     return {


### PR DESCRIPTION
Closes #172.

## What

`verifyAuthorization` could return `ok: true` on the permissive default path (no `trustedKeySets`, `requireSignatureVerification` unset) **without any cryptographic signature verification having run** — the classic integration footgun called out in #172. This makes the fact of verification explicit and unambiguous on the result, without changing default behavior.

Per the discussion on #172, the three facts are kept as **orthogonal fields** (rather than overloading one enum):

```ts
signatureVerified: boolean;                                   // was a signature actually checked?
verificationMode: "strict" | "permissive" | "structure-only"; // HOW verification was performed
verificationCoverage: "authorization-v1-full" | "engine-hmac-subset" | "none"; // WHAT surface was covered
```

- `signatureVerified` flips `true` **only** at the point a cryptographic check actually runs *and* succeeds.
- `verificationMode` describes the posture actually applied (distinct from the `mode: "strict" | "best-effort"` request option): `"structure-only"` when no crypto check was engaged, `"permissive"` when one ran in best-effort, `"strict"` when strict was requested.
- `verificationCoverage` records the covered surface. This verifier only ever emits `"authorization-v1-full"` or `"none"`; the `"engine-hmac-subset"` value is defined here so **#173 can reuse the same vocabulary** on `PolicyEngine.verifyAuthorization` without introducing a parallel status model.

## Types

- `verifyAuthorization` now returns a new `AuthorizationVerificationResult` — a `VerificationResult` in which the three descriptors are **required** (always populated), so an authorization result can never be silently mistaken for verified.
- The shared `VerificationResult` gains the three fields as **optional** (additive, non-breaking for the other verifiers), carrying the shared vocabulary for #173.
- New exported types: `VerificationMode`, `VerificationCoverage`, `AuthorizationVerificationResult`.

## Orthogonal to `ok`

A validly-signed but **expired** authorization is now `signatureVerified: true`, `ok: false` — the signature check and overall validity are reported independently.

## Compatibility

Default/permissive behavior is **unchanged**: a structurally-valid authorization with no trust anchor is still `ok: true`. The result simply now also says `signatureVerified: false`, `verificationMode: "structure-only"`, `verificationCoverage: "none"`, so a caller inspecting the result cannot be misled. Making strict verification the default is intentionally left as a separate, fingerprint-reviewed follow-up.

## Non-goals honored

No changes to canonicalization, Ed25519 semantics, `AuthorizationV1` wire format, or the engine HMAC surface (#173 kept separate).

## Tests

New `verify.authorization.surface.test.ts` covers the #172 list:
- forged signature rejected in strict mode (and not marked verified)
- forged signature not reported as fully verified in default/permissive mode
- `signatureVerified === true` only when a cryptographic check actually ran and succeeded
- missing trusted key set does not silently produce a fully-verified result
- structure-only result is distinguishable from strict verification
- `signatureVerified` orthogonal to `ok` (valid-but-expired)

Core suite: **280 pass / 0 fail**.

## Validation

- `pnpm --filter @oxdeai/core typecheck` — passes
- core tests — 280 pass
- `pnpm -C packages/conformance validate` — 209 assertions pass
- `test:vectors:ts / auth / pep / delegation` — 11 / 12 / 9 / 12 pass
- `security-gate` — `Decision: ALLOW`
- `git diff --check` — clean

## API fingerprint note

The public API surface expands (three new exported types + the widened result), but `packages/core/API_FINGERPRINT` hashes only `dist/index.d.ts`, which is re-export-only and therefore **byte-identical** for this change (verified: a clean `upstream/main` build and this branch produce the same `index.d.ts` hash). I also noticed the committed fingerprint doesn't match a local clean build even without my change — consistent with a CRLF/LF or build-environment difference — so I deliberately left `API_FINGERPRINT` untouched rather than overwrite the canonical value from a Windows build. Happy to regenerate it in whatever way matches CI if you'd prefer it bumped.
