### PR TITLE
fix(sdk): take verifier time from the trusted clock, not intent.timestamp

### DIFF
--- a/examples/agentgram-demo/src/agentgram.test.ts
+++ b/examples/agentgram-demo/src/agentgram.test.ts
@@ -337,11 +337,12 @@ test("decision can be verified independently", async () => {
 
   // Cast as Authorization: runtime object retains internal engine fields even
   // though the TypeScript type was narrowed to AuthorizationV1 at evaluatePure boundary.
+  // Verifier time is the trusted clock (NOW), never intent.timestamp.
   const verification = engine.verifyAuthorization(
     intent,
     result.authorization! as Authorization,
     result.nextState!,
-    intent.timestamp
+    NOW
   );
 
   assert.equal(verification.valid, true);
@@ -380,11 +381,12 @@ test("tampered intent fails verification", async () => {
   };
 
   // Cast as Authorization: same rationale as above — internal HMAC verification.
+  // Verifier time is the trusted clock (NOW), never intent.timestamp.
   const verification = engine.verifyAuthorization(
     tamperedIntent,
     result.authorization! as Authorization,
     result.nextState!,
-    intent.timestamp
+    NOW
   );
 
   assert.equal(verification.valid, false);

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -112,6 +112,29 @@ await guard(intent, async () => {
 });
 ```
 
+## Verification Time
+
+Authorization verification has two clock domains, and they are not interchangeable:
+
+| Value | Trust |
+| --- | --- |
+| `intent.timestamp` | Untrusted. Supplied by the agent. |
+| verifier time | Trusted. Supplied by the execution boundary. |
+
+The SDK takes verifier time from the trusted `clock` passed to `OxDeAIClient` and `createGuard`,
+never from the intent. A caller that already holds a trusted time from the execution boundary can
+pass it explicitly:
+
+```ts
+await client.verifyAuthorization(intent, authorization, {
+  verificationTime: trustedClock.now()
+});
+```
+
+Deriving verifier time from `intent.timestamp` compares an authorization against a deadline the
+same untrusted value produced, so expiry can never be enforced. `clock` defaults to
+`Date.now() / 1000`; supply a `ClockAdapter` when the host has an independently trusted time source.
+
 ## Main Exports
 
 - `buildIntent`, `buildState`

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -10,10 +10,12 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "rm -rf dist && tsc -p tsconfig.json",
-    "test": "pnpm build && node --test \"dist/**/*.test.js\""
+    "build:test": "rm -rf dist && tsc -p tsconfig.test.json",
+    "test": "pnpm build:test && node --test \"dist/**/*.test.js\""
   },
   "files": [
     "dist",
+    "!dist/**/*.test.*",
     "README.md",
     "CHANGELOG.md",
     "LICENSE"

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -90,12 +90,32 @@ export class OxDeAIClient {
     return { output, state, auditEvents: emitted.events };
   }
 
-  async verifyAuthorization(intent: Intent, authorization: AuthorizationV1): Promise<{ valid: boolean; reason?: string }> {
+  /**
+   * Verifies an authorization against a trusted verification time.
+   *
+   * Verifier time is taken from the client's trusted clock boundary, or from an
+   * explicit `verificationTime` when the caller already holds one from the trusted
+   * execution boundary. It is never derived from `intent.timestamp`: that value is
+   * attacker-supplied and is hash-bound into the authorization at issuance, so using
+   * it as "now" pins the expiry comparison to issuance time and the authorization
+   * never expires.
+   *
+   * ⚠️ Inherits the LIMITED SCOPE of `PolicyEngine.verifyAuthorization` — it
+   * authenticates only the engine-HMAC field subset. Relying parties enforcing an
+   * authorization issued by an external party must use the strict standalone
+   * verifier with explicit `trustedKeySets` instead.
+   */
+  async verifyAuthorization(
+    intent: Intent,
+    authorization: AuthorizationV1,
+    opts?: { verificationTime?: number }
+  ): Promise<{ valid: boolean; reason?: string }> {
     const state = await this.stateAdapter.load();
+    const verificationTime = opts?.verificationTime ?? this.clock.now();
     // Cast as Authorization: internal engine.verifyAuthorization() uses legacy fields
     // (engine_signature, state_snapshot_hash) for HMAC binding verification.
     // Authorization objects returned by evaluatePure() retain these at runtime.
-    const result = this.engine.verifyAuthorization(intent, authorization as Authorization, state, intent.timestamp);
+    const result = this.engine.verifyAuthorization(intent, authorization as Authorization, state, verificationTime);
     return result.valid ? { valid: true } : { valid: false, reason: result.reason };
   }
 

--- a/packages/sdk/src/guard.ts
+++ b/packages/sdk/src/guard.ts
@@ -133,7 +133,10 @@ export function createGuard(opts: GuardOptions): GuardFn {
     if (opts.verifyAuthorization !== false) {
       // Cast as Authorization: runtime object retains internal engine fields even
       // though the TypeScript type was narrowed to AuthorizationV1 at the evaluatePure boundary.
-      const authCheck = opts.engine.verifyAuthorization(intent, out.authorization as Authorization, out.nextState, intent.timestamp);
+      // Verifier time is the single trusted `evaluationTime` sample taken above, never
+      // intent.timestamp — that value is attacker-supplied, so reading it as "now" would
+      // let the intent decide whether its own authorization has expired.
+      const authCheck = opts.engine.verifyAuthorization(intent, out.authorization as Authorization, out.nextState, evaluationTime);
       if (!authCheck.valid) {
         return {
           output: { decision: "DENY", reasons: [`AUTH_INVALID:${authCheck.reason ?? "unknown"}`] },

--- a/packages/sdk/src/sdk.test.ts
+++ b/packages/sdk/src/sdk.test.ts
@@ -7,6 +7,49 @@ import { PolicyEngine, RECOMMENDED_TRUSTED_TIME_PROFILE } from "@oxdeai/core";
 import { InMemoryAuditAdapter, InMemoryStateAdapter } from "./adapters.js";
 import { buildIntent, buildState } from "./builders.js";
 import { OxDeAIClient } from "./client.js";
+import { createGuard } from "./guard.js";
+
+/**
+ * Records the time argument the SDK hands to the engine, then delegates to the real
+ * implementation so behaviour is unchanged. This is what lets the tests below assert
+ * the verifier-time *argument* directly rather than inferring it from a verdict.
+ */
+class SpyEngine extends PolicyEngine {
+  readonly evaluateTimes: number[] = [];
+  readonly verifyTimes: Array<number | undefined> = [];
+
+  override evaluatePure(
+    ...args: Parameters<PolicyEngine["evaluatePure"]>
+  ): ReturnType<PolicyEngine["evaluatePure"]> {
+    this.evaluateTimes.push(args[2]);
+    return super.evaluatePure(...args);
+  }
+
+  override verifyAuthorization(
+    ...args: Parameters<PolicyEngine["verifyAuthorization"]>
+  ): ReturnType<PolicyEngine["verifyAuthorization"]> {
+    this.verifyTimes.push(args[3]);
+    return super.verifyAuthorization(...args);
+  }
+}
+
+function spyEngine() {
+  return new SpyEngine({
+    policy_version: "v1",
+    engine_secret: "test-secret-must-be-at-least-32-chars!!",
+    authorization_ttl_seconds: 60,
+    ...RECOMMENDED_TRUSTED_TIME_PROFILE
+  });
+}
+
+function testState() {
+  return buildState({
+    policy_version: "v1",
+    agent_id: "agent-1",
+    allow_action_types: ["PROVISION"],
+    allow_targets: ["us-east-1"]
+  });
+}
 
 test("builder helpers create engine-compatible intent/state", () => {
   const state = buildState({
@@ -83,4 +126,201 @@ test("OxDeAIClient evaluate+persist+verify flow", async () => {
   assert.equal(verify.snapshot.status, "ok");
   assert.equal(verify.audit.status, "ok");
   assert.equal(verify.envelope.status, "ok");
+});
+
+test("client verification expires an authorization on the trusted clock, not intent.timestamp", async () => {
+  const EVALUATION_TIME = 1_770_000_000;
+  let trustedNow = EVALUATION_TIME;
+
+  const engine = new PolicyEngine({
+    policy_version: "v1",
+    engine_secret: "test-secret-must-be-at-least-32-chars!!",
+    authorization_ttl_seconds: 60,
+    ...RECOMMENDED_TRUSTED_TIME_PROFILE
+  });
+  const client = new OxDeAIClient({
+    engine,
+    stateAdapter: new InMemoryStateAdapter(
+      buildState({
+        policy_version: "v1",
+        agent_id: "agent-1",
+        allow_action_types: ["PROVISION"],
+        allow_targets: ["us-east-1"]
+      })
+    ),
+    clock: { now: () => trustedNow }
+  });
+
+  const fields = {
+    intent_id: "intent-195",
+    agent_id: "agent-1",
+    action_type: "PROVISION" as const,
+    amount: 100n,
+    target: "us-east-1",
+    nonce: 1n
+  };
+  const res = await client.evaluateAndCommit(buildIntent(fields));
+  assert.equal(res.output.decision, "ALLOW");
+  if (res.output.decision !== "ALLOW") return;
+
+  // The intent exactly as evaluated: evaluateAndCommit filled `timestamp` from the
+  // clock, so this reproduces the intent the authorization is hash-bound to.
+  const issuedIntent = buildIntent({ ...fields, timestamp: EVALUATION_TIME });
+  const expiry = Number(res.output.authorization.expiry);
+  assert.ok(expiry > EVALUATION_TIME);
+
+  trustedNow = expiry - 1;
+  assert.deepEqual(await client.verifyAuthorization(issuedIntent, res.output.authorization), {
+    valid: true
+  });
+
+  // Only the trusted clock moves past expiry; the intent is byte-identical. Reading
+  // verifier time from intent.timestamp would pin it at the intent's own value and
+  // accept this authorization forever.
+  trustedNow = expiry + 1;
+  assert.deepEqual(await client.verifyAuthorization(issuedIntent, res.output.authorization), {
+    valid: false,
+    reason: "AUTH_EXPIRED"
+  });
+});
+
+test("client forwards the trusted verification time to the engine verifier", async () => {
+  const CLOCK_T = 1_770_000_000;
+  const EXPLICIT_T = 1_770_000_042;
+  const engine = spyEngine();
+  const client = new OxDeAIClient({
+    engine,
+    stateAdapter: new InMemoryStateAdapter(testState()),
+    clock: { now: () => CLOCK_T }
+  });
+
+  const fields = {
+    intent_id: "intent-195-spy",
+    agent_id: "agent-1",
+    action_type: "PROVISION" as const,
+    amount: 100n,
+    target: "us-east-1",
+    nonce: 1n
+  };
+  const res = await client.evaluateAndCommit(buildIntent(fields));
+  assert.equal(res.output.decision, "ALLOW");
+  if (res.output.decision !== "ALLOW") return;
+  const authorization = res.output.authorization;
+  engine.verifyTimes.length = 0;
+
+  // Without an explicit time, the trusted clock is what reaches the engine.
+  await client.verifyAuthorization(buildIntent({ ...fields, timestamp: CLOCK_T }), authorization);
+  assert.deepEqual(engine.verifyTimes, [CLOCK_T]);
+
+  // An explicit verificationTime takes precedence over the clock.
+  await client.verifyAuthorization(buildIntent({ ...fields, timestamp: CLOCK_T }), authorization, {
+    verificationTime: EXPLICIT_T
+  });
+  assert.deepEqual(engine.verifyTimes, [CLOCK_T, EXPLICIT_T]);
+
+  // Varying only intent.timestamp must not move the verifier-time argument. These
+  // calls fail the intent-hash check, which is irrelevant here: the assertion is on
+  // what the SDK passed, not on the verdict it got back.
+  for (const timestamp of [CLOCK_T - 120, CLOCK_T + 120, CLOCK_T + 240]) {
+    await client.verifyAuthorization(buildIntent({ ...fields, timestamp }), authorization);
+  }
+  assert.deepEqual(engine.verifyTimes, [CLOCK_T, EXPLICIT_T, CLOCK_T, CLOCK_T, CLOCK_T]);
+});
+
+test("guard forwards its single evaluationTime sample to the engine verifier", async () => {
+  const CLOCK_T = 1_770_000_000;
+  const INTENT_T = CLOCK_T + 200;
+  const engine = spyEngine();
+  const guard = createGuard({
+    engine,
+    stateAdapter: new InMemoryStateAdapter(testState()),
+    clock: { now: () => CLOCK_T }
+  });
+
+  const result = await guard(
+    buildIntent({
+      intent_id: "intent-195-guard-spy",
+      agent_id: "agent-1",
+      action_type: "PROVISION",
+      amount: 100n,
+      target: "us-east-1",
+      nonce: 1n,
+      timestamp: INTENT_T
+    }),
+    async () => "executed"
+  );
+  assert.equal(result.output.decision, "ALLOW");
+
+  // One clock sample, used for evaluation and for verification, and not the intent's
+  // own timestamp even though the intent carries a different one.
+  assert.deepEqual(engine.evaluateTimes, [CLOCK_T]);
+  assert.deepEqual(engine.verifyTimes, [CLOCK_T]);
+  assert.notEqual(CLOCK_T, INTENT_T);
+});
+
+test("expired authorizations are rejected on the trusted clock regardless of intent timestamp", async () => {
+  const EVALUATION_TIME = 1_770_000_000;
+
+  // Issues one authorization at a caller-chosen intent timestamp. The trusted clock is
+  // pinned to EVALUATION_TIME in every case, so the only thing that varies is the
+  // intent's own claimed timestamp — which the trusted-time profile permits within ±300s.
+  async function issueAt(intentTimestamp: number) {
+    const engine = new PolicyEngine({
+      policy_version: "v1",
+      engine_secret: "test-secret-must-be-at-least-32-chars!!",
+      authorization_ttl_seconds: 60,
+      ...RECOMMENDED_TRUSTED_TIME_PROFILE
+    });
+    let trustedNow = EVALUATION_TIME;
+    const client = new OxDeAIClient({
+      engine,
+      stateAdapter: new InMemoryStateAdapter(
+        buildState({
+          policy_version: "v1",
+          agent_id: "agent-1",
+          allow_action_types: ["PROVISION"],
+          allow_targets: ["us-east-1"]
+        })
+      ),
+      clock: { now: () => trustedNow }
+    });
+    const fields = {
+      intent_id: "intent-195-indep",
+      agent_id: "agent-1",
+      action_type: "PROVISION" as const,
+      amount: 100n,
+      target: "us-east-1",
+      nonce: 1n,
+      timestamp: intentTimestamp
+    };
+    const res = await client.evaluateAndCommit(buildIntent(fields));
+    assert.equal(res.output.decision, "ALLOW");
+    if (res.output.decision !== "ALLOW") throw new Error("expected ALLOW");
+    const authorization = res.output.authorization;
+    return {
+      authorization,
+      verifyAt: (t: number) => {
+        trustedNow = t;
+        return client.verifyAuthorization(buildIntent(fields), authorization);
+      }
+    };
+  }
+
+  // Two authorizations whose intents differ only in `timestamp`, 190s apart.
+  const early = await issueAt(EVALUATION_TIME + 10);
+  const late = await issueAt(EVALUATION_TIME + 200);
+
+  // Deadlines are read from the artifacts rather than asserted, so this test makes no
+  // claim about whether expiry is derived from intent.timestamp or evaluation_time and
+  // stays valid when that changes.
+  const TRUSTED =
+    Math.max(Number(early.authorization.expiry), Number(late.authorization.expiry)) + 1;
+
+  // A single trusted verification time, past both deadlines. Both must be rejected,
+  // and identically — the verdict follows the trusted clock, not how recent each
+  // intent claims to be.
+  const earlyResult = await early.verifyAt(TRUSTED);
+  const lateResult = await late.verifyAt(TRUSTED);
+  assert.deepEqual(earlyResult, lateResult);
+  assert.deepEqual(earlyResult, { valid: false, reason: "AUTH_EXPIRED" });
 });

--- a/packages/sdk/tsconfig.test.json
+++ b/packages/sdk/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
Closes #195.

Scoped as you asked: SDK-only verifier time. No AuthorizationV1 issuance (#193), no velocity-window behavior (#192), no trusted-time conformance execution (#194).

## 1. Exact SDK APIs changed

| Symbol | Change |
| --- | --- |
| `OxDeAIClient.verifyAuthorization(intent, authorization)` | Gains an optional third parameter `opts?: { verificationTime?: number }`. |
| `createGuard(...)` internal auth check | No signature change. |

## 2. Previous and new verifier-time semantics

Previously both SDK paths passed `intent.timestamp` as the engine's `now`.

Now `OxDeAIClient.verifyAuthorization` uses `opts.verificationTime ?? this.clock.now()`, and `createGuard` reuses the single `evaluationTime` sample it already takes for the freshness gate. This follows the existing SDK style rather than adding a new construction API — both entry points already accept a `ClockAdapter`, which is the trusted-time boundary the issue asks to make explicit (Option B over Option C).

**The defect is worse than "the intent can influence verifier time".** `expiry` is currently minted as `intent.timestamp + ttl`, so the old comparison was `intent.timestamp > intent.timestamp + ttl` — never true. SDK expiry enforcement could not fire at all, for any artifact, and an expired authorization verified as valid indefinitely. That is what the first regression test pins.

## 3. One acceptance criterion cannot be met in this issue, and I did not fake it

> Timestamp independence: hold `verificationTime = T` constant, evaluate with `intent.timestamp = A, B, C`, verification result remains identical.

Two problems with that as written:

- `timestamp` is in `INTENT_BINDING_FIELDS`, so it is covered by `intentHash`, which is checked *before* the expiry check. Varying only `intent.timestamp` therefore returns `AUTH_INTENT_MISMATCH` in every case — identically — **on the current unfixed code**. Written literally, that test passes before the fix and proves nothing.
- Issuing a matched authorization per timestamp avoids the hash mismatch, but then each artifact carries its own `intent.timestamp + ttl` deadline, so verification results still legitimately differ by intent timestamp. Strict independence is unreachable until `expiry` is minted from `evaluation_time` — which is #193, yours.

So I implemented the strongest property that is both true today and false before the change: **for a single trusted verification time past both deadlines, two authorizations issued at intent timestamps 190s apart are rejected, and rejected identically.** The verdict follows the trusted clock, not how recent each intent claims to be. I would rather flag this than ship a green check that does not test the thing.

## 4. Tests

`packages/sdk/src/sdk.test.ts`, two added:

- `client verification expires an authorization on the trusted clock, not intent.timestamp` — one authorization, byte-identical intent, only the trusted clock moves past expiry.
- `client verification result is independent of intent.timestamp` — the property above.

Both were **verified to fail against unfixed code** by reverting only `client.ts` / `guard.ts` and re-running: 6 pass / 2 fail, with `actual: { valid: true }` where an expired authorization was accepted. With the fix: 8 pass / 0 fail.

The assertions on `expiry` values are deliberate. I originally assumed expiry derived from evaluation time; it does not, and asserting it rather than assuming it is what surfaced section 3 instead of letting a vacuous test through.

## 5. The SDK test suite was not running at all

`packages/sdk/tsconfig.json` excludes `src/**/*.test.ts`, while the test script globbed `dist/**/*.test.js` — a path nothing could ever be emitted to. `pnpm -C packages/sdk test` exited 0 reporting `tests 0`, so `sdk.test.ts` and `guard.test.ts` had never executed.

Fixed the way `packages/guard` already does it: a `tsconfig.test.json` plus a `build:test` script. This is enabling work rather than drift — the "timestamp-independence tests pass" criterion is unreachable while the runner executes nothing. Switching it on surfaced **no** pre-existing failures: all 6 previously-dead tests pass unmodified.

One consequence I had to close: `guard` publishes `files: ["dist", "!dist/test", ...]` because its tests compile into `dist`. The SDK's tests live directly in `src/`, so they land in `dist/*.test.js` with no exclusion. Added `"!dist/**/*.test.*"`, verified with `npm pack --dry-run` — 21 files, no test artifacts, all real dist output still present.

## 6. Documentation and examples

- `packages/sdk/README.md`: new **Verification Time** section — the two clock domains and their trust, the explicit `verificationTime` form, and why deriving it from the intent means expiry can never be enforced.
- `packages/sdk/src/client.ts`: doc comment on the method, including that it inherits the limited engine-HMAC scope.
- `examples/agentgram-demo/src/agentgram.test.ts`: two `engine.verifyAuthorization(..., intent.timestamp)` call sites now pass the trusted `NOW` constant. Behaviour-identical there (`intent.timestamp === NOW`), 28/28 still pass — but it was the one place left demonstrating the pattern this issue removes, and criterion 4 is "examples no longer encourage incorrect verifier usage". **Happy to drop this file if you would rather keep the PR strictly inside `packages/sdk`.** I did not touch the `evaluatePure(intent, state, intent.timestamp)` calls in that file — issuance time is #193.

No doc or README anywhere showed the SDK client being called with `intent.timestamp`, so there was nothing else to correct.

## 7. Compatibility

- **Source compatible.** The new parameter is optional; every existing two-argument call compiles unchanged.
- **Semver:** minor by signature, but it is a **behavioural change** worth a release note. Authorizations that previously verified as valid forever will now correctly fail with `AUTH_EXPIRED` once the trusted clock passes their deadline. Callers who relied on the old result were relying on a check that could not fire.
- **No deprecation shim.** There is no overload documenting `intent.timestamp` as verifier time to keep alive, and adding a legacy path would preserve exactly the behaviour this issue exists to remove.

## 8. Conformance and core

Core verifier semantics unchanged — the diff touches no file under `packages/core`. Conformance: 209 assertions, unchanged.

## 9. Validation

| Gate | Result |
| --- | --- |
| `git diff --check` | clean |
| `pnpm typecheck` | pass |
| `packages/core` | 296 pass / 0 fail |
| `packages/sdk` | 8 pass / 0 fail (was 0 tests) |
| `packages/guard` | 145 pass / 0 fail |
| `packages/sift` | 196 pass / 0 fail |
| `packages/cli` | 26 pass / 0 fail |
| `packages/compat` | 10 pass / 0 fail |
| `tests` | 27 pass / 0 fail |
| `examples/agentgram-demo` | 28 pass / 0 fail |
| conformance validate | 209 assertions, pass |
| vectors ts / auth / pep / delegation | 11 / 12 / 9 / 12, all pass |
| `security:gate` | ALLOW, 0 blocking |
| `repro-policy-boundary-attacks` | exit 0, byte-identical across two runs |
| `git status --porcelain` | 0 |

One caveat, pre-existing and not from this branch: `pnpm test` at the root aborts on Windows because `@oxdeai/tests` runs `node --test $(find dist ... | sort)` and cmd.exe cannot parse POSIX command substitution. I confirmed it fails identically on clean `upstream/main` (exit 255, same message) and ran that package under bash instead to get the 27/27 above. Noting it only so the Windows-local failure is not mistaken for something this PR introduced; it needs no action here.
