### PR TITLE
fix(core): drive velocity windows from trusted evaluation time

### DIFF
--- a/docs/spec/core/trusted-time-v1.md
+++ b/docs/spec/core/trusted-time-v1.md
@@ -248,8 +248,31 @@ Replay and velocity MUST key off `evaluation_time` only.
   still inside it. Reuse of a retained nonce → `DENY`.
 - **Velocity.** The action window is
   `[window_start, window_start + velocity.windowSeconds)` in `evaluation_time`.
-  A future-dated intent MUST NOT reset or advance it. Exceeding `maxActions`
-  within the trusted window → `DENY`.
+  `window_start` and every reset decision MUST derive exclusively from
+  `evaluation_time`; `intent.timestamp`, authorization timestamps, metadata,
+  ambient clocks, and fallback clocks MUST NOT affect them. The exact rule is:
+
+  ```text
+  while evaluation_time - window_start < window_seconds:
+    the current window remains active
+
+  when evaluation_time - window_start >= window_seconds:
+    begin a new window with window_start = evaluation_time and count = 1
+  ```
+
+  The subtraction form avoids overflowing the protocol safe-integer domain.
+  At the exact boundary a new window begins. If `evaluation_time <
+  window_start`, evaluation MUST fail closed with `STATE_INVALID`; it MUST NOT
+  reset, grant quota, decrease `window_start`, or substitute another clock.
+  Exceeding `maxActions` within an active trusted window →
+  `VELOCITY_EXCEEDED`. A denied action does not consume quota or mutate
+  velocity state.
+
+  Velocity configuration and persisted counter leaves MUST be validated
+  without coercion. `windowSeconds` MUST be a positive safe integer;
+  `maxActions`, `window_start`, and `count` MUST be non-negative safe integers.
+  Missing or malformed required containers and non-finite, fractional,
+  negative, or unsafe values MUST fail closed with `STATE_INVALID`.
 
 The honest path MUST remain admissible: a distinct, unused nonce inside the
 retention window, and a velocity window that legitimately reset because
@@ -262,6 +285,38 @@ not mandate a complete global module order: other `eta-core-v1` gates
 (kill-switch, allowlists, budget, auth) MAY be evaluated before, between, or
 after these, provided that the relative freshness → replay → velocity order among
 the trusted-time gates is preserved.
+
+### 7.1 Persisted velocity state and deployment migration
+
+The state schema is unchanged. Before the trusted-clock migration, existing
+`window_start` values may have been derived from attacker-controlled
+`intent.timestamp`; trusted and legacy values cannot be distinguished
+structurally. Deployments SHOULD flush legacy velocity counters during rollout.
+If flushing is operationally impossible, they MUST conservatively prevent
+quota grants until each legacy window has expired against trusted time; a
+legacy start ahead of `evaluation_time` fails closed rather than self-healing
+through a backward reset. No state-version bump or automatic timestamp
+conversion is defined.
+
+In-memory state is affected whenever it survives an engine upgrade. External
+state providers, including Redis-backed or database-backed deployments that
+persist the full policy state, require the same operational treatment.
+Mixed-version PEP deployments can disagree because older evaluators use
+`intent.timestamp`; they SHOULD NOT share mutable velocity state during a
+rolling upgrade. Upgrade evaluators together or drain/flush counters at the
+version boundary.
+
+Distributed PEPs MUST supply non-decreasing, sufficiently synchronized trusted
+evaluation clocks. Clock rollback relative to a stored `window_start` fails
+closed. Clock skew between PEPs can change when a reset becomes eligible even
+though caller timestamps cannot. Deterministic evaluation performs no ambient
+clock read; the supplied `evaluation_time` is its sole security-relevant
+velocity clock.
+
+State-provider compare-and-set, transactional update, serialization, or
+equivalent conflict rejection remains REQUIRED for concurrent quota updates.
+Trusted time prevents caller-controlled window movement but does not solve
+lost-update races or make concurrent quota consumption atomic.
 
 ---
 

--- a/docs/spec/state-provider-requirements.md
+++ b/docs/spec/state-provider-requirements.md
@@ -72,6 +72,15 @@ The guard enforces that the version read by `getState()` matches the version exp
 
 The state store backing `getState()` and `setState()` MUST provide atomicity guarantees sufficient to make this detection reliable. Implementations SHOULD use database-level CAS, optimistic locking, or conditional write operations.
 
+Trusted-time velocity accounting does not replace this requirement. Although
+velocity window progression is derived exclusively from the trusted
+`evaluation_time` defined in `docs/spec/core/trusted-time-v1.md` §7, concurrent
+evaluators can still read the same counter and each attempt to consume the same
+remaining slot. The provider MUST serialize those updates or reject all but one
+through atomic compare-and-set. Distributed PEP clocks SHOULD be synchronized
+and non-decreasing; a clock behind a persisted velocity `window_start` causes a
+fail-closed `STATE_INVALID` decision.
+
 ### 2.3 Stale replica reads
 
 For Profile C deployments, `getState()` MUST read from the authoritative replica of the state store, not from a potentially stale secondary replica. Reading from a lagging replica can produce a hash that matches an old authorization but not the current authoritative state.

--- a/packages/conformance/src/validate.ts
+++ b/packages/conformance/src/validate.ts
@@ -542,6 +542,73 @@ function validateTrustedTimeIssuanceVectors(ctx: CheckCtx): void {
   );
 }
 
+function validateTrustedTimeVelocityVectors(ctx: CheckCtx): void {
+  type TrustedTimeFile = {
+    velocity_vectors: Array<JsonRecord>;
+  };
+  const file = loadJson<TrustedTimeFile>("trusted-time.json");
+
+  for (const [index, vector] of file.velocity_vectors.entries()) {
+    const id = String(vector.id);
+    const intentTimestamp = Number(vector.intent_timestamp);
+    const evaluationTime = Number(vector.evaluation_time);
+    const storedWindowStart = vector.stored_window_start;
+    const currentCount = vector.current_count;
+    const expected = asRecord(vector.expected);
+    const state = makeBaseState();
+    state.velocity.config = {
+      window_seconds: Number(vector.window_seconds),
+      max_actions: Number(vector.max_actions),
+    };
+    state.velocity.counters =
+      storedWindowStart === null
+        ? {}
+        : {
+            "agent-1": {
+              window_start: Number(storedWindowStart),
+              count: Number(currentCount),
+            },
+          };
+
+    const intent: Intent = {
+      intent_id: `${id}-intent`,
+      agent_id: "agent-1",
+      action_type: "PAYMENT",
+      type: "EXECUTE",
+      amount: 100n,
+      asset: "wallet",
+      target: "merchant-1",
+      timestamp: intentTimestamp,
+      metadata_hash: "0".repeat(64),
+      nonce: BigInt(index + 20_000),
+      signature: "sig-placeholder",
+      depth: 0,
+    };
+
+    const before = structuredClone(state);
+    const evaluate = () => makeEngine().evaluatePure(intent, structuredClone(state), evaluationTime);
+    const out = evaluate();
+    eq(ctx, `${id} decision`, out.decision, String(expected.decision));
+
+    if (out.decision === "DENY") {
+      eq(ctx, `${id} reason`, out.reasons[0], String(expected.reason));
+      eq(ctx, `${id} input velocity unchanged`, state.velocity, before.velocity);
+    } else {
+      const counter = out.nextState.velocity.counters["agent-1"];
+      eq(ctx, `${id} window_start`, counter?.window_start, Number(expected.window_start));
+      eq(ctx, `${id} count`, counter?.count, Number(expected.count));
+    }
+
+    if (Number(vector.repeat) === 2) {
+      const repeated = evaluate();
+      eq(ctx, `${id} repeated decision`, repeated.decision, out.decision);
+      if (repeated.decision === "ALLOW" && out.decision === "ALLOW") {
+        eq(ctx, `${id} repeated velocity state`, repeated.nextState.velocity, out.nextState.velocity);
+      }
+    }
+  }
+}
+
 function validateAuthorizationVerificationVectors(ctx: CheckCtx, adapter: ConformanceAdapter): void {
   const file = loadJson<VectorFile>("authorization-verification.json");
 
@@ -1700,6 +1767,7 @@ function main(): void {
   validateIntentHashVectors(ctx, adapter);
   validateAuthorizationVectors(ctx, adapter);
   validateTrustedTimeIssuanceVectors(ctx);
+  validateTrustedTimeVelocityVectors(ctx);
   validateAuthorizationVerificationVectors(ctx, adapter);
   validateAuthorizationSignatureVectors(ctx, adapter);
   validateSnapshotVectors(ctx, adapter);

--- a/packages/conformance/vectors/authorization-payload.json
+++ b/packages/conformance/vectors/authorization-payload.json
@@ -62,8 +62,8 @@
         "expected_issued_at": 30,
         "expected_expiry": 90,
         "expiry_derivation": "evaluation_time(30) + effective_ttl(60) = 90",
-        "canonical_signing_payload": "{\"expires_at\":90,\"intent_hash\":\"cbe2f7253a1696395cb8353e6995038aa664ac56ac6d1d0e84927b3f5e22ca6e\",\"policy_id\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"state_hash\":\"2abf87e8b312be8a27edbf9e45fb9df493b9feb671da2ccaab16785f551bdc6b\"}",
-        "signature": "c7b11a0a360e828399df6513bee12611fb9cc49f08b062dca5304a633131500f"
+        "canonical_signing_payload": "{\"expires_at\":90,\"intent_hash\":\"cbe2f7253a1696395cb8353e6995038aa664ac56ac6d1d0e84927b3f5e22ca6e\",\"policy_id\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"state_hash\":\"e9fbc6823124eec8c94d860732458343a563342b0dae736030db5a6f581916ca\"}",
+        "signature": "dee7645ceaf86caf6513ccebe163e0491799c42bceee3daff4db2198b8d79363"
       }
     }
   ]

--- a/packages/conformance/vectors/trusted-time.json
+++ b/packages/conformance/vectors/trusted-time.json
@@ -113,6 +113,109 @@
       "expected": { "decision": "ALLOW", "expected_issued_at": 1730000000, "expected_expiry": 1730000060, "identical_authorization": true }
     }
   ],
+  "velocity_vectors": [
+    {
+      "id": "tt-velocity-first",
+      "intent_timestamp": 1730000010,
+      "evaluation_time": 1730000000,
+      "stored_window_start": null,
+      "window_seconds": 60,
+      "current_count": null,
+      "max_actions": 1,
+      "expected": { "decision": "ALLOW", "window_start": 1730000000, "count": 1 }
+    },
+    {
+      "id": "tt-velocity-limit-active",
+      "intent_timestamp": 1730000000,
+      "evaluation_time": 1730000000,
+      "stored_window_start": 1730000000,
+      "window_seconds": 60,
+      "current_count": 1,
+      "max_actions": 1,
+      "expected": { "decision": "DENY", "reason": "VELOCITY_EXCEEDED" }
+    },
+    {
+      "id": "tt-velocity-future-intent-active",
+      "intent_timestamp": 1730000030,
+      "evaluation_time": 1730000010,
+      "stored_window_start": 1730000000,
+      "window_seconds": 60,
+      "current_count": 1,
+      "max_actions": 1,
+      "expected": { "decision": "DENY", "reason": "VELOCITY_EXCEEDED" }
+    },
+    {
+      "id": "tt-velocity-stale-boundary-active",
+      "intent_timestamp": 1729999710,
+      "evaluation_time": 1730000010,
+      "stored_window_start": 1730000000,
+      "window_seconds": 60,
+      "current_count": 1,
+      "max_actions": 1,
+      "expected": { "decision": "DENY", "reason": "VELOCITY_EXCEEDED" }
+    },
+    {
+      "id": "tt-velocity-before-boundary",
+      "intent_timestamp": 1730000059,
+      "evaluation_time": 1730000059,
+      "stored_window_start": 1730000000,
+      "window_seconds": 60,
+      "current_count": 1,
+      "max_actions": 1,
+      "expected": { "decision": "DENY", "reason": "VELOCITY_EXCEEDED" }
+    },
+    {
+      "id": "tt-velocity-exact-boundary",
+      "intent_timestamp": 1730000030,
+      "evaluation_time": 1730000060,
+      "stored_window_start": 1730000000,
+      "window_seconds": 60,
+      "current_count": 1,
+      "max_actions": 1,
+      "expected": { "decision": "ALLOW", "window_start": 1730000060, "count": 1 }
+    },
+    {
+      "id": "tt-velocity-after-boundary",
+      "intent_timestamp": 1730000061,
+      "evaluation_time": 1730000061,
+      "stored_window_start": 1730000000,
+      "window_seconds": 60,
+      "current_count": 1,
+      "max_actions": 1,
+      "expected": { "decision": "ALLOW", "window_start": 1730000061, "count": 1 }
+    },
+    {
+      "id": "tt-velocity-backward-evaluation",
+      "intent_timestamp": 1729999999,
+      "evaluation_time": 1729999999,
+      "stored_window_start": 1730000000,
+      "window_seconds": 60,
+      "current_count": 0,
+      "max_actions": 1,
+      "expected": { "decision": "DENY", "reason": "STATE_INVALID" }
+    },
+    {
+      "id": "tt-velocity-malformed-window-start",
+      "intent_timestamp": 1730000000,
+      "evaluation_time": 1730000000,
+      "stored_window_start": -1,
+      "window_seconds": 60,
+      "current_count": 0,
+      "max_actions": 1,
+      "expected": { "decision": "DENY", "reason": "STATE_INVALID" }
+    },
+    {
+      "id": "tt-velocity-deterministic",
+      "repeat": 2,
+      "intent_timestamp": 1729999990,
+      "evaluation_time": 1730000000,
+      "stored_window_start": 1729999990,
+      "window_seconds": 60,
+      "current_count": 0,
+      "max_actions": 2,
+      "expected": { "decision": "ALLOW", "window_start": 1729999990, "count": 1, "identical_result": true }
+    }
+  ],
   "vectors": [
     {
       "id": "tt-neg-001",

--- a/packages/core/src/policy/modules/VelocityModule.ts
+++ b/packages/core/src/policy/modules/VelocityModule.ts
@@ -1,28 +1,64 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Intent } from "../../types/intent.js";
 import type { State } from "../../types/state.js";
-import type { PolicyResult } from "../../types/policy.js";
+import type { PolicyEvaluationContext, PolicyResult } from "../../types/policy.js";
 import { statelessModuleCodec } from "./_codec.js";
 
 /** @public */
-export function VelocityModule(intent: Intent, state: State): PolicyResult {
+export function VelocityModule(
+  intent: Intent,
+  state: State,
+  context: PolicyEvaluationContext,
+): PolicyResult {
   const cfg = state.velocity?.config;
-  if (!cfg || typeof cfg.window_seconds !== "number" || typeof cfg.max_actions !== "number") {
+  if (
+    !cfg ||
+    typeof state.velocity.counters !== "object" ||
+    state.velocity.counters === null ||
+    Array.isArray(state.velocity.counters) ||
+    !Number.isSafeInteger(cfg.window_seconds) ||
+    cfg.window_seconds <= 0 ||
+    !Number.isSafeInteger(cfg.max_actions) ||
+    cfg.max_actions < 0
+  ) {
     return { decision: "DENY", reasons: ["STATE_INVALID"] };
   }
 
   const agent = intent.agent_id;
-  const now = intent.timestamp;
+  const now = context.evaluationTime;
 
   const c = state.velocity.counters[agent];
-  const windowExpired = !c || now >= c.window_start + cfg.window_seconds;
+  if (
+    c !== undefined &&
+    (
+      typeof c !== "object" ||
+      c === null ||
+      !Number.isSafeInteger(c.window_start) ||
+      c.window_start < 0 ||
+      !Number.isSafeInteger(c.count) ||
+      c.count < 0 ||
+      now < c.window_start
+    )
+  ) {
+    return { decision: "DENY", reasons: ["STATE_INVALID"] };
+  }
 
-  const nextCounter = windowExpired
-    ? { window_start: now, count: 1 }
-    : { window_start: c.window_start, count: c.count + 1 };
+  let nextCounter: { window_start: number; count: number };
 
-  if (nextCounter.count > cfg.max_actions) {
-    return { decision: "DENY", reasons: ["VELOCITY_EXCEEDED"] };
+  // Subtraction is safe after the backward-clock check because both operands
+  // are non-negative safe integers and now >= window_start.
+  if (!c || now - c.window_start >= cfg.window_seconds) {
+    if (cfg.max_actions < 1) {
+      return { decision: "DENY", reasons: ["VELOCITY_EXCEEDED"] };
+    }
+    nextCounter = { window_start: now, count: 1 };
+  } else {
+    // Refuse before incrementing. Because count < max_actions and max_actions
+    // is a safe integer, count + 1 also remains a safe integer.
+    if (c.count >= cfg.max_actions) {
+      return { decision: "DENY", reasons: ["VELOCITY_EXCEEDED"] };
+    }
+    nextCounter = { window_start: c.window_start, count: c.count + 1 };
   }
 
   return {

--- a/packages/core/src/test/velocity.trusted-time.test.ts
+++ b/packages/core/src/test/velocity.trusted-time.test.ts
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: Apache-2.0
+import test from "node:test";
+import assert from "node:assert/strict";
+import fc from "fast-check";
+
+import { PolicyEngine } from "../policy/PolicyEngine.js";
+import { VelocityModule } from "../policy/modules/VelocityModule.js";
+import type { Intent } from "../types/intent.js";
+import type { PolicyResult } from "../types/policy.js";
+import type { State } from "../types/state.js";
+
+const AGENT = "agent-velocity";
+const T0 = 1_730_000_000;
+const WINDOW = 60;
+
+function intentAt(timestamp: number, nonce = 1n): Intent {
+  return {
+    intent_id: `velocity-${nonce}`,
+    agent_id: AGENT,
+    action_type: "PAYMENT",
+    type: "EXECUTE",
+    amount: 1n,
+    asset: "USDC",
+    target: "merchant",
+    timestamp,
+    metadata_hash: "0".repeat(64),
+    nonce,
+    signature: "sig",
+    tool: "pay",
+    tool_call: true,
+    depth: 0,
+  };
+}
+
+function velocityState(
+  counter?: { window_start: number; count: number },
+  config: { window_seconds: number; max_actions: number } = {
+    window_seconds: WINDOW,
+    max_actions: 1,
+  },
+): State {
+  return {
+    velocity: {
+      config,
+      counters: counter ? { [AGENT]: counter } : {},
+    },
+  } as unknown as State;
+}
+
+function counterFrom(result: PolicyResult): { window_start: number; count: number } {
+  assert.equal(result.decision, "ALLOW");
+  const counter = result.stateDelta?.velocity?.counters[AGENT];
+  assert.ok(counter);
+  return counter;
+}
+
+function fullState(counter?: { window_start: number; count: number }): State {
+  return {
+    policy_version: "velocity-trusted-time-v1",
+    period_id: "period-1",
+    kill_switch: { global: false, agents: {} },
+    allowlists: { action_types: ["PAYMENT"], assets: ["USDC"], targets: ["merchant"] },
+    budget: { budget_limit: { [AGENT]: 1_000n }, spent_in_period: { [AGENT]: 0n } },
+    max_amount_per_action: { [AGENT]: 1_000n },
+    velocity: {
+      config: { window_seconds: WINDOW, max_actions: 1 },
+      counters: counter ? { [AGENT]: counter } : {},
+    },
+    replay: { window_seconds: 600, max_nonces_per_agent: 256, nonces: {} },
+    concurrency: {
+      max_concurrent: { [AGENT]: 10 },
+      active: {},
+      active_auths: {},
+    },
+    recursion: { max_depth: { [AGENT]: 10 } },
+    tool_limits: {
+      window_seconds: 600,
+      max_calls: { [AGENT]: 100 },
+      calls: {},
+    },
+  };
+}
+
+function engine(): PolicyEngine {
+  return new PolicyEngine({
+    policy_version: "velocity-trusted-time-v1",
+    engine_secret: "velocity-trusted-time-test-secret-32-bytes",
+    maxClockSkewSeconds: 30,
+    maxIntentAgeSeconds: 300,
+  });
+}
+
+test("#192 first window starts at evaluationTime, not a distinct fresh intent.timestamp", () => {
+  const intent = intentAt(T0 + 10);
+  const result = VelocityModule(intent, velocityState(), { evaluationTime: T0 });
+  assert.deepEqual(counterFrom(result), { window_start: T0, count: 1 });
+  assert.notEqual(counterFrom(result).window_start, intent.timestamp);
+});
+
+test("#192 exhausted active window denies without consuming quota or mutating state", () => {
+  const state = velocityState({ window_start: T0, count: 1 });
+  const before = structuredClone(state);
+  const result = VelocityModule(intentAt(T0 + 10), state, { evaluationTime: T0 });
+  assert.deepEqual(result, { decision: "DENY", reasons: ["VELOCITY_EXCEEDED"] });
+  assert.deepEqual(state, before);
+});
+
+for (const [label, evaluationTime, decision] of [
+  ["just before", T0 + WINDOW - 1, "DENY"],
+  ["at", T0 + WINDOW, "ALLOW"],
+  ["just after", T0 + WINDOW + 1, "ALLOW"],
+] as const) {
+  test(`#192 trusted reset ${label} the exact boundary`, () => {
+    const result = VelocityModule(
+      intentAt(T0 + 5),
+      velocityState({ window_start: T0, count: 1 }),
+      { evaluationTime },
+    );
+    assert.equal(result.decision, decision);
+    if (result.decision === "ALLOW") {
+      assert.deepEqual(counterFrom(result), { window_start: evaluationTime, count: 1 });
+    }
+  });
+}
+
+test("#192 freshness-valid intent timestamps do not affect velocity decisions or state", () => {
+  const timestamps = [T0 - 300, T0, T0 + 30];
+  const results = timestamps.map((timestamp) =>
+    VelocityModule(
+      intentAt(timestamp),
+      velocityState({ window_start: T0 - 10, count: 1 }),
+      { evaluationTime: T0 },
+    ),
+  );
+  assert.deepEqual(results[1], results[0]);
+  assert.deepEqual(results[2], results[0]);
+});
+
+test("#192 future dating inside the freshness band cannot reset an exhausted trusted window", () => {
+  let state = velocityState();
+  const first = VelocityModule(intentAt(T0 - 300, 1n), state, { evaluationTime: T0 });
+  assert.equal(first.decision, "ALLOW");
+  state = { ...state, ...first.stateDelta };
+
+  for (const [timestamp, nonce] of [[T0, 2n], [T0 + 30, 3n]] as const) {
+    const result = VelocityModule(intentAt(timestamp, nonce), state, { evaluationTime: T0 });
+    assert.deepEqual(result, { decision: "DENY", reasons: ["VELOCITY_EXCEEDED"] });
+  }
+});
+
+test("#192 only evaluationTime crossing the boundary resets the window", () => {
+  const state = velocityState({ window_start: T0, count: 1 });
+  const before = VelocityModule(intentAt(T0 + 30), state, { evaluationTime: T0 + WINDOW - 1 });
+  const exact = VelocityModule(intentAt(T0 - 30), state, { evaluationTime: T0 + WINDOW });
+  const after = VelocityModule(intentAt(T0), state, { evaluationTime: T0 + WINDOW + 1 });
+  assert.equal(before.decision, "DENY");
+  assert.deepEqual(counterFrom(exact), { window_start: T0 + WINDOW, count: 1 });
+  assert.deepEqual(counterFrom(after), { window_start: T0 + WINDOW + 1, count: 1 });
+});
+
+test("#192 backward evaluationTime fails closed without state mutation or quota grant", () => {
+  const state = velocityState({ window_start: T0, count: 0 });
+  const before = structuredClone(state);
+  const result = VelocityModule(intentAt(T0), state, { evaluationTime: T0 - 1 });
+  assert.deepEqual(result, { decision: "DENY", reasons: ["STATE_INVALID"] });
+  assert.deepEqual(state, before);
+});
+
+test("#192 malformed velocity counter and configuration matrix fails closed", () => {
+  const malformed: State[] = [
+    velocityState({ window_start: -1, count: 0 }),
+    velocityState({ window_start: 1.5, count: 0 }),
+    velocityState({ window_start: NaN, count: 0 }),
+    velocityState({ window_start: Infinity, count: 0 }),
+    velocityState({ window_start: Number.MAX_SAFE_INTEGER + 1, count: 0 }),
+    velocityState({ window_start: T0, count: -1 }),
+    velocityState({ window_start: T0, count: 1.5 }),
+    velocityState({ window_start: T0, count: NaN }),
+    velocityState({ window_start: T0, count: Infinity }),
+    velocityState({ window_start: T0, count: Number.MAX_SAFE_INTEGER + 1 }),
+    velocityState(undefined, { window_seconds: 0, max_actions: 1 }),
+    velocityState(undefined, { window_seconds: -1, max_actions: 1 }),
+    velocityState(undefined, { window_seconds: 1.5, max_actions: 1 }),
+    velocityState(undefined, { window_seconds: NaN, max_actions: 1 }),
+    velocityState(undefined, { window_seconds: Infinity, max_actions: 1 }),
+    velocityState(undefined, { window_seconds: Number.MAX_SAFE_INTEGER + 1, max_actions: 1 }),
+    velocityState(undefined, { window_seconds: 60, max_actions: -1 }),
+    velocityState(undefined, { window_seconds: 60, max_actions: 1.5 }),
+    velocityState(undefined, { window_seconds: 60, max_actions: NaN }),
+    velocityState(undefined, { window_seconds: 60, max_actions: Infinity }),
+    velocityState(undefined, { window_seconds: 60, max_actions: Number.MAX_SAFE_INTEGER + 1 }),
+    velocityState(undefined, {
+      window_seconds: "60" as unknown as number,
+      max_actions: 1,
+    }),
+    velocityState(undefined, {
+      window_seconds: null as unknown as number,
+      max_actions: 1,
+    }),
+    velocityState(undefined, {
+      window_seconds: 60,
+      max_actions: "1" as unknown as number,
+    }),
+    velocityState(undefined, {
+      window_seconds: 60,
+      max_actions: null as unknown as number,
+    }),
+    velocityState({
+      window_start: "1730000000" as unknown as number,
+      count: 0,
+    }),
+    velocityState({
+      window_start: T0,
+      count: "0" as unknown as number,
+    }),
+    { velocity: { config: { window_seconds: 60, max_actions: 1 }, counters: { [AGENT]: null } } } as unknown as State,
+    { velocity: { config: { window_seconds: 60, max_actions: 1 } } } as unknown as State,
+  ];
+
+  for (const state of malformed) {
+    const result = VelocityModule(intentAt(T0), state, { evaluationTime: T0 });
+    assert.deepEqual(result, { decision: "DENY", reasons: ["STATE_INVALID"] });
+  }
+});
+
+test("#192 freshness denial occurs before velocity and leaves caller state unchanged", () => {
+  const state = fullState();
+  const before = structuredClone(state);
+  const result = engine().evaluatePure(intentAt(T0 + 31), state, T0);
+  assert.deepEqual(result, { decision: "DENY", reasons: ["INTENT_FRESHNESS_FUTURE"] });
+  assert.deepEqual(state, before);
+  assert.deepEqual(state.velocity.counters, {});
+});
+
+test("#192 identical inputs are deterministic and caller intent/state remain immutable", () => {
+  const intent = intentAt(T0 - 10);
+  const state = velocityState({ window_start: T0 - 20, count: 0 });
+  const intentBefore = structuredClone(intent);
+  const stateBefore = structuredClone(state);
+  const first = VelocityModule(intent, state, { evaluationTime: T0 });
+  const second = VelocityModule(intent, state, { evaluationTime: T0 });
+  assert.deepEqual(first, second);
+  assert.deepEqual(intent, intentBefore);
+  assert.deepEqual(state, stateBefore);
+});
+
+test("#192 property: freshness-valid intent timestamps are velocity-noninterfering", () => {
+  fc.assert(fc.property(
+    fc.integer({ min: T0 - 300, max: T0 + 30 }),
+    fc.integer({ min: T0 - 300, max: T0 + 30 }),
+    (t1, t2) => {
+      const state = velocityState({ window_start: T0 - 10, count: 0 }, {
+        window_seconds: WINDOW,
+        max_actions: 3,
+      });
+      assert.deepEqual(
+        VelocityModule(intentAt(t1), state, { evaluationTime: T0 }),
+        VelocityModule(intentAt(t2), state, { evaluationTime: T0 }),
+      );
+    },
+  ));
+});
+
+test("#192 property: no intent timestamp can prematurely reset an exhausted active window", () => {
+  fc.assert(fc.property(
+    fc.integer({ min: 1, max: 3_600 }),
+    fc.integer({ min: 0, max: 30 }),
+    (windowSeconds, elapsed) => {
+      fc.pre(elapsed < windowSeconds);
+      const state = velocityState({ window_start: T0, count: 1 }, {
+        window_seconds: windowSeconds,
+        max_actions: 1,
+      });
+      const result = VelocityModule(intentAt(T0 + 30), state, { evaluationTime: T0 + elapsed });
+      assert.deepEqual(result, { decision: "DENY", reasons: ["VELOCITY_EXCEEDED"] });
+    },
+  ));
+});
+
+test("#192 property: trusted resets use evaluationTime and window starts progress monotonically", () => {
+  fc.assert(fc.property(
+    fc.integer({ min: 1, max: 3_600 }),
+    fc.integer({ min: 0, max: 30 }),
+    (windowSeconds, extra) => {
+      const evaluationTime = T0 + windowSeconds + extra;
+      const result = VelocityModule(
+        intentAt(T0 - 30),
+        velocityState({ window_start: T0, count: 1 }, {
+          window_seconds: windowSeconds,
+          max_actions: 1,
+        }),
+        { evaluationTime },
+      );
+      assert.deepEqual(counterFrom(result), { window_start: evaluationTime, count: 1 });
+      assert.ok(counterFrom(result).window_start >= T0);
+    },
+  ));
+});
+
+test("#192 active window denies at MAX_SAFE_INTEGER without unsafe increment", () => {
+  const state = velocityState(
+    {
+      window_start: T0,
+      count: Number.MAX_SAFE_INTEGER,
+    },
+    {
+      window_seconds: WINDOW,
+      max_actions: Number.MAX_SAFE_INTEGER,
+    },
+  );
+
+  const before = structuredClone(state);
+  const result = VelocityModule(intentAt(T0), state, { evaluationTime: T0 });
+
+  assert.deepEqual(result, {
+    decision: "DENY",
+    reasons: ["VELOCITY_EXCEEDED"],
+  });
+  assert.deepEqual(state, before);
+});

--- a/scripts/security/repro-policy-boundary-attacks.ts
+++ b/scripts/security/repro-policy-boundary-attacks.ts
@@ -24,11 +24,11 @@ function engine(): PolicyEngine {
 
 // Fixed trusted "now" for every attack below — deliberately NOT derived from
 // each attack's (attacker-controlled) intent.timestamp. This is the two-clock
-// model itself: attacks that future-date intent.timestamp are now expected to
-// be caught by the freshness gate (INTENT_FRESHNESS_FUTURE) before they ever
-// reach replay/velocity/tool-window logic. Attacks C, K3, J, and I probe
-// exactly this boundary and are expected to flip from VULNERABLE to
-// RESISTED/FIXED now that freshness is wired in ahead of those gates.
+// model itself: attacks that grossly future-date intent.timestamp are expected
+// to be caught by freshness before later policy modules. Attack J deliberately
+// stays inside the valid freshness band so it proves velocity itself is driven
+// by evaluationTime; the other future-dating cases continue to probe the
+// freshness boundary.
 const EVAL_TIME = BASE_TS;
 
 function baseState(overrides?: (s: State) => void): State {
@@ -257,28 +257,35 @@ function attackK_replayFutureDating(): void {
 }
 
 /**
- * J — velocity window bypass by future-dating every action.
+ * J — velocity window bypass by varying caller time inside the freshness band.
  *
  * Expected vulnerable behavior:
  *   max_actions = 1
- *   5 sequential actions with timestamps beyond window
+ *   sequential actions vary freshness-valid intent timestamps
  *   all ALLOW
+ *
+ * Expected fixed behavior:
+ *   first ALLOW, all later actions VELOCITY_EXCEEDED while evaluationTime
+ *   remains inside the same trusted window.
  */
 function attackJ_velocityFutureDating(): void {
   const e = engine();
   let s = baseState((st) => {
-    st.velocity.config.window_seconds = 3600;
+    // Each attacker timestamp step is larger than this window, while all
+    // timestamps remain inside the ±300-second freshness band.
+    st.velocity.config.window_seconds = 100;
     st.velocity.config.max_actions = 1;
     st.tool_limits.max_calls[AGENT] = 1000;
   });
 
   const outs: Outcome[] = [];
+  const freshnessValidOffsets = [-300, -150, 0, 150, 300];
 
   for (let i = 0; i < 5; i++) {
     const out = e.evaluatePure(
       intent({
         nonce: BigInt(100 + i),
-        timestamp: BASE_TS + i * 7200,
+        timestamp: BASE_TS + freshnessValidOffsets[i]!,
       }),
       s,
       EVAL_TIME,
@@ -287,7 +294,7 @@ function attackJ_velocityFutureDating(): void {
     if (out.decision === "ALLOW") s = out.nextState;
   }
 
-  console.log("\n=== J: velocity future-dating ===");
+  console.log("\n=== J: velocity timestamp noninterference ===");
   console.log("decisions:", outs.map((o) => o.decision).join(", "));
   console.log("reasons:", outs.map((o) => JSON.stringify(o.reasons ?? [])).join(" | "));
 
@@ -295,7 +302,7 @@ function attackJ_velocityFutureDating(): void {
     "J",
     outs.every((o) => o.decision === "ALLOW"),
     "VULNERABLE: velocity limit reset by attacker-controlled future timestamps",
-    "velocity future-dating rejected or bounded",
+    "freshness-valid caller timestamps cannot reset trusted velocity quota",
   );
 }
 


### PR DESCRIPTION
## Summary

- derive velocity window progression exclusively from trusted `evaluationTime`
- fail closed on backward trusted time and malformed velocity state
- preserve exact boundary semantics and prevent unsafe counter increments
- add trusted-time velocity vectors, property tests, migration guidance, and security repro coverage

## Security invariant

Caller-controlled `intent.timestamp` cannot reset, advance, or otherwise influence velocity quota windows.

## Validation

- core tests: 325 passed
- workspace tests: passed
- workspace typecheck: passed
- conformance: 293 assertions passed
- API Extractor: passed
- policy-boundary repro: attack J resisted
- `git diff --check`: passed

Closes #192