### PR TITLE
fix(core): mint authorization timestamps from trusted evaluation time

### DIFF
--- a/docs/spec/artifacts/authorization-v1.md
+++ b/docs/spec/artifacts/authorization-v1.md
@@ -279,6 +279,10 @@ The canonicalized preimage includes whichever expiry field name (`expiry` or `ex
 ### issued_at
 
 * Unix timestamp (seconds) recording when the authorization was issued
+* A `PolicyEngine` issuer conforming to the trusted-time core profile **MUST**
+  set `issued_at = evaluation_time`, using the same single trusted clock sample
+  used for freshness and policy evaluation. `intent.timestamp` remains part of
+  intent binding but **MUST NOT** drive this field.
 * The verifier validates that this field is an integer but does NOT enforce `now >= issued_at` as a lower bound. A verifier whose clock is slightly behind the issuer will still accept a valid-window authorization.
 * No "not yet valid" (nbf) semantics exist in this protocol version — `issued_at` in the future relative to `now` is not, by itself, a rejection condition.
 * **Bounded future-plausibility check (upper bound):** `issued_at` **MUST NOT** exceed `verificationTime + maxFutureIssuedAtSkewSeconds`. This is a plausibility backstop, not an nbf check — it absorbs ordinary clock drift (default `maxFutureIssuedAtSkewSeconds` is 300s) but rejects grossly implausible future-dated artifacts (e.g. `issued_at` decades ahead of `now`), which would otherwise remain valid for their entire stated lifetime regardless of how far in the future they claim to have been issued. Violation code: `AUTH_ISSUED_AT_IMPLAUSIBLE`. The comparison **MUST** use the trusted `verificationTime` supplied to the verifier — never an agent-supplied `Intent.timestamp` or any other untrusted input.
@@ -288,6 +292,11 @@ The canonicalized preimage includes whichever expiry field name (`expiry` or `ex
 ### expiry / expires_at
 
 * Unix timestamp (seconds) recording when the authorization expires
+* A `PolicyEngine` issuer conforming to the trusted-time core profile **MUST**
+  derive this field as `evaluation_time + effective_ttl`, where
+  `effective_ttl` is the single validated fixed authorization TTL defined by
+  `trusted-time-v1.md` §5.1. Invalid TTL or unsafe arithmetic fails before
+  construction or signing.
 * **MUST** be strictly enforced: valid iff `now < expiry`; `now >= expiry` → `AUTH_EXPIRED`
 * **No clock skew tolerance** — the protocol uses strict zero tolerance. There is no `skew` parameter and no grace period.
 * Wire-format field name depends on encoding (see §5)

--- a/docs/spec/core/trusted-time-v1.md
+++ b/docs/spec/core/trusted-time-v1.md
@@ -114,7 +114,7 @@ A conformant trusted-time evaluation MUST hold all four invariants:
 2. **Trusted issuance.** `issued_at` MUST be minted from trusted time:
    `issued_at = evaluation_time`.
 3. **Trusted, bounded expiry.** `expiry` MUST be derived from trusted time and a
-   bounded TTL: `expiry = evaluation_time + maxTtlSeconds`.
+   validated fixed TTL: `expiry = evaluation_time + effective_ttl`.
 4. **Enforcement stays zero-tolerance.** Trusted-time *mints* the expiry;
    downstream expiry verification remains zero-tolerance (`now < expiry`),
    unchanged from `eta-core-v1`. This profile does not relax enforcement.
@@ -128,17 +128,73 @@ A conformant trusted-time evaluation MUST hold all four invariants:
 | `maxClockSkewSeconds` | max `intent.timestamp − evaluation_time` tolerated as fresh (future side) | REQUIRED |
 | `maxIntentAgeSeconds` | max `evaluation_time − intent.timestamp` tolerated as fresh (stale side) | REQUIRED |
 | `replayWindowSeconds` | nonce retention window, keyed to `evaluation_time` | REQUIRED |
-| `maxTtlSeconds` | upper bound on the minted expiry TTL | REQUIRED |
+| `maxTtlSeconds` | specification name for the resolved fixed issuance TTL; implementation mapping: `authorization_ttl_seconds ?? 60` | REQUIRED after resolution; implementation default 60 |
 | `maxInterPepSkewSeconds` | bound on inter-PEP clock disagreement (§2.1) | profile-defined; REQUIRED for multi-PEP |
 | `velocity.maxActions`, `velocity.windowSeconds` | actions per trusted-time window | profile-defined |
 
-- **REQUIRED** fields MUST be present for a conformant trusted-time evaluation.
+- **REQUIRED** fields MUST be present after configuration resolution for a
+  conformant trusted-time evaluation. The fixed authorization TTL is resolved
+  through the explicit 60-second default defined below; this does not make a
+  second TTL authority.
 - **profile-defined** fields MAY be set or omitted by a profile, which MUST
   document its default when omitted. `maxInterPepSkewSeconds` is REQUIRED only
   for a deployment that runs more than one PEP without a single authoritative
   clock (§2.1).
 
-### 5.1 Numeric Domain
+### 5.1 Fixed Authorization TTL
+
+The current profile has exactly one authorization TTL authority. It does not
+support a caller-requested TTL, a policy-selected shorter TTL, or a
+`min(requested_ttl, max_ttl)` selection rule.
+
+Normatively:
+
+```text
+effective_ttl = configured fixed authorization TTL
+issued_at = evaluation_time
+expiry = evaluation_time + effective_ttl
+```
+
+For `PolicyEngine`, the implementation mapping is:
+
+```text
+effective_ttl =
+  authorization_ttl_seconds, when explicitly configured
+  60, when authorization_ttl_seconds is undefined
+```
+
+Where older trusted-time documents or vectors use `maxTtlSeconds`, that term
+names this same resolved fixed TTL. It is not an independent runtime control.
+Because there is no requested or policy-selected shorter TTL, the fixed
+configured maximum is also the effective TTL.
+
+The 60-second default applies only when `authorization_ttl_seconds` is
+`undefined`. `null`, strings, NaN, infinities, fractional values, zero,
+negative values, and unsafe integers are invalid configuration and MUST NOT be
+coerced, clamped, or replaced by the default.
+
+`evaluation_time + effective_ttl` MUST be a non-negative safe integer.
+Overflow or any value outside the protocol numeric domain MUST refuse the
+evaluation before authorization construction, canonicalization, or signing.
+The same single `evaluation_time` sample MUST be used by freshness evaluation,
+policy evaluation, `issued_at`, and expiry derivation. Timestamps MUST NOT be
+mutated after signing.
+
+The resulting authorization validity interval remains `[issued_at, expiry)`:
+verification at `expiry - 1` succeeds when all other checks pass, while
+verification at `expiry` fails with `AUTH_EXPIRED`.
+
+This derivation changes signed field values whenever `evaluation_time` differs
+from `intent.timestamp`. Consequently, canonical authorization bytes,
+authorization hashes and `auth_id`, signatures, ALLOW/AUTH_EMITTED audit
+timestamps, and EXECUTE concurrency expiry entries also change. Field names,
+wire encodings, canonicalization rules, signing domains, algorithms, and intent
+binding are unchanged, so no AuthorizationV1 schema-version increment is
+required. Previously stored authorizations remain verifiable under their
+original signed timestamps; mixed-version issuers may mint different artifacts
+for the same logical intent until rollout is complete.
+
+### 5.2 Numeric Domain
 
 All time and duration quantities MUST lie in a well-defined numeric domain;
 values outside it MUST cause the evaluation to fail closed, never a silent
@@ -150,7 +206,7 @@ coercion:
   `replayWindowSeconds`, `maxTtlSeconds`, `maxInterPepSkewSeconds`,
   `velocity.windowSeconds` — MUST be a finite non-negative
   integer; `velocity.maxActions` MUST be a finite non-negative integer count.
-  `maxTtlSeconds` MUST additionally be `≥ 1` (a zero TTL
+  `maxTtlSeconds` / `effective_ttl` MUST additionally be `≥ 1` (a zero TTL
   would mint `expiry == issued_at`).
 - A malformed `intent.timestamp` (NaN, Infinity, non-integer, negative, or
   unsafe magnitude) MUST `DENY` with `STATE_INVALID` at the freshness gate (§6),
@@ -166,7 +222,7 @@ Let `Δ = intent.timestamp − evaluation_time`. The freshness gate is evaluated
 `intent.timestamp`.
 
 **Precondition.** A malformed `intent.timestamp` (NaN, Infinity, non-integer,
-negative, or unsafe magnitude) fails closed with `STATE_INVALID` per §5.1
+negative, or unsafe magnitude) fails closed with `STATE_INVALID` per §5.2
 *before* `Δ` is computed; the freshness comparisons below assume a well-formed
 `intent.timestamp`.
 
@@ -242,13 +298,13 @@ No code is final until the enum change is reviewed and merged separately.
 
 ## 9. Out of Scope
 
-This document specifies rules only. The following are explicitly deferred to
-separate, independently reviewed changes and MUST NOT be inferred from this
-profile:
+The following are explicitly outside the trusted-issuance rule and MUST NOT be
+inferred from this profile:
 
-- `verifyTrustedTime` verifier wiring
-- engine / runtime integration of `evaluation_time`
-- conformance vectors, including the stale-intent negative/positive pair
+- verifier-side future-`issued_at` policy changes
+- SDK verifier-time changes
+- replay-store clock changes
+- velocity-window changes
 - trusted-time rules for **tool-call windows**. This profile does not make
   tool-call-window accounting (the existing `TOOL_CALL_LIMIT_EXCEEDED`
   enforcement path) trusted-time-aware. A follow-up MAY do so, keying the window

--- a/examples/autogen/src/run.ts
+++ b/examples/autogen/src/run.ts
@@ -54,7 +54,9 @@ export async function runDemo(log: (msg: string) => void = (msg) => console.log(
 
   log(`\n${c(C.dim, "── Agent proposals (from AutoGen) ─────────────────────────────────")}`);
   for (const call of plannedCalls) {
-    const timestamp = baseTimestamp + callIndex;
+    // Keep the intent clock stable across this synchronous demo run. Authorization
+    // issuance is stamped from the engine's evaluation clock, not this client time.
+    const timestamp = baseTimestamp;
     const result = await guardedProvision(call.asset, call.region, state, timestamp, log);
 
     if (result.allowed) {

--- a/examples/crewai/src/run.ts
+++ b/examples/crewai/src/run.ts
@@ -54,7 +54,9 @@ export async function runDemo(log: (msg: string) => void = (msg) => console.log(
 
   log(`\n${c(C.dim, "── Agent proposals (from CrewAI) ──────────────────────────────────")}`);
   for (const call of plannedCalls) {
-    const timestamp = baseTimestamp + callIndex;
+    // Keep the intent clock stable across this synchronous demo run. Authorization
+    // issuance is stamped from the engine's evaluation clock, not this client time.
+    const timestamp = baseTimestamp;
     const result = await guardedProvision(call.asset, call.region, state, timestamp, log);
 
     if (result.allowed) {

--- a/examples/langgraph/src/run.ts
+++ b/examples/langgraph/src/run.ts
@@ -66,7 +66,9 @@ export async function runDemo(log: (msg: string) => void = (msg) => console.log(
 
   log(`\n${c(C.dim, "── Agent proposals (from LangGraph) ───────────────────────────────")}`);
   for (const call of plannedCalls) {
-    const timestamp = baseTimestamp + callIndex;
+    // Keep the intent clock stable across this synchronous demo run. Authorization
+    // issuance is stamped from the engine's evaluation clock, not this client time.
+    const timestamp = baseTimestamp;
     const result = await guardedProvision(call.asset, call.region, state, timestamp, log);
 
     if (result.allowed) {

--- a/examples/openai-agents-sdk/src/run.ts
+++ b/examples/openai-agents-sdk/src/run.ts
@@ -54,7 +54,9 @@ export async function runDemo(log: (msg: string) => void = (msg) => console.log(
 
   log(`\n${c(C.dim, "── Agent proposals (from OpenAI Agents SDK) ───────────────────────")}`);
   for (const call of plannedCalls) {
-    const timestamp = baseTimestamp + callIndex;
+    // Keep the intent clock stable across this synchronous demo run. Authorization
+    // issuance is stamped from the engine's evaluation clock, not this client time.
+    const timestamp = baseTimestamp;
     const result = await guardedProvision(call.asset, call.region, state, timestamp, log);
 
     if (result.allowed) {

--- a/examples/openclaw/src/run.ts
+++ b/examples/openclaw/src/run.ts
@@ -84,7 +84,9 @@ export async function runDemo(log: (msg: string) => void = (msg) => console.log(
   log(`\n${c(C.dim, "── Agent proposals ─────────────────────────────────────────────────")}`);
 
   for (const call of PLANNED_CALLS) {
-    const timestamp = baseTimestamp + callIndex;
+    // Keep the intent clock stable across this synchronous demo run. Authorization
+    // issuance is stamped from the engine's evaluation clock, not this client time.
+    const timestamp = baseTimestamp;
 
     const result = await guardedProvision(
       call.asset,

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -18,7 +18,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "extract": "pnpm build && node dist/scripts/extract-vectors.js",
+    "extract": "pnpm -C ../core build && pnpm build && node dist/scripts/extract-vectors.js",
     "validate": "pnpm -C ../core build && pnpm build && node dist/src/validate.js"
   },
   "dependencies": {

--- a/packages/conformance/scripts/extract-vectors.ts
+++ b/packages/conformance/scripts/extract-vectors.ts
@@ -218,34 +218,47 @@ async function extractAuthorizationPayload(): Promise<void> {
   // The runtime object still carries these fields; only the TypeScript type was narrowed.
   const r1auth = r1.authorization as Authorization;
 
-  const r2 = engine.evaluatePure(makeIntent(101n, 0), makeState(), 0);
+  const r2EvaluationTime = 30;
+  const r2 = engine.evaluatePure(makeIntent(101n, 0), makeState(), r2EvaluationTime);
   if (r2.decision !== "ALLOW") throw new Error("expected ALLOW for auth vector 2");
   const r2auth = r2.authorization as Authorization;
 
   writeVector("authorization-payload.json", {
     version: "1.0.0",
-    ttl_seconds: 60,
+    effective_ttl: 60,
     signing_algorithm: "HMAC-SHA256",
     vectors: [
       {
         id: "auth-payload-001",
-        input: makeIntent(100n, 1730000000),
+        input: {
+          intent_timestamp: 1730000000,
+          evaluation_time: 1730000000,
+          effective_ttl: 60,
+          intent: makeIntent(100n, 1730000000)
+        },
         expected: {
           intent_hash: r1auth.intent_hash,
           policy_id: policyId,
           state_hash: r1auth.state_snapshot_hash,
-          expires_at: r1auth.expires_at,
+          expected_issued_at: r1auth.issued_at,
+          expected_expiry: r1auth.expires_at,
           canonical_signing_payload: canonicalJson(authSigningPayload(r1auth, policyId)),
           signature: r1auth.engine_signature
         }
       },
       {
         id: "auth-payload-002",
-        input: makeIntent(101n, 0),
+        input: {
+          intent_timestamp: 0,
+          evaluation_time: r2EvaluationTime,
+          effective_ttl: 60,
+          intent: makeIntent(101n, 0)
+        },
         expected: {
           intent_hash: r2auth.intent_hash,
-          expires_at: r2auth.expires_at,
-          expires_at_derivation: "intent.timestamp(0) + ttl_seconds(60) = 60",
+          expected_issued_at: r2auth.issued_at,
+          expected_expiry: r2auth.expires_at,
+          expiry_derivation: "evaluation_time(30) + effective_ttl(60) = 90",
           canonical_signing_payload: canonicalJson(authSigningPayload(r2auth, policyId)),
           signature: r2auth.engine_signature
         }

--- a/packages/conformance/src/validate.ts
+++ b/packages/conformance/src/validate.ts
@@ -66,7 +66,7 @@ type ConformanceAdapter = {
   name: string;
   canonicalJson(value: unknown): string;
   intentHash(intent: Intent): string;
-  evaluateAuthorization(intent: Intent): { authorization: AuthorizationLike; policyId: string };
+  evaluateAuthorization(intent: Intent, evaluationTime: number): { authorization: AuthorizationLike; policyId: string };
   encodeSnapshot(state: State): { bytes: Uint8Array; policyId: string };
   verifySnapshot(bytes: Uint8Array, expectedPolicyId?: string): VerificationResult;
   verifyAuditEvents(
@@ -126,11 +126,11 @@ const INTENT_BINDING_FIELDS = [
   "tool_call"
 ] as const;
 
-function makeEngine(): PolicyEngine {
+function makeEngine(authorizationTtlSeconds = 60): PolicyEngine {
   return new PolicyEngine({
     policy_version: "v1.0.0",
     engine_secret: CORE_ENGINE_SECRET, // now typed as string
-    authorization_ttl_seconds: 60,
+    authorization_ttl_seconds: authorizationTtlSeconds,
     policyId: CORE_POLICY_ID,
     ...RECOMMENDED_TRUSTED_TIME_PROFILE
   });
@@ -311,9 +311,9 @@ const coreAdapter: ConformanceAdapter = {
     }
     return sha256HexFromJson(binding);
   },
-  evaluateAuthorization(intent: Intent) {
+  evaluateAuthorization(intent: Intent, evaluationTime: number) {
     const engine = makeEngine();
-    const out = engine.evaluatePure(intent, makeBaseState(), intent.timestamp);
+    const out = engine.evaluatePure(intent, makeBaseState(), evaluationTime);
     if (out.decision !== "ALLOW") {
       throw new Error(`expected ALLOW, got DENY: ${out.reasons.join(",")}`);
     }
@@ -390,15 +390,21 @@ function validateAuthorizationVectors(ctx: CheckCtx, adapter: ConformanceAdapter
 
   for (const v of file.vectors) {
     const id = String(v.id);
-    const intent = parseIntent(v.input);
-    const { authorization, policyId } = adapter.evaluateAuthorization(intent);
+    const input = asRecord(v.input);
+    const intent = parseIntent(input.intent);
+    const evaluationTime = Number(input.evaluation_time);
+    const effectiveTtl = Number(input.effective_ttl);
+    eq(ctx, `${id} intent_timestamp`, intent.timestamp, Number(input.intent_timestamp));
+    const { authorization, policyId } = adapter.evaluateAuthorization(intent, evaluationTime);
     const expected = asRecord(v.expected);
 
     eq(ctx, `${id} intent_hash`, authorization.intent_hash, String(expected.intent_hash));
     if (expected.state_hash !== undefined) {
       eq(ctx, `${id} state_hash`, authorization.state_snapshot_hash, String(expected.state_hash));
     }
-    eq(ctx, `${id} expires_at`, authorization.expires_at, Number(expected.expires_at));
+    eq(ctx, `${id} issued_at`, authorization.issued_at, Number(expected.expected_issued_at));
+    eq(ctx, `${id} expiry`, authorization.expires_at, Number(expected.expected_expiry));
+    eq(ctx, `${id} effective_ttl`, authorization.expires_at - authorization.issued_at, effectiveTtl);
 
     const payload = adapter.canonicalJson({
       expires_at: authorization.expires_at,
@@ -409,6 +415,131 @@ function validateAuthorizationVectors(ctx: CheckCtx, adapter: ConformanceAdapter
     eq(ctx, `${id} canonical_signing_payload`, payload, String(expected.canonical_signing_payload));
     eq(ctx, `${id} signature`, authorization.engine_signature, String(expected.signature));
   }
+}
+
+function validateTrustedTimeIssuanceVectors(ctx: CheckCtx): void {
+  type TrustedTimeFile = {
+    issuance_vectors: Array<JsonRecord>;
+  };
+  const file = loadJson<TrustedTimeFile>("trusted-time.json");
+  const comparisonWindows = new Map<string, Array<[number, number]>>();
+
+  for (const [index, vector] of file.issuance_vectors.entries()) {
+    const id = String(vector.id);
+    const intentTimestamp = Number(vector.intent_timestamp);
+    const evaluationTime = Number(vector.evaluation_time);
+    const effectiveTtl = Number(vector.effective_ttl);
+    const action = String(vector.authorization_action);
+    const expected = asRecord(vector.expected);
+
+    if (String(expected.decision) === "CONFIG_INVALID") {
+      let message = "";
+      try {
+        makeEngine(effectiveTtl);
+      } catch (error) {
+        message = error instanceof Error ? error.message : String(error);
+      }
+      eq(ctx, `${id} config rejection`, message.includes(String(expected.error)), true);
+      continue;
+    }
+
+    const engine = makeEngine(effectiveTtl);
+    const releasedId = "existing-authorization";
+    const state = makeBaseState();
+    if (action === "RELEASE") {
+      state.concurrency.active = { "agent-1": 1 };
+      state.concurrency.active_auths = {
+        "agent-1": {
+          [releasedId]: { expires_at: evaluationTime + 600 },
+        },
+      };
+    }
+    const intent: Intent = {
+      intent_id: `${id}-intent`,
+      agent_id: "agent-1",
+      action_type: "PAYMENT",
+      amount: 100n,
+      asset: "wallet",
+      target: "merchant-1",
+      timestamp: intentTimestamp,
+      metadata_hash: "0".repeat(64),
+      nonce: BigInt(index + 1000),
+      signature: "sig-placeholder",
+      depth: 0,
+      ...(action === "RELEASE"
+        ? { type: "RELEASE" as const, authorization_id: releasedId }
+        : { type: "EXECUTE" as const }),
+    };
+
+    if (String(expected.decision) === "PRECONDITION_INVALID") {
+      let message = "";
+      try {
+        engine.evaluatePure(intent, state, evaluationTime);
+      } catch (error) {
+        message = error instanceof Error ? error.message : String(error);
+      }
+      eq(ctx, `${id} precondition rejection`, message.includes(String(expected.error)), true);
+      eq(ctx, `${id} no audit before rejection`, engine.audit.snapshot(), []);
+      continue;
+    }
+
+    const out = engine.evaluatePure(intent, state, evaluationTime);
+    eq(ctx, `${id} decision`, out.decision, String(expected.decision));
+
+    if (out.decision === "DENY") {
+      eq(ctx, `${id} reason`, out.reasons[0], String(expected.reason));
+      eq(ctx, `${id} authorization absent`, "authorization" in out, false);
+      continue;
+    }
+
+    eq(ctx, `${id} issued_at`, out.authorization.issued_at, Number(expected.expected_issued_at));
+    eq(ctx, `${id} expiry`, out.authorization.expiry, Number(expected.expected_expiry));
+    eq(
+      ctx,
+      `${id} effective_ttl`,
+      out.authorization.expiry - out.authorization.issued_at,
+      effectiveTtl,
+    );
+    if (vector.comparison_group !== undefined) {
+      const group = String(vector.comparison_group);
+      const windows = comparisonWindows.get(group) ?? [];
+      windows.push([out.authorization.issued_at, out.authorization.expiry]);
+      comparisonWindows.set(group, windows);
+    }
+
+    if (Number(vector.repeat) === 2) {
+      const repeated = makeEngine(effectiveTtl).evaluatePure(
+        intent,
+        action === "RELEASE" ? structuredClone(state) : makeBaseState(),
+        evaluationTime,
+      );
+      eq(ctx, `${id} repeated decision`, repeated.decision, "ALLOW");
+      if (repeated.decision === "ALLOW") {
+        eq(
+          ctx,
+          `${id} identical authorization`,
+          repeated.authorization,
+          out.authorization,
+        );
+      }
+    }
+  }
+
+  const sameEvaluationWindows = comparisonWindows.get("same-evaluation-time") ?? [];
+  eq(
+    ctx,
+    "trusted-time intent timestamp noninterference",
+    sameEvaluationWindows[0],
+    sameEvaluationWindows[1],
+  );
+  const differentEvaluationWindows =
+    comparisonWindows.get("different-evaluation-time") ?? [];
+  eq(
+    ctx,
+    "trusted-time evaluation sensitivity",
+    differentEvaluationWindows[1]?.[0] - differentEvaluationWindows[0]?.[0],
+    10,
+  );
 }
 
 function validateAuthorizationVerificationVectors(ctx: CheckCtx, adapter: ConformanceAdapter): void {
@@ -1568,6 +1699,7 @@ function main(): void {
 
   validateIntentHashVectors(ctx, adapter);
   validateAuthorizationVectors(ctx, adapter);
+  validateTrustedTimeIssuanceVectors(ctx);
   validateAuthorizationVerificationVectors(ctx, adapter);
   validateAuthorizationSignatureVectors(ctx, adapter);
   validateSnapshotVectors(ctx, adapter);

--- a/packages/conformance/vectors/authorization-payload.json
+++ b/packages/conformance/vectors/authorization-payload.json
@@ -1,30 +1,36 @@
 {
   "version": "1.0.0",
-  "ttl_seconds": 60,
+  "effective_ttl": 60,
   "signing_algorithm": "HMAC-SHA256",
   "vectors": [
     {
       "id": "auth-payload-001",
       "input": {
-        "intent_id": "intent-100",
-        "agent_id": "agent-1",
-        "action_type": "PAYMENT",
-        "amount": "1000000",
-        "target": "merchant-1",
-        "timestamp": 1730000000,
-        "metadata_hash": "0000000000000000000000000000000000000000000000000000000000000000",
-        "nonce": "100",
-        "signature": "sig-placeholder",
-        "depth": 0,
-        "tool": "openai.responses",
-        "tool_call": true,
-        "type": "EXECUTE"
+        "intent_timestamp": 1730000000,
+        "evaluation_time": 1730000000,
+        "effective_ttl": 60,
+        "intent": {
+          "intent_id": "intent-100",
+          "agent_id": "agent-1",
+          "action_type": "PAYMENT",
+          "amount": "1000000",
+          "target": "merchant-1",
+          "timestamp": 1730000000,
+          "metadata_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "nonce": "100",
+          "signature": "sig-placeholder",
+          "depth": 0,
+          "tool": "openai.responses",
+          "tool_call": true,
+          "type": "EXECUTE"
+        }
       },
       "expected": {
         "intent_hash": "c272c586c9c9bd258cc1e794322401f3de021882f255ba16ff921255776066a5",
         "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "state_hash": "af09972eef400827903e75e75ff0b0be7cb467167433ae01e38686b18f02550f",
-        "expires_at": 1730000060,
+        "expected_issued_at": 1730000000,
+        "expected_expiry": 1730000060,
         "canonical_signing_payload": "{\"expires_at\":1730000060,\"intent_hash\":\"c272c586c9c9bd258cc1e794322401f3de021882f255ba16ff921255776066a5\",\"policy_id\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"state_hash\":\"af09972eef400827903e75e75ff0b0be7cb467167433ae01e38686b18f02550f\"}",
         "signature": "1358bc29f268003247ce54aa80ad4ee2931ff56bc8158b3dab099e1e811d406c"
       }
@@ -32,26 +38,32 @@
     {
       "id": "auth-payload-002",
       "input": {
-        "intent_id": "intent-101",
-        "agent_id": "agent-1",
-        "action_type": "PAYMENT",
-        "amount": "1000000",
-        "target": "merchant-1",
-        "timestamp": 0,
-        "metadata_hash": "0000000000000000000000000000000000000000000000000000000000000000",
-        "nonce": "101",
-        "signature": "sig-placeholder",
-        "depth": 0,
-        "tool": "openai.responses",
-        "tool_call": true,
-        "type": "EXECUTE"
+        "intent_timestamp": 0,
+        "evaluation_time": 30,
+        "effective_ttl": 60,
+        "intent": {
+          "intent_id": "intent-101",
+          "agent_id": "agent-1",
+          "action_type": "PAYMENT",
+          "amount": "1000000",
+          "target": "merchant-1",
+          "timestamp": 0,
+          "metadata_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "nonce": "101",
+          "signature": "sig-placeholder",
+          "depth": 0,
+          "tool": "openai.responses",
+          "tool_call": true,
+          "type": "EXECUTE"
+        }
       },
       "expected": {
         "intent_hash": "cbe2f7253a1696395cb8353e6995038aa664ac56ac6d1d0e84927b3f5e22ca6e",
-        "expires_at": 60,
-        "expires_at_derivation": "intent.timestamp(0) + ttl_seconds(60) = 60",
-        "canonical_signing_payload": "{\"expires_at\":60,\"intent_hash\":\"cbe2f7253a1696395cb8353e6995038aa664ac56ac6d1d0e84927b3f5e22ca6e\",\"policy_id\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"state_hash\":\"b6546e0417c651053f6150bfd4c8c33ccbe12be2faf67f646aad5397397d5cb5\"}",
-        "signature": "b00612ffd4c16a57eb2f311b63bcc3fd648b89493cfb78c2580ffa7c3651416e"
+        "expected_issued_at": 30,
+        "expected_expiry": 90,
+        "expiry_derivation": "evaluation_time(30) + effective_ttl(60) = 90",
+        "canonical_signing_payload": "{\"expires_at\":90,\"intent_hash\":\"cbe2f7253a1696395cb8353e6995038aa664ac56ac6d1d0e84927b3f5e22ca6e\",\"policy_id\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"state_hash\":\"2abf87e8b312be8a27edbf9e45fb9df493b9feb671da2ccaab16785f551bdc6b\"}",
+        "signature": "c7b11a0a360e828399df6513bee12611fb9cc49f08b062dca5304a633131500f"
       }
     }
   ]

--- a/packages/conformance/vectors/delegation-chain-verification.json
+++ b/packages/conformance/vectors/delegation-chain-verification.json
@@ -23,13 +23,13 @@
           "expiry": 1003000,
           "kid": "2026-01",
           "alg": "Ed25519",
-          "signature": "J4dE0PDdlUEYQWD8TqPxNM6PeroJx4ZpW5MrfLke/8bzFbX7FNRTADSfI4O/vY47BqyNXGw2srOk2hab57bLAA=="
+          "signature": "r2+gZu1GsLL4HpNAwD61IUTGax1C8GDADopFLgnr2ZCIjvlLZaob6kO5qnirYpgnJf+eF2YFj3zJNpw6RoVkCg=="
         },
         "delegation": {
           "delegation_id": "d1d1d1d1-0000-0000-0000-c0nf0rm4nce",
           "issuer": "parent-agent",
           "audience": "child-agent",
-          "parent_auth_hash": "8b8c5074b713974303a4781a554c9b41d2dcb595e46a0b013197410b19438c95",
+          "parent_auth_hash": "bc25c98576d0f7f7d674e7c3485cdce0597f7091a389b75a89daf831c649b80d",
           "delegator": "parent-agent",
           "delegatee": "child-agent",
           "scope": {
@@ -42,7 +42,7 @@
           "expiry": 1002000,
           "alg": "Ed25519",
           "kid": "2026-01",
-          "signature": "wMxxXxCUu1my+MiL3hjT6HlGfemDGRwzeJvOlrSMqtBgkpQ4Sm0WcghPnURpJrwb/kV6bGyIeiAVGQAdD/yfAg=="
+          "signature": "OKfqOEMyQpnd0HGwN8mMZTWMM84AOZvARgqM/ttrDCluAoROJxxPqN3Bhx5nsRt7uQYgM7FrOTXRh1ApowrFAQ=="
         },
         "opts": {
           "now": 1001000
@@ -75,13 +75,13 @@
           "expiry": 1003000,
           "kid": "2026-01",
           "alg": "Ed25519",
-          "signature": "pVDnYaZTQdF5x7Is0COISIG2V78KPzDT6Vn736/qT8Lya5mv4HvrxWRD0ok5IG1AgLjVK0qqK/WEjbm86rAhBg=="
+          "signature": "O7KI55KHW8ofKMZo65eOlM+IMAAvdKYoiki5eqFjklZHMfgo/2T5XhCeovj1aC1WhEUufdLqqG85c2o5CB6GDQ=="
         },
         "delegation": {
           "delegation_id": "d1d1d1d1-0000-0000-0000-c0nf0rm4nce",
           "issuer": "parent-agent",
           "audience": "child-agent",
-          "parent_auth_hash": "8b8c5074b713974303a4781a554c9b41d2dcb595e46a0b013197410b19438c95",
+          "parent_auth_hash": "bc25c98576d0f7f7d674e7c3485cdce0597f7091a389b75a89daf831c649b80d",
           "delegator": "parent-agent",
           "delegatee": "child-agent",
           "scope": {
@@ -94,7 +94,7 @@
           "expiry": 1002000,
           "alg": "Ed25519",
           "kid": "2026-01",
-          "signature": "wMxxXxCUu1my+MiL3hjT6HlGfemDGRwzeJvOlrSMqtBgkpQ4Sm0WcghPnURpJrwb/kV6bGyIeiAVGQAdD/yfAg=="
+          "signature": "OKfqOEMyQpnd0HGwN8mMZTWMM84AOZvARgqM/ttrDCluAoROJxxPqN3Bhx5nsRt7uQYgM7FrOTXRh1ApowrFAQ=="
         },
         "opts": {
           "now": 1001000
@@ -127,13 +127,13 @@
           "expiry": 1003000,
           "kid": "2026-01",
           "alg": "Ed25519",
-          "signature": "J4dE0PDdlUEYQWD8TqPxNM6PeroJx4ZpW5MrfLke/8bzFbX7FNRTADSfI4O/vY47BqyNXGw2srOk2hab57bLAA=="
+          "signature": "r2+gZu1GsLL4HpNAwD61IUTGax1C8GDADopFLgnr2ZCIjvlLZaob6kO5qnirYpgnJf+eF2YFj3zJNpw6RoVkCg=="
         },
         "delegation": {
           "delegation_id": "d1d1d1d1-0000-0000-0000-c0nf0rm4nce",
           "issuer": "parent-agent",
           "audience": "child-agent",
-          "parent_auth_hash": "8b8c5074b713974303a4781a554c9b41d2dcb595e46a0b013197410b19438c95",
+          "parent_auth_hash": "bc25c98576d0f7f7d674e7c3485cdce0597f7091a389b75a89daf831c649b80d",
           "delegator": "wrong-agent",
           "delegatee": "child-agent",
           "scope": {
@@ -146,7 +146,7 @@
           "expiry": 1002000,
           "alg": "Ed25519",
           "kid": "2026-01",
-          "signature": "wMxxXxCUu1my+MiL3hjT6HlGfemDGRwzeJvOlrSMqtBgkpQ4Sm0WcghPnURpJrwb/kV6bGyIeiAVGQAdD/yfAg=="
+          "signature": "OKfqOEMyQpnd0HGwN8mMZTWMM84AOZvARgqM/ttrDCluAoROJxxPqN3Bhx5nsRt7uQYgM7FrOTXRh1ApowrFAQ=="
         },
         "opts": {
           "now": 1001000
@@ -179,13 +179,13 @@
           "expiry": 1003000,
           "kid": "2026-01",
           "alg": "Ed25519",
-          "signature": "J4dE0PDdlUEYQWD8TqPxNM6PeroJx4ZpW5MrfLke/8bzFbX7FNRTADSfI4O/vY47BqyNXGw2srOk2hab57bLAA=="
+          "signature": "r2+gZu1GsLL4HpNAwD61IUTGax1C8GDADopFLgnr2ZCIjvlLZaob6kO5qnirYpgnJf+eF2YFj3zJNpw6RoVkCg=="
         },
         "delegation": {
           "delegation_id": "d1d1d1d1-0000-0000-0000-c0nf0rm4nce",
           "issuer": "parent-agent",
           "audience": "child-agent",
-          "parent_auth_hash": "8b8c5074b713974303a4781a554c9b41d2dcb595e46a0b013197410b19438c95",
+          "parent_auth_hash": "bc25c98576d0f7f7d674e7c3485cdce0597f7091a389b75a89daf831c649b80d",
           "delegator": "parent-agent",
           "delegatee": "child-agent",
           "scope": {
@@ -198,7 +198,7 @@
           "expiry": 1002000,
           "alg": "Ed25519",
           "kid": "2026-01",
-          "signature": "wMxxXxCUu1my+MiL3hjT6HlGfemDGRwzeJvOlrSMqtBgkpQ4Sm0WcghPnURpJrwb/kV6bGyIeiAVGQAdD/yfAg=="
+          "signature": "OKfqOEMyQpnd0HGwN8mMZTWMM84AOZvARgqM/ttrDCluAoROJxxPqN3Bhx5nsRt7uQYgM7FrOTXRh1ApowrFAQ=="
         },
         "opts": {
           "now": 1003000
@@ -231,13 +231,13 @@
           "expiry": 1003000,
           "kid": "2026-01",
           "alg": "Ed25519",
-          "signature": "J4dE0PDdlUEYQWD8TqPxNM6PeroJx4ZpW5MrfLke/8bzFbX7FNRTADSfI4O/vY47BqyNXGw2srOk2hab57bLAA=="
+          "signature": "r2+gZu1GsLL4HpNAwD61IUTGax1C8GDADopFLgnr2ZCIjvlLZaob6kO5qnirYpgnJf+eF2YFj3zJNpw6RoVkCg=="
         },
         "delegation": {
           "delegation_id": "d1d1d1d1-0000-0000-0000-ex1ry0verrun",
           "issuer": "parent-agent",
           "audience": "child-agent",
-          "parent_auth_hash": "8b8c5074b713974303a4781a554c9b41d2dcb595e46a0b013197410b19438c95",
+          "parent_auth_hash": "bc25c98576d0f7f7d674e7c3485cdce0597f7091a389b75a89daf831c649b80d",
           "delegator": "parent-agent",
           "delegatee": "child-agent",
           "scope": {},
@@ -246,7 +246,7 @@
           "expiry": 1003001,
           "alg": "Ed25519",
           "kid": "2026-01",
-          "signature": "Agwg5ylQqoBU0JQPTQhlwqchoq1MR40+OoMJMAmWxUZ1C+L4x2S4JdcX16wU7twGfuTfcu1YUUf3smBY5/DHBQ=="
+          "signature": "3qN638hL81WjfFKIQHTgaIySksn5BLZhkmrEcngzhiuGzLmhEkLvNgU2z+hp+88enneY4zFDrgMq+3lsFB9VCA=="
         },
         "opts": {
           "now": 1001000
@@ -271,7 +271,7 @@
           "delegation_id": "d1d1d1d1-0000-0000-0000-c0nf0rm4nce",
           "issuer": "parent-agent",
           "audience": "child-agent",
-          "parent_auth_hash": "8b8c5074b713974303a4781a554c9b41d2dcb595e46a0b013197410b19438c95",
+          "parent_auth_hash": "bc25c98576d0f7f7d674e7c3485cdce0597f7091a389b75a89daf831c649b80d",
           "delegator": "parent-agent",
           "delegatee": "child-agent",
           "scope": {
@@ -284,13 +284,13 @@
           "expiry": 1002000,
           "alg": "Ed25519",
           "kid": "2026-01",
-          "signature": "wMxxXxCUu1my+MiL3hjT6HlGfemDGRwzeJvOlrSMqtBgkpQ4Sm0WcghPnURpJrwb/kV6bGyIeiAVGQAdD/yfAg=="
+          "signature": "OKfqOEMyQpnd0HGwN8mMZTWMM84AOZvARgqM/ttrDCluAoROJxxPqN3Bhx5nsRt7uQYgM7FrOTXRh1ApowrFAQ=="
         },
         "delegation": {
           "delegation_id": "d1d1d1d1-0000-0000-0000-c0nf0rm4nce",
           "issuer": "parent-agent",
           "audience": "child-agent",
-          "parent_auth_hash": "8b8c5074b713974303a4781a554c9b41d2dcb595e46a0b013197410b19438c95",
+          "parent_auth_hash": "bc25c98576d0f7f7d674e7c3485cdce0597f7091a389b75a89daf831c649b80d",
           "delegator": "parent-agent",
           "delegatee": "child-agent",
           "scope": {
@@ -303,7 +303,7 @@
           "expiry": 1002000,
           "alg": "Ed25519",
           "kid": "2026-01",
-          "signature": "wMxxXxCUu1my+MiL3hjT6HlGfemDGRwzeJvOlrSMqtBgkpQ4Sm0WcghPnURpJrwb/kV6bGyIeiAVGQAdD/yfAg=="
+          "signature": "OKfqOEMyQpnd0HGwN8mMZTWMM84AOZvARgqM/ttrDCluAoROJxxPqN3Bhx5nsRt7uQYgM7FrOTXRh1ApowrFAQ=="
         },
         "opts": {
           "now": 1001000
@@ -336,13 +336,13 @@
           "expiry": 1003000,
           "kid": "2026-01",
           "alg": "Ed25519",
-          "signature": "J4dE0PDdlUEYQWD8TqPxNM6PeroJx4ZpW5MrfLke/8bzFbX7FNRTADSfI4O/vY47BqyNXGw2srOk2hab57bLAA=="
+          "signature": "r2+gZu1GsLL4HpNAwD61IUTGax1C8GDADopFLgnr2ZCIjvlLZaob6kO5qnirYpgnJf+eF2YFj3zJNpw6RoVkCg=="
         },
         "delegation": {
           "delegation_id": "d1d1d1d1-0000-0000-0000-c0nf0rm4nce",
           "issuer": "parent-agent",
           "audience": "child-agent",
-          "parent_auth_hash": "8b8c5074b713974303a4781a554c9b41d2dcb595e46a0b013197410b19438c95",
+          "parent_auth_hash": "bc25c98576d0f7f7d674e7c3485cdce0597f7091a389b75a89daf831c649b80d",
           "delegator": "parent-agent",
           "delegatee": "child-agent",
           "scope": {
@@ -355,7 +355,7 @@
           "expiry": 1002000,
           "alg": "Ed25519",
           "kid": "2026-01",
-          "signature": "wMxxXxCUu1my+MiL3hjT6HlGfemDGRwzeJvOlrSMqtBgkpQ4Sm0WcghPnURpJrwb/kV6bGyIeiAVGQAdD/yfAg=="
+          "signature": "OKfqOEMyQpnd0HGwN8mMZTWMM84AOZvARgqM/ttrDCluAoROJxxPqN3Bhx5nsRt7uQYgM7FrOTXRh1ApowrFAQ=="
         },
         "opts": {
           "now": 1001000

--- a/packages/conformance/vectors/delegation-signature-verification.json
+++ b/packages/conformance/vectors/delegation-signature-verification.json
@@ -23,13 +23,13 @@
           "expiry": 1003000,
           "kid": "2026-01",
           "alg": "Ed25519",
-          "signature": "J4dE0PDdlUEYQWD8TqPxNM6PeroJx4ZpW5MrfLke/8bzFbX7FNRTADSfI4O/vY47BqyNXGw2srOk2hab57bLAA=="
+          "signature": "r2+gZu1GsLL4HpNAwD61IUTGax1C8GDADopFLgnr2ZCIjvlLZaob6kO5qnirYpgnJf+eF2YFj3zJNpw6RoVkCg=="
         },
         "delegation": {
           "delegation_id": "d1d1d1d1-0000-0000-0000-c0nf0rm4nce",
           "issuer": "parent-agent",
           "audience": "child-agent",
-          "parent_auth_hash": "8b8c5074b713974303a4781a554c9b41d2dcb595e46a0b013197410b19438c95",
+          "parent_auth_hash": "bc25c98576d0f7f7d674e7c3485cdce0597f7091a389b75a89daf831c649b80d",
           "delegator": "parent-agent",
           "delegatee": "child-agent",
           "scope": {
@@ -42,7 +42,7 @@
           "expiry": 1002000,
           "alg": "Ed25519",
           "kid": "2026-01",
-          "signature": "wMxxXxCUu1my+MiL3hjT6HlGfemDGRwzeJvOlrSMqtBgkpQ4Sm0WcghPnURpJrwb/kV6bGyIeiAVGQAdD/yfAg=="
+          "signature": "OKfqOEMyQpnd0HGwN8mMZTWMM84AOZvARgqM/ttrDCluAoROJxxPqN3Bhx5nsRt7uQYgM7FrOTXRh1ApowrFAQ=="
         },
         "opts": {
           "now": 1001000,
@@ -87,13 +87,13 @@
           "expiry": 1003000,
           "kid": "2026-01",
           "alg": "Ed25519",
-          "signature": "J4dE0PDdlUEYQWD8TqPxNM6PeroJx4ZpW5MrfLke/8bzFbX7FNRTADSfI4O/vY47BqyNXGw2srOk2hab57bLAA=="
+          "signature": "r2+gZu1GsLL4HpNAwD61IUTGax1C8GDADopFLgnr2ZCIjvlLZaob6kO5qnirYpgnJf+eF2YFj3zJNpw6RoVkCg=="
         },
         "delegation": {
           "delegation_id": "d1d1d1d1-0000-0000-0000-c0nf0rm4nce",
           "issuer": "parent-agent",
           "audience": "child-agent",
-          "parent_auth_hash": "8b8c5074b713974303a4781a554c9b41d2dcb595e46a0b013197410b19438c95",
+          "parent_auth_hash": "bc25c98576d0f7f7d674e7c3485cdce0597f7091a389b75a89daf831c649b80d",
           "delegator": "parent-agent",
           "delegatee": "child-agent",
           "scope": {
@@ -106,7 +106,7 @@
           "expiry": 1002000,
           "alg": "Ed25519",
           "kid": "2026-01",
-          "signature": "wMxxXxCUu1my+MiL3hjT6HlGfemDGRwzeJvOlrSMqtBgkpQ4Sm0WcghPnURpJrwb/kV6bGyIeiAVGQAdD/yfAAAA"
+          "signature": "OKfqOEMyQpnd0HGwN8mMZTWMM84AOZvARgqM/ttrDCluAoROJxxPqN3Bhx5nsRt7uQYgM7FrOTXRh1ApowrFAAAA"
         },
         "opts": {
           "now": 1001000,
@@ -151,13 +151,13 @@
           "expiry": 1003000,
           "kid": "2026-01",
           "alg": "Ed25519",
-          "signature": "J4dE0PDdlUEYQWD8TqPxNM6PeroJx4ZpW5MrfLke/8bzFbX7FNRTADSfI4O/vY47BqyNXGw2srOk2hab57bLAA=="
+          "signature": "r2+gZu1GsLL4HpNAwD61IUTGax1C8GDADopFLgnr2ZCIjvlLZaob6kO5qnirYpgnJf+eF2YFj3zJNpw6RoVkCg=="
         },
         "delegation": {
           "delegation_id": "d1d1d1d1-0000-0000-0000-c0nf0rm4nce",
           "issuer": "parent-agent",
           "audience": "child-agent",
-          "parent_auth_hash": "8b8c5074b713974303a4781a554c9b41d2dcb595e46a0b013197410b19438c95",
+          "parent_auth_hash": "bc25c98576d0f7f7d674e7c3485cdce0597f7091a389b75a89daf831c649b80d",
           "delegator": "parent-agent",
           "delegatee": "child-agent",
           "scope": {
@@ -170,7 +170,7 @@
           "expiry": 1002000,
           "alg": "Ed25519",
           "kid": "unknown-kid",
-          "signature": "wMxxXxCUu1my+MiL3hjT6HlGfemDGRwzeJvOlrSMqtBgkpQ4Sm0WcghPnURpJrwb/kV6bGyIeiAVGQAdD/yfAg=="
+          "signature": "OKfqOEMyQpnd0HGwN8mMZTWMM84AOZvARgqM/ttrDCluAoROJxxPqN3Bhx5nsRt7uQYgM7FrOTXRh1ApowrFAQ=="
         },
         "opts": {
           "now": 1001000,
@@ -215,13 +215,13 @@
           "expiry": 1003000,
           "kid": "2026-01",
           "alg": "Ed25519",
-          "signature": "J4dE0PDdlUEYQWD8TqPxNM6PeroJx4ZpW5MrfLke/8bzFbX7FNRTADSfI4O/vY47BqyNXGw2srOk2hab57bLAA=="
+          "signature": "r2+gZu1GsLL4HpNAwD61IUTGax1C8GDADopFLgnr2ZCIjvlLZaob6kO5qnirYpgnJf+eF2YFj3zJNpw6RoVkCg=="
         },
         "delegation": {
           "delegation_id": "d1d1d1d1-0000-0000-0000-c0nf0rm4nce",
           "issuer": "parent-agent",
           "audience": "child-agent",
-          "parent_auth_hash": "8b8c5074b713974303a4781a554c9b41d2dcb595e46a0b013197410b19438c95",
+          "parent_auth_hash": "bc25c98576d0f7f7d674e7c3485cdce0597f7091a389b75a89daf831c649b80d",
           "delegator": "parent-agent",
           "delegatee": "evil-agent",
           "scope": {
@@ -234,7 +234,7 @@
           "expiry": 1002000,
           "alg": "Ed25519",
           "kid": "2026-01",
-          "signature": "wMxxXxCUu1my+MiL3hjT6HlGfemDGRwzeJvOlrSMqtBgkpQ4Sm0WcghPnURpJrwb/kV6bGyIeiAVGQAdD/yfAg=="
+          "signature": "OKfqOEMyQpnd0HGwN8mMZTWMM84AOZvARgqM/ttrDCluAoROJxxPqN3Bhx5nsRt7uQYgM7FrOTXRh1ApowrFAQ=="
         },
         "opts": {
           "now": 1001000,
@@ -279,13 +279,13 @@
           "expiry": 1003000,
           "kid": "2026-01",
           "alg": "Ed25519",
-          "signature": "J4dE0PDdlUEYQWD8TqPxNM6PeroJx4ZpW5MrfLke/8bzFbX7FNRTADSfI4O/vY47BqyNXGw2srOk2hab57bLAA=="
+          "signature": "r2+gZu1GsLL4HpNAwD61IUTGax1C8GDADopFLgnr2ZCIjvlLZaob6kO5qnirYpgnJf+eF2YFj3zJNpw6RoVkCg=="
         },
         "delegation": {
           "delegation_id": "d1d1d1d1-0000-0000-0000-exp1r3d00000",
           "issuer": "parent-agent",
           "audience": "child-agent",
-          "parent_auth_hash": "8b8c5074b713974303a4781a554c9b41d2dcb595e46a0b013197410b19438c95",
+          "parent_auth_hash": "bc25c98576d0f7f7d674e7c3485cdce0597f7091a389b75a89daf831c649b80d",
           "delegator": "parent-agent",
           "delegatee": "child-agent",
           "scope": {},
@@ -294,7 +294,7 @@
           "expiry": 1000999,
           "alg": "Ed25519",
           "kid": "2026-01",
-          "signature": "6KmAdQfgV0Z9LKrdX//Jn7oYs59ac93HbPMr7D6EEIckLJ67O+swDPo4fQTVDzvGu6XMlGC5/gg8FXOS1f/JCg=="
+          "signature": "kZVhvVrd3yqR5m1eTT/xAyMFR+PXe3ZdApv8870f2wMhNooXpzFDfuO7WYbpBJmRc/LVLrT2bP1fBFW9fv4GAw=="
         },
         "opts": {
           "now": 1001000,

--- a/packages/conformance/vectors/trusted-time.json
+++ b/packages/conformance/vectors/trusted-time.json
@@ -1,14 +1,118 @@
 {
   "version": "0.1.0-draft",
-  "description": "Trusted-time authorization conformance vectors (issue #171). intent.timestamp is a bounded freshness claim only; evaluation_time is the trusted PEP clock used for issuance, expiry, replay retention, and velocity windows. Times are abstract epoch-seconds; T0 is the trusted evaluation_time baseline. Evaluation order: the freshness gate (intent.timestamp vs evaluation_time) is checked BEFORE replay and velocity, so a future-dated intent denies with INTENT_FRESHNESS_FUTURE even when a retained nonce or an active window would also fail — the replay/velocity vectors therefore use fresh timestamps to isolate those gates. Both freshness directions are now covered: future-dating (Δ = intent.timestamp − evaluation_time > maxClockSkewSeconds → INTENT_FRESHNESS_FUTURE) and staleness (−Δ > maxIntentAgeSeconds → INTENT_STALE), each with a basic denial, an evaluation-order case (freshness precedes replay), and a positive control on its side of the band. Reason codes are PROVISIONAL pending the spec enum. Each vector is a pure evaluate(intent, state, evaluation_time) call. Sketch for review before wiring.",
+  "description": "Trusted-time authorization conformance vectors. intent.timestamp is a bounded freshness claim only; evaluation_time is the trusted PEP clock used for issuance. In this fixed-TTL profile, maxTtlSeconds names the same resolved fixed issuance TTL as EngineOptions.authorization_ttl_seconds ?? 60. It is not an independent runtime control and there is no requested-TTL selection.",
   "config": {
     "maxClockSkewSeconds": 300,
     "maxIntentAgeSeconds": 300,
     "replayWindowSeconds": 600,
     "velocity": { "maxActions": 1, "windowSeconds": 60 },
     "maxTtlSeconds": 60,
+    "effective_ttl": 60,
     "T0": 1730000000
   },
+  "issuance_vectors": [
+    {
+      "id": "tt-issuance-before",
+      "intent_timestamp": 1729999990,
+      "evaluation_time": 1730000000,
+      "effective_ttl": 60,
+      "authorization_action": "EXECUTE",
+      "expected": { "decision": "ALLOW", "expected_issued_at": 1730000000, "expected_expiry": 1730000060 }
+    },
+    {
+      "id": "tt-issuance-equal",
+      "intent_timestamp": 1730000000,
+      "evaluation_time": 1730000000,
+      "effective_ttl": 60,
+      "authorization_action": "EXECUTE",
+      "expected": { "decision": "ALLOW", "expected_issued_at": 1730000000, "expected_expiry": 1730000060 }
+    },
+    {
+      "id": "tt-issuance-after",
+      "intent_timestamp": 1730000010,
+      "evaluation_time": 1730000000,
+      "effective_ttl": 60,
+      "authorization_action": "EXECUTE",
+      "expected": { "decision": "ALLOW", "expected_issued_at": 1730000000, "expected_expiry": 1730000060 }
+    },
+    {
+      "id": "tt-noninterference-earlier",
+      "comparison_group": "same-evaluation-time",
+      "intent_timestamp": 1729999980,
+      "evaluation_time": 1730000000,
+      "effective_ttl": 60,
+      "authorization_action": "EXECUTE",
+      "expected": { "decision": "ALLOW", "expected_issued_at": 1730000000, "expected_expiry": 1730000060 }
+    },
+    {
+      "id": "tt-noninterference-later",
+      "comparison_group": "same-evaluation-time",
+      "intent_timestamp": 1730000020,
+      "evaluation_time": 1730000000,
+      "effective_ttl": 60,
+      "authorization_action": "EXECUTE",
+      "expected": { "decision": "ALLOW", "expected_issued_at": 1730000000, "expected_expiry": 1730000060 }
+    },
+    {
+      "id": "tt-evaluation-sensitivity-first",
+      "comparison_group": "different-evaluation-time",
+      "intent_timestamp": 1730000000,
+      "evaluation_time": 1730000000,
+      "effective_ttl": 60,
+      "authorization_action": "EXECUTE",
+      "expected": { "decision": "ALLOW", "expected_issued_at": 1730000000, "expected_expiry": 1730000060 }
+    },
+    {
+      "id": "tt-evaluation-sensitivity-second",
+      "comparison_group": "different-evaluation-time",
+      "intent_timestamp": 1730000000,
+      "evaluation_time": 1730000010,
+      "effective_ttl": 60,
+      "authorization_action": "EXECUTE",
+      "expected": { "decision": "ALLOW", "expected_issued_at": 1730000010, "expected_expiry": 1730000070 }
+    },
+    {
+      "id": "tt-release-issuance",
+      "intent_timestamp": 1730000001,
+      "evaluation_time": 1730000000,
+      "effective_ttl": 60,
+      "authorization_action": "RELEASE",
+      "expected": { "decision": "ALLOW", "expected_issued_at": 1730000000, "expected_expiry": 1730000060 }
+    },
+    {
+      "id": "tt-invalid-ttl-zero",
+      "intent_timestamp": 1730000000,
+      "evaluation_time": 1730000000,
+      "effective_ttl": 0,
+      "authorization_action": "EXECUTE",
+      "expected": { "decision": "CONFIG_INVALID", "error": "authorization_ttl_seconds" }
+    },
+    {
+      "id": "tt-expiry-overflow",
+      "intent_timestamp": 9007199254740932,
+      "evaluation_time": 9007199254740932,
+      "effective_ttl": 60,
+      "authorization_action": "EXECUTE",
+      "expected": { "decision": "PRECONDITION_INVALID", "error": "safe integer" }
+    },
+    {
+      "id": "tt-freshness-denial",
+      "intent_timestamp": 1730000301,
+      "evaluation_time": 1730000000,
+      "effective_ttl": 60,
+      "authorization_action": "EXECUTE",
+      "expected": { "decision": "DENY", "reason": "INTENT_FRESHNESS_FUTURE", "authorization_present": false }
+    },
+    {
+      "id": "tt-deterministic",
+      "intent_timestamp": 1730000005,
+      "evaluation_time": 1730000000,
+      "effective_ttl": 60,
+      "authorization_action": "EXECUTE",
+      "repeat": 2,
+      "expected": { "decision": "ALLOW", "expected_issued_at": 1730000000, "expected_expiry": 1730000060, "identical_authorization": true }
+    }
+  ],
   "vectors": [
     {
       "id": "tt-neg-001",

--- a/packages/core/src/policy/PolicyEngine.ts
+++ b/packages/core/src/policy/PolicyEngine.ts
@@ -138,6 +138,17 @@ export type EngineOptions = {
 
 // Keep canonical snapshot hashes stable across host package managers/runners.
 const ENGINE_VERSION = "unknown";
+const DEFAULT_AUTHORIZATION_TTL_SECONDS = 60;
+
+function resolveAuthorizationTtlSeconds(value: unknown): number {
+  const ttl = value === undefined ? DEFAULT_AUTHORIZATION_TTL_SECONDS : value;
+  if (typeof ttl !== "number" || !Number.isSafeInteger(ttl) || ttl <= 0) {
+    throw new Error(
+      "authorization_ttl_seconds must be a positive finite safe integer (seconds)"
+    );
+  }
+  return ttl;
+}
 
 const RELEASE_MODULES: readonly PolicyModule[] = [
   { id: "KillSwitchModule", evaluate: KillSwitchModule, codec: MODULE_CODECS.KillSwitchModule },
@@ -159,6 +170,7 @@ const EXECUTE_MODULES: readonly PolicyModule[] = [
 /** @public */
 export class PolicyEngine {
   private readonly opts: EngineOptions;
+  private readonly authorizationTtl: number;
   private currentState?: State;
   private auditEventCount = 0;
   // Adapter writes are sequenced here so evaluate/evaluatePure remain synchronous.
@@ -180,11 +192,12 @@ export class PolicyEngine {
     }
     assertProtocolSeconds(opts.maxClockSkewSeconds, "EngineOptions.maxClockSkewSeconds");
     assertProtocolSeconds(opts.maxIntentAgeSeconds, "EngineOptions.maxIntentAgeSeconds");
+    this.authorizationTtl = resolveAuthorizationTtlSeconds(opts.authorization_ttl_seconds);
     this.opts = opts;
   }
 
   private authorizationTtlSeconds(): number {
-    return this.opts.authorization_ttl_seconds ?? 60;
+    return this.authorizationTtl;
   }
 
   private authorizationIssuer(): string {
@@ -404,6 +417,10 @@ export class PolicyEngine {
    * synchronously, before entering its evaluation `try` block, rather than
    * returning any `EvaluatePureOutput` (no decision, no `nextState`, no
    * audit event is produced for a rejected precondition).
+   * The same validated value drives freshness, module evaluation, and every
+   * emitted authorization validity window: `issued_at = evaluationTime` and
+   * `expiry = evaluationTime + authorization_ttl_seconds` (default 60 only
+   * when the option is undefined).
    *
    * Trusted-time freshness is evaluated before module execution - before
    * `ReplayModule` and (on EXECUTE) `VelocityModule`. When freshness denies,
@@ -433,6 +450,12 @@ export class PolicyEngine {
     // the try block below: this must never be caught and converted into a
     // DENY/INTERNAL_ERROR policy result.
     assertProtocolSeconds(evaluationTime, "evaluationTime");
+    const effectiveTtl = this.authorizationTtlSeconds();
+    if (evaluationTime > Number.MAX_SAFE_INTEGER - effectiveTtl) {
+      throw new Error(
+        "evaluationTime + authorization_ttl_seconds must be a safe integer (unix seconds)"
+      );
+    }
 
     try {
       const intent_hash = intentHash(intent);
@@ -499,8 +522,8 @@ export class PolicyEngine {
       // working carries all module deltas from the decision phase.
       let working = decisionResult.nextState;
       const state_snapshot_hash = this.computeStateHashFor(working);
-      const issued_at = intent.timestamp;
-      const expires_at = issued_at + this.authorizationTtlSeconds();
+      const issued_at = evaluationTime;
+      const expires_at = issued_at + effectiveTtl;
       const policy_id = policyId;
       const issuer = this.authorizationIssuer();
       const audience = this.authorizationAudience();

--- a/packages/core/src/test/authorization.trusted-time-issuance.test.ts
+++ b/packages/core/src/test/authorization.trusted-time-issuance.test.ts
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: Apache-2.0
+import test from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+import fc from "fast-check";
+
+import { PolicyEngine, type EngineOptions } from "../policy/PolicyEngine.js";
+import type { Intent } from "../types/intent.js";
+import type { State } from "../types/state.js";
+import { verifyAuthorization } from "../verification/verifyAuthorization.js";
+const EVALUATION_TIME = 1_730_000_000;
+const TTL = 60;
+const SECRET = "trusted-issuance-test-secret-32chars!!";
+const AGENT = "agent-1";
+const TEST_PRIVATE_KEY_PEM = generateKeyPairSync("ed25519").privateKey.export({
+  type: "pkcs8",
+  format: "pem",
+}).toString();
+
+function makeEngine(overrides: Partial<EngineOptions> = {}): PolicyEngine {
+  return new PolicyEngine({
+    policy_version: "v1-issuance",
+    engine_secret: SECRET,
+    authorization_ttl_seconds: TTL,
+    maxClockSkewSeconds: 300,
+    maxIntentAgeSeconds: 300,
+    ...overrides,
+  });
+}
+
+function makeState(overrides: Partial<State> = {}): State {
+  return {
+    policy_version: "v1-issuance",
+    period_id: "period-1",
+    kill_switch: { global: false, agents: {} },
+    allowlists: {
+      action_types: ["PAYMENT"],
+      assets: ["wallet"],
+      targets: ["merchant-1"],
+    },
+    budget: {
+      budget_limit: { [AGENT]: 1_000_000n },
+      spent_in_period: { [AGENT]: 0n },
+    },
+    max_amount_per_action: { [AGENT]: 1_000_000n },
+    velocity: { config: { window_seconds: 60, max_actions: 100 }, counters: {} },
+    replay: { window_seconds: 600, max_nonces_per_agent: 256, nonces: {} },
+    concurrency: { max_concurrent: { [AGENT]: 10 }, active: {}, active_auths: {} },
+    recursion: { max_depth: { [AGENT]: 5 } },
+    tool_limits: { window_seconds: 60, max_calls: { [AGENT]: 100 }, calls: {} },
+    ...overrides,
+  };
+}
+
+function makeIntent(overrides: Partial<Intent> = {}): Intent {
+  return {
+    intent_id: "intent-1",
+    agent_id: AGENT,
+    action_type: "PAYMENT",
+    amount: 100n,
+    asset: "wallet",
+    target: "merchant-1",
+    timestamp: EVALUATION_TIME,
+    metadata_hash: "0".repeat(64),
+    nonce: 1n,
+    signature: "sig",
+    depth: 0,
+    type: "EXECUTE",
+    ...overrides,
+  } as Intent;
+}
+
+function issue(
+  engine: PolicyEngine,
+  intent: Intent,
+  state = makeState(),
+  evaluationTime = EVALUATION_TIME,
+) {
+  const out = engine.evaluatePure(intent, state, evaluationTime);
+  assert.equal(out.decision, "ALLOW");
+  if (out.decision !== "ALLOW") throw new Error("expected ALLOW");
+  return out;
+}
+
+test("trusted issuance covers intent timestamps before, equal to, and after evaluationTime", () => {
+  for (const [index, intentTimestamp] of [
+    EVALUATION_TIME - 300,
+    EVALUATION_TIME,
+    EVALUATION_TIME + 300,
+  ].entries()) {
+    const out = issue(
+      makeEngine(),
+      makeIntent({ intent_id: `intent-${index}`, nonce: BigInt(index + 1), timestamp: intentTimestamp }),
+    );
+    assert.equal(out.authorization.issued_at, EVALUATION_TIME);
+    assert.equal(out.authorization.expiry, EVALUATION_TIME + TTL);
+    assert.equal(out.authorization.expiry - out.authorization.issued_at, TTL);
+  }
+});
+
+test("freshness-valid intent.timestamp changes cannot shift the issued validity window", () => {
+  const earlier = issue(makeEngine(), makeIntent({ timestamp: EVALUATION_TIME - 20 }));
+  const later = issue(makeEngine(), makeIntent({ timestamp: EVALUATION_TIME + 20 }));
+
+  assert.deepEqual(
+    [earlier.authorization.issued_at, earlier.authorization.expiry],
+    [later.authorization.issued_at, later.authorization.expiry],
+  );
+  assert.notEqual(earlier.authorization.intent_hash, later.authorization.intent_hash);
+  assert.notEqual(earlier.authorization.auth_id, later.authorization.auth_id);
+  assert.notEqual(earlier.authorization.signature, later.authorization.signature);
+});
+
+test("changing only evaluationTime shifts issued_at and expiry by the same amount", () => {
+  const intent = makeIntent({ timestamp: EVALUATION_TIME });
+  const first = issue(makeEngine(), intent, makeState(), EVALUATION_TIME);
+  const second = issue(makeEngine(), intent, makeState(), EVALUATION_TIME + 10);
+
+  assert.equal(second.authorization.issued_at - first.authorization.issued_at, 10);
+  assert.equal(second.authorization.expiry - first.authorization.expiry, 10);
+  assert.equal(first.authorization.expiry - first.authorization.issued_at, TTL);
+  assert.equal(second.authorization.expiry - second.authorization.issued_at, TTL);
+});
+
+test("undefined TTL uses the existing 60-second default and no other invalid value does", () => {
+  const defaultEngine = makeEngine({ authorization_ttl_seconds: undefined });
+  const out = issue(defaultEngine, makeIntent());
+  assert.equal(out.authorization.expiry - out.authorization.issued_at, 60);
+
+  const invalidTtls: unknown[] = [
+    null,
+    "60",
+    NaN,
+    Infinity,
+    -Infinity,
+    1.5,
+    0,
+    -1,
+    Number.MAX_SAFE_INTEGER + 1,
+  ];
+  for (const ttl of invalidTtls) {
+    assert.throws(
+      () => makeEngine({ authorization_ttl_seconds: ttl as number }),
+      /authorization_ttl_seconds/,
+      `TTL ${String(ttl)} must be rejected rather than defaulted or coerced`,
+    );
+  }
+});
+
+test("unsafe expiry arithmetic rejects before audit, authorization construction, or signing", () => {
+  const engine = makeEngine({
+    authorization_signing_alg: "Ed25519",
+    authorization_private_key_pem: undefined,
+  });
+  const evaluationTime = Number.MAX_SAFE_INTEGER - TTL + 1;
+
+  assert.throws(
+    () =>
+      engine.evaluatePure(
+        makeIntent({ timestamp: evaluationTime }),
+        makeState(),
+        evaluationTime,
+      ),
+    /safe integer/,
+  );
+  assert.deepEqual(engine.audit.snapshot(), []);
+});
+
+test("freshness denial produces no authorization and does not reach signing", () => {
+  const engine = makeEngine({
+    authorization_signing_alg: "Ed25519",
+    authorization_private_key_pem: undefined,
+  });
+  const out = engine.evaluatePure(
+    makeIntent({ timestamp: EVALUATION_TIME + 301 }),
+    makeState(),
+    EVALUATION_TIME,
+  );
+  assert.deepEqual(out, {
+    decision: "DENY",
+    reasons: ["INTENT_FRESHNESS_FUTURE"],
+  });
+});
+
+test("EXECUTE and RELEASE share trusted-time issuance", () => {
+  const execute = issue(
+    makeEngine(),
+    makeIntent({ type: "EXECUTE", nonce: 10n, timestamp: EVALUATION_TIME - 1 }),
+  );
+  assert.equal(execute.authorization.issued_at, EVALUATION_TIME);
+  assert.equal(
+    execute.nextState.concurrency.active_auths[AGENT]?.[execute.authorization.auth_id]?.expires_at,
+    EVALUATION_TIME + TTL,
+  );
+
+  const releasedId = "existing-authorization";
+  const releaseState = makeState({
+    concurrency: {
+      max_concurrent: { [AGENT]: 10 },
+      active: { [AGENT]: 1 },
+      active_auths: {
+        [AGENT]: { [releasedId]: { expires_at: EVALUATION_TIME + 600 } },
+      },
+    },
+  });
+  const release = issue(
+    makeEngine(),
+    makeIntent({
+      type: "RELEASE",
+      authorization_id: releasedId,
+      nonce: 11n,
+      timestamp: EVALUATION_TIME + 1,
+    }),
+    releaseState,
+  );
+  assert.equal(release.authorization.issued_at, EVALUATION_TIME);
+  assert.equal(release.authorization.expiry, EVALUATION_TIME + TTL);
+});
+
+test("expiry remains an exclusive upper bound", () => {
+  const out = issue(makeEngine(), makeIntent());
+  const common = {
+    expectedIssuer: out.authorization.issuer,
+    expectedAudience: out.authorization.audience,
+    expectedPolicyId: out.authorization.policy_id,
+    legacyHmacSecret: SECRET,
+  };
+
+  assert.equal(
+    verifyAuthorization(out.authorization, {
+      ...common,
+      now: out.authorization.expiry - 1,
+    }).status,
+    "ok",
+  );
+  assert.equal(
+    verifyAuthorization(out.authorization, {
+      ...common,
+      now: out.authorization.expiry,
+    }).status,
+    "invalid",
+  );
+});
+
+test("identical trusted inputs produce deterministic Ed25519 authorizations", () => {
+  const options = {
+    authorization_signing_alg: "Ed25519" as const,
+    authorization_signing_kid: "test-key",
+    authorization_private_key_pem: TEST_PRIVATE_KEY_PEM,
+  };
+  const first = issue(makeEngine(options), makeIntent());
+  const second = issue(makeEngine(options), makeIntent());
+
+  assert.deepEqual(first.authorization, second.authorization);
+  assert.equal(first.authorization.issued_at, EVALUATION_TIME);
+  assert.equal(first.authorization.expiry, EVALUATION_TIME + TTL);
+});
+
+test("property: every successful authorization has a safe trusted-time fixed-TTL window", () => {
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 1_000_000, max: 2_000_000_000 }),
+      fc.integer({ min: -300, max: 300 }),
+      fc.integer({ min: 1, max: 1_000_000 }),
+      (evaluationTime, offset, nonce) => {
+        const out = issue(
+          makeEngine(),
+          makeIntent({
+            intent_id: `intent-${nonce}`,
+            nonce: BigInt(nonce),
+            timestamp: evaluationTime + offset,
+          }),
+          makeState(),
+          evaluationTime,
+        );
+        assert.equal(out.authorization.issued_at, evaluationTime);
+        assert.equal(out.authorization.expiry - out.authorization.issued_at, TTL);
+        assert.ok(Number.isFinite(out.authorization.issued_at));
+        assert.ok(Number.isSafeInteger(out.authorization.issued_at));
+        assert.ok(Number.isFinite(out.authorization.expiry));
+        assert.ok(Number.isSafeInteger(out.authorization.expiry));
+      },
+    ),
+  );
+});
+
+test("property: freshness-valid intent timestamps do not affect the issued window", () => {
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 1_000_000, max: 2_000_000_000 }),
+      fc.integer({ min: -300, max: 300 }),
+      fc.integer({ min: -300, max: 300 }),
+      (evaluationTime, firstOffset, secondOffset) => {
+        const first = issue(
+          makeEngine(),
+          makeIntent({ timestamp: evaluationTime + firstOffset }),
+          makeState(),
+          evaluationTime,
+        );
+        const second = issue(
+          makeEngine(),
+          makeIntent({ timestamp: evaluationTime + secondOffset }),
+          makeState(),
+          evaluationTime,
+        );
+        assert.deepEqual(
+          [first.authorization.issued_at, first.authorization.expiry],
+          [second.authorization.issued_at, second.authorization.expiry],
+        );
+      },
+    ),
+  );
+});
+
+test("property: freshness denial never includes an authorization", () => {
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 1_000_000, max: 2_000_000_000 }),
+      fc.boolean(),
+      (evaluationTime, future) => {
+        const timestamp = future ? evaluationTime + 301 : evaluationTime - 301;
+        const out = makeEngine().evaluatePure(
+          makeIntent({ timestamp }),
+          makeState(),
+          evaluationTime,
+        );
+        assert.equal(out.decision, "DENY");
+        assert.equal("authorization" in out, false);
+      },
+    ),
+  );
+});
+
+test("property: nondecreasing trusted evaluation times produce nondecreasing issued_at", () => {
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 1_000_000, max: 2_000_000_000 }),
+      fc.integer({ min: 0, max: 300 }),
+      (firstEvaluationTime, delta) => {
+        const intent = makeIntent({ timestamp: firstEvaluationTime });
+        const first = issue(
+          makeEngine(),
+          intent,
+          makeState(),
+          firstEvaluationTime,
+        );
+        const second = issue(
+          makeEngine(),
+          intent,
+          makeState(),
+          firstEvaluationTime + delta,
+        );
+        assert.ok(second.authorization.issued_at >= first.authorization.issued_at);
+      },
+    ),
+  );
+});

--- a/packages/core/src/test/property.decision.test.ts
+++ b/packages/core/src/test/property.decision.test.ts
@@ -555,10 +555,9 @@ test("D-6 strict mode: verifyAuthorization requires explicit now", () => {
   }
 });
 
-test("D-6 strict mode: evaluatePure uses intent.timestamp, not Date.now()", () => {
-  // evaluatePure must derive issued_at from intent.timestamp, never from
-  // Date.now(). Two calls with the same intent must produce the same issued_at
-  // and the same auth_id even when the wall clock advances between calls.
+test("D-6 strict mode: evaluatePure mints the validity window from evaluationTime", () => {
+  // Deliberately inverted by #193: intent.timestamp remains hash-bound, but
+  // issued_at and expiry derive exclusively from the explicit trusted clock.
   for (const seed of seeds()) {
     const engine = makeEngine(); // strictDeterminism: true
     const state = genState(seed);
@@ -567,15 +566,18 @@ test("D-6 strict mode: evaluatePure uses intent.timestamp, not Date.now()", () =
 
     const intent = buildExecIntent(op, seed, 0, 5_000n);
 
-    const out1 = engine.evaluatePure(intent, structuredClone(state), intent.timestamp, { mode: "fail-fast" });
-    const out2 = engine.evaluatePure(intent, structuredClone(state), intent.timestamp, { mode: "fail-fast" });
+    const evaluationTime = intent.timestamp + 1;
+    const out1 = engine.evaluatePure(intent, structuredClone(state), evaluationTime, { mode: "fail-fast" });
+    const out2 = engine.evaluatePure(intent, structuredClone(state), evaluationTime, { mode: "fail-fast" });
 
     assert.equal(out1.decision, out2.decision,
       `seed=${seed} strict mode evaluatePure decision not stable`);
 
     if (out1.decision === "ALLOW" && out2.decision === "ALLOW") {
-      assert.equal(out1.authorization.issued_at, intent.timestamp,
-        `seed=${seed} issued_at must equal intent.timestamp, not Date.now()`);
+      assert.equal(out1.authorization.issued_at, evaluationTime,
+        `seed=${seed} issued_at must equal evaluationTime`);
+      assert.equal(out1.authorization.expiry - out1.authorization.issued_at, 120,
+        `seed=${seed} validity window must equal the configured fixed TTL`);
       assert.equal(out1.authorization.issued_at, out2.authorization.issued_at,
         `seed=${seed} issued_at not stable across calls`);
       assert.equal(out1.authorization.auth_id, out2.authorization.auth_id,

--- a/packages/core/src/test/trusted-time-integration.test.ts
+++ b/packages/core/src/test/trusted-time-integration.test.ts
@@ -7,10 +7,9 @@
  *
  * These tests exercise the integration boundary only — evaluate/evaluatePure
  * with the new required `evaluationTime` parameter and the freshness gate's
- * interaction with the module pipeline, audit trail, and constructor/call
- * preconditions. `verifyTrustedTime` itself is unit-tested in
- * verify.trusted-time.test.ts; issuance/expiry derivation is intentionally
- * untouched and guarded by property.decision.test.ts's D-6 tripwire.
+ * interaction with the module pipeline, audit trail, constructor/call
+ * preconditions, and trusted-time authorization issuance. `verifyTrustedTime`
+ * itself is unit-tested in verify.trusted-time.test.ts.
  *
  * "No module ran" is proven the way the repository's own tooling requires:
  * a positive control (collect-all mode against a state where BOTH Replay and
@@ -343,22 +342,17 @@ test("freshness-DENY audit shape: INTENT_RECEIVED then DECISION, in order, with 
   assert.deepEqual(decisionEvent?.reasons, ["INTENT_FRESHNESS_FUTURE"]);
 });
 
-// ── 16. Existing issuance tripwire ──────────────────────────────────────────
-// D-6 in property.decision.test.ts already asserts
-// authorization.issued_at === intent.timestamp and is left unmodified by
-// #184 — re-asserted here at the integration-test level as a second,
-// independent tripwire against accidental scope creep into issuance
-// derivation.
+// ── 16. Trusted-time issuance tripwire ──────────────────────────────────────
+// Deliberately inverted by #193 from the old intent.timestamp-based assertion.
+// D-6 in property.decision.test.ts independently enforces the same boundary.
 
-test("issuance tripwire: issued_at still derives from intent.timestamp, not evaluationTime", () => {
+test("issuance tripwire: issued_at and expiry derive from evaluationTime, not intent.timestamp", () => {
   const engine = makeEngine();
-  // evaluationTime deliberately differs from intent.timestamp (both fresh,
-  // within tolerance) so this test would fail loudly if issuance were ever
-  // switched to key off evaluationTime instead.
   const intent = makeIntent({ timestamp: T0 + 10 });
   const out = engine.evaluatePure(intent, freshState(), T0);
   assert.equal(out.decision, "ALLOW");
   if (out.decision !== "ALLOW") return;
-  assert.equal(out.authorization.issued_at, intent.timestamp);
-  assert.notEqual(out.authorization.issued_at, T0);
+  assert.equal(out.authorization.issued_at, T0);
+  assert.equal(out.authorization.expiry, T0 + 60);
+  assert.notEqual(out.authorization.issued_at, intent.timestamp);
 });


### PR DESCRIPTION
## Summary

Mint `AuthorizationV1` timestamps from the trusted `evaluation_time` supplied to `PolicyEngine.evaluatePure`, instead of deriving them from the agent-controlled `intent.timestamp`.

The issuance rule is now:

```text
effective_ttl = authorization_ttl_seconds ?? 60
issued_at     = evaluation_time
expiry        = evaluation_time + effective_ttl
````

`intent.timestamp` remains freshness-checked and included in intent binding, but it no longer controls the signed authorization validity window.

## Changes

* derive `issued_at` from trusted `evaluation_time`;
* derive `expiry` from `evaluation_time + effective_ttl`;
* validate `authorization_ttl_seconds` as a positive finite safe integer;
* apply the 60-second default only when the option is `undefined`;
* reject unsafe expiry arithmetic before authorization construction or signing;
* apply the same issuance rule to `EXECUTE` and `RELEASE`;
* update existing trusted-time issuance tripwires;
* add dedicated boundary and property tests;
* add executable trusted-time issuance conformance vectors;
* regenerate dependent authorization and delegation vectors;
* update the trusted-time and AuthorizationV1 specifications;
* stabilize synchronous example intent timestamps while the PEP captures trusted time independently.

## Security impact

A caller can no longer shift an authorization validity window by modifying a freshness-valid `intent.timestamp`.

For the same trusted `evaluation_time` and TTL:

```text
different intent.timestamp
        does not change
issued_at or expiry
```

The intent timestamp still changes the intent hash, authorization ID, and signature because it remains cryptographically bound to the intent.

## TTL behavior

The current profile has one TTL authority:

```text
authorization_ttl_seconds
```

Invalid values such as `null`, strings, `NaN`, infinity, fractions, zero, negative values, and unsafe integers fail closed.

No caller-requested TTL or independent runtime `maxTtlSeconds` control is introduced.

## Compatibility

AuthorizationV1 field names, canonicalization rules, signing algorithms, domains, and intent binding are unchanged.

Signed timestamp values, authorization hashes, signatures, audit timestamps, concurrency expiry entries, and dependent delegation hashes may change when `evaluation_time` differs from `intent.timestamp`.

No AuthorizationV1 schema-version increment is required.

## Validation

* full repository tests passed;
* core build, typecheck, and tests passed;
* conformance passed with 261 assertions;
* regenerated vectors validated successfully;
* TypeScript, Go, and Python vector suites passed;
* API Extractor passed;
* API shape guard passed, 8/8;
* API fingerprint check passed;
* security gate returned `ALLOW` with 0 findings;
* policy-boundary attack repro completed successfully.  

Closes #193
Refs #171