### PR TITLE
fix(deps): resolve newly disclosed security advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,13 +49,14 @@
       "langsmith": "0.7.1",
       "minimatch": ">=10.2.3",
       "lodash": ">=4.18.0",
-      "brace-expansion": ">=5.0.8",
+      "brace-expansion": ">=5.0.9",
       "ws": "8.21.1",
       "uuid": "14.0.0",
       "basic-ftp": ">=5.3.0",
-      "fast-uri": ">=3.1.4",
+      "fast-uri": ">=4.1.2",
       "form-data": "4.0.6",
-      "js-yaml": ">=5.2.2"
+      "js-yaml": ">=5.2.2",
+      "ip-address": ">=10.3.1"
     }
   },
   "type": "module"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,13 +8,14 @@ overrides:
   langsmith: 0.7.1
   minimatch: '>=10.2.3'
   lodash: '>=4.18.0'
-  brace-expansion: '>=5.0.8'
+  brace-expansion: '>=5.0.9'
   ws: 8.21.1
   uuid: 14.0.0
   basic-ftp: '>=5.3.0'
-  fast-uri: '>=3.1.4'
+  fast-uri: '>=4.1.2'
   form-data: 4.0.6
   js-yaml: '>=5.2.2'
+  ip-address: '>=10.3.1'
 
 importers:
 
@@ -896,8 +897,8 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   buffer-crc32@0.2.13:
@@ -1106,8 +1107,8 @@ packages:
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
@@ -1216,8 +1217,8 @@ packages:
     resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
     engines: {node: '>=12.22.0'}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
     engines: {node: '>= 12'}
 
   is-arrayish@0.2.1:
@@ -2019,7 +2020,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2089,7 +2090,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2299,7 +2300,7 @@ snapshots:
 
   fast-fifo@1.3.2: {}
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fd-slicer@1.1.0:
     dependencies:
@@ -2426,7 +2427,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ip-address@10.2.0: {}
+  ip-address@10.4.0: {}
 
   is-arrayish@0.2.1: {}
 
@@ -2485,7 +2486,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -2723,7 +2724,7 @@ snapshots:
 
   socks@2.8.8:
     dependencies:
-      ip-address: 10.2.0
+      ip-address: 10.4.0
       smart-buffer: 4.2.0
 
   source-map@0.6.1: {}


### PR DESCRIPTION
## Summary

Resolve five newly disclosed security findings that caused the repository security gate to fail on both `main` and unrelated pull requests.

This change updates the root pnpm overrides and lockfile resolutions for three vulnerable transitive dependencies:

- `fast-uri` from `4.1.1` to `4.1.2`
- `brace-expansion` from `5.0.8` to `5.0.9`
- `ip-address` from `10.2.0` to `10.4.0`

## Findings resolved

- High-severity `fast-uri` host-confusion advisory
- High-severity `ip-address` leading-zero address parsing advisory
- Two moderate `ip-address` classification advisories
- High-severity `brace-expansion` denial-of-service advisory

## Dependency paths

The affected dependencies are transitive development dependencies reached through:

- `@microsoft/api-extractor` and `ajv`
- `@microsoft/api-extractor` and `minimatch`
- `puppeteer`, proxy agents, and `socks`

No production source, protocol artifact, schema, API, or runtime behavior was modified.

## Changes

- Raise the `fast-uri` override to `>=4.1.2`
- Raise the `brace-expansion` override to `>=5.0.9`
- Add an `ip-address` override at `>=10.3.1`
- Regenerate `pnpm-lock.yaml`

## Validation

- `pnpm security:audit && pnpm security:gate`
  - Findings: 0
  - Blocking: 0
  - Decision: ALLOW
- `pnpm typecheck`
- `pnpm test`
- `git diff --check`

All validation passed.

## Scope

This is a narrow dependency-security correction intended to restore the security gate on `main` and unblock unrelated pull requests.