### PR TITLE
fix(examples): update gpu-guard for trusted-time evaluation

### DIFF
--- a/examples/gpu-guard/demo.mjs
+++ b/examples/gpu-guard/demo.mjs
@@ -1,4 +1,4 @@
-import { PolicyEngine } from "../../packages/core/dist/index.js";
+import { PolicyEngine, RECOMMENDED_TRUSTED_TIME_PROFILE } from "../../packages/core/dist/index.js";
 
 const DEFAULT_DEMO_SECRET = "test-secret-must-be-at-least-32-chars!!";
 const _engineSecret = process.env.OXDEAI_ENGINE_SECRET || DEFAULT_DEMO_SECRET;
@@ -8,11 +8,16 @@ if (!process.env.OXDEAI_ENGINE_SECRET) {
   );
 }
 
+// Stable demo timestamp - no Date.now(), output is fully deterministic.
+// Supplied as the trusted evaluation time; the intent carries the same value.
+const DEMO_EVALUATION_TIME = 1730000000; // 2024-10-27T04:53:20Z
+
 const engine = new PolicyEngine({
   policy_version: "v1.0.0",
   engine_secret: _engineSecret,
   authorization_ttl_seconds: 60,
-  policyId: "a".repeat(64)
+  policyId: "a".repeat(64),
+  ...RECOMMENDED_TRUSTED_TIME_PROFILE
 });
 
 const state = {
@@ -41,7 +46,7 @@ const intent = {
   action_type: "PROVISION",
   amount: 1_500_000n,
   target: "gpu:a100",
-  timestamp: 1730000000,
+  timestamp: DEMO_EVALUATION_TIME,
   metadata_hash: "0".repeat(64),
   nonce: 1n,
   signature: "sig",
@@ -51,7 +56,7 @@ const intent = {
   tool: "aws.ec2.runInstances"
 };
 
-const out = engine.evaluatePure(intent, state, { mode: "fail-fast" });
+const out = engine.evaluatePure(intent, state, DEMO_EVALUATION_TIME, { mode: "fail-fast" });
 
 console.log("decision:", out.decision);
 if (out.decision === "ALLOW") {

--- a/tests/src/unit/gpuGuardDemo.test.ts
+++ b/tests/src/unit/gpuGuardDemo.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+// `examples/gpu-guard/demo.mjs` is the only plain-JavaScript example, so it is
+// invisible to `pnpm typecheck` (there is no `allowJs`/`checkJs`) and nothing
+// else executes it. Running it is the only thing that can detect it drifting
+// away from the core API — which is how it silently broke against the required
+// trusted-time options and the `evaluatePure` signature.
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const DEMO_PATH = path.join(REPO_ROOT, "examples", "gpu-guard", "demo.mjs");
+
+test("gpu-guard demo runs against the current core API and authorizes its sample intent", () => {
+  // execFileSync throws on a non-zero exit, so this also asserts the demo runs.
+  const stdout = execFileSync(process.execPath, [DEMO_PATH], { encoding: "utf8" });
+
+  assert.match(stdout, /^decision: ALLOW$/m);
+});


### PR DESCRIPTION
Closes #211. Kept completely isolated from #166, where this was found.

## What was wrong

`examples/gpu-guard/demo.mjs` had drifted from the trusted-time API in **two independent places**, so fixing either alone still left it failing.

1. `PolicyEngine` asserts `maxClockSkewSeconds` and `maxIntentAgeSeconds`, which are required with no engine-side default. The demo supplied neither.
2. `evaluatePure(intent, state, evaluationTime, opts?)` takes a trusted Unix-seconds `evaluationTime` third; the demo passed the options object in that position.

## The fix

- The constructor spreads `RECOMMENDED_TRUSTED_TIME_PROFILE`.
- `evaluatePure` receives an explicit evaluation time, then `{ mode: "fail-fast" }`.
- The timestamp is one named constant used both to build the intent and as the trusted evaluation time. That follows the stable-demo-timestamp convention already used in `examples/openai-tools` (`// Stable demo timestamp - no Date.now(), output is fully deterministic.`) rather than introducing `Date.now()` — passing `intent.timestamp` as the trusted time would have modelled exactly the pattern #208 removed.

## Regression check

`demo.mjs` is the only plain-JavaScript example. There is no `allowJs`/`checkJs`, so `pnpm typecheck` cannot see it, and no workflow executed it — which is why this drifted silently while every other `PolicyEngine` construction outside `packages/core/src/test` already spreads `RECOMMENDED_TRUSTED_TIME_PROFILE`.

`tests/src/unit/gpuGuardDemo.test.ts` runs the demo and asserts it authorizes its sample intent. Executing it is the only thing that can catch this class of drift.

**Confirmed non-vacuous**: with `demo.mjs` reverted to its previous state the check fails, and passes with the fix.

```
reverted -> ℹ pass 0   ℹ fail 1
fixed    -> ✔ gpu-guard demo runs against the current core API and authorizes its sample intent
```

## What I ran

- `node examples/gpu-guard/demo.mjs` → `decision: ALLOW`, exit 0
- `@oxdeai/tests` → **28 passing, 0 failing** (was 27; this PR adds the 28th)
- `pnpm typecheck` → exit 0 across the workspace
- `git diff --check` clean, `git status --porcelain` empty

I did not run the conformance, vectors, `security:gate` or `repro-policy-boundary-attacks` gates locally — the change touches one example and adds one test, with no protocol semantics change, so I have left those to CI rather than claim runs I did not perform.

One note for the gate list: `@oxdeai/tests` moves from 27 to 28 with this PR.
