### PR TITLE
fix(deps): remediate js-yaml and brace-expansion advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,13 +48,13 @@
       "langsmith": "0.7.1",
       "minimatch": ">=10.2.3",
       "lodash": ">=4.18.0",
-      "brace-expansion": ">=5.0.7",
+      "brace-expansion": ">=5.0.8",
       "ws": "8.21.1",
       "uuid": "14.0.0",
       "basic-ftp": ">=5.3.0",
       "fast-uri": ">=3.1.4",
       "form-data": "4.0.6",
-      "js-yaml": ">=4.3.0"
+      "js-yaml": ">=5.2.2"
     }
   },
   "type": "module"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,13 +8,13 @@ overrides:
   langsmith: 0.7.1
   minimatch: '>=10.2.3'
   lodash: '>=4.18.0'
-  brace-expansion: '>=5.0.7'
+  brace-expansion: '>=5.0.8'
   ws: 8.21.1
   uuid: 14.0.0
   basic-ftp: '>=5.3.0'
   fast-uri: '>=3.1.4'
   form-data: 4.0.6
-  js-yaml: '>=4.3.0'
+  js-yaml: '>=5.2.2'
 
 importers:
 
@@ -896,9 +896,9 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
@@ -1247,8 +1247,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@5.2.2:
+    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
 
   json-parse-even-better-errors@2.3.1:
@@ -2095,7 +2095,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2158,7 +2158,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -2456,7 +2456,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.2.1:
+  js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
 
@@ -2495,7 +2495,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary

Remediate the two high-severity transitive dependency advisories currently blocking the repository security gate.

The affected resolutions were:

```text
puppeteer@24.43.0
└─ cosmiconfig@9.0.1
   └─ js-yaml@5.2.1

@oxdeai/core
└─ @microsoft/api-extractor@7.58.7
   └─ minimatch@10.2.5
      └─ brace-expansion@5.0.7
````

The existing global `pnpm.overrides` ranges allowed pnpm to resolve the vulnerable versions.

## Changes

Raise the existing override floors to the audit-confirmed patched versions:

```text
js-yaml: >=4.3.0 → >=5.2.2
brace-expansion: >=5.0.7 → >=5.0.8
```

Regenerate `pnpm-lock.yaml`.

Final resolutions:

```text
puppeteer@24.43.0
└─ cosmiconfig@9.0.1
   └─ js-yaml@5.2.2

@oxdeai/core
└─ @microsoft/api-extractor@7.58.7
   └─ minimatch@10.2.5
      └─ brace-expansion@5.0.8
```

No vulnerable `js-yaml@5.2.1` or `brace-expansion@5.0.7` resolution remains in the lockfile.

## Scope

This PR is intentionally limited to dependency remediation.

Changed files:

* `package.json`
* `pnpm-lock.yaml`

No changes to:

* protocol behavior
* `AuthorizationV1`
* canonicalization
* signing payloads
* verification semantics
* trusted-time
* policy behavior
* API fingerprints


## Security gate

Before:

```text
Findings: 3
Blocking: 2
Warnings: 1

Decision: DENY
```

After:

```text
Findings: 1
Blocking: 0
Warnings: 1

Decision: ALLOW
```

The remaining warning is a non-blocking low-severity `esbuild` advisory and is outside the scope of this P0 remediation.

## Validation

* `pnpm install`  passed
* `pnpm install --frozen-lockfile`  passed
* security gate  `Decision: ALLOW`
* core typecheck  passed
* core tests  passed
* conformance validation  209 assertions passed
* TypeScript vectors  passed
* authorization vectors  passed
* PEP vectors  passed
* delegation vectors  passed
* repository-wide typecheck  passed
* repository-wide build/test  passed
* Go vectors  passed
* Python vectors  passed
* adapter validation  passed
* `git diff --check`  clean

## Rationale

This is the smallest safe remediation.

Upgrading parent packages would introduce broader unrelated dependency churn while retaining the same transitive structure. Raising the existing override floors directly removes the vulnerable resolutions without changing application or protocol behavior.

Closes #203.