### PR TITLE
feat(conformance): execute trusted-time vectors

### DIFF
--- a/docs/spec/conformance/conformance-v1.md
+++ b/docs/spec/conformance/conformance-v1.md
@@ -120,11 +120,41 @@ From repo root:
 - Python verifier: `pnpm test:vectors:py`
 - Authorization vectors: `pnpm test:vectors:auth`
 - PEP vectors: `pnpm test:vectors:pep`
+- Trusted-time vectors: `pnpm test:vectors:trusted-time`
 - Aggregate: `pnpm test:vectors:all`
 
 Pass/Fail rule: any mismatch in canonical JSON, SHA-256, or expected error code MUST exit non-zero and is non-conformant.
 
-### 4.2 Pending vectors
+### 4.2 Trusted-time vector schema
+
+`packages/conformance/vectors/trusted-time.json` uses strict schema version
+`1.0.0` and one category-discriminated `vectors` collection. Every vector has
+an ID unique across the file, an explicit `active` or `pending` status, a
+description, category-specific `input`, and category-specific `expected`
+behavior. Pending vectors additionally require a non-empty `blocked_by` and are
+reported separately; they never count as passing.
+
+The schema names clock domains explicitly (`intent_timestamp`,
+`evaluation_time`, `authorization_issued_at`, `authorization_expiry`,
+`nonce_first_seen_time`, `velocity_window_start`, `tool_window_start`, and
+`verifier_time`). Generic or overloaded timestamp fields are forbidden.
+
+The TypeScript reference runner rejects duplicate IDs, unknown categories or
+fields, malformed status, unsupported public reason codes, and malformed or
+unsafe protocol-second values before executing any vector. Active vectors run
+through Core reference surfaces and are release-blocking through both
+`pnpm -C packages/conformance validate` and `pnpm test:vectors:all`.
+
+TypeScript executes every active trusted-time category. The current Go and
+Python harnesses claim canonicalization, Profile C verification, and SignedKRL
+verification only; they do not expose PolicyEngine freshness, issuance,
+stateful replay, velocity, or the standalone trusted-time authorization
+verification surface. Those categories are explicitly unsupported in those
+runtimes and MUST NOT be emulated in a harness merely to claim parity. All
+languages enforce the JavaScript safe-integer bound for protocol numeric data
+in the categories they implement.
+
+### 4.3 Pending vectors
 
 Locked vectors exist for canonicalization, authorization, and PEP gateway behavior as listed above. Delegation conformance is presently validated via code-level harnesses; additional locked vectors MAY be added in future versions.
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "test:vectors:auth": "node scripts/verify-authorization-vectors.mjs",
     "test:vectors:pep": "node scripts/verify-pep-vectors.mjs",
     "test:vectors:delegation": "node scripts/verify-delegation-vectors.mjs",
-    "test:vectors:all": "pnpm test:vectors:ts && pnpm test:vectors:auth && pnpm test:vectors:pep && pnpm test:vectors:delegation && pnpm test:vectors:go && pnpm test:vectors:py"
+    "test:vectors:trusted-time": "pnpm -C packages/conformance validate:trusted-time",
+    "test:vectors:all": "pnpm test:vectors:ts && pnpm test:vectors:auth && pnpm test:vectors:pep && pnpm test:vectors:delegation && pnpm test:vectors:trusted-time && pnpm test:vectors:go && pnpm test:vectors:py"
   },
   "devDependencies": {
     "@oxdeai/core": "workspace:*",

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -19,7 +19,9 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "extract": "pnpm -C ../core build && pnpm build && node dist/scripts/extract-vectors.js",
-    "validate": "pnpm -C ../core build && pnpm build && node dist/src/validate.js"
+    "validate": "pnpm -C ../core build && pnpm build && node dist/src/validate.js",
+    "validate:trusted-time": "pnpm -C ../core build && pnpm build && node dist/src/validate-trusted-time.js",
+    "test": "pnpm -C ../core build && pnpm build && node --test dist/src/trustedTimeConformance.test.js"
   },
   "dependencies": {
     "@oxdeai/core": "workspace:*"

--- a/packages/conformance/src/trustedTimeConformance.test.ts
+++ b/packages/conformance/src/trustedTimeConformance.test.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseTrustedTimeFile, runTrustedTimeConformance, trustedTimeExitCode } from "./trustedTimeConformance.js";
+
+const root = fileURLToPath(new URL("../../../../", import.meta.url));
+const source = JSON.parse(readFileSync(resolve(root, "packages/conformance/vectors/trusted-time.json"), "utf8"));
+const clone = <T>(value: T): T => structuredClone(value);
+
+test("trusted-time schema accepts the normative vector file", () => {
+  const parsed = parseTrustedTimeFile(source);
+  assert.equal(parsed.schema_version, "1.0.0");
+  assert.equal(parsed.vectors.length, 41);
+});
+
+test("trusted-time schema rejects duplicate IDs with the exact ID", () => {
+  const raw = clone(source);
+  raw.vectors.push(clone(raw.vectors[0]));
+  assert.throws(() => parseTrustedTimeFile(raw), /tt-issuance-before: duplicate vector ID/);
+});
+
+test("trusted-time schema rejects unknown categories", () => {
+  const raw = clone(source);
+  raw.vectors[0].category = "unknown_clock";
+  assert.throws(() => parseTrustedTimeFile(raw), /tt-issuance-before: unknown category unknown_clock/);
+});
+
+test("trusted-time schema rejects unknown public reason codes", () => {
+  const raw = clone(source);
+  raw.vectors.find((v: any) => v.id === "tt-neg-001").expected.reasons = ["NOT_A_REASON"];
+  assert.throws(() => parseTrustedTimeFile(raw), /tt-neg-001.*unsupported ReasonCode NOT_A_REASON/);
+});
+
+test("trusted-time schema rejects malformed status", () => {
+  const raw = clone(source);
+  raw.vectors[0].status = "skipped";
+  assert.throws(() => parseTrustedTimeFile(raw), /tt-issuance-before: malformed status skipped/);
+});
+
+test("trusted-time schema requires blocked_by on pending vectors", () => {
+  const raw = clone(source);
+  delete raw.vectors.find((v: any) => v.status === "pending").blocked_by;
+  assert.throws(() => parseTrustedTimeFile(raw), /tt-tool-window-trusted-time blocked_by/);
+});
+
+for (const [label, value] of [["fractional", 1.5], ["negative", -1], ["unsafe", Number.MAX_SAFE_INTEGER + 1], ["non-finite", Infinity], ["string", "10"]] as const) {
+  test(`trusted-time schema rejects ${label} protocol seconds`, () => {
+    const raw = clone(source);
+    raw.vectors.find((v: any) => v.id === "tt-issuance-before").input.evaluation_time = value;
+    assert.throws(() => parseTrustedTimeFile(raw), /tt-issuance-before input.evaluation_time/);
+  });
+}
+
+test("an active expectation regression is a failing result with actionable ID", () => {
+  const raw = clone(source);
+  const vector = raw.vectors.find((v: any) => v.id === "tt-neg-001");
+  vector.expected = { decision: "ALLOW", reasons: [] };
+  const lines: string[] = [];
+  const summary = runTrustedTimeConformance(raw, line => lines.push(line));
+  assert.equal(summary.failed, 1);
+  assert.equal(trustedTimeExitCode(summary), 1);
+  assert.match(summary.failures[0]!, /^tt-neg-001:/);
+  assert.ok(lines.some(line => line.startsWith("FAIL tt-neg-001:")));
+});
+
+test("pending vectors are reported separately and never counted as passing", () => {
+  const summary = runTrustedTimeConformance(source, () => {});
+  assert.equal(summary.active, 40);
+  assert.equal(summary.passed, 40);
+  assert.equal(summary.pending, 1);
+});
+
+test("replay sequence propagates nextState and detects corrupted step-two state", () => {
+  const raw = clone(source);
+  const vector = raw.vectors.find((v: any) => v.id === "tt-neg-002");
+  vector.expected.steps[1].nonce_state = [];
+  const summary = runTrustedTimeConformance(raw, () => {});
+  assert.ok(summary.failures.some(f => f.startsWith("tt-neg-002:")));
+  assert.match(summary.failures.find(f => f.startsWith("tt-neg-002:"))!, /step 2 intent_timestamp=1730000005 evaluation_time=1730000005/);
+});
+
+test("velocity sequence propagates nextState and preserves it on DENY", () => {
+  const raw = clone(source);
+  const vector = raw.vectors.find((v: any) => v.id === "tt-velocity-limit-active");
+  vector.expected.steps[1].velocity_count = 2;
+  const summary = runTrustedTimeConformance(raw, () => {});
+  assert.ok(summary.failures.some(f => f.startsWith("tt-velocity-limit-active:")));
+});
+
+test("exact velocity time boundaries and deterministic repetition pass", () => {
+  const ids = new Set(["tt-velocity-before-boundary", "tt-velocity-exact-boundary", "tt-velocity-after-boundary", "tt-velocity-deterministic"]);
+  const raw = clone(source);
+  raw.vectors = raw.vectors.filter((v: any) => ids.has(v.id));
+  const summary = runTrustedTimeConformance(raw, () => {});
+  assert.deepEqual({ active: summary.active, passed: summary.passed, failed: summary.failed }, { active: 4, passed: 4, failed: 0 });
+});

--- a/packages/conformance/src/trustedTimeConformance.ts
+++ b/packages/conformance/src/trustedTimeConformance.ts
@@ -1,0 +1,431 @@
+// SPDX-License-Identifier: Apache-2.0
+import {
+  PolicyEngine,
+  signAuthorizationEd25519,
+  verifyAuthorization,
+} from "@oxdeai/core";
+import type { AuthorizationV1, Intent, KeySet, ReasonCode, State } from "@oxdeai/core";
+import { resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+// Conformance-only reference surface. Core builds before this package, so the
+// emitted declaration/runtime pair is available without widening Core's public API.
+const trustedTimeReference = await import(pathToFileURL(resolve(
+  fileURLToPath(new URL("../../../../", import.meta.url)),
+  "packages/core/dist/policy/verifyTrustedTime.js",
+)).href) as {
+  verifyTrustedTime(input: {
+    intentTimestamp: number;
+    evaluationTime: number;
+    maxClockSkewSeconds: number;
+    maxIntentAgeSeconds: number;
+  }): { decision: "ALLOW"; reasons: [] } | { decision: "DENY"; reasons: ReasonCode[] };
+};
+const { verifyTrustedTime } = trustedTimeReference;
+import {
+  TEST_ONLY_ED25519_PRIVATE_KEY_PEM_DO_NOT_USE_IN_PRODUCTION,
+  TEST_ONLY_ED25519_PUBLIC_KEY_PEM_DO_NOT_USE_IN_PRODUCTION,
+} from "./fixtures/ed25519.test-only.fixture.js";
+import { CONFORMANCE_ENGINE_SECRET } from "./fixtures/conformance-engine-secret.fixture.js";
+
+export const TRUSTED_TIME_SCHEMA_VERSION = "1.0.0";
+export const TRUSTED_TIME_CATEGORIES = [
+  "intent_freshness", "authorization_issuance", "replay", "velocity",
+  "authorization_verification", "determinism", "malformed_configuration",
+  "protocol_seconds_validation", "tool_window",
+] as const;
+
+type Category = (typeof TRUSTED_TIME_CATEGORIES)[number];
+type RecordValue = Record<string, unknown>;
+export type TrustedTimeVector = {
+  id: string;
+  category: Category;
+  status: "active" | "pending";
+  description: string;
+  blocked_by?: string;
+  comparison_group?: string;
+  input: RecordValue;
+  expected: RecordValue;
+};
+export type TrustedTimeFile = {
+  schema_version: string;
+  description: string;
+  vectors: TrustedTimeVector[];
+};
+export type TrustedTimeSummary = {
+  active: number;
+  passed: number;
+  failed: number;
+  pending: number;
+  failures: string[];
+};
+
+const CATEGORY_SET = new Set<string>(TRUSTED_TIME_CATEGORIES);
+// The package root currently exposes ReasonCode as a public type rather than a
+// runtime value. `satisfies` keeps this registry compile-time checked against
+// that public union while providing strict runtime validation for vector data.
+const PUBLIC_REASON_CODES = [
+  "KILL_SWITCH", "ALLOWLIST_ACTION", "ALLOWLIST_ASSET", "ALLOWLIST_TARGET",
+  "POLICY_VERSION_MISMATCH", "STATE_INVALID", "BUDGET_EXCEEDED",
+  "PER_ACTION_CAP_EXCEEDED", "VELOCITY_EXCEEDED", "CONCURRENCY_LIMIT_EXCEEDED",
+  "RECURSION_DEPTH_EXCEEDED", "REPLAY_NONCE", "REPLAY_DETECTED", "AUTH_EXPIRED",
+  "AUTH_SIGNATURE_INVALID", "AUTH_INTENT_MISMATCH", "INTERNAL_ERROR",
+  "CONCURRENCY_RELEASE_INVALID", "TOOL_CALL_LIMIT_EXCEEDED",
+  "INTENT_FRESHNESS_FUTURE", "INTENT_STALE",
+] as const satisfies readonly ReasonCode[];
+type MissingPublicReasonCode = Exclude<ReasonCode, (typeof PUBLIC_REASON_CODES)[number]>;
+const ALL_PUBLIC_REASON_CODES_COVERED: MissingPublicReasonCode extends never ? true : never = true;
+void ALL_PUBLIC_REASON_CODES_COVERED;
+const REASON_CODES = new Set<string>(PUBLIC_REASON_CODES);
+const VERIFICATION_CODES = new Set(["AUTH_EXPIRED", "AUTH_ISSUED_AT_IMPLAUSIBLE"]);
+const COMMON_KEYS = new Set(["id", "category", "status", "description", "blocked_by", "comparison_group", "input", "expected"]);
+const INPUT_KEYS: Record<Category, Set<string>> = {
+  intent_freshness: new Set(["intent_timestamp", "evaluation_time", "max_clock_skew_seconds", "max_intent_age_seconds"]),
+  authorization_issuance: new Set(["intent_timestamp", "evaluation_time", "effective_ttl", "authorization_action"]),
+  replay: new Set(["replay_window_seconds", "max_nonces_per_agent", "initial_nonce_state", "steps"]),
+  velocity: new Set(["window_seconds", "max_actions", "initial_velocity", "steps"]),
+  authorization_verification: new Set(["authorization_issued_at", "authorization_expiry", "verifier_time", "max_future_issued_at_skew_seconds"]),
+  determinism: new Set(["kind", "repeat", "intent_timestamp", "evaluation_time", "effective_ttl", "window_seconds", "max_actions", "initial_velocity", "steps"]),
+  malformed_configuration: new Set(["configuration_field", "configuration_value"]),
+  protocol_seconds_validation: new Set(["case", "intent_timestamp", "evaluation_time", "effective_ttl"]),
+  tool_window: new Set(["intent_timestamp", "evaluation_time", "tool_window_start", "window_seconds"]),
+};
+const EXPECTED_KEYS: Record<Category, Set<string>> = {
+  intent_freshness: new Set(["decision", "reasons"]),
+  authorization_issuance: new Set(["decision", "reasons", "authorization_issued_at", "authorization_expiry"]),
+  replay: new Set(["steps"]),
+  velocity: new Set(["steps"]),
+  authorization_verification: new Set(["status", "violation_codes"]),
+  determinism: new Set(["decision", "reasons", "authorization_issued_at", "authorization_expiry", "identical_output"]),
+  malformed_configuration: new Set(["throws", "error_includes"]),
+  protocol_seconds_validation: new Set(["decision", "reasons", "throws", "error_includes"]),
+  tool_window: new Set(["decision", "reasons"]),
+};
+
+function object(value: unknown, where: string): RecordValue {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error(`${where}: expected object`);
+  return value as RecordValue;
+}
+function exactKeys(value: RecordValue, allowed: Set<string>, where: string): void {
+  for (const key of Object.keys(value)) if (!allowed.has(key)) throw new Error(`${where}: unknown field ${key}`);
+}
+function text(value: unknown, where: string): string {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${where}: expected non-empty string`);
+  return value;
+}
+function array(value: unknown, where: string): unknown[] {
+  if (!Array.isArray(value)) throw new Error(`${where}: expected array`);
+  return value;
+}
+function safeSeconds(value: unknown, where: string, positive = false): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < (positive ? 1 : 0)) {
+    throw new Error(`${where}: expected ${positive ? "positive" : "non-negative"} safe-integer protocol seconds`);
+  }
+  return value;
+}
+function nonNegativeCount(value: unknown, where: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) throw new Error(`${where}: expected non-negative safe integer`);
+  return value;
+}
+function validateReasons(value: unknown, id: string, where: string): void {
+  for (const [index, reason] of array(value, `${id} ${where}`).entries()) {
+    if (typeof reason !== "string" || !REASON_CODES.has(reason)) throw new Error(`${id} ${where}[${index}]: unsupported ReasonCode ${String(reason)}`);
+  }
+}
+function validateDecisionExpected(expected: RecordValue, id: string): void {
+  if (expected.decision !== "ALLOW" && expected.decision !== "DENY") throw new Error(`${id} expected.decision: expected ALLOW or DENY`);
+  validateReasons(expected.reasons, id, "expected.reasons");
+  if (expected.decision === "ALLOW" && (expected.reasons as unknown[]).length !== 0) throw new Error(`${id} expected.reasons: ALLOW must have no reasons`);
+}
+function validateNonceState(value: unknown, id: string, where: string): void {
+  for (const [i, raw] of array(value, `${id} ${where}`).entries()) {
+    const item = object(raw, `${id} ${where}[${i}]`);
+    exactKeys(item, new Set(["nonce", "nonce_first_seen_time"]), `${id} ${where}[${i}]`);
+    text(item.nonce, `${id} ${where}[${i}].nonce`);
+    safeSeconds(item.nonce_first_seen_time, `${id} ${where}[${i}].nonce_first_seen_time`);
+  }
+}
+function validateSteps(vector: TrustedTimeVector): void {
+  const steps = array(vector.input.steps, `${vector.id} input.steps`);
+  if (steps.length === 0) throw new Error(`${vector.id} input.steps: must not be empty`);
+  for (const [i, raw] of steps.entries()) {
+    const step = object(raw, `${vector.id} input.steps[${i}]`);
+    exactKeys(step, new Set(["intent_timestamp", "evaluation_time", "nonce"]), `${vector.id} input.steps[${i}]`);
+    safeSeconds(step.intent_timestamp, `${vector.id} input.steps[${i}].intent_timestamp`);
+    safeSeconds(step.evaluation_time, `${vector.id} input.steps[${i}].evaluation_time`);
+    text(step.nonce, `${vector.id} input.steps[${i}].nonce`);
+  }
+  if (vector.category === "determinism") return;
+  const expectedSteps = array(vector.expected.steps, `${vector.id} expected.steps`);
+  if (expectedSteps.length !== steps.length) throw new Error(`${vector.id} expected.steps: expected ${steps.length} entries`);
+  for (const [i, raw] of expectedSteps.entries()) {
+    const step = object(raw, `${vector.id} expected.steps[${i}]`);
+    const allowed = vector.category === "replay"
+      ? new Set(["decision", "reasons", "nonce_state"])
+      : new Set(["decision", "reasons", "velocity_window_start", "velocity_count"]);
+    exactKeys(step, allowed, `${vector.id} expected.steps[${i}]`);
+    validateDecisionExpected(step, `${vector.id} step ${i + 1}`);
+    if (vector.category === "replay") validateNonceState(step.nonce_state, vector.id, `expected.steps[${i}].nonce_state`);
+    else {
+      // Negative starts are permitted only as an expected preservation value for the malformed-state vector.
+      if (typeof step.velocity_window_start !== "number" || !Number.isSafeInteger(step.velocity_window_start)) throw new Error(`${vector.id} expected.steps[${i}].velocity_window_start: expected safe integer`);
+      nonNegativeCount(step.velocity_count, `${vector.id} expected.steps[${i}].velocity_count`);
+    }
+  }
+}
+
+export function parseTrustedTimeFile(raw: unknown): TrustedTimeFile {
+  const file = object(raw, "trusted-time");
+  exactKeys(file, new Set(["schema_version", "description", "vectors"]), "trusted-time");
+  if (file.schema_version !== TRUSTED_TIME_SCHEMA_VERSION) throw new Error(`trusted-time schema_version: expected ${TRUSTED_TIME_SCHEMA_VERSION}`);
+  text(file.description, "trusted-time description");
+  const seen = new Set<string>();
+  const vectors = array(file.vectors, "trusted-time vectors") as unknown as TrustedTimeVector[];
+  for (const rawVector of vectors) {
+    const vector = object(rawVector, "trusted-time vector") as unknown as TrustedTimeVector;
+    exactKeys(vector as unknown as RecordValue, COMMON_KEYS, `trusted-time vector ${String(vector.id ?? "(missing)")}`);
+    const id = text(vector.id, "trusted-time vector id");
+    if (seen.has(id)) throw new Error(`${id}: duplicate vector ID`);
+    seen.add(id);
+    if (!CATEGORY_SET.has(String(vector.category))) throw new Error(`${id}: unknown category ${String(vector.category)}`);
+    if (vector.status !== "active" && vector.status !== "pending") throw new Error(`${id}: malformed status ${String(vector.status)}`);
+    text(vector.description, `${id} description`);
+    if (vector.status === "pending") text(vector.blocked_by, `${id} blocked_by`);
+    else if (vector.blocked_by !== undefined) throw new Error(`${id}: active vector must not define blocked_by`);
+    if (vector.comparison_group !== undefined) text(vector.comparison_group, `${id} comparison_group`);
+    const input = object(vector.input, `${id} input`);
+    const expected = object(vector.expected, `${id} expected`);
+    exactKeys(input, INPUT_KEYS[vector.category], `${id} input`);
+    exactKeys(expected, EXPECTED_KEYS[vector.category], `${id} expected`);
+
+    if (vector.category === "intent_freshness") {
+      safeSeconds(input.intent_timestamp, `${id} input.intent_timestamp`);
+      safeSeconds(input.evaluation_time, `${id} input.evaluation_time`);
+      safeSeconds(input.max_clock_skew_seconds, `${id} input.max_clock_skew_seconds`);
+      safeSeconds(input.max_intent_age_seconds, `${id} input.max_intent_age_seconds`);
+      validateDecisionExpected(expected, id);
+    } else if (vector.category === "authorization_issuance") {
+      safeSeconds(input.intent_timestamp, `${id} input.intent_timestamp`);
+      safeSeconds(input.evaluation_time, `${id} input.evaluation_time`);
+      safeSeconds(input.effective_ttl, `${id} input.effective_ttl`, true);
+      if (input.authorization_action !== "EXECUTE" && input.authorization_action !== "RELEASE") throw new Error(`${id} input.authorization_action: unknown action`);
+      validateDecisionExpected(expected, id);
+      safeSeconds(expected.authorization_issued_at, `${id} expected.authorization_issued_at`);
+      safeSeconds(expected.authorization_expiry, `${id} expected.authorization_expiry`);
+    } else if (vector.category === "replay") {
+      safeSeconds(input.replay_window_seconds, `${id} input.replay_window_seconds`, true);
+      nonNegativeCount(input.max_nonces_per_agent, `${id} input.max_nonces_per_agent`);
+      if (input.initial_nonce_state !== undefined) validateNonceState(input.initial_nonce_state, id, "input.initial_nonce_state");
+      validateSteps(vector);
+    } else if (vector.category === "velocity") {
+      safeSeconds(input.window_seconds, `${id} input.window_seconds`, true);
+      nonNegativeCount(input.max_actions, `${id} input.max_actions`);
+      if (input.initial_velocity !== undefined) validateInitialVelocity(input.initial_velocity, id);
+      validateSteps(vector);
+    } else if (vector.category === "authorization_verification") {
+      safeSeconds(input.authorization_issued_at, `${id} input.authorization_issued_at`);
+      safeSeconds(input.authorization_expiry, `${id} input.authorization_expiry`);
+      safeSeconds(input.verifier_time, `${id} input.verifier_time`);
+      safeSeconds(input.max_future_issued_at_skew_seconds, `${id} input.max_future_issued_at_skew_seconds`);
+      if (expected.status !== "ok" && expected.status !== "invalid") throw new Error(`${id} expected.status: unsupported verifier status`);
+      for (const code of array(expected.violation_codes, `${id} expected.violation_codes`)) if (typeof code !== "string" || !VERIFICATION_CODES.has(code)) throw new Error(`${id} expected.violation_codes: unsupported verification code ${String(code)}`);
+    } else if (vector.category === "determinism") {
+      nonNegativeCount(input.repeat, `${id} input.repeat`);
+      if ((input.repeat as number) < 2) throw new Error(`${id} input.repeat: must be at least 2`);
+      if (input.kind === "velocity_sequence") {
+        safeSeconds(input.window_seconds, `${id} input.window_seconds`, true);
+        nonNegativeCount(input.max_actions, `${id} input.max_actions`);
+        if (input.initial_velocity !== undefined) validateInitialVelocity(input.initial_velocity, id);
+        validateSteps(vector);
+      } else {
+        if (input.kind !== undefined) throw new Error(`${id} input.kind: unsupported determinism kind`);
+        safeSeconds(input.intent_timestamp, `${id} input.intent_timestamp`);
+        safeSeconds(input.evaluation_time, `${id} input.evaluation_time`);
+        safeSeconds(input.effective_ttl, `${id} input.effective_ttl`, true);
+        validateDecisionExpected(expected, id);
+      }
+      if (expected.identical_output !== true) throw new Error(`${id} expected.identical_output: must be true`);
+    } else if (vector.category === "malformed_configuration") {
+      text(input.configuration_field, `${id} input.configuration_field`);
+      if (expected.throws !== true) throw new Error(`${id} expected.throws: must be true`);
+      text(expected.error_includes, `${id} expected.error_includes`);
+    } else if (vector.category === "protocol_seconds_validation") {
+      text(input.case, `${id} input.case`);
+      if (expected.reasons !== undefined) validateDecisionExpected(expected, id);
+      if (expected.throws !== undefined && expected.throws !== true) throw new Error(`${id} expected.throws: must be true`);
+      if (expected.error_includes !== undefined) text(expected.error_includes, `${id} expected.error_includes`);
+    } else if (vector.category === "tool_window") {
+      safeSeconds(input.intent_timestamp, `${id} input.intent_timestamp`);
+      safeSeconds(input.evaluation_time, `${id} input.evaluation_time`);
+      safeSeconds(input.tool_window_start, `${id} input.tool_window_start`);
+      safeSeconds(input.window_seconds, `${id} input.window_seconds`, true);
+      validateDecisionExpected(expected, id);
+    }
+  }
+  return file as unknown as TrustedTimeFile;
+}
+
+function validateInitialVelocity(raw: unknown, id: string): void {
+  const value = object(raw, `${id} input.initial_velocity`);
+  exactKeys(value, new Set(["velocity_window_start", "velocity_count"]), `${id} input.initial_velocity`);
+  if (typeof value.velocity_window_start !== "number" || !Number.isSafeInteger(value.velocity_window_start)) throw new Error(`${id} input.initial_velocity.velocity_window_start: expected safe integer`);
+  nonNegativeCount(value.velocity_count, `${id} input.initial_velocity.velocity_count`);
+}
+
+function makeState(): State {
+  return {
+    policy_version: "v1.0.0", period_id: "period-1",
+    kill_switch: { global: false, agents: {} }, allowlists: {},
+    budget: { budget_limit: { "agent-1": 5_000_000n }, spent_in_period: { "agent-1": 0n } },
+    max_amount_per_action: { "agent-1": 2_000_000n },
+    velocity: { config: { window_seconds: 60, max_actions: 10 }, counters: {} },
+    replay: { window_seconds: 600, max_nonces_per_agent: 256, nonces: {} },
+    concurrency: { max_concurrent: { "agent-1": 10 }, active: {}, active_auths: {} },
+    recursion: { max_depth: { "agent-1": 10 } },
+    tool_limits: { window_seconds: 600, max_calls: { "agent-1": 100 }, calls: {} },
+  };
+}
+function makeEngine(ttl = 60, skew = 300, age = 300): PolicyEngine {
+  return new PolicyEngine({ policy_version: "v1.0.0", engine_secret: CONFORMANCE_ENGINE_SECRET, authorization_ttl_seconds: ttl, maxClockSkewSeconds: skew, maxIntentAgeSeconds: age, policyId: "a".repeat(64) });
+}
+function intent(id: string, timestamp: number, nonce: string, action: "EXECUTE" | "RELEASE" = "EXECUTE"): Intent {
+  const nonceValue = /^\d+$/.test(nonce)
+    ? BigInt(nonce)
+    : BigInt([...nonce].reduce((n, c) => n + c.charCodeAt(0), 10_000));
+  return {
+    intent_id: `${id}-${nonce}`, agent_id: "agent-1", action_type: "PAYMENT", amount: 100n,
+    asset: "wallet", target: "merchant-1", timestamp, metadata_hash: "0".repeat(64),
+    nonce: nonceValue, signature: "sig", depth: 0,
+    ...(action === "RELEASE" ? { type: "RELEASE" as const, authorization_id: "release-id" } : { type: "EXECUTE" as const }),
+  };
+}
+function normalize(value: unknown): unknown {
+  return JSON.parse(JSON.stringify(value, (_key, item) => typeof item === "bigint" ? `${item}n` : item));
+}
+function equal(actual: unknown, expected: unknown): boolean { return JSON.stringify(normalize(actual)) === JSON.stringify(normalize(expected)); }
+
+function runSequence(vector: TrustedTimeVector, category: "replay" | "velocity"): unknown[] {
+  const input = vector.input;
+  let state = makeState();
+  if (category === "replay") {
+    state.replay.window_seconds = input.replay_window_seconds as number;
+    state.replay.max_nonces_per_agent = input.max_nonces_per_agent as number;
+    state.replay.nonces["agent-1"] = ((input.initial_nonce_state ?? []) as RecordValue[]).map(x => ({ nonce: x.nonce as string, ts: x.nonce_first_seen_time as number }));
+  } else {
+    state.velocity.config = { window_seconds: input.window_seconds as number, max_actions: input.max_actions as number };
+    if (input.initial_velocity) {
+      const initial = input.initial_velocity as RecordValue;
+      state.velocity.counters["agent-1"] = { window_start: initial.velocity_window_start as number, count: initial.velocity_count as number };
+    }
+  }
+  const observations: unknown[] = [];
+  for (const [index, rawStep] of (input.steps as RecordValue[]).entries()) {
+    const before = structuredClone(state);
+    const stepIntent = intent(vector.id, rawStep.intent_timestamp as number, rawStep.nonce as string);
+    const out = makeEngine().evaluatePure(stepIntent, state, rawStep.evaluation_time as number);
+    if (out.decision === "ALLOW") state = out.nextState;
+    else state = before;
+    const base = { decision: out.decision, reasons: [...out.reasons] };
+    observations.push(category === "replay"
+      ? { ...base, nonce_state: (state.replay.nonces["agent-1"] ?? []).map(x => ({ nonce: x.nonce, nonce_first_seen_time: x.ts })) }
+      : { ...base, velocity_window_start: state.velocity.counters["agent-1"]?.window_start, velocity_count: state.velocity.counters["agent-1"]?.count });
+    void index;
+  }
+  return observations;
+}
+
+const KEYSET: KeySet = { issuer: "issuer", version: "1", keys: [{ kid: "k1", alg: "Ed25519", public_key: TEST_ONLY_ED25519_PUBLIC_KEY_PEM_DO_NOT_USE_IN_PRODUCTION }] };
+function runVector(vector: TrustedTimeVector): unknown {
+  const input = vector.input;
+  if (vector.category === "intent_freshness") {
+    return verifyTrustedTime({ intentTimestamp: input.intent_timestamp as number, evaluationTime: input.evaluation_time as number, maxClockSkewSeconds: input.max_clock_skew_seconds as number, maxIntentAgeSeconds: input.max_intent_age_seconds as number });
+  }
+  if (vector.category === "authorization_issuance") {
+    const action = input.authorization_action as "EXECUTE" | "RELEASE";
+    const state = makeState();
+    if (action === "RELEASE") { state.concurrency.active["agent-1"] = 1; state.concurrency.active_auths["agent-1"] = { "release-id": { expires_at: (input.evaluation_time as number) + 600 } }; }
+    const out = makeEngine(input.effective_ttl as number).evaluatePure(intent(vector.id, input.intent_timestamp as number, "1", action), state, input.evaluation_time as number);
+    return out.decision === "ALLOW" ? { decision: out.decision, reasons: out.reasons, authorization_issued_at: out.authorization.issued_at, authorization_expiry: out.authorization.expiry } : { decision: out.decision, reasons: out.reasons };
+  }
+  if (vector.category === "replay" || vector.category === "velocity") return { steps: runSequence(vector, vector.category) };
+  if (vector.category === "authorization_verification") {
+    const unsigned = { auth_id: vector.id, issuer: "issuer", audience: "aud", intent_hash: "1".repeat(64), state_hash: "2".repeat(64), policy_id: "3".repeat(64), decision: "ALLOW" as const, issued_at: input.authorization_issued_at as number, expiry: input.authorization_expiry as number, kid: "k1" };
+    const auth = signAuthorizationEd25519(unsigned, TEST_ONLY_ED25519_PRIVATE_KEY_PEM_DO_NOT_USE_IN_PRODUCTION);
+    const result = verifyAuthorization(auth, { now: input.verifier_time as number, mode: "strict", expectedIssuer: "issuer", expectedAudience: "aud", trustedKeySets: KEYSET, maxFutureIssuedAtSkewSeconds: input.max_future_issued_at_skew_seconds as number });
+    return { status: result.status, violation_codes: result.violations.map(v => v.code) };
+  }
+  if (vector.category === "malformed_configuration") {
+    try {
+      if (input.configuration_field === "authorization_ttl_seconds") makeEngine(input.configuration_value as number);
+      else verifyAuthorization({} as AuthorizationV1, { maxFutureIssuedAtSkewSeconds: input.configuration_value as number });
+      return { throws: false, error_includes: "" };
+    } catch (error) { return { throws: true, error_includes: error instanceof Error ? error.message : String(error) }; }
+  }
+  if (vector.category === "protocol_seconds_validation") {
+    try {
+      if (input.case === "intent_timestamp") {
+        return verifyTrustedTime({ intentTimestamp: input.intent_timestamp as number, evaluationTime: input.evaluation_time as number, maxClockSkewSeconds: 300, maxIntentAgeSeconds: 300 });
+      }
+      const out = makeEngine(input.effective_ttl as number | undefined ?? 60).evaluatePure(intent(vector.id, input.intent_timestamp as number, "1"), makeState(), input.evaluation_time as number);
+      return { decision: out.decision, reasons: out.reasons };
+    } catch (error) { return { throws: true, error_includes: error instanceof Error ? error.message : String(error) }; }
+  }
+  if (vector.category === "determinism") {
+    const outputs: unknown[] = [];
+    for (let i = 0; i < (input.repeat as number); i++) {
+      if (input.kind === "velocity_sequence") outputs.push({ steps: runSequence(vector, "velocity") });
+      else {
+        const out = makeEngine(input.effective_ttl as number).evaluatePure(intent(vector.id, input.intent_timestamp as number, "1"), makeState(), input.evaluation_time as number);
+        outputs.push(out.decision === "ALLOW" ? { decision: out.decision, reasons: out.reasons, authorization_issued_at: out.authorization.issued_at, authorization_expiry: out.authorization.expiry, full: normalize(out) } : normalize(out));
+      }
+    }
+    const first = outputs[0];
+    const identical = outputs.every(x => equal(x, first));
+    if (input.kind === "velocity_sequence") return { identical_output: identical };
+    const base = first as RecordValue;
+    return { decision: base.decision, reasons: base.reasons, authorization_issued_at: base.authorization_issued_at, authorization_expiry: base.authorization_expiry, identical_output: identical };
+  }
+  throw new Error(`${vector.id}: active category ${vector.category} has no executor`);
+}
+
+function matches(actual: unknown, expected: RecordValue): boolean {
+  if (expected.throws === true) return (actual as RecordValue).throws === true && String((actual as RecordValue).error_includes).includes(String(expected.error_includes));
+  return equal(actual, expected);
+}
+
+function mismatchDetail(vector: TrustedTimeVector, actual: unknown): string | undefined {
+  if (vector.category !== "replay" && vector.category !== "velocity") return undefined;
+  const actualSteps = (actual as { steps: unknown[] }).steps;
+  const expectedSteps = vector.expected.steps as unknown[];
+  const inputSteps = vector.input.steps as RecordValue[];
+  for (let index = 0; index < expectedSteps.length; index++) {
+    if (!equal(actualSteps[index], expectedSteps[index])) {
+      const input = inputSteps[index]!;
+      return `step ${index + 1} intent_timestamp=${String(input.intent_timestamp)} evaluation_time=${String(input.evaluation_time)} expected=${JSON.stringify(expectedSteps[index])} actual=${JSON.stringify(actualSteps[index])}`;
+    }
+  }
+  return undefined;
+}
+
+export function runTrustedTimeConformance(raw: unknown, log: (line: string) => void = console.log): TrustedTimeSummary {
+  const file = parseTrustedTimeFile(raw);
+  const summary: TrustedTimeSummary = { active: 0, passed: 0, failed: 0, pending: 0, failures: [] };
+  for (const vector of file.vectors) {
+    if (vector.status === "pending") { summary.pending++; log(`PENDING ${vector.id} blocked_by=${vector.blocked_by}`); continue; }
+    summary.active++;
+    try {
+      const actual = runVector(vector);
+      if (!matches(actual, vector.expected)) throw new Error(mismatchDetail(vector, actual) ?? `expected=${JSON.stringify(vector.expected)} actual=${JSON.stringify(actual)}`);
+      summary.passed++; log(`PASS ${vector.id}`);
+    } catch (error) {
+      summary.failed++;
+      const detail = error instanceof Error ? error.message : String(error);
+      const message = `${vector.id}: ${detail}`;
+      summary.failures.push(message); log(`FAIL ${message}`);
+    }
+  }
+  return summary;
+}
+
+export function trustedTimeExitCode(summary: TrustedTimeSummary): 0 | 1 {
+  return summary.failed === 0 ? 0 : 1;
+}

--- a/packages/conformance/src/validate-trusted-time.ts
+++ b/packages/conformance/src/validate-trusted-time.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runTrustedTimeConformance, trustedTimeExitCode } from "./trustedTimeConformance.js";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const raw = JSON.parse(readFileSync(resolve(here, "../../vectors/trusted-time.json"), "utf8"));
+const summary = runTrustedTimeConformance(raw);
+console.log(`Trusted-time summary: active=${summary.active} passed=${summary.passed} failed=${summary.failed} pending=${summary.pending}`);
+if (trustedTimeExitCode(summary) !== 0) process.exit(1);

--- a/packages/conformance/src/validate.ts
+++ b/packages/conformance/src/validate.ts
@@ -32,6 +32,7 @@ import {
   KRL_TEST_ONLY_ED25519_PUBLIC_KEY_PEM_DO_NOT_USE_IN_PRODUCTION,
 } from "./fixtures/krl-ed25519.test-only.fixture.js";
 import { CONFORMANCE_ENGINE_SECRET } from "./fixtures/conformance-engine-secret.fixture.js";
+import { runTrustedTimeConformance } from "./trustedTimeConformance.js";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -414,198 +415,6 @@ function validateAuthorizationVectors(ctx: CheckCtx, adapter: ConformanceAdapter
     });
     eq(ctx, `${id} canonical_signing_payload`, payload, String(expected.canonical_signing_payload));
     eq(ctx, `${id} signature`, authorization.engine_signature, String(expected.signature));
-  }
-}
-
-function validateTrustedTimeIssuanceVectors(ctx: CheckCtx): void {
-  type TrustedTimeFile = {
-    issuance_vectors: Array<JsonRecord>;
-  };
-  const file = loadJson<TrustedTimeFile>("trusted-time.json");
-  const comparisonWindows = new Map<string, Array<[number, number]>>();
-
-  for (const [index, vector] of file.issuance_vectors.entries()) {
-    const id = String(vector.id);
-    const intentTimestamp = Number(vector.intent_timestamp);
-    const evaluationTime = Number(vector.evaluation_time);
-    const effectiveTtl = Number(vector.effective_ttl);
-    const action = String(vector.authorization_action);
-    const expected = asRecord(vector.expected);
-
-    if (String(expected.decision) === "CONFIG_INVALID") {
-      let message = "";
-      try {
-        makeEngine(effectiveTtl);
-      } catch (error) {
-        message = error instanceof Error ? error.message : String(error);
-      }
-      eq(ctx, `${id} config rejection`, message.includes(String(expected.error)), true);
-      continue;
-    }
-
-    const engine = makeEngine(effectiveTtl);
-    const releasedId = "existing-authorization";
-    const state = makeBaseState();
-    if (action === "RELEASE") {
-      state.concurrency.active = { "agent-1": 1 };
-      state.concurrency.active_auths = {
-        "agent-1": {
-          [releasedId]: { expires_at: evaluationTime + 600 },
-        },
-      };
-    }
-    const intent: Intent = {
-      intent_id: `${id}-intent`,
-      agent_id: "agent-1",
-      action_type: "PAYMENT",
-      amount: 100n,
-      asset: "wallet",
-      target: "merchant-1",
-      timestamp: intentTimestamp,
-      metadata_hash: "0".repeat(64),
-      nonce: BigInt(index + 1000),
-      signature: "sig-placeholder",
-      depth: 0,
-      ...(action === "RELEASE"
-        ? { type: "RELEASE" as const, authorization_id: releasedId }
-        : { type: "EXECUTE" as const }),
-    };
-
-    if (String(expected.decision) === "PRECONDITION_INVALID") {
-      let message = "";
-      try {
-        engine.evaluatePure(intent, state, evaluationTime);
-      } catch (error) {
-        message = error instanceof Error ? error.message : String(error);
-      }
-      eq(ctx, `${id} precondition rejection`, message.includes(String(expected.error)), true);
-      eq(ctx, `${id} no audit before rejection`, engine.audit.snapshot(), []);
-      continue;
-    }
-
-    const out = engine.evaluatePure(intent, state, evaluationTime);
-    eq(ctx, `${id} decision`, out.decision, String(expected.decision));
-
-    if (out.decision === "DENY") {
-      eq(ctx, `${id} reason`, out.reasons[0], String(expected.reason));
-      eq(ctx, `${id} authorization absent`, "authorization" in out, false);
-      continue;
-    }
-
-    eq(ctx, `${id} issued_at`, out.authorization.issued_at, Number(expected.expected_issued_at));
-    eq(ctx, `${id} expiry`, out.authorization.expiry, Number(expected.expected_expiry));
-    eq(
-      ctx,
-      `${id} effective_ttl`,
-      out.authorization.expiry - out.authorization.issued_at,
-      effectiveTtl,
-    );
-    if (vector.comparison_group !== undefined) {
-      const group = String(vector.comparison_group);
-      const windows = comparisonWindows.get(group) ?? [];
-      windows.push([out.authorization.issued_at, out.authorization.expiry]);
-      comparisonWindows.set(group, windows);
-    }
-
-    if (Number(vector.repeat) === 2) {
-      const repeated = makeEngine(effectiveTtl).evaluatePure(
-        intent,
-        action === "RELEASE" ? structuredClone(state) : makeBaseState(),
-        evaluationTime,
-      );
-      eq(ctx, `${id} repeated decision`, repeated.decision, "ALLOW");
-      if (repeated.decision === "ALLOW") {
-        eq(
-          ctx,
-          `${id} identical authorization`,
-          repeated.authorization,
-          out.authorization,
-        );
-      }
-    }
-  }
-
-  const sameEvaluationWindows = comparisonWindows.get("same-evaluation-time") ?? [];
-  eq(
-    ctx,
-    "trusted-time intent timestamp noninterference",
-    sameEvaluationWindows[0],
-    sameEvaluationWindows[1],
-  );
-  const differentEvaluationWindows =
-    comparisonWindows.get("different-evaluation-time") ?? [];
-  eq(
-    ctx,
-    "trusted-time evaluation sensitivity",
-    differentEvaluationWindows[1]?.[0] - differentEvaluationWindows[0]?.[0],
-    10,
-  );
-}
-
-function validateTrustedTimeVelocityVectors(ctx: CheckCtx): void {
-  type TrustedTimeFile = {
-    velocity_vectors: Array<JsonRecord>;
-  };
-  const file = loadJson<TrustedTimeFile>("trusted-time.json");
-
-  for (const [index, vector] of file.velocity_vectors.entries()) {
-    const id = String(vector.id);
-    const intentTimestamp = Number(vector.intent_timestamp);
-    const evaluationTime = Number(vector.evaluation_time);
-    const storedWindowStart = vector.stored_window_start;
-    const currentCount = vector.current_count;
-    const expected = asRecord(vector.expected);
-    const state = makeBaseState();
-    state.velocity.config = {
-      window_seconds: Number(vector.window_seconds),
-      max_actions: Number(vector.max_actions),
-    };
-    state.velocity.counters =
-      storedWindowStart === null
-        ? {}
-        : {
-            "agent-1": {
-              window_start: Number(storedWindowStart),
-              count: Number(currentCount),
-            },
-          };
-
-    const intent: Intent = {
-      intent_id: `${id}-intent`,
-      agent_id: "agent-1",
-      action_type: "PAYMENT",
-      type: "EXECUTE",
-      amount: 100n,
-      asset: "wallet",
-      target: "merchant-1",
-      timestamp: intentTimestamp,
-      metadata_hash: "0".repeat(64),
-      nonce: BigInt(index + 20_000),
-      signature: "sig-placeholder",
-      depth: 0,
-    };
-
-    const before = structuredClone(state);
-    const evaluate = () => makeEngine().evaluatePure(intent, structuredClone(state), evaluationTime);
-    const out = evaluate();
-    eq(ctx, `${id} decision`, out.decision, String(expected.decision));
-
-    if (out.decision === "DENY") {
-      eq(ctx, `${id} reason`, out.reasons[0], String(expected.reason));
-      eq(ctx, `${id} input velocity unchanged`, state.velocity, before.velocity);
-    } else {
-      const counter = out.nextState.velocity.counters["agent-1"];
-      eq(ctx, `${id} window_start`, counter?.window_start, Number(expected.window_start));
-      eq(ctx, `${id} count`, counter?.count, Number(expected.count));
-    }
-
-    if (Number(vector.repeat) === 2) {
-      const repeated = evaluate();
-      eq(ctx, `${id} repeated decision`, repeated.decision, out.decision);
-      if (repeated.decision === "ALLOW" && out.decision === "ALLOW") {
-        eq(ctx, `${id} repeated velocity state`, repeated.nextState.velocity, out.nextState.velocity);
-      }
-    }
   }
 }
 
@@ -1766,8 +1575,9 @@ function main(): void {
 
   validateIntentHashVectors(ctx, adapter);
   validateAuthorizationVectors(ctx, adapter);
-  validateTrustedTimeIssuanceVectors(ctx);
-  validateTrustedTimeVelocityVectors(ctx);
+  const trustedTime = runTrustedTimeConformance(loadJson<unknown>("trusted-time.json"));
+  ctx.passed += trustedTime.passed;
+  ctx.failures.push(...trustedTime.failures);
   validateAuthorizationVerificationVectors(ctx, adapter);
   validateAuthorizationSignatureVectors(ctx, adapter);
   validateSnapshotVectors(ctx, adapter);

--- a/packages/conformance/vectors/trusted-time.json
+++ b/packages/conformance/vectors/trusted-time.json
@@ -1,401 +1,47 @@
 {
-  "version": "0.1.0-draft",
-  "description": "Trusted-time authorization conformance vectors. intent.timestamp is a bounded freshness claim only; evaluation_time is the trusted PEP clock used for issuance. In this fixed-TTL profile, maxTtlSeconds names the same resolved fixed issuance TTL as EngineOptions.authorization_ttl_seconds ?? 60. It is not an independent runtime control and there is no requested-TTL selection.",
-  "config": {
-    "maxClockSkewSeconds": 300,
-    "maxIntentAgeSeconds": 300,
-    "replayWindowSeconds": 600,
-    "velocity": { "maxActions": 1, "windowSeconds": 60 },
-    "maxTtlSeconds": 60,
-    "effective_ttl": 60,
-    "T0": 1730000000
-  },
-  "issuance_vectors": [
-    {
-      "id": "tt-issuance-before",
-      "intent_timestamp": 1729999990,
-      "evaluation_time": 1730000000,
-      "effective_ttl": 60,
-      "authorization_action": "EXECUTE",
-      "expected": { "decision": "ALLOW", "expected_issued_at": 1730000000, "expected_expiry": 1730000060 }
-    },
-    {
-      "id": "tt-issuance-equal",
-      "intent_timestamp": 1730000000,
-      "evaluation_time": 1730000000,
-      "effective_ttl": 60,
-      "authorization_action": "EXECUTE",
-      "expected": { "decision": "ALLOW", "expected_issued_at": 1730000000, "expected_expiry": 1730000060 }
-    },
-    {
-      "id": "tt-issuance-after",
-      "intent_timestamp": 1730000010,
-      "evaluation_time": 1730000000,
-      "effective_ttl": 60,
-      "authorization_action": "EXECUTE",
-      "expected": { "decision": "ALLOW", "expected_issued_at": 1730000000, "expected_expiry": 1730000060 }
-    },
-    {
-      "id": "tt-noninterference-earlier",
-      "comparison_group": "same-evaluation-time",
-      "intent_timestamp": 1729999980,
-      "evaluation_time": 1730000000,
-      "effective_ttl": 60,
-      "authorization_action": "EXECUTE",
-      "expected": { "decision": "ALLOW", "expected_issued_at": 1730000000, "expected_expiry": 1730000060 }
-    },
-    {
-      "id": "tt-noninterference-later",
-      "comparison_group": "same-evaluation-time",
-      "intent_timestamp": 1730000020,
-      "evaluation_time": 1730000000,
-      "effective_ttl": 60,
-      "authorization_action": "EXECUTE",
-      "expected": { "decision": "ALLOW", "expected_issued_at": 1730000000, "expected_expiry": 1730000060 }
-    },
-    {
-      "id": "tt-evaluation-sensitivity-first",
-      "comparison_group": "different-evaluation-time",
-      "intent_timestamp": 1730000000,
-      "evaluation_time": 1730000000,
-      "effective_ttl": 60,
-      "authorization_action": "EXECUTE",
-      "expected": { "decision": "ALLOW", "expected_issued_at": 1730000000, "expected_expiry": 1730000060 }
-    },
-    {
-      "id": "tt-evaluation-sensitivity-second",
-      "comparison_group": "different-evaluation-time",
-      "intent_timestamp": 1730000000,
-      "evaluation_time": 1730000010,
-      "effective_ttl": 60,
-      "authorization_action": "EXECUTE",
-      "expected": { "decision": "ALLOW", "expected_issued_at": 1730000010, "expected_expiry": 1730000070 }
-    },
-    {
-      "id": "tt-release-issuance",
-      "intent_timestamp": 1730000001,
-      "evaluation_time": 1730000000,
-      "effective_ttl": 60,
-      "authorization_action": "RELEASE",
-      "expected": { "decision": "ALLOW", "expected_issued_at": 1730000000, "expected_expiry": 1730000060 }
-    },
-    {
-      "id": "tt-invalid-ttl-zero",
-      "intent_timestamp": 1730000000,
-      "evaluation_time": 1730000000,
-      "effective_ttl": 0,
-      "authorization_action": "EXECUTE",
-      "expected": { "decision": "CONFIG_INVALID", "error": "authorization_ttl_seconds" }
-    },
-    {
-      "id": "tt-expiry-overflow",
-      "intent_timestamp": 9007199254740932,
-      "evaluation_time": 9007199254740932,
-      "effective_ttl": 60,
-      "authorization_action": "EXECUTE",
-      "expected": { "decision": "PRECONDITION_INVALID", "error": "safe integer" }
-    },
-    {
-      "id": "tt-freshness-denial",
-      "intent_timestamp": 1730000301,
-      "evaluation_time": 1730000000,
-      "effective_ttl": 60,
-      "authorization_action": "EXECUTE",
-      "expected": { "decision": "DENY", "reason": "INTENT_FRESHNESS_FUTURE", "authorization_present": false }
-    },
-    {
-      "id": "tt-deterministic",
-      "intent_timestamp": 1730000005,
-      "evaluation_time": 1730000000,
-      "effective_ttl": 60,
-      "authorization_action": "EXECUTE",
-      "repeat": 2,
-      "expected": { "decision": "ALLOW", "expected_issued_at": 1730000000, "expected_expiry": 1730000060, "identical_authorization": true }
-    }
-  ],
-  "velocity_vectors": [
-    {
-      "id": "tt-velocity-first",
-      "intent_timestamp": 1730000010,
-      "evaluation_time": 1730000000,
-      "stored_window_start": null,
-      "window_seconds": 60,
-      "current_count": null,
-      "max_actions": 1,
-      "expected": { "decision": "ALLOW", "window_start": 1730000000, "count": 1 }
-    },
-    {
-      "id": "tt-velocity-limit-active",
-      "intent_timestamp": 1730000000,
-      "evaluation_time": 1730000000,
-      "stored_window_start": 1730000000,
-      "window_seconds": 60,
-      "current_count": 1,
-      "max_actions": 1,
-      "expected": { "decision": "DENY", "reason": "VELOCITY_EXCEEDED" }
-    },
-    {
-      "id": "tt-velocity-future-intent-active",
-      "intent_timestamp": 1730000030,
-      "evaluation_time": 1730000010,
-      "stored_window_start": 1730000000,
-      "window_seconds": 60,
-      "current_count": 1,
-      "max_actions": 1,
-      "expected": { "decision": "DENY", "reason": "VELOCITY_EXCEEDED" }
-    },
-    {
-      "id": "tt-velocity-stale-boundary-active",
-      "intent_timestamp": 1729999710,
-      "evaluation_time": 1730000010,
-      "stored_window_start": 1730000000,
-      "window_seconds": 60,
-      "current_count": 1,
-      "max_actions": 1,
-      "expected": { "decision": "DENY", "reason": "VELOCITY_EXCEEDED" }
-    },
-    {
-      "id": "tt-velocity-before-boundary",
-      "intent_timestamp": 1730000059,
-      "evaluation_time": 1730000059,
-      "stored_window_start": 1730000000,
-      "window_seconds": 60,
-      "current_count": 1,
-      "max_actions": 1,
-      "expected": { "decision": "DENY", "reason": "VELOCITY_EXCEEDED" }
-    },
-    {
-      "id": "tt-velocity-exact-boundary",
-      "intent_timestamp": 1730000030,
-      "evaluation_time": 1730000060,
-      "stored_window_start": 1730000000,
-      "window_seconds": 60,
-      "current_count": 1,
-      "max_actions": 1,
-      "expected": { "decision": "ALLOW", "window_start": 1730000060, "count": 1 }
-    },
-    {
-      "id": "tt-velocity-after-boundary",
-      "intent_timestamp": 1730000061,
-      "evaluation_time": 1730000061,
-      "stored_window_start": 1730000000,
-      "window_seconds": 60,
-      "current_count": 1,
-      "max_actions": 1,
-      "expected": { "decision": "ALLOW", "window_start": 1730000061, "count": 1 }
-    },
-    {
-      "id": "tt-velocity-backward-evaluation",
-      "intent_timestamp": 1729999999,
-      "evaluation_time": 1729999999,
-      "stored_window_start": 1730000000,
-      "window_seconds": 60,
-      "current_count": 0,
-      "max_actions": 1,
-      "expected": { "decision": "DENY", "reason": "STATE_INVALID" }
-    },
-    {
-      "id": "tt-velocity-malformed-window-start",
-      "intent_timestamp": 1730000000,
-      "evaluation_time": 1730000000,
-      "stored_window_start": -1,
-      "window_seconds": 60,
-      "current_count": 0,
-      "max_actions": 1,
-      "expected": { "decision": "DENY", "reason": "STATE_INVALID" }
-    },
-    {
-      "id": "tt-velocity-deterministic",
-      "repeat": 2,
-      "intent_timestamp": 1729999990,
-      "evaluation_time": 1730000000,
-      "stored_window_start": 1729999990,
-      "window_seconds": 60,
-      "current_count": 0,
-      "max_actions": 2,
-      "expected": { "decision": "ALLOW", "window_start": 1729999990, "count": 1, "identical_result": true }
-    }
-  ],
+  "schema_version": "1.0.0",
+  "description": "Strict trusted-time conformance vectors. Every active vector is release-blocking. Pending vectors describe unsupported normative categories and never count as passing.",
   "vectors": [
-    {
-      "id": "tt-neg-001",
-      "mode": "future-dated-authorization",
-      "description": "V1 — intent future-dated ~100y beyond trusted time; freshness gate must deny before issuance.",
-      "input": {
-        "evaluation_time": 1730000000,
-        "intent": { "timestamp": 4883600000, "nonce": "n1", "action": "a1" },
-        "preconditions": []
-      },
-      "expected": {
-        "decision": "DENY",
-        "status": "denied",
-        "violations": [
-          { "code": "INTENT_FRESHNESS_FUTURE", "provisional": true, "message": "intent.timestamp > evaluation_time + maxClockSkew; no issued_at/expiry minted" }
-        ]
-      }
-    },
-    {
-      "id": "tt-neg-002",
-      "mode": "replay-fresh-intent-retained-nonce",
-      "description": "V2 — fresh intent (within maxClockSkew) reuses nonce n7 still retained under trusted evaluation_time; the replay gate denies. Fresh timestamp isolates replay from the freshness gate.",
-      "input": {
-        "evaluation_time": 1730000005,
-        "intent": { "timestamp": 1730000005, "nonce": "n7", "action": "a1" },
-        "preconditions": [
-          { "event": "nonce_seen", "nonce": "n7", "at_evaluation_time": 1730000000, "retained_until": 1730000600 }
-        ]
-      },
-      "expected": {
-        "decision": "DENY",
-        "status": "denied",
-        "violations": [
-          { "code": "REPLAY_NONCE", "provisional": true, "message": "nonce n7 still retained at evaluation_time 1730000005 (< retained_until 1730000600); reuse denied" }
-        ]
-      }
-    },
-    {
-      "id": "tt-neg-003",
-      "mode": "velocity-fresh-intent-active-window",
-      "description": "V3 — fresh intent (within maxClockSkew); trusted evaluation_time is still inside the active velocity window, so the second action is denied. Fresh timestamp isolates velocity from the freshness gate.",
-      "input": {
-        "evaluation_time": 1730000005,
-        "intent": { "timestamp": 1730000005, "nonce": "n2", "action": "a2" },
-        "preconditions": [
-          { "event": "action_consumed_slot", "action": "a1", "at_evaluation_time": 1730000000, "window": [1730000000, 1730000060], "count": 1 }
-        ]
-      },
-      "expected": {
-        "decision": "DENY",
-        "status": "denied",
-        "violations": [
-          { "code": "VELOCITY_EXCEEDED", "provisional": true, "message": "second action at evaluation_time 1730000005 still inside window [T0, T0+60); maxActions=1 exceeded" }
-        ]
-      }
-    },
-    {
-      "id": "tt-neg-004",
-      "mode": "freshness-precedes-replay",
-      "description": "V4 (evaluation order) — a future-dated intent that would ALSO be a replay (nonce n7 still retained). The freshness gate is evaluated first, so the reason is INTENT_FRESHNESS_FUTURE, not REPLAY_NONCE. Pins the ordering: freshness before replay and velocity.",
-      "input": {
-        "evaluation_time": 1730000005,
-        "intent": { "timestamp": 1730600010, "nonce": "n7", "action": "a1" },
-        "preconditions": [
-          { "event": "nonce_seen", "nonce": "n7", "at_evaluation_time": 1730000000, "retained_until": 1730000600 }
-        ]
-      },
-      "expected": {
-        "decision": "DENY",
-        "status": "denied",
-        "violations": [
-          { "code": "INTENT_FRESHNESS_FUTURE", "provisional": true, "message": "intent.timestamp > evaluation_time + maxClockSkew; freshness denies before replay is evaluated, even though nonce n7 is retained" }
-        ]
-      }
-    },
-    {
-      "id": "tt-neg-005",
-      "mode": "stale-dated-authorization",
-      "description": "V5 (mirrors V1 for the stale direction) — intent staler than maxIntentAgeSeconds; freshness gate must deny before issuance.",
-      "input": {
-        "evaluation_time": 1730000000,
-        "intent": { "timestamp": 1729999400, "nonce": "n3", "action": "a1" },
-        "preconditions": []
-      },
-      "expected": {
-        "decision": "DENY",
-        "status": "denied",
-        "violations": [
-          { "code": "INTENT_STALE", "provisional": true, "message": "evaluation_time - intent.timestamp = 600 > maxIntentAgeSeconds (300); intent too stale, no issued_at/expiry minted" }
-        ]
-      }
-    },
-    {
-      "id": "tt-neg-006",
-      "mode": "freshness-precedes-replay-stale",
-      "description": "V6 (evaluation order, mirrors V4 for the stale direction) — a stale intent that would ALSO be a replay (nonce n7 still retained). The freshness gate is evaluated first, so the reason is INTENT_STALE, not REPLAY_NONCE. Pins the ordering for the stale direction: freshness before replay and velocity.",
-      "input": {
-        "evaluation_time": 1730000005,
-        "intent": { "timestamp": 1729999400, "nonce": "n7", "action": "a1" },
-        "preconditions": [
-          { "event": "nonce_seen", "nonce": "n7", "at_evaluation_time": 1730000000, "retained_until": 1730000600 }
-        ]
-      },
-      "expected": {
-        "decision": "DENY",
-        "status": "denied",
-        "violations": [
-          { "code": "INTENT_STALE", "provisional": true, "message": "evaluation_time - intent.timestamp = 605 > maxIntentAgeSeconds (300); freshness denies before replay is evaluated, even though nonce n7 is retained" }
-        ]
-      }
-    },
-    {
-      "id": "tt-pos-001",
-      "mode": "honest-fresh-authorization",
-      "description": "P1 (mirrors V1) — honest intent within maxClockSkew; freshness gate passes and issuance proceeds from trusted time.",
-      "input": {
-        "evaluation_time": 1730000000,
-        "intent": { "timestamp": 1730000030, "nonce": "p1", "action": "a1" },
-        "preconditions": []
-      },
-      "expected": {
-        "decision": "ALLOW",
-        "status": "ok",
-        "issued_at": 1730000000,
-        "expiry": 1730000060,
-        "expiry_rule": "evaluation_time + maxTtlSeconds (60)",
-        "violations": []
-      }
-    },
-    {
-      "id": "tt-pos-002",
-      "mode": "new-nonce-inside-retention",
-      "description": "P2 (mirrors V2) — a distinct unused nonce inside the retention window is not a replay; retention must not block legitimate new actions.",
-      "input": {
-        "evaluation_time": 1730000005,
-        "intent": { "timestamp": 1730000005, "nonce": "n8", "action": "a1" },
-        "preconditions": [
-          { "event": "nonce_seen", "nonce": "n7", "at_evaluation_time": 1730000000, "retained_until": 1730000600 }
-        ]
-      },
-      "expected": {
-        "decision": "ALLOW",
-        "status": "ok",
-        "violations": []
-      }
-    },
-    {
-      "id": "tt-pos-003",
-      "mode": "velocity-after-trusted-window-expiry",
-      "description": "P3 (mirrors V3) — the window legitimately reset because enough trusted time elapsed; the sharp contrast to V3 (same 'window looks expired' surface, opposite trusted-time truth).",
-      "input": {
-        "evaluation_time": 1730000065,
-        "intent": { "timestamp": 1730000065, "nonce": "p3", "action": "a2" },
-        "preconditions": [
-          { "event": "action_consumed_slot", "action": "a1", "at_evaluation_time": 1730000000, "window": [1730000000, 1730000060], "count": 1 }
-        ]
-      },
-      "expected": {
-        "decision": "ALLOW",
-        "status": "ok",
-        "violations": []
-      }
-    },
-    {
-      "id": "tt-pos-004",
-      "mode": "honest-recent-authorization",
-      "description": "P4 (mirrors V5) — honest intent slightly in the past but within maxIntentAgeSeconds; the freshness gate passes and issuance proceeds entirely from trusted time. Stale-side complement to P1 (which sits on the future side of the band).",
-      "input": {
-        "evaluation_time": 1730000000,
-        "intent": { "timestamp": 1729999750, "nonce": "p4", "action": "a1" },
-        "preconditions": []
-      },
-      "expected": {
-        "decision": "ALLOW",
-        "status": "ok",
-        "issued_at": 1730000000,
-        "expiry": 1730000060,
-        "expiry_rule": "evaluation_time + maxTtlSeconds (60); issuance derives entirely from trusted evaluation_time, independent of how far intent.timestamp lags within the freshness band",
-        "violations": []
-      }
-    }
+    {"id":"tt-issuance-before","category":"authorization_issuance","status":"active","description":"Fresh intent before evaluation time.","input":{"intent_timestamp":1729999990,"evaluation_time":1730000000,"effective_ttl":60,"authorization_action":"EXECUTE"},"expected":{"decision":"ALLOW","reasons":[],"authorization_issued_at":1730000000,"authorization_expiry":1730000060}},
+    {"id":"tt-issuance-equal","category":"authorization_issuance","status":"active","description":"Intent and evaluation clocks equal.","input":{"intent_timestamp":1730000000,"evaluation_time":1730000000,"effective_ttl":60,"authorization_action":"EXECUTE"},"expected":{"decision":"ALLOW","reasons":[],"authorization_issued_at":1730000000,"authorization_expiry":1730000060}},
+    {"id":"tt-issuance-after","category":"authorization_issuance","status":"active","description":"Fresh intent after evaluation time.","input":{"intent_timestamp":1730000010,"evaluation_time":1730000000,"effective_ttl":60,"authorization_action":"EXECUTE"},"expected":{"decision":"ALLOW","reasons":[],"authorization_issued_at":1730000000,"authorization_expiry":1730000060}},
+    {"id":"tt-noninterference-earlier","category":"authorization_issuance","status":"active","description":"Earlier freshness-valid intent has the trusted issuance window.","comparison_group":"issuance-intent-noninterference","input":{"intent_timestamp":1729999980,"evaluation_time":1730000000,"effective_ttl":60,"authorization_action":"EXECUTE"},"expected":{"decision":"ALLOW","reasons":[],"authorization_issued_at":1730000000,"authorization_expiry":1730000060}},
+    {"id":"tt-noninterference-later","category":"authorization_issuance","status":"active","description":"Later freshness-valid intent has the trusted issuance window.","comparison_group":"issuance-intent-noninterference","input":{"intent_timestamp":1730000020,"evaluation_time":1730000000,"effective_ttl":60,"authorization_action":"EXECUTE"},"expected":{"decision":"ALLOW","reasons":[],"authorization_issued_at":1730000000,"authorization_expiry":1730000060}},
+    {"id":"tt-evaluation-sensitivity-first","category":"authorization_issuance","status":"active","description":"First trusted evaluation time.","comparison_group":"issuance-evaluation-sensitivity","input":{"intent_timestamp":1730000000,"evaluation_time":1730000000,"effective_ttl":60,"authorization_action":"EXECUTE"},"expected":{"decision":"ALLOW","reasons":[],"authorization_issued_at":1730000000,"authorization_expiry":1730000060}},
+    {"id":"tt-evaluation-sensitivity-second","category":"authorization_issuance","status":"active","description":"Advancing trusted time advances issuance.","comparison_group":"issuance-evaluation-sensitivity","input":{"intent_timestamp":1730000000,"evaluation_time":1730000010,"effective_ttl":60,"authorization_action":"EXECUTE"},"expected":{"decision":"ALLOW","reasons":[],"authorization_issued_at":1730000010,"authorization_expiry":1730000070}},
+    {"id":"tt-release-issuance","category":"authorization_issuance","status":"active","description":"RELEASE uses the shared trusted issuance block.","input":{"intent_timestamp":1730000001,"evaluation_time":1730000000,"effective_ttl":60,"authorization_action":"RELEASE"},"expected":{"decision":"ALLOW","reasons":[],"authorization_issued_at":1730000000,"authorization_expiry":1730000060}},
+    {"id":"tt-freshness-denial","category":"intent_freshness","status":"active","description":"Intent one second beyond future skew denies before issuance.","input":{"intent_timestamp":1730000301,"evaluation_time":1730000000,"max_clock_skew_seconds":300,"max_intent_age_seconds":300},"expected":{"decision":"DENY","reasons":["INTENT_FRESHNESS_FUTURE"]}},
+    {"id":"tt-deterministic","category":"determinism","status":"active","description":"Identical issuance inputs produce identical normalized output.","input":{"intent_timestamp":1730000005,"evaluation_time":1730000000,"effective_ttl":60,"repeat":2},"expected":{"decision":"ALLOW","reasons":[],"authorization_issued_at":1730000000,"authorization_expiry":1730000060,"identical_output":true}},
+    {"id":"tt-invalid-ttl-zero","category":"malformed_configuration","status":"active","description":"Zero fixed issuance TTL is rejected.","input":{"configuration_field":"authorization_ttl_seconds","configuration_value":0},"expected":{"throws":true,"error_includes":"authorization_ttl_seconds"}},
+    {"id":"tt-invalid-verifier-skew-fraction","category":"malformed_configuration","status":"active","description":"Fractional verifier future-issued skew is rejected.","input":{"configuration_field":"maxFutureIssuedAtSkewSeconds","configuration_value":1.5},"expected":{"throws":true,"error_includes":"maxFutureIssuedAtSkewSeconds"}},
+    {"id":"tt-expiry-overflow","category":"protocol_seconds_validation","status":"active","description":"Issuance refuses unsafe expiry arithmetic.","input":{"case":"issuance_expiry_overflow","intent_timestamp":9007199254740932,"evaluation_time":9007199254740932,"effective_ttl":60},"expected":{"throws":true,"error_includes":"safe integer"}},
+    {"id":"tt-protocol-negative-intent","category":"protocol_seconds_validation","status":"active","description":"Negative intent protocol seconds deny.","input":{"case":"intent_timestamp","intent_timestamp":-1,"evaluation_time":1730000000},"expected":{"decision":"DENY","reasons":["STATE_INVALID"]}},
+    {"id":"tt-protocol-fractional-intent","category":"protocol_seconds_validation","status":"active","description":"Fractional intent protocol seconds deny.","input":{"case":"intent_timestamp","intent_timestamp":1729999999.5,"evaluation_time":1730000000},"expected":{"decision":"DENY","reasons":["STATE_INVALID"]}},
+    {"id":"tt-protocol-negative-evaluation","category":"protocol_seconds_validation","status":"active","description":"Negative trusted evaluation time refuses evaluation.","input":{"case":"evaluation_time","intent_timestamp":1730000000,"evaluation_time":-1},"expected":{"throws":true,"error_includes":"evaluationTime"}},
+    {"id":"tt-neg-001","category":"intent_freshness","status":"active","description":"Grossly future-dated intent denies.","input":{"intent_timestamp":4883600000,"evaluation_time":1730000000,"max_clock_skew_seconds":300,"max_intent_age_seconds":300},"expected":{"decision":"DENY","reasons":["INTENT_FRESHNESS_FUTURE"]}},
+    {"id":"tt-neg-005","category":"intent_freshness","status":"active","description":"Stale intent denies.","input":{"intent_timestamp":1729999400,"evaluation_time":1730000000,"max_clock_skew_seconds":300,"max_intent_age_seconds":300},"expected":{"decision":"DENY","reasons":["INTENT_STALE"]}},
+    {"id":"tt-pos-001","category":"intent_freshness","status":"active","description":"Fresh future-side boundary intent passes.","input":{"intent_timestamp":1730000300,"evaluation_time":1730000000,"max_clock_skew_seconds":300,"max_intent_age_seconds":300},"expected":{"decision":"ALLOW","reasons":[]}},
+    {"id":"tt-pos-004","category":"intent_freshness","status":"active","description":"Fresh stale-side boundary intent passes.","input":{"intent_timestamp":1729999700,"evaluation_time":1730000000,"max_clock_skew_seconds":300,"max_intent_age_seconds":300},"expected":{"decision":"ALLOW","reasons":[]}},
+    {"id":"tt-neg-002","category":"replay","status":"active","description":"First use is allowed and immediate replay is denied using persisted nextState.","input":{"replay_window_seconds":600,"max_nonces_per_agent":256,"steps":[{"intent_timestamp":1730000000,"evaluation_time":1730000000,"nonce":"7"},{"intent_timestamp":1730000005,"evaluation_time":1730000005,"nonce":"7"}]},"expected":{"steps":[{"decision":"ALLOW","reasons":[],"nonce_state":[{"nonce":"7","nonce_first_seen_time":1730000000}]},{"decision":"DENY","reasons":["REPLAY_NONCE"],"nonce_state":[{"nonce":"7","nonce_first_seen_time":1730000000}]}]}},
+    {"id":"tt-pos-002","category":"replay","status":"active","description":"A distinct nonce inside retention is allowed and appended.","input":{"replay_window_seconds":600,"max_nonces_per_agent":256,"steps":[{"intent_timestamp":1730000000,"evaluation_time":1730000000,"nonce":"7"},{"intent_timestamp":1730000005,"evaluation_time":1730000005,"nonce":"8"}]},"expected":{"steps":[{"decision":"ALLOW","reasons":[],"nonce_state":[{"nonce":"7","nonce_first_seen_time":1730000000}]},{"decision":"ALLOW","reasons":[],"nonce_state":[{"nonce":"7","nonce_first_seen_time":1730000000},{"nonce":"8","nonce_first_seen_time":1730000005}]}]}},
+    {"id":"tt-neg-004","category":"replay","status":"active","description":"Future freshness denial precedes retained-nonce replay.","input":{"replay_window_seconds":600,"max_nonces_per_agent":256,"initial_nonce_state":[{"nonce":"n7","nonce_first_seen_time":1730000000}],"steps":[{"intent_timestamp":1730600010,"evaluation_time":1730000005,"nonce":"n7"}]},"expected":{"steps":[{"decision":"DENY","reasons":["INTENT_FRESHNESS_FUTURE"],"nonce_state":[{"nonce":"n7","nonce_first_seen_time":1730000000}]}]}},
+    {"id":"tt-neg-006","category":"replay","status":"active","description":"Stale freshness denial precedes retained-nonce replay.","input":{"replay_window_seconds":600,"max_nonces_per_agent":256,"initial_nonce_state":[{"nonce":"n7","nonce_first_seen_time":1730000000}],"steps":[{"intent_timestamp":1729999400,"evaluation_time":1730000005,"nonce":"n7"}]},"expected":{"steps":[{"decision":"DENY","reasons":["INTENT_STALE"],"nonce_state":[{"nonce":"n7","nonce_first_seen_time":1730000000}]}]}},
+    {"id":"tt-replay-future-within-band","category":"replay","status":"active","description":"Freshness-valid future intent cannot evict trusted replay state.","input":{"replay_window_seconds":600,"max_nonces_per_agent":256,"steps":[{"intent_timestamp":1730000000,"evaluation_time":1730000000,"nonce":"9"},{"intent_timestamp":1730000300,"evaluation_time":1730000000,"nonce":"9"}]},"expected":{"steps":[{"decision":"ALLOW","reasons":[],"nonce_state":[{"nonce":"9","nonce_first_seen_time":1730000000}]},{"decision":"DENY","reasons":["REPLAY_NONCE"],"nonce_state":[{"nonce":"9","nonce_first_seen_time":1730000000}]}]}},
+    {"id":"tt-velocity-first","category":"velocity","status":"active","description":"First action starts at trusted time.","input":{"window_seconds":60,"max_actions":1,"steps":[{"intent_timestamp":1730000010,"evaluation_time":1730000000,"nonce":"v1"}]},"expected":{"steps":[{"decision":"ALLOW","reasons":[],"velocity_window_start":1730000000,"velocity_count":1}]}},
+    {"id":"tt-velocity-limit-active","category":"velocity","status":"active","description":"Persisted first action followed by active-window denial.","input":{"window_seconds":60,"max_actions":1,"steps":[{"intent_timestamp":1730000000,"evaluation_time":1730000000,"nonce":"v1"},{"intent_timestamp":1730000001,"evaluation_time":1730000000,"nonce":"v2"}]},"expected":{"steps":[{"decision":"ALLOW","reasons":[],"velocity_window_start":1730000000,"velocity_count":1},{"decision":"DENY","reasons":["VELOCITY_EXCEEDED"],"velocity_window_start":1730000000,"velocity_count":1}]}},
+    {"id":"tt-velocity-future-intent-active","category":"velocity","status":"active","description":"Fresh future intent cannot reset the active window.","input":{"window_seconds":60,"max_actions":1,"initial_velocity":{"velocity_window_start":1730000000,"velocity_count":1},"steps":[{"intent_timestamp":1730000030,"evaluation_time":1730000010,"nonce":"v2"}]},"expected":{"steps":[{"decision":"DENY","reasons":["VELOCITY_EXCEEDED"],"velocity_window_start":1730000000,"velocity_count":1}]}},
+    {"id":"tt-velocity-stale-boundary-active","category":"velocity","status":"active","description":"Fresh stale-boundary intent cannot reset the active window.","input":{"window_seconds":60,"max_actions":1,"initial_velocity":{"velocity_window_start":1730000000,"velocity_count":1},"steps":[{"intent_timestamp":1729999710,"evaluation_time":1730000010,"nonce":"v2"}]},"expected":{"steps":[{"decision":"DENY","reasons":["VELOCITY_EXCEEDED"],"velocity_window_start":1730000000,"velocity_count":1}]}},
+    {"id":"tt-velocity-before-boundary","category":"velocity","status":"active","description":"Just before boundary remains exhausted.","input":{"window_seconds":60,"max_actions":1,"initial_velocity":{"velocity_window_start":1730000000,"velocity_count":1},"steps":[{"intent_timestamp":1730000059,"evaluation_time":1730000059,"nonce":"v2"}]},"expected":{"steps":[{"decision":"DENY","reasons":["VELOCITY_EXCEEDED"],"velocity_window_start":1730000000,"velocity_count":1}]}},
+    {"id":"tt-velocity-exact-boundary","category":"velocity","status":"active","description":"Exact boundary resets at trusted time.","input":{"window_seconds":60,"max_actions":1,"initial_velocity":{"velocity_window_start":1730000000,"velocity_count":1},"steps":[{"intent_timestamp":1730000030,"evaluation_time":1730000060,"nonce":"v2"}]},"expected":{"steps":[{"decision":"ALLOW","reasons":[],"velocity_window_start":1730000060,"velocity_count":1}]}},
+    {"id":"tt-velocity-after-boundary","category":"velocity","status":"active","description":"After boundary resets at trusted time.","input":{"window_seconds":60,"max_actions":1,"initial_velocity":{"velocity_window_start":1730000000,"velocity_count":1},"steps":[{"intent_timestamp":1730000061,"evaluation_time":1730000061,"nonce":"v2"}]},"expected":{"steps":[{"decision":"ALLOW","reasons":[],"velocity_window_start":1730000061,"velocity_count":1}]}},
+    {"id":"tt-velocity-backward-evaluation","category":"velocity","status":"active","description":"Backward trusted time fails closed.","input":{"window_seconds":60,"max_actions":1,"initial_velocity":{"velocity_window_start":1730000000,"velocity_count":0},"steps":[{"intent_timestamp":1729999999,"evaluation_time":1729999999,"nonce":"v2"}]},"expected":{"steps":[{"decision":"DENY","reasons":["STATE_INVALID"],"velocity_window_start":1730000000,"velocity_count":0}]}},
+    {"id":"tt-velocity-malformed-window-start","category":"velocity","status":"active","description":"Negative stored start fails closed.","input":{"window_seconds":60,"max_actions":1,"initial_velocity":{"velocity_window_start":-1,"velocity_count":0},"steps":[{"intent_timestamp":1730000000,"evaluation_time":1730000000,"nonce":"v2"}]},"expected":{"steps":[{"decision":"DENY","reasons":["STATE_INVALID"],"velocity_window_start":-1,"velocity_count":0}]}},
+    {"id":"tt-velocity-deterministic","category":"determinism","status":"active","description":"Repeated velocity sequence is deterministic.","input":{"kind":"velocity_sequence","repeat":2,"window_seconds":60,"max_actions":2,"initial_velocity":{"velocity_window_start":1729999990,"velocity_count":0},"steps":[{"intent_timestamp":1729999990,"evaluation_time":1730000000,"nonce":"vd1"}]},"expected":{"identical_output":true}},
+    {"id":"tt-neg-003","category":"velocity","status":"active","description":"Legacy active-window case is executable.","input":{"window_seconds":60,"max_actions":1,"initial_velocity":{"velocity_window_start":1730000000,"velocity_count":1},"steps":[{"intent_timestamp":1730000005,"evaluation_time":1730000005,"nonce":"v3"}]},"expected":{"steps":[{"decision":"DENY","reasons":["VELOCITY_EXCEEDED"],"velocity_window_start":1730000000,"velocity_count":1}]}},
+    {"id":"tt-pos-003","category":"velocity","status":"active","description":"Trusted time after expiry resets the window.","input":{"window_seconds":60,"max_actions":1,"initial_velocity":{"velocity_window_start":1730000000,"velocity_count":1},"steps":[{"intent_timestamp":1730000065,"evaluation_time":1730000065,"nonce":"v4"}]},"expected":{"steps":[{"decision":"ALLOW","reasons":[],"velocity_window_start":1730000065,"velocity_count":1}]}},
+    {"id":"tt-auth-verify-future-boundary","category":"authorization_verification","status":"active","description":"Issued-at exactly at verifier skew boundary is accepted.","input":{"authorization_issued_at":1730000300,"authorization_expiry":1730000360,"verifier_time":1730000000,"max_future_issued_at_skew_seconds":300},"expected":{"status":"ok","violation_codes":[]}},
+    {"id":"tt-auth-verify-future-implausible","category":"authorization_verification","status":"active","description":"Issued-at beyond verifier skew is rejected.","input":{"authorization_issued_at":1730000301,"authorization_expiry":1730000361,"verifier_time":1730000000,"max_future_issued_at_skew_seconds":300},"expected":{"status":"invalid","violation_codes":["AUTH_ISSUED_AT_IMPLAUSIBLE"]}},
+    {"id":"tt-auth-verify-expiry-boundary","category":"authorization_verification","status":"active","description":"Verifier time at expiry rejects.","input":{"authorization_issued_at":1729999940,"authorization_expiry":1730000000,"verifier_time":1730000000,"max_future_issued_at_skew_seconds":300},"expected":{"status":"invalid","violation_codes":["AUTH_EXPIRED"]}},
+    {"id":"tt-tool-window-trusted-time","category":"tool_window","status":"pending","blocked_by":"https://github.com/oxdeai/oxdeai/issues/213","description":"Tool-call windows must eventually use trusted evaluation time.","input":{"intent_timestamp":1730000300,"evaluation_time":1730000000,"tool_window_start":1730000000,"window_seconds":60},"expected":{"decision":"DENY","reasons":["TOOL_CALL_LIMIT_EXCEEDED"]}}
   ]
 }


### PR DESCRIPTION
## Summary

Makes the trusted-time conformance family strict, executable, stateful, and release-blocking.

This PR converts `packages/conformance/vectors/trusted-time.json` from a partially executed fixture into a validated conformance contract covering trusted-time behavior across policy evaluation, authorization issuance, authorization verification, replay state, and velocity state.

Closes #194

## Problem

The trusted-time vector file previously contained 32 vector IDs, but execution coverage was fragmented:

- 12 authorization issuance vectors were executed;
- 10 isolated velocity vectors were executed;
- 10 generic positive and negative vectors were present but not executed;
- replay and velocity behavior was not evaluated as persisted multi-step sequences;
- trusted-time validation was not included in `test:vectors:all`;
- malformed vector structure could be accepted without strict schema validation;
- active-vector regressions were not consistently release-blocking.

This allowed the fixture inventory and the executable conformance surface to diverge.

## Changes

### Strict versioned vector schema

Defines and validates a single trusted-time schema with:

- explicit `schema_version`;
- category-discriminated vector inputs;
- explicit `active` and `pending` status;
- mandatory `blocked_by` for pending vectors;
- unique IDs across the complete file;
- strict protocol-second validation;
- exact public reason-code validation;
- rejection of unknown fields, categories, and status values.

Validation rejects:

- missing or duplicate IDs;
- unknown categories;
- unknown reason codes;
- pending vectors without a blocker;
- strings used as protocol seconds;
- fractional values;
- negative values where prohibited;
- non-finite values;
- unsafe integers;
- unsupported or unexpected fields.

No numeric coercion is performed.

### Executable trusted-time categories

The TypeScript reference executor now runs active vectors for:

| Category | Active |
|---|---:|
| `authorization_issuance` | 8 |
| `authorization_verification` | 3 |
| `determinism` | 2 |
| `intent_freshness` | 5 |
| `malformed_configuration` | 2 |
| `protocol_seconds_validation` | 4 |
| `replay` | 5 |
| `velocity` | 11 |
| **Total** | **40** |

All 32 original vector IDs remain represented. Nine vectors were added, resulting in:

```text
active=40 passed=40 failed=0 pending=1
```

## Stateful replay and velocity execution

Replay and velocity cases now execute as deterministic sequences.

For each step, the harness:

1. starts from the declared initial state;
2. evaluates through the real reference implementation;
3. compares the exact decision and ordered reason list;
4. compares authorization and state-transition fields where applicable;
5. propagates the exact returned `nextState` into the next step;
6. preserves the previous state after a denial;
7. reports the vector ID, step index, intent timestamp, and evaluation time on failure.

Coverage includes:

- first nonce use followed by immediate replay denial;
- replay retention and trusted-time pruning;
- nonce timestamping from `evaluation_time`;
- future-dated intent noninterference;
- first velocity action and active-window exhaustion;
- intent timestamp changes that cannot reset a velocity window;
- just-before, exact, and after-boundary behavior;
- backward trusted time failing closed;
- deterministic repeated execution.

## Authorization verification coverage

Adds executable trusted-time checks for:

- future `issued_at` exactly at the accepted skew boundary;
- implausible future `issued_at`;
- strict expiration at `verifier_time == authorization_expiry`.

## Explicit pending behavior

One unsupported category remains pending:

```text
tt-tool-window-trusted-time
````

It is blocked by:

```text
#213 P2: Drive tool-call windows from trusted evaluation time
```

Pending vectors:

* are validated;
* are reported separately;
* do not execute;
* cannot count as passing;
* do not hide unsupported normative behavior.

The vector must become active when #213 migrates `ToolAmplificationModule` window accounting to trusted `PolicyEvaluationContext.evaluationTime`.

## Release-blocking integration

Trusted-time conformance now runs through:

```bash
pnpm test:vectors:trusted-time
pnpm -C packages/conformance validate
pnpm test:vectors:all
```

It is therefore included in the repository's existing:

* pull-request conformance validation;
* aggregate vector validation;
* conformance package release validation.

Any failing active trusted-time vector produces a non-zero exit code.

## Controlled regression proof

A temporary local mutation changed the expected result of `tt-neg-001` to `ALLOW`.

Both primary validation paths failed as required:

```text
pnpm -C packages/conformance validate
exit: 1
FAIL tt-neg-001
```

```text
pnpm test:vectors:all
exit: 1
active=40 passed=39 failed=1 pending=1
```

The fixture was restored immediately and both commands passed afterward.

No intentional corruption remains in the diff.

## Cross-language scope

Go and Python currently execute zero trusted-time vectors because their harnesses do not expose the reference `PolicyEngine` trusted-time evaluation or strict authorization-verification surfaces.

This PR does not emulate unsupported engine behavior in those runtimes.

Their existing suites remain enabled and passing:

* 11 canonicalization vectors;
* 8 Profile C vectors;
* 9 SignedKRLV1 vectors.

## Compatibility and API impact

No production runtime behavior or public API is changed.

This PR does not modify:

* `AuthorizationV1`;
* `DelegationV1`;
* `SignedKRLV1`;
* `canonicalization-v1`;
* signing or verification algorithms;
* policy semantics;
* trusted-time runtime behavior;
* public package exports;
* API reports;
* API fingerprints.

The change is limited to conformance fixtures, execution infrastructure, package scripts, and conformance documentation.

## Validation

Passed:

```text
pnpm install --frozen-lockfile
pnpm -C packages/conformance test
pnpm -C packages/conformance validate
pnpm test:vectors:trusted-time
pnpm test:vectors:all
pnpm test:vectors:py
pnpm test:vectors:go
pnpm typecheck
pnpm test
pnpm api:check
pnpm api:guard:test
pnpm api:fingerprint:check
pnpm security:gate
git diff --check
```

Key results:

```text
Trusted-time: active=40 passed=40 failed=0 pending=1
Aggregate conformance: 255 assertions passed
API compatibility guard: 8 tests passed
Security gate: ALLOW
Findings: 0
Blocking findings: 0
Warnings: 0
```

## Files changed

* `docs/spec/conformance/conformance-v1.md`
* `package.json`
* `packages/conformance/package.json`
* `packages/conformance/src/validate.ts`
* `packages/conformance/src/trustedTimeConformance.ts`
* `packages/conformance/src/trustedTimeConformance.test.ts`
* `packages/conformance/src/validate-trusted-time.ts`
* `packages/conformance/vectors/trusted-time.json`

## Security invariant

Caller-controlled intent timestamps must not influence trusted authorization issuance, replay retention, replay eviction, nonce stamping, or velocity-window progression.

Trusted-time regressions in any active vector now block validation and release.
