### PR TITLE
docs(integrations): add policy and state modeling guidance

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -22,6 +22,7 @@ Shared references:
 - [Shared adapter contract](../adapters/adapter-contract.md)
 - [Production PEP wiring guide](../architecture/pep-production-guide.md)
 - [Adapter reference architecture](../adapters/adapter-reference-architecture.md)
+- [Policy and state modeling guidance](./policy-state-modeling.md)
 
 Maintained integration guides:
 

--- a/docs/integrations/policy-state-modeling.md
+++ b/docs/integrations/policy-state-modeling.md
@@ -1,0 +1,270 @@
+# Policy And State Modeling Guidance
+
+## Status
+
+Non-normative (developer documentation)
+
+
+
+
+
+
+This guide illustrates how an operator *could* model external policy and state
+inputs against the current OxDeAI intent and state model.
+
+It is downstream of [State Provider Requirements](../spec/state-provider-requirements.md),
+which is normative and owns the trust contract around `getState()`, the
+compare-and-set obligation, and the Profile A/B/C split. This document
+references that specification rather than restating it, so the two cannot drift
+apart. Where the two appear to disagree, the specification governs.
+
+Every pattern below is an illustration of what an operator might express. None
+of it is a recommendation from OxDeAI, and none of it defines protocol
+semantics. OxDeAI defines the authorization boundary; operators own their
+business rules.
+
+Patterns that the current model cannot express are recorded in
+[Recorded gaps](#recorded-gaps) rather than omitted or approximated.
+
+## How To Read This Guide
+
+Each pattern states what an operator wants, which fields carry it today, and
+what the boundary does *not* decide. Field names refer to `State` and `Intent`
+in `@oxdeai/core`, and to the guard configuration in `@oxdeai/guard`.
+
+## Trusted Inputs And Agent-Supplied Inputs
+
+The single most useful distinction when modeling policy is which inputs the
+agent controls.
+
+The repository already draws this line explicitly. `ToolAmplificationModule`
+documents that `intent.tool_call` is *"a self-declared, agent-controlled field
+and MUST NOT influence this decision (an agent can omit or falsify it to bypass
+enforcement)"*, and that `intent.tool` is used *"only as a lookup key"* which
+"must also resolve against trusted state". `AllowlistModule` resolves
+`intent.action_type` and `intent.target` against `state.allowlists` the same
+way.
+
+The generalisation an operator can carry into their own rules: **an
+agent-supplied field is safe as a lookup key into trusted state, and unsafe as
+a decision by itself.** A rule shaped like "allow when the intent says it is
+low-risk" places the decision in the agent's hands. A rule shaped like "look up
+the intent's declared target in an operator-maintained allowlist" does not.
+
+## State And Lifecycle
+
+### Compare-and-set on a budget counter
+
+This is the worked example, because it exercises state versioning, stale-write
+rejection, retry behaviour, the retry/replay distinction, and why trusted state
+provenance matters — in one flow.
+
+The concurrency mechanism lives in the guard configuration
+(`@oxdeai/guard`), and it is distinct from the semantic `state_hash` binding:
+
+- `getState()` returns a `VersionedState`, that is `{ state, version }`, where
+  `StateVersion` is `string | number` — "a monotonically-increasing integer,
+  ETag, or any comparable value".
+- `setState(state, expectedVersion)` must atomically verify that the persisted
+  version still equals `expectedVersion` before committing, returning `true` on
+  success and `false` on a version mismatch.
+- On `false` the guard raises `OxDeAIConflictError` and blocks execution, with
+  no execution side effects.
+
+Two different things are therefore being checked, and it is worth keeping them
+apart when reasoning about a deployment:
+
+| Mechanism | Question it answers |
+|---|---|
+| `state_hash` (`computeStateHash`) | Is the live state the same logical state the authorization was minted against? |
+| `StateVersion` (`getState`/`setState`) | Did anyone else advance the state between read and write? |
+
+A budget counter is the clearest case. `state.budget.budget_limit[agent]` and
+`state.budget.spent_in_period[agent]` are keyed per agent. Two evaluators can
+read the same remaining budget and each conclude there is room for one more
+action. The CAS write is what makes only one of them win; the
+loser sees `OxDeAIConflictError` and never executes.
+
+Non-normative sketch:
+
+```js
+const { state, version } = await getState();
+
+const out = engine.evaluatePure(intent, state, evaluationTime, { mode: "fail-fast" });
+if (out.decision !== "ALLOW") {
+  return refuse(out.reasons);
+}
+
+// Commit only if nobody advanced the state since the read.
+if (!(await setState(out.nextState, version))) {
+  // Concurrent modification. Nothing executed; the caller may re-read and retry.
+  return conflict();
+}
+```
+
+`evaluatePure(intent, state, evaluationTime, opts?)` is pure: it returns the
+proposed `nextState` rather than mutating, which is what makes the read →
+evaluate → CAS-write sequence expressible at all.
+
+§2.2 of the specification adds a point worth surfacing here because it is easy
+to get wrong: trusted-time velocity accounting **does not** remove the CAS
+obligation. Window progression being derived from the trusted `evaluation_time`
+does not stop two evaluators racing for the same remaining slot.
+
+### Retries versus replay
+
+An operator usually wants a retry after a network failure to succeed, and a
+duplicate submission of an already-consumed action to be refused. These look
+identical from the outside.
+
+`state.replay` carries `window_seconds`, `max_nonces_per_agent`, and `nonces`
+per agent. The discriminator is `intent.nonce`, keyed by `agent_id` — an intent
+presented twice with the same nonce inside the window is refused. `intent_id`
+plays no part in replay detection; if an operator wants to correlate a retry
+with its original attempt, that is a convention they maintain in their own
+records, not something the boundary reads.
+
+The consequence for operators: retry logic mints a fresh nonce, and a replay
+refusal is not a transient error to be retried harder.
+
+This is also the sharpest illustration of the trusted-input principle above.
+`ReplayModule` documents that window eviction is driven exclusively by the
+trusted evaluation clock and never by `intent.timestamp`, because entries are
+retained while `entry.ts >= windowStart` — so an agent that postdates its intent
+would push `windowStart` forward, prune its own previously recorded nonce, and
+walk its replay straight through. The field is agent-controlled, so it cannot be
+what decides.
+
+### Budget counters
+
+`state.budget.budget_limit` and `state.budget.spent_in_period` are keyed per
+agent. `state.max_amount_per_action` is a per-action hard cap independent of the
+remaining balance, so "no single action above X, and no more than Y in total"
+is two separate controls rather than one.
+
+`state.period_id` is worth being explicit about, because its name invites an
+assumption the code does not support: **no policy module reads it.** Outside the
+type definition it appears only in `stateGuards.ts`, which requires it to be
+present and to be a string. Nothing resets `spent_in_period` when it changes.
+Rolling a period is therefore an operator action — write the new `period_id` and
+zero the counters in the same state mutation — and `period_id` serves as the
+label that makes the two epochs distinguishable in the canonical state, not as
+a trigger.
+
+### Concurrency limits
+
+`state.concurrency` carries `max_concurrent` and `active` per agent, plus
+`active_auths` keyed by authorization id with an `expires_at`. An `EXECUTE`
+intent takes a slot; a `RELEASE` intent carrying `authorization_id` returns it.
+
+`RELEASE` deliberately runs a narrower module set than `EXECUTE` — kill switch,
+replay and concurrency only — so release paths are not gated on the same policy
+surface as execution, and a release cannot be starved by, say, an exhausted
+budget.
+
+One property to model around: **`active_auths[...].expires_at` is stored and
+validated, but nothing evicts on it.** It is carried through the state codec and
+contributes to the state hash, and no module reads it to reclaim a slot. A
+long-running action whose `RELEASE` never arrives therefore holds its
+concurrency slot until an operator writes the state to reclaim it. An operator
+modeling long-running work owns that sweep; `expires_at` is the timestamp such a
+sweep would key on, not a mechanism that acts on its own.
+
+### State versioning
+
+Covered by the CAS pattern above. The specification's §2 and §6 own the
+normative requirements — including that a version token is never null, and is
+not decremented or reset except through an audited rollback.
+
+### Failure handling
+
+`evaluatePure` accepts `{ mode: "collect-all" | "fail-fast" }`, defaulting to
+`"fail-fast"`, and returns `reasons[]` alongside the decision. `"collect-all"`
+suits a policy console where an operator wants every reason an action was
+refused; `"fail-fast"` suits the enforcement path, where the first refusal is
+sufficient and the remaining checks are wasted work.
+
+A refusal is not an error. The decision path returns `DENY` with reasons, and
+the tool does not run.
+
+### Approval state
+
+Not expressible today — see [Recorded gaps](#recorded-gaps).
+
+## Scope And Binding
+
+### Action target binding
+
+`state.allowlists` carries `action_types`, `targets`, and `assets`, resolved
+against `intent.action_type`, `intent.target`, and `intent.asset`.
+
+Two properties are worth being precise about, because "allowlist" suggests
+default-deny and the behaviour is narrower than that:
+
+- **Each list constrains only when it is non-empty.** `AllowlistModule` checks a
+  list only if it is present and has entries, so an unset or empty
+  `allowlists.targets` permits every target rather than refusing all of them.
+  Default-deny holds *within* a configured list, not at the configuration level.
+- **The asset check requires the intent to carry an asset.** `intent.asset` is
+  optional, and the asset comparison is skipped when it is absent — so an intent
+  that omits `asset` is not measured against a populated `allowlists.assets`.
+
+An operator relying on allowlists for isolation should therefore treat "the list
+is configured and non-empty" as part of the policy, not as a given.
+
+### Tool allowlists
+
+Partially expressible, and the shape of the limitation matters — see
+[Recorded gaps](#recorded-gaps). `state.tool_limits` expresses *rate*:
+`max_calls` per agent and `max_calls_by_tool` per agent per tool, over
+`window_seconds`. Setting a per-tool cap to `0` refuses that tool outright, so
+a denylist is expressible by enumeration.
+
+What is not expressible is the default-deny direction, because `state.allowlists`
+has no tool axis.
+
+### Credential provenance and scope binding
+
+Not expressible today — see [Recorded gaps](#recorded-gaps).
+
+### Argument provenance
+
+Not expressible today — see [Recorded gaps](#recorded-gaps). `intent.metadata_hash`
+binds arguments as an opaque digest, which is enough to detect that arguments
+changed, and not enough to say which of them the operator fixed.
+
+### Per-user and per-tenant limits
+
+Partially expressible. Every enforcement counter — budget, velocity,
+concurrency, tool limits, recursion — is keyed by `agent_id`. A tenant
+dimension can be encoded into the agent identifier by convention, for example
+`tenant-a/agent-1`, and this works for accounting.
+
+What it does not give is a checked property: nothing in the enforcement path
+verifies that an agent belongs to the tenant its identifier claims. `DelegationV1`
+carries `delegatee`, `issuer`, `audience` and a `scope` at the artifact layer,
+so tenancy can be represented and verified there; the counters that gate the
+decision do not read it. An operator relying on identifier conventions for
+tenant isolation should know the boundary is a naming convention rather than a
+verified one.
+
+## Recorded Gaps
+
+Recorded rather than approximated, per the acceptance criteria of #166. Each is
+tracked as its own issue, linked below.
+
+| Gap | Why it is not expressible today |
+|---|---|
+| [Default-deny tool allowlist](https://github.com/oxdeai/oxdeai/issues/214) | `state.allowlists` has no tool axis; `AllowlistModule` reads `action_types`, `assets` and `targets` only. Per-tool refusal exists via `tool_limits.max_calls_by_tool[agent][tool] = 0`, but that is a denylist requiring enumeration, and a tool absent from configuration is permitted when `max_calls[agent]` is unset. |
+| [Operator-defined action types](https://github.com/oxdeai/oxdeai/issues/215) | `ActionType` is a closed union of `PAYMENT`, `PURCHASE`, `PROVISION` and `ONCHAIN_TX`. An action outside that set cannot be named. |
+| [Credential provenance and scope binding](https://github.com/oxdeai/oxdeai/issues/216) | Neither `Intent` nor `State` carries a credential identifier or scope, so a rule cannot require that an action was taken with a specific credential. |
+| [Argument provenance](https://github.com/oxdeai/oxdeai/issues/217) | `metadata_hash` is a single opaque digest over arguments. Operator-fixed and agent-generated arguments cannot be distinguished. |
+| [Approval state](https://github.com/oxdeai/oxdeai/issues/218) | There is no pending/approved/rejected concept in the policy state. `concurrency.active_auths` records granted authorizations with an `expires_at`, which is a lease rather than a workflow. |
+| [Per-tenant limits as a verified property](https://github.com/oxdeai/oxdeai/issues/219) | Enforcement counters are keyed by `agent_id`; tenancy is a naming convention at that layer. |
+
+## Related
+
+- [State Provider Requirements](../spec/state-provider-requirements.md) — normative
+- [Trusted Time](../spec/core/trusted-time-v1.md) — normative
+- [Shared demo scenario](./shared-demo-scenario.md)
+- [Production PEP wiring guide](../architecture/pep-production-guide.md)

--- a/docs/integrations/shared-demo-scenario.md
+++ b/docs/integrations/shared-demo-scenario.md
@@ -97,6 +97,53 @@ This demonstrates that:
 - refusal remained explicit
 - audit and snapshot evidence were sufficient for offline verification
 
+## Concurrent Variant: Compare-And-Set On The Budget Counter
+
+The sequence above is single-threaded: each proposal is evaluated and committed
+before the next is built. Deployments are not, and the budget counter is where
+that difference shows first.
+
+This variant is optional for adapter demos. It exists because the canonical
+scenario already contains everything needed to exercise it: a counter with room
+for exactly two actions.
+
+### Scenario
+
+Two evaluators read the same state and each propose the second low-cost action:
+
+1. both read state at the same `StateVersion`, with one action's worth of
+   allowance remaining
+2. both evaluate, and both receive `ALLOW` with a proposed next state
+3. both attempt to commit
+
+### Expected Outcome
+
+Exactly one commit succeeds.
+
+- the first `setState(nextState, expectedVersion)` MUST return `true`
+- the second MUST return `false`, because the persisted version no longer
+  matches the version it read
+- the losing evaluator's guard MUST raise `OxDeAIConflictError`, and its tool
+  MUST NOT execute
+
+The budget MUST NOT be double-spent. After the exchange, exactly one of the two
+proposals has consumed allowance, and a subsequent equivalent proposal is denied
+as in the canonical sequence.
+
+### Why This Belongs In The Shared Scenario
+
+Both evaluators received `ALLOW`. The decision was correct in each case, against
+the state each of them read. What separates the two outcomes is not policy but
+the atomicity of the commit, which is why the state provider requirements make
+compare-and-set a provider obligation rather than an engine one - see
+[State Provider Requirements](../spec/state-provider-requirements.md) §2.2.
+
+This also demonstrates the distinction between the two state checks: the
+`state_hash` binding answers whether the live state is the one the authorization
+was minted against, while the `StateVersion` token answers whether anyone
+advanced it between read and write. A demo that only exercises the first will
+not show this failure mode at all.
+
 ## Reproducibility Guidance
 
 Adapters MAY differ in:


### PR DESCRIPTION
Closes #166. Documentation only — no protocol semantics change. Kept isolated from #211/#212 as you asked.

## What's here

- **`docs/integrations/policy-state-modeling.md`** — the guide, strictly downstream of the normative [State Provider Requirements](https://github.com/oxdeai/oxdeai/blob/main/docs/spec/state-provider-requirements.md), referencing it rather than restating it. Grouped by the issue's own headings (*State and lifecycle* / *Scope and binding*), every example labelled non-normative.
- **`docs/integrations/shared-demo-scenario.md`** — a concurrent variant of the canonical sequence covering the CAS budget counter. The existing scenario already has a counter with room for exactly two actions, so the race falls straight out of it.
- **`docs/integrations/README.md`** — one line linking the guide.

## Two things worth your eye

**1. "Shared references" already existed.** You asked for a new section; the block is already in the README, so I added the entry to it rather than creating a second heading with the same name. Say the word if you'd rather it were separate.

**2. The runnable-example conditional resolved toward the executable path.** You said a code sample in the guide would do *unless the shared scenario can be executed directly*. It can — `node examples/openai-tools/dist/run.js` runs the full canonical path end to end (ALLOW / ALLOW / DENY, then offline envelope replay `ok`, `violations: none`). So the scenario doc carries the pattern as an executable contract, and the guide keeps a short sketch for reading rather than as a substitute.

## Recorded gaps

Recorded rather than approximated, each narrowly scoped and linked back to #166:

| Gap | Issue |
|---|---|
| Default-deny tool allowlist — `allowlists` has no tool axis | #214 |
| `ActionType` is a closed union | #215 |
| No credential provenance or scope binding | #216 |
| Argument provenance — `metadata_hash` is one opaque digest | #217 |
| No approval-state concept | #218 |
| Per-tenant limits are a naming convention | #219 |

**One I flagged rather than filed**, because it reads as a design choice rather than a missing capability: `concurrency.active_auths[...].expires_at` is stored, validated and hashed, but nothing evicts on it — an unreleased slot is reclaimed by the operator or not at all. Documented in the guide. Happy to open an issue if you want it tracked.

## Three claims I had to correct while writing

Each of these was in my first draft and was wrong. Since the whole point of the guide is that an operator can rely on it, I checked them against the module source rather than the type definitions:

- **Allowlists are not unconditionally default-deny.** `AllowlistModule` applies each list only when it is present *and* non-empty, so an unset `allowlists.targets` permits every target. The asset comparison additionally requires `intent.asset` to be present, and `asset` is optional — so an intent omitting it is never measured against a populated `allowlists.assets`.
- **No policy module reads `period_id`.** Outside the type it appears only in `stateGuards.ts` as a presence/type check. Nothing resets `spent_in_period`; rolling a period is an operator action.
- **`intent_id` plays no part in replay detection** — `nonceKey()` is `intent.nonce.toString()`, keyed by `agent_id`.

## What I ran

- `pnpm typecheck` → exit 0 across the workspace
- `@oxdeai/tests` → **27 passing, 0 failing** on this branch (the 28th test is #212's and does not exist here)
- `git diff --check` clean, `git status --porcelain` empty

I did not run conformance, vectors, `security:gate` or `repro-policy-boundary-attacks` locally — this is a docs-only change, so I left those to CI rather than claim runs I did not perform.
