### PR TITLE
docs(architecture): clarify Tier 1 state mutation semantics

### DIFF
--- a/docs/architecture/decisions/tier1-evaluator-input-provenance.md
+++ b/docs/architecture/decisions/tier1-evaluator-input-provenance.md
@@ -198,16 +198,58 @@ These properties remain distinct:
 
 | Property | Tier 1 source |
 |---|---|
-| Snapshot integrity or consistency | `state_hash` binds the authorization to the evaluated snapshot |
-| Provider authority | Guard-selected and deployment-authenticated provider |
+| Snapshot binding | `state_hash` binds the authorization to the evaluated snapshot |
+| Provider authority | Trusted provider selection and authentication |
 | Freshness | Provider consistency guarantees and version policy |
-| Version consistency | Validated version returned with the read |
-| Atomic transition | Exact-version CAS or equivalent conflict rejection |
-| Authorization binding | Existing signed authorization fields and verification |
+| Version consistency | Expected-version validation |
+| Atomic transition | CAS or equivalent atomic mutation |
+| Caller authority | Authenticated principal and authorization mapping |
+| Operator authority | Authenticated privileged mutation path |
+| Execution safety | Successful verification and CAS before execution |
 
 A matching `state_hash` does not prove that the provider was authoritative or
 the snapshot latest. Successful CAS does not authenticate the provider. This
 ADR does not prescribe the final StateProvider TypeScript interface.
+
+### Relationship to Profile C
+
+Tier 1 wraps and extends the existing versioned guard/Profile C state-provider
+contract with provenance controls: authoritative provider selection, provider
+identity validation, authenticated tenant or namespace binding, guard ownership
+of reads and transitions, and exact-version conflict rejection before protected
+execution. It does not introduce a competing state model.
+
+The normative [State Provider Requirements](../../spec/state-provider-requirements.md)
+remain the source of Profile C provider, versioning, and CAS obligations. This
+ADR records architectural ownership and trust boundaries; it does not replace
+or redefine that provider contract. A later secure-path API must conform to the
+normative requirements. If implementation requires different Profile C
+interfaces or guarantees, those changes require a dedicated specification
+change rather than reinterpretation through this ADR.
+
+### One version domain for guard and operator mutations
+
+Policy-driven guard transitions and operator-initiated maintenance mutations
+use the same authoritative StateProvider and version domain. A privileged
+operator operation may enter through a separate authenticated administrative
+API, but it cannot use a separate consistency model or bypass provider
+versioning through a direct or out-of-band storage rewrite.
+
+Period rollover, administrative correction, concurrency-lease reclamation,
+and similar maintenance operations therefore require an authenticated
+privileged operation, the authoritative provider, an exact expected version,
+and CAS or an equivalent atomic conflict-rejection primitive. If an operator
+mutation races a guard transition, only one commits and the loser observes a
+version conflict. A failed guard CAS prevents protected execution; a subsequent
+authorization attempt begins with a fresh authoritative state and version read.
+
+Reclamation of expired `active_auths` leases is tracked separately by
+[#227](https://github.com/oxdeai/oxdeai/issues/227). Its final owner and
+algorithm remain unresolved. Whether reclamation is automatic,
+operator-initiated, or provider-managed, a future implementation uses trusted
+`evaluationTime` and the same authoritative versioned mutation path. This ADR
+does not implement or resolve reclamation, and lease reclamation remains
+distinct from the approval/workflow semantics tracked by #218.
 
 ## Authoritative Policy
 
@@ -392,6 +434,11 @@ selection must be protected from proposer influence. A rolling deployment must
 not advertise Tier 1 while requests can reach older guards that interpret the
 same inputs as self-declared. Secure profiles require authenticated transport.
 
+Migration must also place existing administrative and maintenance writers in
+the authoritative provider's version domain. Direct database or storage
+rewrites that do not participate in provider versioning do not satisfy Tier 1,
+even when they are initiated by an operator.
+
 ## Reason-Code Implications
 
 The current public reason registry does not precisely classify every new
@@ -413,6 +460,11 @@ does not invent names or modify the registry.
 
 - [#197](https://github.com/oxdeai/oxdeai/issues/197) governs this provenance
   architecture and remains open for implementation.
+- [#227](https://github.com/oxdeai/oxdeai/issues/227) separately tracks
+  expiration and reclamation of concurrency leases stored in `active_auths`.
+  It touches the same state object as #218 but has a distinct scope:
+  #218 concerns approval/workflow semantics, while #227 concerns lease
+  lifecycle, expiry, and capacity reclamation.
 - [#214](https://github.com/oxdeai/oxdeai/issues/214) is dependent: default-deny
   tool policy requires trusted tool identity, then a separate schema and policy
   decision.
@@ -480,4 +532,3 @@ An implementation satisfies this decision only when:
 - the adapter selected before authorization is the adapter that executes;
 - secure and legacy guarantees are not conflated; and
 - existing protocol artifacts and canonicalization remain unchanged.
-

--- a/docs/integrations/policy-state-modeling.md
+++ b/docs/integrations/policy-state-modeling.md
@@ -157,6 +157,12 @@ executor, or otherwise reconcile the outcome before issuing a new nonce. This
 does not give `intent_id` replay-protection semantics; it remains an
 application-level correlation convention.
 
+A known CAS conflict occurs before protected execution in the guard path. The
+losing operation should re-read authoritative state and its new version before
+attempting a new authorization. That state-transition retry is distinct from
+blindly retrying an operation whose execution outcome is unknown, and does not
+by itself require minting a new execution nonce.
+
 This is also the sharpest illustration of the trusted-input principle above.
 `ReplayModule` documents that window eviction is driven exclusively by the
 trusted evaluation clock and never by `intent.timestamp`, because entries are
@@ -176,10 +182,28 @@ is two separate controls rather than one.
 assumption the code does not support: **no policy module reads it.** Outside the
 type definition it appears only in `stateGuards.ts`, which requires it to be
 present and to be a string. Nothing resets `spent_in_period` when it changes.
-Rolling a period is therefore an operator action — write the new `period_id` and
-zero the counters in the same state mutation — and `period_id` serves as the
-label that makes the two epochs distinguishable in the canonical state, not as
-a trigger.
+Rolling a period is therefore an operator action, and `period_id` serves as the
+label that makes two epochs distinguishable in canonical state rather than as a
+trigger. Updating `period_id` and resetting `spent_in_period` describes one
+logical mutation; it is not permission to overwrite provider storage directly.
+
+Under the accepted Tier 1 architecture, rollover uses an authenticated
+privileged operation against the same authoritative provider and version domain
+as guard transitions:
+
+```text
+read current authoritative state and version
+→ construct one atomic rollover mutation
+→ update period_id and reset spent_in_period together
+→ commit with the expected version
+→ reject and retry from a fresh read on conflict
+```
+
+Administrative correction and other operator-initiated state changes follow
+the same pattern. A separate authenticated administrative entry point may be
+used, but direct or out-of-band rewrites that bypass provider versioning do not
+satisfy Tier 1. This guide does not prescribe an operator identity technology,
+role model, provider API, or administrative wire format.
 
 ### Concurrency limits
 
@@ -195,16 +219,29 @@ budget.
 One property to model around: **`active_auths[...].expires_at` is stored and
 validated, but nothing evicts on it.** It is carried through the state codec and
 contributes to the state hash, and no module reads it to reclaim a slot. A
-long-running action whose `RELEASE` never arrives therefore holds its
-concurrency slot until an operator writes the state to reclaim it. An operator
-modeling long-running work owns that sweep; `expires_at` is the timestamp such a
-sweep would key on, not a mechanism that acts on its own.
+long-running action whose `RELEASE` never arrives therefore retains its
+concurrency slot under current runtime behavior.
+
+Expired-lease reclamation is tracked separately by
+[#227](https://github.com/oxdeai/oxdeai/issues/227); its final owner and algorithm
+remain unresolved. Any future automatic, operator-driven, or provider-managed
+reclamation uses trusted `evaluationTime` and the same authoritative provider
+and version domain as guard transitions. It must commit with an exact expected
+version through CAS or equivalent conflict rejection. This guidance does not
+implement reclamation, and the lease problem remains distinct from the
+approval/workflow gap tracked by #218.
 
 ### State versioning
 
 Covered by the CAS pattern above. The specification's §2 and §6 own the
 normative requirements — including that a version token is never null, and is
 not decremented or reset except through an audited rollback.
+
+For Tier 1, the guard and privileged operator mutations share that one
+authoritative version domain. `state_hash` binds an authorization to a snapshot;
+it does not establish provider authority, freshness, or successful mutation.
+CAS establishes atomic conflict handling; it does not authenticate the provider
+or establish authorization provenance.
 
 ### Failure handling
 


### PR DESCRIPTION
## Summary

Clarify the accepted Tier 1 evaluator-input provenance ADR and the policy/state modeling guidance following contributor review on #197.

This documentation follow-up records the relationship between Tier 1, the existing Profile C StateProvider contract, privileged operator mutations, and exact-version CAS.

## Clarifications

### Profile C remains normative

The ADR now states explicitly that:

- Tier 1 wraps and extends the existing versioned guard/Profile C model;
- `docs/spec/state-provider-requirements.md` remains normative for provider, versioning, and CAS obligations;
- the ADR defines architecture and trust-boundary ownership, not a competing provider specification;
- any change to normative Profile C guarantees requires a separate specification PR.

### One authoritative version domain

Guard transitions and privileged operator mutations must use:

- the same authoritative StateProvider;
- the same version domain;
- an exact expected version;
- CAS or an equivalent atomic conflict-rejection primitive.

A separately authenticated administrative API is permitted, but direct database or out-of-band state rewrites do not satisfy Tier 1.

When an operator mutation races a guard transition:

- only one mutation may commit;
- the losing operation observes a version conflict;
- protected execution cannot proceed after a failed guard CAS;
- a subsequent authorization attempt begins from a fresh authoritative read.

### Period rollover

The modeling guidance now defines rollover as one atomic versioned mutation:

```text
read current authoritative state and version
→ construct one atomic rollover mutation
→ update period_id and reset spent_in_period together
→ commit with the expected version
→ reject and retry from a fresh read on conflict
````

The same model applies to administrative corrections and other maintenance writes.

### Retry semantics

The guidance distinguishes:

* pre-authorization retries;
* retries after a known CAS conflict;
* ambiguous execution outcomes.

A known CAS conflict requires a fresh authoritative state and version read. It does not inherently require minting a new execution nonce.

Ambiguous execution outcomes still require reconciliation or application-level idempotency to avoid duplicate execution.

### Expired active_auths leases

#227 remains a separate issue for expired concurrency-lease reclamation.

The ADR and modeling guidance clarify that:

* the final reclaim owner and algorithm remain unresolved;
* any automatic, operator-driven, or provider-managed reclaim must use trusted `evaluationTime`;
* reclaim mutations must use the authoritative provider and version domain;
* #227 remains distinct from the approval/workflow semantics tracked by #218.

## Files changed

* `docs/architecture/decisions/tier1-evaluator-input-provenance.md`
* `docs/integrations/policy-state-modeling.md`

## Compatibility

No changes to:

* runtime behavior;
* public APIs;
* StateProvider interfaces;
* policy semantics;
* reason codes;
* protocol artifacts;
* canonicalization;
* conformance vectors.

The ADR remains Accepted.

## Validation

* `git diff --check`
* Markdown path validation
* `pnpm typecheck`
* documentation-only scope review

All validation passed.

Refs #197
Refs #227
Related to #218

