### PR TITLE
fix(core): reclaim expired concurrency leases and remove released ones

### DIFF
--- a/docs/integrations/policy-state-modeling.md
+++ b/docs/integrations/policy-state-modeling.md
@@ -216,20 +216,25 @@ replay and concurrency only — so release paths are not gated on the same polic
 surface as execution, and a release cannot be starved by, say, an exhausted
 budget.
 
-One property to model around: **`active_auths[...].expires_at` is stored and
-validated, but nothing evicts on it.** It is carried through the state codec and
-contributes to the state hash, and no module reads it to reclaim a slot. A
-long-running action whose `RELEASE` never arrives therefore retains its
-concurrency slot under current runtime behavior.
+`active_auths[...].expires_at` is evicted on. A lease is expired when
+`evaluationTime >= expires_at`, and expired leases are reclaimed during policy
+evaluation rather than by a background sweeper, so a long-running action whose
+`RELEASE` never arrives stops holding its concurrency slot once the lease
+expires. Reclamation uses trusted `evaluationTime` and the same authoritative
+provider and version domain as guard transitions, and the counter and the lease
+map move together in the transition that triggered it, committed through the
+same exact-version CAS ([#227](https://github.com/oxdeai/oxdeai/issues/227)). The
+lease problem remains distinct from the approval/workflow gap tracked by #218.
 
-Expired-lease reclamation is tracked separately by
-[#227](https://github.com/oxdeai/oxdeai/issues/227); its final owner and algorithm
-remain unresolved. Any future automatic, operator-driven, or provider-managed
-reclamation uses trusted `evaluationTime` and the same authoritative provider
-and version domain as guard transitions. It must commit with an exact expected
-version through CAS or equivalent conflict rejection. This guidance does not
-implement reclamation, and the lease problem remains distinct from the
-approval/workflow gap tracked by #218.
+One property to model around: **`active` is an authoritative input, not a value
+derived from `active_auths`.** State must satisfy `active[agent] >=` the number
+of resident entries in `active_auths[agent]`. A counter *above* the tracked
+lease count is intentionally valid — it can represent capacity you account for
+but never lease-track, and reclamation decrements rather than recomputes so that
+capacity survives. A counter *below* it fails closed with `STATE_INVALID`.
+Because a missing `active[agent]` reads as `0`, populating `active_auths`
+without setting `active` denies every call for that agent: set `active`
+explicitly when adopting lease tracking.
 
 ### State versioning
 

--- a/docs/spec/state-provider-requirements.md
+++ b/docs/spec/state-provider-requirements.md
@@ -88,6 +88,25 @@ Concurrent evaluators can still race to consume the same remaining tool quota,
 so providers MUST serialize or reject conflicting updates. An evaluation clock
 behind a persisted call timestamp fails closed with `STATE_INVALID`.
 
+The same requirements apply to concurrency leases. A lease in
+`concurrency.active_auths` is expired when `evaluation_time >= expires_at`, and
+expired leases are reclaimed deterministically during policy evaluation rather
+than by a background sweeper. Reclamation removes the expired entries and
+decrements `concurrency.active` by exactly the number of entries removed, so the
+counter and the lease map MUST be written in the same transition as the
+operation that triggered the reclamation — a provider that commits one without
+the other leaves capacity permanently mis-accounted. Concurrent evaluators can
+read the same leases and each reclaim them, so providers MUST serialize or
+reject all but one through atomic compare-and-set; because reclamation is a pure
+function of the state read and the trusted `evaluation_time`, the rejected
+evaluator recomputes the same transition against the winner's state rather than
+applying a second decrement. A malformed `expires_at` leaf — missing,
+non-finite, non-integer, or negative — fails closed with `STATE_INVALID`.
+
+A separately authenticated privileged provider mutation remains available as an
+operational recovery path (§4.3); it is not the normal path, and deployments
+MUST NOT rely on it to release capacity in ordinary operation.
+
 ### 2.3 Stale replica reads
 
 For Profile C deployments, `getState()` MUST read from the authoritative replica of the state store, not from a potentially stale secondary replica. Reading from a lagging replica can produce a hash that matches an old authorization but not the current authoritative state.

--- a/docs/spec/state-provider-requirements.md
+++ b/docs/spec/state-provider-requirements.md
@@ -103,6 +103,19 @@ evaluator recomputes the same transition against the winner's state rather than
 applying a second decrement. A malformed `expires_at` leaf — missing,
 non-finite, non-integer, or negative — fails closed with `STATE_INVALID`.
 
+The counter is an authoritative input, not a value inferred from the lease map.
+Before any reclamation is applied, state MUST satisfy `concurrency.active[agent]
+>= the number of resident entries in concurrency.active_auths[agent]` for the
+acting agent. A counter above the tracked lease count is intentionally valid — a
+deployment may account capacity in `active` that it never lease-tracked, and
+reclamation decrements rather than recomputes so that capacity keeps being
+counted — while a counter below it offers capacity the resident leases have
+already consumed, and fails closed with `STATE_INVALID`. Because a missing
+`concurrency.active[agent]` entry reads as `0`, a provider that populates
+`active_auths` without setting `active` is under-counted by this rule and its
+agents fail closed; deployments adopting lease tracking MUST set `active`
+explicitly as a migration step rather than relying on it being inferred.
+
 A separately authenticated privileged provider mutation remains available as an
 operational recovery path (§4.3); it is not the normal path, and deployments
 MUST NOT rely on it to release capacity in ordinary operation.

--- a/packages/core/src/policy/PolicyEngine.ts
+++ b/packages/core/src/policy/PolicyEngine.ts
@@ -10,7 +10,6 @@ import { canonicalJson, intentHash, sha256HexFromJson } from "../crypto/hashes.j
 import { engineSignHmac } from "../crypto/sign.js";
 import { engineVerifyHmac } from "../crypto/verify.js";
 import { SIGNING_DOMAINS, signEd25519, signHmacDomain } from "../crypto/signatures.js";
-import { deepMerge } from "../utils/deepMerge.js";
 import { runDecisionModules } from "./decision/index.js";
 
 import { HashChainedLog } from "../audit/HashChainedLog.js";
@@ -24,7 +23,7 @@ import { BudgetModule } from "./modules/BudgetModule.js";
 import { VelocityModule } from "./modules/VelocityModule.js";
 
 import { ReplayModule } from "./modules/ReplayModule.js";
-import { ConcurrencyModule } from "./modules/ConcurrencyModule.js";
+import { ConcurrencyModule, computeConcurrencyLeases } from "./modules/ConcurrencyModule.js";
 import { RecursionDepthModule } from "./modules/RecursionDepthModule.js";
 import { ToolAmplificationModule } from "./modules/ToolAmplificationModule.js";
 import type { StateStore, AuditSink } from "../adapters/types.js";
@@ -524,6 +523,41 @@ export class PolicyEngine {
       // Authorization is bound to the post-decision state snapshot.
       // working carries all module deltas from the decision phase.
       let working = decisionResult.nextState;
+
+      // Materialize the concurrency lease decision as a replacement assignment.
+      //
+      // Module deltas are deep-merged, and deepMerge is additive: a lease map
+      // returned by ConcurrencyModule with an entry omitted merges back onto the
+      // prior map and the omitted entry survives. Reclaiming an expired lease -
+      // and removing a cleanly released one - therefore cannot be expressed from
+      // inside a module without giving the delta protocol generic deletion
+      // semantics, which would change the state transition contract for every
+      // module.
+      //
+      // Instead ConcurrencyModule keeps the decision and the engine assigns the
+      // resulting map here, replacing rather than merging that one path. This
+      // runs inside the same evaluated transition as the triggering operation
+      // and is committed by the same exact-version CAS below, so `active` and
+      // `active_auths` move atomically.
+      //
+      // Computed from `state`, the same pre-delta input the module evaluated
+      // against, and with the same trusted `evaluationTime` - engine and module
+      // cannot diverge because there is only one definition of the decision.
+      const concurrencyLeases = computeConcurrencyLeases(intent, state, evaluationTime);
+      if (concurrencyLeases !== null) {
+        const leaseAgent = intent.agent_id;
+        working = {
+          ...working,
+          concurrency: {
+            ...working.concurrency,
+            active_auths: {
+              ...working.concurrency.active_auths,
+              [leaseAgent]: concurrencyLeases.auths
+            }
+          }
+        };
+      }
+
       const state_snapshot_hash = this.computeStateHashFor(working);
       const issued_at = evaluationTime;
       const expires_at = issued_at + effectiveTtl;
@@ -603,9 +637,12 @@ export class PolicyEngine {
 
       if (t === "EXECUTE") {
         const agent = intent.agent_id;
+        // `working` already carries the reclaimed map assigned above, so the new
+        // lease is added to the post-reclamation set rather than to the stale one.
         const current = working.concurrency.active_auths?.[agent] ?? {};
 
-        working = deepMerge(working, {
+        working = {
+          ...working,
           concurrency: {
             ...working.concurrency,
             active_auths: {
@@ -616,7 +653,7 @@ export class PolicyEngine {
               }
             }
           }
-        });
+        };
       }
 
       this.emitAudit({

--- a/packages/core/src/policy/modules/ConcurrencyModule.ts
+++ b/packages/core/src/policy/modules/ConcurrencyModule.ts
@@ -1,11 +1,102 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Intent } from "../../types/intent.js";
 import type { State } from "../../types/state.js";
-import type { PolicyResult } from "../../types/policy.js";
+import type { PolicyEvaluationContext, PolicyResult } from "../../types/policy.js";
+import { isProtocolSeconds } from "../trustedTimeValidation.js";
 import { statelessModuleCodec } from "./_codec.js";
 
+/**
+ * The resulting `concurrency.active_auths[agent]` map for one evaluation,
+ * plus the accounting needed to keep the scalar `active` counter consistent
+ * with it.
+ *
+ * @public
+ */
+export interface ConcurrencyLeaseTransition {
+  /** The agent's lease map after reclamation and, for a valid RELEASE, removal. */
+  auths: Record<string, { expires_at: number }>;
+  /**
+   * Number of entries removed: expired leases, plus the released lease when
+   * the intent is a RELEASE naming a live lease.
+   */
+  removed: number;
+  /** True when a RELEASE names a lease that is not live at `evaluationTime`. */
+  releaseInvalid: boolean;
+}
+
+/**
+ * computeConcurrencyLeases - the concurrency lease decision for one evaluation.
+ *
+ * A lease is expired, and therefore reclaimable, when
+ *
+ *   evaluationTime >= expires_at
+ *
+ * This is the same strict zero-tolerance boundary AuthorizationV1 uses: at the
+ * exact `expires_at` the lease is no longer live and may be reclaimed.
+ *
+ * Returns `null` when any of the agent's resident leases carries a malformed
+ * `expires_at` (missing, non-finite, non-integer, or negative), so callers fail
+ * closed with `STATE_INVALID`. No "maximum plausible TTL" ceiling is applied -
+ * clock-regression handling must not depend on an implicit deployment
+ * assumption, and no such ceiling is an authoritative policy input today.
+ *
+ * Only the acting agent's leases are read. Another agent's corrupt entry cannot
+ * deny this agent, which keeps one malformed leaf from bricking every agent
+ * sharing the state.
+ *
+ * This is the single definition of the reclamation decision. `PolicyEngine`
+ * calls it with the same `(intent, state, evaluationTime)` to materialize
+ * `auths` as a replacement assignment, because a module `stateDelta` is
+ * deep-merged and so cannot express key removal on its own.
+ *
+ * @public
+ */
+export function computeConcurrencyLeases(
+  intent: Intent,
+  state: State,
+  evaluationTime: number
+): ConcurrencyLeaseTransition | null {
+  const agent = intent.agent_id;
+  const resident = state.concurrency?.active_auths?.[agent] ?? {};
+
+  const auths: Record<string, { expires_at: number }> = {};
+  let removed = 0;
+
+  for (const authId of Object.keys(resident)) {
+    const lease = resident[authId];
+    if (!lease || !isProtocolSeconds(lease.expires_at)) return null;
+
+    if (evaluationTime >= lease.expires_at) {
+      removed += 1;
+      continue;
+    }
+    auths[authId] = lease;
+  }
+
+  if ((intent.type ?? "EXECUTE") !== "RELEASE") {
+    return { auths, removed, releaseInvalid: false };
+  }
+
+  // A RELEASE naming a lease that is absent - fabricated, already released, or
+  // already reclaimed as expired - is a deterministic DENY. Unknown RELEASE
+  // operations are deliberately not idempotent: making them so would require a
+  // separately authenticated tombstone, or equivalent evidence that the lease
+  // once existed, which v1 does not have.
+  const authId = intent.authorization_id;
+  if (!authId || !auths[authId]) {
+    return { auths, removed, releaseInvalid: true };
+  }
+
+  const { [authId]: _released, ...rest } = auths;
+  return { auths: rest, removed: removed + 1, releaseInvalid: false };
+}
+
 /** @public */
-export function ConcurrencyModule(intent: Intent, state: State): PolicyResult {
+export function ConcurrencyModule(
+  intent: Intent,
+  state: State,
+  context: PolicyEvaluationContext
+): PolicyResult {
   const agent = intent.agent_id;
   const t = intent.type ?? "EXECUTE";
 
@@ -14,19 +105,21 @@ export function ConcurrencyModule(intent: Intent, state: State): PolicyResult {
 
   const active = state.concurrency.active?.[agent] ?? 0;
 
+  const leases = computeConcurrencyLeases(intent, state, context.evaluationTime);
+  if (leases === null) return { decision: "DENY", reasons: ["STATE_INVALID"] };
+
+  // Reclaiming N expired leases decrements `active` by exactly N, floored at
+  // zero. The counter is decremented rather than recomputed from the map size:
+  // a deployment that tracks `active` without populating `active_auths` keeps
+  // its existing accounting, so reclamation cannot silently release capacity
+  // that was never lease-tracked.
+  const activeAfterReclaim = Math.max(0, active - leases.removed);
+
   // --- RELEASE path ---
   if (t === "RELEASE") {
-    const authId = intent.authorization_id;
-    if (!authId) return { decision: "DENY", reasons: ["CONCURRENCY_RELEASE_INVALID"] };
-
-    const activeAuths = state.concurrency.active_auths?.[agent] ?? {};
-    if (!activeAuths[authId]) {
+    if (leases.releaseInvalid) {
       return { decision: "DENY", reasons: ["CONCURRENCY_RELEASE_INVALID"] };
     }
-
-    // remove auth + decrement active (never below 0)
-    const { [authId]: _, ...rest } = activeAuths;
-    const nextActive = active > 0 ? active - 1 : 0;
 
     return {
       decision: "ALLOW",
@@ -36,11 +129,11 @@ export function ConcurrencyModule(intent: Intent, state: State): PolicyResult {
           ...state.concurrency,
           active: {
             ...state.concurrency.active,
-            [agent]: nextActive
+            [agent]: activeAfterReclaim
           },
           active_auths: {
             ...state.concurrency.active_auths,
-            [agent]: rest
+            [agent]: leases.auths
           }
         }
       }
@@ -48,7 +141,9 @@ export function ConcurrencyModule(intent: Intent, state: State): PolicyResult {
   }
 
   // --- EXECUTE path ---
-  if (active >= max) {
+  // The limit is checked against the post-reclamation count, so leases whose
+  // holder never sent a RELEASE stop consuming capacity once they expire.
+  if (activeAfterReclaim >= max) {
     return { decision: "DENY", reasons: ["CONCURRENCY_LIMIT_EXCEEDED"] };
   }
 
@@ -60,7 +155,11 @@ export function ConcurrencyModule(intent: Intent, state: State): PolicyResult {
         ...state.concurrency,
         active: {
           ...state.concurrency.active,
-          [agent]: active + 1
+          [agent]: activeAfterReclaim + 1
+        },
+        active_auths: {
+          ...state.concurrency.active_auths,
+          [agent]: leases.auths
         }
       }
     }

--- a/packages/core/src/policy/modules/ConcurrencyModule.ts
+++ b/packages/core/src/policy/modules/ConcurrencyModule.ts
@@ -34,15 +34,19 @@ export interface ConcurrencyLeaseTransition {
  * This is the same strict zero-tolerance boundary AuthorizationV1 uses: at the
  * exact `expires_at` the lease is no longer live and may be reclaimed.
  *
- * Returns `null` when any of the agent's resident leases carries a malformed
- * `expires_at` (missing, non-finite, non-integer, or negative), so callers fail
- * closed with `STATE_INVALID`. No "maximum plausible TTL" ceiling is applied -
- * clock-regression handling must not depend on an implicit deployment
- * assumption, and no such ceiling is an authoritative policy input today.
+ * Returns `null` - so callers fail closed with `STATE_INVALID` - in two cases:
  *
- * Only the acting agent's leases are read. Another agent's corrupt entry cannot
- * deny this agent, which keeps one malformed leaf from bricking every agent
- * sharing the state.
+ *  1. The agent's scalar `active` counter is lower than the number of leases
+ *     actually tracked for it (see the precondition below).
+ *  2. Any of the agent's resident leases carries a malformed `expires_at`
+ *     (missing, non-finite, non-integer, or negative). No "maximum plausible
+ *     TTL" ceiling is applied - clock-regression handling must not depend on an
+ *     implicit deployment assumption, and no such ceiling is an authoritative
+ *     policy input today.
+ *
+ * Only the acting agent's leases and counter are read. Another agent's corrupt
+ * entry cannot deny this agent, which keeps one malformed leaf from bricking
+ * every agent sharing the state.
  *
  * This is the single definition of the reclamation decision. `PolicyEngine`
  * calls it with the same `(intent, state, evaluationTime)` to materialize
@@ -58,11 +62,32 @@ export function computeConcurrencyLeases(
 ): ConcurrencyLeaseTransition | null {
   const agent = intent.agent_id;
   const resident = state.concurrency?.active_auths?.[agent] ?? {};
+  const residentIds = Object.keys(resident);
+
+  // Authoritative-state consistency precondition, evaluated before any
+  // reclamation is applied:
+  //
+  //   active >= number of tracked resident leases
+  //
+  // Equality is deliberately NOT required. `active > tracked` stays valid and
+  // conservative - a deployment may account capacity in `active` that it never
+  // lease-tracked, and that capacity must keep being counted.
+  //
+  // `active < tracked` is incoherent authoritative state and fails closed
+  // rather than being silently normalized. Under-counting hands out capacity
+  // the tracked leases have already consumed: with max_concurrent 1, active 0
+  // and one live tracked lease, an EXECUTE would see zero usage, ALLOW, and
+  // leave two live leases against a limit of one.
+  //
+  // Establishing this here is also what lets the callers subtract without a
+  // floor: removed <= residentIds.length <= active, so active - removed >= 0.
+  const active = state.concurrency?.active?.[agent] ?? 0;
+  if (active < residentIds.length) return null;
 
   const auths: Record<string, { expires_at: number }> = {};
   let removed = 0;
 
-  for (const authId of Object.keys(resident)) {
+  for (const authId of residentIds) {
     const lease = resident[authId];
     if (!lease || !isProtocolSeconds(lease.expires_at)) return null;
 
@@ -108,12 +133,17 @@ export function ConcurrencyModule(
   const leases = computeConcurrencyLeases(intent, state, context.evaluationTime);
   if (leases === null) return { decision: "DENY", reasons: ["STATE_INVALID"] };
 
-  // Reclaiming N expired leases decrements `active` by exactly N, floored at
-  // zero. The counter is decremented rather than recomputed from the map size:
-  // a deployment that tracks `active` without populating `active_auths` keeps
-  // its existing accounting, so reclamation cannot silently release capacity
-  // that was never lease-tracked.
-  const activeAfterReclaim = Math.max(0, active - leases.removed);
+  // Reclaiming N expired leases decrements `active` by exactly N. The counter
+  // is decremented rather than recomputed from the map size: a deployment that
+  // tracks `active` without populating `active_auths` keeps its existing
+  // accounting, so reclamation cannot silently release capacity that was never
+  // lease-tracked.
+  //
+  // No zero floor is needed. computeConcurrencyLeases has already established
+  // active >= resident leases, and removed <= resident leases, so this cannot
+  // go negative. A floor here would mask exactly the under-count state that
+  // precondition now rejects.
+  const activeAfterReclaim = active - leases.removed;
 
   // --- RELEASE path ---
   if (t === "RELEASE") {

--- a/packages/core/src/test/toctou.test.ts
+++ b/packages/core/src/test/toctou.test.ts
@@ -14,6 +14,14 @@
 //   T-8  expired parent delegation  → DELEGATION_PARENT_EXPIRED (chain level)
 //   T-9  delegation scope escape    → DELEGATION_SCOPE_VIOLATION (amount)
 //   T-10 delegation scope escape    → guard blocks tool not in scope
+//   T-11 clean RELEASE removes its own lease, preserves unrelated leases
+//   T-12 expired lease reclaimed during EXECUTE
+//   T-13 exact expires_at boundary is expired
+//   T-14 saturation recovery after abandoned leases
+//   T-15 late RELEASE after reclaim → CONCURRENCY_RELEASE_INVALID
+//   T-16 malformed expires_at fails closed → STATE_INVALID
+//   T-17 reclamation removes only eligible entries
+//   T-18 two evaluators on one version cannot double-decrement
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -226,14 +234,13 @@ test("T-6 RELEASE with unknown authorization_id → CONCURRENCY_RELEASE_INVALID"
   // Tests the fail-closed path for fabricated or already-expired authorization
   // IDs presented to the RELEASE lifecycle.
   //
-  // Observation (not asserted): deepMerge is additive and cannot express key
-  // deletion. The ConcurrencyModule RELEASE path therefore cannot remove the
-  // authorization_id from active_auths via stateDelta — the stale entry
-  // persists across RELEASE. The concurrency `active` counter IS correctly
-  // decremented (scalar leaf overwrite). A second RELEASE with the same
-  // authorization_id and a *different* nonce would be ALLOWED by
-  // ConcurrencyModule (finding the stale entry), but blocked by the
-  // ReplayModule if the same nonce is reused.
+  // The observation that previously sat here — deepMerge is additive, so the
+  // RELEASE path could not remove the authorization_id from active_auths and
+  // the stale entry persisted — was fixed in #227. PolicyEngine now assigns the
+  // resulting lease map rather than merging it, so a successful RELEASE removes
+  // its own entry and a second RELEASE of the same authorization_id is DENIED by
+  // ConcurrencyModule on its own merits rather than only by nonce reuse in the
+  // ReplayModule. T-11 asserts that removal directly.
   const engine = makeEngine();
   const state  = makeState();
 
@@ -494,4 +501,244 @@ test("T-10 delegation scope escape: tool not in parentScope → DELEGATION_SCOPE
     escapeResult.violations.some((v) => v.code === "DELEGATION_SCOPE_VIOLATION"),
     `expected DELEGATION_SCOPE_VIOLATION, got: ${JSON.stringify(escapeResult.violations)}`
   );
+});
+
+// ── #227 concurrency lease lifecycle ─────────────────────────────────────────
+//
+// T-11 clean RELEASE removes its own lease, preserves unrelated leases
+// T-12 expired lease reclaimed during EXECUTE
+// T-13 exact expires_at boundary is expired (evaluationTime >= expires_at)
+// T-14 saturation recovery after abandoned leases
+// T-15 late RELEASE after reclaim → CONCURRENCY_RELEASE_INVALID
+// T-16 malformed expires_at fails closed → STATE_INVALID
+// T-17 reclamation removes only eligible entries
+// T-18 two evaluators reading one version cannot double-decrement
+
+const AUTH_A = "a".repeat(64);
+const AUTH_B = "b".repeat(64);
+const AUTH_C = "c".repeat(64);
+
+// A state whose agent already holds leases, so reclamation has something to act
+// on. `active` is seeded to the lease count, which is the consistent starting
+// point a live deployment would be in.
+function stateWithLeases(
+  leases: Record<string, { expires_at: number }>,
+  maxConcurrent = 3,
+  active = Object.keys(leases).length
+): State {
+  const s = makeState();
+  s.concurrency = {
+    max_concurrent: { "agent-1": maxConcurrent },
+    active: { "agent-1": active },
+    active_auths: { "agent-1": leases },
+  };
+  return s;
+}
+
+function leaseKeys(s: State): string[] {
+  return Object.keys(s.concurrency.active_auths["agent-1"] ?? {}).sort();
+}
+
+test("T-11 clean RELEASE removes its own active_auths entry and preserves unrelated leases", () => {
+  const engine = makeEngine();
+  const state = stateWithLeases({
+    [AUTH_A]: { expires_at: T0 + 100 },
+    [AUTH_B]: { expires_at: T0 + 100 },
+  });
+
+  const out = engine.evaluatePure(
+    { ...makeIntent({ nonce: 111n }), type: "RELEASE", authorization_id: AUTH_A },
+    state,
+    T0
+  );
+  assert.equal(out.decision, "ALLOW", "RELEASE of a live lease must ALLOW");
+
+  assert.deepEqual(
+    leaseKeys(out.nextState),
+    [AUTH_B],
+    "RELEASE must remove exactly its own lease and leave unrelated leases resident"
+  );
+  assert.equal(
+    out.nextState.concurrency.active["agent-1"],
+    1,
+    "active must be decremented by exactly the one entry removed"
+  );
+});
+
+test("T-12 expired lease is reclaimed during EXECUTE", () => {
+  const engine = makeEngine();
+  const state = stateWithLeases({ [AUTH_A]: { expires_at: T0 - 1 } }, 3, 1);
+
+  const out = engine.evaluatePure(makeIntent({ nonce: 112n }), state, T0);
+  assert.equal(out.decision, "ALLOW");
+
+  const keys = leaseKeys(out.nextState);
+  assert.ok(!keys.includes(AUTH_A), "expired lease must not remain resident");
+  assert.equal(keys.length, 1, "only the newly issued lease remains");
+  assert.equal(
+    out.nextState.concurrency.active["agent-1"],
+    1,
+    "one reclaimed (-1) plus one issued (+1) leaves active at 1"
+  );
+});
+
+test("T-13 a lease at exactly expires_at is expired and reclaimable", () => {
+  const engine = makeEngine();
+
+  // evaluationTime === expires_at → expired (strict zero-tolerance boundary).
+  const atBoundary = engine.evaluatePure(
+    makeIntent({ nonce: 113n }),
+    stateWithLeases({ [AUTH_A]: { expires_at: T0 } }, 3, 1),
+    T0
+  );
+  assert.equal(atBoundary.decision, "ALLOW");
+  assert.ok(
+    !leaseKeys(atBoundary.nextState).includes(AUTH_A),
+    "at expires_at the lease is no longer live and must be reclaimed"
+  );
+
+  // One second earlier the same lease is still live and must be retained.
+  const beforeBoundary = engine.evaluatePure(
+    makeIntent({ nonce: 114n }),
+    stateWithLeases({ [AUTH_A]: { expires_at: T0 } }, 3, 1),
+    T0 - 1
+  );
+  assert.equal(beforeBoundary.decision, "ALLOW");
+  assert.ok(
+    leaseKeys(beforeBoundary.nextState).includes(AUTH_A),
+    "one second before expires_at the lease is still live and must be retained"
+  );
+});
+
+test("T-14 saturation recovers after every lease is abandoned", () => {
+  const engine = makeEngine();
+  // Both slots held by leases whose holder never sent a RELEASE.
+  const state = stateWithLeases(
+    { [AUTH_A]: { expires_at: T0 - 5 }, [AUTH_B]: { expires_at: T0 - 5 } },
+    2,
+    2
+  );
+
+  // Before expiry the agent is genuinely saturated.
+  const saturated = engine.evaluatePure(makeIntent({ nonce: 115n }), state, T0 - 10);
+  assert.equal(saturated.decision, "DENY", "live leases must still consume capacity");
+  assert.deepEqual(saturated.reasons, ["CONCURRENCY_LIMIT_EXCEEDED"]);
+
+  // Once expired, capacity returns without any operator intervention.
+  const recovered = engine.evaluatePure(makeIntent({ nonce: 116n }), state, T0);
+  assert.equal(recovered.decision, "ALLOW", "expired leases must stop consuming capacity");
+  assert.equal(leaseKeys(recovered.nextState).length, 1, "both abandoned leases reclaimed");
+  assert.equal(recovered.nextState.concurrency.active["agent-1"], 1);
+});
+
+test("T-15 RELEASE arriving after its lease was reclaimed → CONCURRENCY_RELEASE_INVALID", () => {
+  const engine = makeEngine();
+  const state = stateWithLeases({ [AUTH_A]: { expires_at: T0 - 1 } }, 3, 1);
+
+  const out = engine.evaluatePure(
+    { ...makeIntent({ nonce: 117n }), type: "RELEASE", authorization_id: AUTH_A },
+    state,
+    T0
+  );
+  assert.equal(out.decision, "DENY", "a late RELEASE must not be silently idempotent");
+  assert.deepEqual(out.reasons, ["CONCURRENCY_RELEASE_INVALID"]);
+});
+
+test("T-16 malformed expires_at fails closed with STATE_INVALID", () => {
+  const engine = makeEngine();
+
+  const malformed: ReadonlyArray<readonly [string, number]> = [
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["non-integer", T0 + 0.5],
+    ["negative", -1],
+  ];
+
+  for (const [label, bad] of malformed) {
+    const state = stateWithLeases({ [AUTH_A]: { expires_at: bad } }, 3, 1);
+
+    const exec = engine.evaluatePure(makeIntent({ nonce: 118n }), state, T0);
+    assert.equal(exec.decision, "DENY", `EXECUTE must fail closed on ${label} expires_at`);
+    assert.deepEqual(exec.reasons, ["STATE_INVALID"], `EXECUTE reason for ${label}`);
+
+    const rel = engine.evaluatePure(
+      { ...makeIntent({ nonce: 119n }), type: "RELEASE", authorization_id: AUTH_A },
+      state,
+      T0
+    );
+    assert.equal(rel.decision, "DENY", `RELEASE must fail closed on ${label} expires_at`);
+    assert.deepEqual(rel.reasons, ["STATE_INVALID"], `RELEASE reason for ${label}`);
+  }
+});
+
+test("T-17 reclamation removes only eligible entries", () => {
+  const engine = makeEngine();
+  const state = stateWithLeases(
+    {
+      [AUTH_A]: { expires_at: T0 - 10 }, // expired  → reclaim
+      [AUTH_B]: { expires_at: T0 },      // boundary → reclaim
+      [AUTH_C]: { expires_at: T0 + 10 }, // live     → keep
+    },
+    3,
+    3
+  );
+
+  const out = engine.evaluatePure(makeIntent({ nonce: 120n }), state, T0);
+  assert.equal(out.decision, "ALLOW");
+
+  const keys = leaseKeys(out.nextState);
+  assert.ok(keys.includes(AUTH_C), "a live lease must survive reclamation");
+  assert.ok(!keys.includes(AUTH_A) && !keys.includes(AUTH_B), "only expired leases are removed");
+  assert.equal(keys.length, 2, "the live lease plus the newly issued one");
+
+  // active is decremented by exactly the number removed (3 - 2), then the new
+  // lease adds one back — which is also the resulting map size.
+  assert.equal(out.nextState.concurrency.active["agent-1"], 2);
+  assert.equal(
+    out.nextState.concurrency.active["agent-1"],
+    keys.length,
+    "scalar active must agree with the resulting lease map"
+  );
+});
+
+test("T-18 two evaluators reading the same version cannot double-decrement", () => {
+  // Core's StateStore is a plain get/set; the exact-version CAS that serializes
+  // committers lives in the Profile C StateProvider. What is asserted here is
+  // the property that makes that CAS sufficient: reclamation is a pure function
+  // of (intent, state, evaluationTime), so two evaluators racing from the same
+  // version compute the *same* transition rather than two stacking ones.
+  // Whichever wins the CAS commits exactly one decrement; the loser is rejected
+  // and re-evaluates against the winner's state.
+  const engine = makeEngine();
+  const base = stateWithLeases(
+    { [AUTH_A]: { expires_at: T0 - 1 }, [AUTH_B]: { expires_at: T0 + 100 } },
+    3,
+    2
+  );
+
+  const releaseB = { ...makeIntent({ nonce: 121n }), type: "RELEASE", authorization_id: AUTH_B } as Intent;
+  const first = engine.evaluatePure(releaseB, base, T0);
+  const second = engine.evaluatePure(releaseB, base, T0);
+  assert.equal(first.decision, "ALLOW");
+  assert.equal(second.decision, "ALLOW");
+
+  // AUTH_A reclaimed (-1) and AUTH_B released (-1): exactly two removals, once.
+  assert.equal(first.nextState.concurrency.active["agent-1"], 0);
+  assert.equal(
+    second.nextState.concurrency.active["agent-1"],
+    first.nextState.concurrency.active["agent-1"],
+    "the same version must yield the same counter, never a stacked decrement"
+  );
+  assert.deepEqual(leaseKeys(first.nextState), []);
+  assert.deepEqual(leaseKeys(second.nextState), leaseKeys(first.nextState));
+
+  // Re-evaluating the loser against the winner's committed state is the DENY
+  // that prevents the second decrement from ever being applied.
+  const loserRetry = engine.evaluatePure(
+    { ...makeIntent({ nonce: 122n }), type: "RELEASE", authorization_id: AUTH_B },
+    first.nextState,
+    T0
+  );
+  assert.equal(loserRetry.decision, "DENY");
+  assert.deepEqual(loserRetry.reasons, ["CONCURRENCY_RELEASE_INVALID"]);
 });

--- a/packages/core/src/test/toctou.test.ts
+++ b/packages/core/src/test/toctou.test.ts
@@ -22,6 +22,8 @@
 //   T-16 malformed expires_at fails closed → STATE_INVALID
 //   T-17 reclamation removes only eligible entries
 //   T-18 two evaluators on one version cannot double-decrement
+//   T-19 EXECUTE fails closed when active under-counts tracked leases
+//   T-20 RELEASE shares that under-count precondition
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -513,6 +515,8 @@ test("T-10 delegation scope escape: tool not in parentScope → DELEGATION_SCOPE
 // T-16 malformed expires_at fails closed → STATE_INVALID
 // T-17 reclamation removes only eligible entries
 // T-18 two evaluators reading one version cannot double-decrement
+// T-19 EXECUTE fails closed when active under-counts tracked leases
+// T-20 RELEASE shares that under-count precondition
 
 const AUTH_A = "a".repeat(64);
 const AUTH_B = "b".repeat(64);
@@ -741,4 +745,64 @@ test("T-18 two evaluators reading the same version cannot double-decrement", () 
   );
   assert.equal(loserRetry.decision, "DENY");
   assert.deepEqual(loserRetry.reasons, ["CONCURRENCY_RELEASE_INVALID"]);
+});
+
+test("T-19 EXECUTE fails closed when active under-counts tracked leases", () => {
+  const engine = makeEngine();
+
+  // AngeYobo's case on #231: max_concurrent 1, active 0, one live tracked
+  // lease. Without the precondition an EXECUTE reads zero usage, ALLOWs, and
+  // leaves two live leases against a limit of one.
+  const underCounted = stateWithLeases({ [AUTH_A]: { expires_at: T0 + 100 } }, 1, 0);
+
+  const denied = engine.evaluatePure(makeIntent({ nonce: 120n }), underCounted, T0);
+  assert.equal(denied.decision, "DENY", "active < tracked leases must fail closed");
+  assert.deepEqual(denied.reasons, ["STATE_INVALID"], "under-count is invalid state, not a limit breach");
+
+  // Under-count is rejected even with headroom on max_concurrent, because the
+  // defect is in the authoritative state, not in the limit.
+  const roomySpare = stateWithLeases(
+    { [AUTH_A]: { expires_at: T0 + 100 }, [AUTH_B]: { expires_at: T0 + 100 } },
+    9,
+    1
+  );
+  const deniedRoomy = engine.evaluatePure(makeIntent({ nonce: 121n }), roomySpare, T0);
+  assert.equal(deniedRoomy.decision, "DENY", "under-count is invalid regardless of spare capacity");
+  assert.deepEqual(deniedRoomy.reasons, ["STATE_INVALID"]);
+
+  // Equality is NOT required. active > tracked stays valid and conservative:
+  // a deployment may account capacity it never lease-tracked, and that capacity
+  // must keep being counted rather than being normalized away.
+  const overCounted = stateWithLeases({ [AUTH_A]: { expires_at: T0 + 100 } }, 3, 2);
+  const allowed = engine.evaluatePure(makeIntent({ nonce: 122n }), overCounted, T0);
+  assert.equal(allowed.decision, "ALLOW", "active > tracked leases must remain valid");
+  assert.equal(
+    allowed.nextState.concurrency.active["agent-1"],
+    3,
+    "untracked capacity is preserved: nothing reclaimed, one issued"
+  );
+});
+
+test("T-20 RELEASE shares the under-count precondition and fails closed on it", () => {
+  const engine = makeEngine();
+
+  // Two live tracked leases, active seeded at 1. The RELEASE names a lease that
+  // really is resident, so the only defect is the counter.
+  const state = stateWithLeases(
+    { [AUTH_A]: { expires_at: T0 + 100 }, [AUTH_B]: { expires_at: T0 + 100 } },
+    3,
+    1
+  );
+
+  const out = engine.evaluatePure(
+    { ...makeIntent({ nonce: 123n }), type: "RELEASE", authorization_id: AUTH_A },
+    state,
+    T0
+  );
+  assert.equal(out.decision, "DENY", "RELEASE must fail closed on under-counted state");
+  assert.deepEqual(
+    out.reasons,
+    ["STATE_INVALID"],
+    "the state precondition precedes CONCURRENCY_RELEASE_INVALID: the lease is resident, the counter is wrong"
+  );
 });

--- a/tests/src/invariants/inv_concurrency_leases.test.ts
+++ b/tests/src/invariants/inv_concurrency_leases.test.ts
@@ -158,3 +158,59 @@ test("INV-ConcurrencyLeases: expired leases stop consuming capacity, live ones d
   );
   assert.equal(recovered.nextState.concurrency.active["agent-1"], 1);
 });
+
+/**
+ * The counter is an authoritative input, not a hint. `active` may exceed the
+ * tracked lease count — a deployment can account capacity it never
+ * lease-tracked — but it may never fall below it: that state hands out capacity
+ * the tracked leases have already consumed.
+ *
+ * The invariant this pins is that no reachable transition can produce a state
+ * where live tracked leases outnumber `max_concurrent`.
+ */
+test("INV-ConcurrencyLeases: active may over-count tracked leases but never under-count", () => {
+  const engine = makeEngine();
+  const AUTH_A = "a".repeat(64);
+  const AUTH_B = "b".repeat(64);
+  const AUTH_C = "c".repeat(64);
+
+  // Under-count fails closed rather than being normalized.
+  const underCounted = baseState(1);
+  underCounted.concurrency.active = { "agent-1": 0 };
+  underCounted.concurrency.active_auths = { "agent-1": { [AUTH_A]: { expires_at: T0 + 100 } } };
+
+  const denied = engine.evaluatePure(execIntent(1n, T0), underCounted, T0);
+  assert.equal(denied.decision, "DENY", "active < tracked leases must fail closed");
+  assert.ok(
+    denied.decision === "DENY" && denied.reasons.includes("STATE_INVALID"),
+    "under-counted state is invalid, not a limit breach"
+  );
+
+  // Over-count is valid and conservative, and the untracked capacity survives
+  // the transition instead of being silently released.
+  const overCounted = baseState(4);
+  overCounted.concurrency.active = { "agent-1": 2 };
+  overCounted.concurrency.active_auths = { "agent-1": { [AUTH_B]: { expires_at: T0 + 100 } } };
+
+  const allowed = engine.evaluatePure(execIntent(2n, T0), overCounted, T0);
+  assert.equal(allowed.decision, "ALLOW", "active > tracked leases must remain valid");
+  if (allowed.decision !== "ALLOW") throw new Error("expected ALLOW");
+  assert.equal(
+    allowed.nextState.concurrency.active["agent-1"],
+    3,
+    "the one untracked slot must still be counted after the transition"
+  );
+
+  // The point of the precondition: an agent at its limit cannot be talked past
+  // it by an under-counted counter.
+  const atLimit = baseState(1);
+  atLimit.concurrency.active = { "agent-1": 1 };
+  atLimit.concurrency.active_auths = { "agent-1": { [AUTH_C]: { expires_at: T0 + 100 } } };
+
+  const blocked = engine.evaluatePure(execIntent(3n, T0), atLimit, T0);
+  assert.equal(blocked.decision, "DENY", "a live lease at the limit must block");
+  assert.ok(
+    blocked.decision === "DENY" && blocked.reasons.includes("CONCURRENCY_LIMIT_EXCEEDED"),
+    "consistent state at the limit is a limit breach, not invalid state"
+  );
+});

--- a/tests/src/invariants/inv_concurrency_leases.test.ts
+++ b/tests/src/invariants/inv_concurrency_leases.test.ts
@@ -1,0 +1,160 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { PolicyEngine, RECOMMENDED_TRUSTED_TIME_PROFILE } from "@oxdeai/core";
+import type { State } from "@oxdeai/core";
+import { makeIntent } from "../helpers/intent.js";
+import { makeState } from "../helpers/state.js";
+
+const T0 = 1_700_000_000;
+const TTL = 60;
+
+function makeEngine(): PolicyEngine {
+  return new PolicyEngine({
+    policy_version: "0.1.0",
+    engine_secret: "test-secret-must-be-at-least-32-chars!!",
+    authorization_ttl_seconds: TTL,
+    ...RECOMMENDED_TRUSTED_TIME_PROFILE
+  });
+}
+
+function baseState(maxConcurrent: number): State {
+  const state = makeState({
+    policy_version: "0.1.0",
+    allowlists: { action_types: ["PAYMENT"], assets: ["USDC"], targets: ["merchant"] },
+    budget: { budget_limit: { "agent-1": 10_000_000n }, spent_in_period: { "agent-1": 0n } },
+    max_amount_per_action: { "agent-1": 5_000_000n }
+  });
+  state.concurrency = {
+    max_concurrent: { "agent-1": maxConcurrent },
+    active: {},
+    active_auths: {}
+  };
+  return state;
+}
+
+function execIntent(nonce: bigint, timestamp: number) {
+  return makeIntent({
+    intent_id: `intent-${nonce}`,
+    nonce,
+    amount: 1_000n,
+    asset: "USDC",
+    target: "merchant",
+    timestamp
+  });
+}
+
+function leases(state: State): Record<string, { expires_at: number }> {
+  return state.concurrency.active_auths["agent-1"] ?? {};
+}
+
+/**
+ * INV-ConcurrencyLeases (oxdeai/oxdeai#227)
+ *
+ * After any successful transition, no lease that has been released or reclaimed
+ * may remain resident in `concurrency.active_auths`, and the scalar `active`
+ * counter must not contradict the resulting map.
+ *
+ * This is the invariant the reclamation change exists to establish: before it,
+ * a module `stateDelta` could not express key removal, so entries accumulated
+ * on both the RELEASE path and the expiry path.
+ */
+test("INV-ConcurrencyLeases: successful transitions leave no released or reclaimed lease resident", () => {
+  const engine = makeEngine();
+  let state = baseState(4);
+
+  // Drive a mixed sequence of EXECUTE and RELEASE across advancing time, so
+  // both removal paths — explicit release and expiry-driven reclamation — are
+  // exercised against the same accumulating state.
+  const issued: Array<{ authId: string; expires_at: number }> = [];
+  let nonce = 1n;
+
+  for (let step = 0; step < 3; step++) {
+    const at = T0 + step * 10;
+    const out = engine.evaluatePure(execIntent(nonce++, at), state, at);
+    assert.equal(out.decision, "ALLOW", `EXECUTE ${step} must ALLOW`);
+    if (out.decision !== "ALLOW") throw new Error("expected ALLOW");
+    state = out.nextState;
+    issued.push({ authId: out.authorization.auth_id, expires_at: out.authorization.expiry });
+  }
+
+  // Release the first lease explicitly, well before it expires.
+  const releasedId = issued[0].authId;
+  const releaseAt = T0 + 30;
+  const released = engine.evaluatePure(
+    { ...execIntent(nonce++, releaseAt), type: "RELEASE", authorization_id: releasedId },
+    state,
+    releaseAt
+  );
+  assert.equal(released.decision, "ALLOW", "RELEASE of a live lease must ALLOW");
+  if (released.decision !== "ALLOW") throw new Error("expected ALLOW");
+  state = released.nextState;
+
+  assert.ok(
+    !(releasedId in leases(state)),
+    "a released lease must not remain resident after a successful transition"
+  );
+  assert.equal(
+    state.concurrency.active["agent-1"],
+    Object.keys(leases(state)).length,
+    "active must agree with the resulting lease map"
+  );
+
+  // Advance past every remaining lease's expiry and drive one more successful
+  // transition. Everything issued above is now reclaimable.
+  const afterAll = Math.max(...issued.map((i) => i.expires_at));
+  const final = engine.evaluatePure(execIntent(nonce++, afterAll), state, afterAll);
+  assert.equal(final.decision, "ALLOW", "capacity must be available once leases expire");
+  if (final.decision !== "ALLOW") throw new Error("expected ALLOW");
+  state = final.nextState;
+
+  const resident = leases(state);
+  for (const { authId } of issued) {
+    assert.ok(
+      !(authId in resident),
+      `reclaimed lease ${authId.slice(0, 8)}… must not remain resident`
+    );
+  }
+  assert.deepEqual(
+    Object.keys(resident),
+    [final.authorization.auth_id],
+    "only the lease issued by the final transition may remain"
+  );
+  assert.equal(
+    state.concurrency.active["agent-1"],
+    Object.keys(resident).length,
+    "active must agree with the resulting lease map"
+  );
+});
+
+/**
+ * The limit must be enforced against live leases only. An agent saturated
+ * purely by leases nobody released regains capacity at expiry, and an agent
+ * saturated by live leases does not.
+ */
+test("INV-ConcurrencyLeases: expired leases stop consuming capacity, live ones do not", () => {
+  const engine = makeEngine();
+  let state = baseState(1);
+
+  const first = engine.evaluatePure(execIntent(1n, T0), state, T0);
+  assert.equal(first.decision, "ALLOW");
+  if (first.decision !== "ALLOW") throw new Error("expected ALLOW");
+  state = first.nextState;
+
+  // Still live: the single slot is genuinely occupied.
+  const blocked = engine.evaluatePure(execIntent(2n, T0 + 1), state, T0 + 1);
+  assert.equal(blocked.decision, "DENY", "a live lease must still occupy the slot");
+  assert.ok(blocked.decision === "DENY" && blocked.reasons.includes("CONCURRENCY_LIMIT_EXCEEDED"));
+
+  // At exactly expires_at the lease is no longer live and the slot returns.
+  const atExpiry = first.authorization.expiry;
+  const recovered = engine.evaluatePure(execIntent(3n, atExpiry), state, atExpiry);
+  assert.equal(recovered.decision, "ALLOW", "at expires_at the slot must be reclaimable");
+  if (recovered.decision !== "ALLOW") throw new Error("expected ALLOW");
+
+  assert.deepEqual(
+    Object.keys(leases(recovered.nextState)),
+    [recovered.authorization.auth_id],
+    "the abandoned lease must be gone, replaced by the newly issued one"
+  );
+  assert.equal(recovered.nextState.concurrency.active["agent-1"], 1);
+});


### PR DESCRIPTION
Closes #227. Implements ruling **(b)** from https://github.com/oxdeai/oxdeai/issues/227#issuecomment-5213888429, with the clean-RELEASE non-removal included as you directed.

## Shape

`ConcurrencyModule` keeps the decision. `PolicyEngine` materializes the resulting `concurrency.active_auths[agent]` map as a replacement assignment after module evaluation, inside the same evaluated transition and the same exact-version CAS, so `active` and `active_auths` move atomically. `deepMerge` is untouched, no tombstones, no generic deletion semantics.

The two call sites share one exported function, `computeConcurrencyLeases(intent, state, evaluationTime)`, so the decision has exactly one definition. The engine calls it with `state` — the same pre-delta input the module evaluated against — and the same trusted `evaluationTime`, so engine and module cannot drift apart.

## Against your requirements

| Requirement | Where |
|---|---|
| reclamation uses only the trusted `evaluationTime` | `computeConcurrencyLeases`; the module reads `context.evaluationTime`, the engine passes the same value |
| remove only leases the concurrency evaluation determined reclaimable | engine assigns the map that function returned; it does not re-derive one |
| no mutation outside the evaluated transition/CAS | assignment sits between the decision phase and `state_snapshot_hash`, on `working` |
| no tombstones | none |
| no change to generic `deepMerge` semantics | `deepMerge` is no longer referenced by `PolicyEngine` at all, and is otherwise unmodified |
| clean RELEASE removes its entry | `T-11` |
| `active` consistent with the resulting map | decremented by exactly the number removed, floored at zero |
| invariant: no released/reclaimed lease resident after a successful transition | `INV-ConcurrencyLeases` |

Rulings 2, 3 and 5 from your earlier comment are implemented as issued: expiry is `evaluationTime >= expires_at`, malformed `expires_at` fails closed with `STATE_INVALID` with no maximum-plausible-TTL ceiling, and a late RELEASE stays a deterministic `CONCURRENCY_RELEASE_INVALID`.

## Two judgement calls worth your eye

**1. `active` is decremented, not recomputed from the map size.** Ruling 4 says decrement by exactly the number removed, so that is what it does — but it is worth naming why the alternative is wrong. A deployment that maintains `active` without populating `active_auths` would have its counter silently reset to the map size, which would *release* capacity that was never lease-tracked. Decrementing leaves such a deployment exactly as it was.

**2. Only the acting agent's leases are read.** Ruling 3 says a malformed `expires_at` fails closed, and the scope it applies at is mine to choose. Reading only `active_auths[intent.agent_id]` means one corrupt entry denies that agent rather than every agent sharing the state. If you would rather a malformed leaf anywhere fail the whole evaluation closed, say so and I will widen it — it is a two-line change, but it converts one bad entry into a full outage, so I did not assume it.

## Coverage

`T-11`–`T-18` in the TOCTOU suite, covering all six cases from ruling 6 plus the two you added: clean RELEASE preserving unrelated leases, reclamation during EXECUTE, the exact `expires_at` boundary in both directions, saturation recovery after abandoned leases, late RELEASE after reclaim, malformed `expires_at` (NaN / Infinity / non-integer / negative, on both EXECUTE and RELEASE), eligibility, and no double decrement. Plus `INV-ConcurrencyLeases` in the invariants suite.

I reverted `ConcurrencyModule.ts` and `PolicyEngine.ts` to `cef2d72` and re-ran with the tests in place: **all 8 new TOCTOU tests fail, all 10 pre-existing ones pass, and both invariants fail.** Every new test depends on the change rather than passing incidentally.

`T-6` carried an "Observation (not asserted)" recording the old `deepMerge` limitation. That observation is now false, so it has been rewritten to point at `T-11`, which asserts the removal directly.

**On `T-18`**, so the name does not overclaim: core's `StateStore` is a plain `get`/`set` and has no CAS to exercise. The test asserts the property that makes the Profile C CAS sufficient — reclamation is a pure function of `(intent, state, evaluationTime)`, so two evaluators racing from one version compute the *same* transition rather than two stacking ones, and the loser re-evaluating against the winner's state is a `DENY`. The CAS itself is the provider's obligation, which is what the §2.2 paragraph now states.

## Spec

`state-provider-requirements` §2.2 gains one paragraph on lease reclamation, parallel in structure to the existing velocity and tool-call window paragraphs, plus a line pointing at §4.3 for the privileged recovery path so it is not read as the normal one.

## Verification

- `packages/core` **354/354** (346 before, +8)
- `tests` **32/32** (30 before, +2)
- `packages/guard` **145/145**
- monorepo `pnpm typecheck` — 0 errors
- portable vectors — canonicalization 11, authorization 12, PEP 9, delegation 12, all unchanged
- `check-api-fingerprint.sh` OK; `api-extractor` produces no diff, since `policy/modules/` is not re-exported from the package entry point

Consistent with your note that no `AuthorizationV1`, canonicalization, or portable artifact-vector change was expected.
