### PR TITLE
feat(guard): add Tier 1 secure guard entry point and trusted execution context

### DIFF
--- a/docs/architecture/decisions/tier1-evaluator-input-provenance.md
+++ b/docs/architecture/decisions/tier1-evaluator-input-provenance.md
@@ -154,9 +154,16 @@ interface TrustedExecutionContext {
   adapterId: string;
   tool?: string;
   depth: number;
-  evaluationTime: number;
 }
 ```
+
+The context deliberately does not carry `evaluationTime`. Trusted evaluation
+time is captured by the secure guard at the evaluation boundary, immediately
+before evaluation, following the existing trusted-time model, rather than being
+carried in a reusable authenticated context. Authentication establishes who and
+where; `evaluationTime` establishes when a specific decision is being made, so a
+context constructed once must not become a reusable time capsule for later
+decisions.
 
 The context is created server-side and must not be accepted directly from
 request JSON. The exact interface and construction rules belong to a follow-up

--- a/packages/guard/package.json
+++ b/packages/guard/package.json
@@ -32,7 +32,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "rm -rf dist && tsc -p tsconfig.json",
     "build:test": "rm -rf dist && tsc -p tsconfig.test.json",
-    "test": "pnpm build:test && node --test \"dist/test/guard.test.js\" \"dist/test/guard.property.test.js\" \"dist/test/guard.delegation.test.js\" \"dist/test/guard.delegation.matrix.test.js\" \"dist/test/guard.delegation.property.test.js\" \"dist/test/guard.toctou.test.js\" \"dist/test/guard.boundary.test.js\" \"dist/test/guard.replay-store.test.js\" \"dist/test/guard.replay-store.redis.test.js\" \"dist/test/guard.authorization.test.js\" \"dist/test/guard.state-binding.test.js\" \"dist/test/guard.cas.test.js\" \"dist/test/guard.pep-conformance.test.js\" \"dist/test/guard.intent-binding.test.js\""
+    "test": "pnpm build:test && node --test \"dist/test/guard.test.js\" \"dist/test/guard.property.test.js\" \"dist/test/guard.delegation.test.js\" \"dist/test/guard.delegation.matrix.test.js\" \"dist/test/guard.delegation.property.test.js\" \"dist/test/guard.toctou.test.js\" \"dist/test/guard.boundary.test.js\" \"dist/test/guard.replay-store.test.js\" \"dist/test/guard.replay-store.redis.test.js\" \"dist/test/guard.authorization.test.js\" \"dist/test/guard.state-binding.test.js\" \"dist/test/guard.cas.test.js\" \"dist/test/guard.pep-conformance.test.js\" \"dist/test/guard.intent-binding.test.js\" \"dist/test/guard.provenance.test.js\""
   },
   "files": [
   "dist",

--- a/packages/guard/src/errors.ts
+++ b/packages/guard/src/errors.ts
@@ -63,6 +63,33 @@ export class OxDeAIConflictError extends OxDeAIAuthorizationError {
 }
 
 /**
+ * Thrown when a proposer claim contradicts a trusted execution-context premise
+ * on the Tier 1 secure guard path.
+ *
+ * Extends OxDeAIAuthorizationError so existing catch blocks remain valid. This
+ * is a guard-layer error by design: the Tier 1 provenance boundary is enforced
+ * at the PEP, and representing it here keeps core `ReasonCode`, the public
+ * conformance registries, and the API fingerprint unchanged.
+ *
+ * Raised before evaluation, authorization issuance, state mutation, or
+ * execution. `fields` lists every conflicting field in declaration order, and
+ * `provenance` carries the full per-field outcome for the audit record.
+ */
+export class OxDeAIProvenanceConflictError extends OxDeAIAuthorizationError {
+  readonly fields: readonly string[];
+  readonly provenance: Readonly<Record<string, string>>;
+
+  constructor(fields: readonly string[], provenance: Readonly<Record<string, string>>) {
+    super(
+      `Proposer claim conflicts with trusted execution context on [${fields.join(", ")}]. Execution blocked.`
+    );
+    this.name = "OxDeAIProvenanceConflictError";
+    this.fields = Object.freeze([...fields]);
+    this.provenance = Object.freeze({ ...provenance });
+  }
+}
+
+/**
  * Thrown when DelegationV1 verification fails at the guard boundary.
  * Extends OxDeAIAuthorizationError so existing catch blocks remain valid.
  * The `violations` field carries structured delegation-specific failure codes.

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -12,6 +12,7 @@ import {
   OxDeAIDelegationError,
   OxDeAIGuardConfigurationError,
   OxDeAINormalizationError,
+  OxDeAIProvenanceConflictError,
 } from "./errors.js";
 
 // ── validation ────────────────────────────────────────────────────────────────
@@ -147,6 +148,11 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
       intent = normalize(action);
     } catch (err) {
       if (err instanceof OxDeAINormalizationError) throw err;
+      // The secure path performs trusted-vs-proposer reconciliation inside the
+      // normalizer, so a provenance conflict surfaces here. It is an
+      // authorization boundary failure, not a normalization failure, and must
+      // reach the caller with its own type and conflicting-field list intact.
+      if (err instanceof OxDeAIProvenanceConflictError) throw err;
       // Custom mapActionToIntent threw something unexpected — fail closed.
       throw new OxDeAINormalizationError(
         `mapActionToIntent threw an unexpected error: ${err instanceof Error ? err.message : String(err)}`

--- a/packages/guard/src/index.ts
+++ b/packages/guard/src/index.ts
@@ -9,6 +9,14 @@
  */
 
 export { OxDeAIGuard } from "./guard.js";
+export { createSecureGuard } from "./secureGuard.js";
+export {
+  createTrustedExecutionContext,
+  isTrustedExecutionContext,
+} from "./trustedContext.js";
+export type { TrustedExecutionContext } from "./trustedContext.js";
+export { reconcileWithTrustedContext } from "./provenance.js";
+export type { ClaimProvenance, ProvenanceRecord, ReconciliationResult } from "./provenance.js";
 export {
   INTERNAL_EXECUTOR_TOKEN_HEADER,
   createPepGatewayExecutor,
@@ -30,6 +38,7 @@ export {
   OxDeAIDelegationError,
   OxDeAIGuardConfigurationError,
   OxDeAINormalizationError,
+  OxDeAIProvenanceConflictError,
 } from "./errors.js";
 export type {
   ProposedAction,

--- a/packages/guard/src/index.ts
+++ b/packages/guard/src/index.ts
@@ -10,13 +10,14 @@
 
 export { OxDeAIGuard } from "./guard.js";
 export { createSecureGuard } from "./secureGuard.js";
+export type { SecureGuardOptions } from "./secureGuard.js";
 export {
   createTrustedExecutionContext,
   isTrustedExecutionContext,
 } from "./trustedContext.js";
 export type { TrustedExecutionContext } from "./trustedContext.js";
 export { reconcileWithTrustedContext } from "./provenance.js";
-export type { ClaimProvenance, ProvenanceRecord, ReconciliationResult } from "./provenance.js";
+export type { ClaimProvenance, ProvenanceRecord, ReconciliationResult, ReconciliationOptions } from "./provenance.js";
 export {
   INTERNAL_EXECUTOR_TOKEN_HEADER,
   createPepGatewayExecutor,

--- a/packages/guard/src/provenance.ts
+++ b/packages/guard/src/provenance.ts
@@ -56,6 +56,22 @@ export type ClaimProvenance = "absent" | "matched" | "conflict" | "unverified";
 export type ProvenanceRecord = Readonly<Record<string, ClaimProvenance>>;
 
 /** @public */
+export type ReconciliationOptions = {
+  /**
+   * Field names whose value the guard supplied to the normalizer because the
+   * proposer omitted them, and which therefore must not audit as a proposer
+   * `matched` claim.
+   *
+   * Needed because `defaultNormalizeAction` requires `context.agent_id` and
+   * throws before reconciliation can run, so "absent claim → fill from the
+   * derived premise" is not reachable end-to-end for identity unless the guard
+   * supplies the premise up front. The claim is still compared, so a normalizer
+   * that returns something else still fails closed.
+   */
+  readonly synthesized?: ReadonlySet<string>;
+};
+
+/** @public */
 export type ReconciliationResult = {
   /** Intent with trusted premises applied. Proposer claims never override. */
   readonly intent: Intent;
@@ -185,15 +201,18 @@ const FIELDS: readonly ProvenanceField[] = [
 export function reconcileWithTrustedContext(
   intent: Intent,
   ctx: TrustedExecutionContext,
-  actionContext: Record<string, unknown> | undefined
+  actionContext: Record<string, unknown> | undefined,
+  options?: ReconciliationOptions
 ): ReconciliationResult {
   const merged: Record<string, unknown> = { ...(intent as unknown as Record<string, unknown>) };
   const provenance: Record<string, ClaimProvenance> = {};
   const conflicts: string[] = [];
+  const synthesized = options?.synthesized;
 
   for (const field of FIELDS) {
     const premise = field.derived(ctx);
     const claims = field.claims(intent, actionContext);
+    const wasSynthesized = synthesized?.has(field.name) === true;
 
     if (premise === undefined) {
       provenance[field.name] = claims.length > 0 ? "unverified" : "absent";
@@ -207,6 +226,11 @@ export function reconcileWithTrustedContext(
     }
 
     // Exact equality against every source that carried a claim.
+    //
+    // A synthesized field is still compared: the guard supplied the premise to
+    // the normalizer, so the normalizer is expected to echo it back exactly. A
+    // deviation means the normalizer substituted an identity of its own, which
+    // must fail closed rather than being silently overwritten.
     const conflicting = claims.some((claim) => claim !== premise);
     if (conflicting) {
       provenance[field.name] = "conflict";
@@ -214,7 +238,11 @@ export function reconcileWithTrustedContext(
       continue;
     }
 
-    provenance[field.name] = "matched";
+    // The record describes the PROPOSER's claim, not the normalizer's echo of a
+    // guard-supplied premise. A synthesized field the proposer never claimed
+    // audits as `absent`, so a trusted fill is not reported as a match the
+    // proposer earned.
+    provenance[field.name] = wasSynthesized ? "absent" : "matched";
     field.apply?.(merged, premise);
   }
 

--- a/packages/guard/src/provenance.ts
+++ b/packages/guard/src/provenance.ts
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { Intent } from "@oxdeai/core";
+import type { TrustedExecutionContext } from "./trustedContext.js";
+import { OxDeAIProvenanceConflictError } from "./errors.js";
+
+/**
+ * Provenance modes for an evaluator input.
+ *
+ * The boundary is expressed in terms of how a premise was obtained, not in
+ * terms of one specific source, so that further modes attach without
+ * restructuring:
+ *
+ *  - `declared`  — proposer-controlled claim; never authoritative.
+ *  - `derived`   — obtained from authenticated or trusted enforcement context.
+ *  - `read`      — obtained from an authoritative provider with explicit
+ *                  version/freshness semantics. NOT implemented here.
+ *  - `attested`  — independently verifiable statement from an accepted
+ *                  authority. NOT implemented here.
+ *
+ * The governing rule, which further modes must preserve:
+ *
+ * ```text
+ * declared never overrides derived, read, or attested.
+ * ```
+ *
+ * This module implements `declared` and `derived` only. A later `read` or
+ * `attested` premise attaches as an additional resolver on {@link ProvenanceField},
+ * consulted ahead of `declared` in precedence order; nothing here assumes the
+ * enforcement context is the only non-declared source.
+ *
+ * @public
+ */
+
+/**
+ * How a non-declared premise related to the proposer's corresponding claim.
+ *
+ * Recorded per field so that an audit reader can distinguish a value the guard
+ * filled in from one the proposer asserted. Without this, a derived fill and a
+ * proposer assertion that happened to be correct look identical after the fact.
+ *
+ *  - `"absent"`     — the proposer made no claim; the non-declared premise was used.
+ *  - `"matched"`    — the proposer's claim was present and exactly equal to the
+ *                     non-declared premise, which was used regardless.
+ *  - `"conflict"`   — the proposer's claim contradicted the non-declared premise.
+ *                     Fails closed; never reaches evaluation.
+ *  - `"unverified"` — the proposer made a claim for which NO non-declared premise
+ *                     exists, so nothing could be checked. The claim is retained
+ *                     as-is. **This is not a verified value** — see the note on
+ *                     attack M in {@link reconcileWithTrustedContext}.
+ *
+ * @public
+ */
+export type ClaimProvenance = "absent" | "matched" | "conflict" | "unverified";
+
+/** Per-field provenance outcome for one evaluation. @public */
+export type ProvenanceRecord = Readonly<Record<string, ClaimProvenance>>;
+
+/** @public */
+export type ReconciliationResult = {
+  /** Intent with trusted premises applied. Proposer claims never override. */
+  readonly intent: Intent;
+  readonly provenance: ProvenanceRecord;
+};
+
+/**
+ * One row of the premise-vs-claim comparison.
+ *
+ * Declaring the boundary as a table rather than a chain of per-field `if`
+ * statements keeps the rule in one place and lets later structured-argument
+ * provenance work reuse the same seam instead of re-deriving it.
+ *
+ * Extensibility: `derived` is the only non-declared resolver today. A `read`
+ * premise (authoritative provider with version/freshness semantics) or an
+ * `attested` premise (independently verifiable statement) attaches as a sibling
+ * resolver consulted ahead of `declared`, without changing the comparison rule
+ * or the recorded outcomes. Nothing below assumes the enforcement context is the
+ * only possible source of a non-declared premise.
+ */
+type ProvenanceField = {
+  /** Key under which the outcome is recorded. */
+  readonly name: string;
+  /**
+   * `derived` premise — obtained from the authenticated/trusted enforcement
+   * context. `undefined` when this route supplies none.
+   */
+  readonly derived: (ctx: TrustedExecutionContext) => string | number | undefined;
+  /** `declared` claims for this field, from every source that can carry one. */
+  readonly claims: (intent: Intent, context: Record<string, unknown> | undefined) => unknown[];
+  /**
+   * Apply the resolved premise to the intent. Omitted for fields that have no
+   * representation in `Intent` — those are conflict-checked only and are
+   * deliberately not wired into policy-module evaluation.
+   */
+  readonly apply?: (intent: Record<string, unknown>, premise: string | number) => void;
+};
+
+function claimsOf(...values: unknown[]): unknown[] {
+  return values.filter((v) => v !== undefined && v !== null);
+}
+
+const FIELDS: readonly ProvenanceField[] = [
+  {
+    name: "agent_id",
+    derived: (ctx) => ctx.agentId,
+    claims: (intent, context) => claimsOf(intent.agent_id, context?.["agent_id"]),
+    apply: (intent, premise) => {
+      intent["agent_id"] = premise;
+    },
+  },
+  {
+    name: "tool",
+    derived: (ctx) => ctx.tool,
+    claims: (intent, context) => claimsOf(intent.tool, context?.["tool"]),
+    apply: (intent, premise) => {
+      intent["tool"] = premise;
+    },
+  },
+  {
+    name: "depth",
+    derived: (ctx) => ctx.depth,
+    claims: (intent, context) => claimsOf(intent.depth, context?.["depth"]),
+    apply: (intent, premise) => {
+      intent["depth"] = premise;
+    },
+  },
+  // Fields with no `Intent` representation: conflict-checked only. A proposer
+  // that asserts one of these in `action.context` must not be able to state
+  // something the trusted context contradicts, even though nothing downstream
+  // consumes the value yet.
+  {
+    name: "principal_id",
+    derived: (ctx) => ctx.principalId,
+    claims: (_intent, context) => claimsOf(context?.["principal_id"]),
+  },
+  {
+    name: "tenant_id",
+    derived: (ctx) => ctx.tenantId,
+    claims: (_intent, context) => claimsOf(context?.["tenant_id"]),
+  },
+  {
+    name: "adapter_id",
+    derived: (ctx) => ctx.adapterId,
+    claims: (_intent, context) => claimsOf(context?.["adapter_id"]),
+  },
+  {
+    name: "route_classification",
+    derived: (ctx) => ctx.routeClassification,
+    claims: (_intent, context) => claimsOf(context?.["route_classification"]),
+  },
+];
+
+/**
+ * Merge a proposer's normalized intent with server-created trusted context.
+ *
+ * The rule, applied uniformly to every field in the table:
+ *
+ * ```text
+ * declared absent            → fill from the non-declared premise
+ * declared present, equal    → use the non-declared premise
+ * declared present, differs  → fail closed
+ * no non-declared premise    → retain the claim, record it as unverified
+ * ```
+ *
+ * `derived` is the only non-declared mode implemented here; the rule is written
+ * so that a later `read` or `attested` premise obeys it unchanged.
+ *
+ * Comparison is exact deterministic equality. No case folding, trimming, or
+ * implicit normalization is applied: two spellings that a downstream system
+ * might treat as equivalent are a conflict here, because silently accepting a
+ * near-match is how a rename bypass re-enters.
+ *
+ * Reconciliation runs on the OUTPUT of the configured `mapActionToIntent`.
+ * A deployment-supplied normalizer returns a full `Intent`, so applying trusted
+ * premises beforehand would let a custom normalizer overwrite them.
+ *
+ * **Attack coverage.** With a trusted `agentId` this closes per-agent limit
+ * inheritance by self-declared `agent_id` (case L). Tool-rename bypass (case M)
+ * is closed ONLY for routes that supply an authoritative `tool`; where the route
+ * has no tool identity, the proposer's tool name is recorded `"unverified"` and
+ * no closure should be claimed. Default-deny tool semantics remain out of scope.
+ *
+ * All conflicting fields are collected before throwing, in declaration order, so
+ * the same conflicting request always reports the same deterministic set.
+ */
+export function reconcileWithTrustedContext(
+  intent: Intent,
+  ctx: TrustedExecutionContext,
+  actionContext: Record<string, unknown> | undefined
+): ReconciliationResult {
+  const merged: Record<string, unknown> = { ...(intent as unknown as Record<string, unknown>) };
+  const provenance: Record<string, ClaimProvenance> = {};
+  const conflicts: string[] = [];
+
+  for (const field of FIELDS) {
+    const premise = field.derived(ctx);
+    const claims = field.claims(intent, actionContext);
+
+    if (premise === undefined) {
+      provenance[field.name] = claims.length > 0 ? "unverified" : "absent";
+      continue;
+    }
+
+    if (claims.length === 0) {
+      provenance[field.name] = "absent";
+      field.apply?.(merged, premise);
+      continue;
+    }
+
+    // Exact equality against every source that carried a claim.
+    const conflicting = claims.some((claim) => claim !== premise);
+    if (conflicting) {
+      provenance[field.name] = "conflict";
+      conflicts.push(field.name);
+      continue;
+    }
+
+    provenance[field.name] = "matched";
+    field.apply?.(merged, premise);
+  }
+
+  if (conflicts.length > 0) {
+    throw new OxDeAIProvenanceConflictError(conflicts, Object.freeze({ ...provenance }));
+  }
+
+  return {
+    intent: merged as unknown as Intent,
+    provenance: Object.freeze(provenance),
+  };
+}

--- a/packages/guard/src/secureGuard.ts
+++ b/packages/guard/src/secureGuard.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { Intent } from "@oxdeai/core";
+import { OxDeAIGuard } from "./guard.js";
+import { defaultNormalizeAction } from "./normalizeAction.js";
+import { createInMemoryReplayStore } from "./replayStore.js";
+import { OxDeAIAuthorizationError } from "./errors.js";
+import { isTrustedExecutionContext, type TrustedExecutionContext } from "./trustedContext.js";
+import { reconcileWithTrustedContext, type ProvenanceRecord } from "./provenance.js";
+import type { OxDeAIGuardConfig, ProposedAction, GuardCallOptions } from "./types.js";
+
+/**
+ * Tier 1 secure guard entry point.
+ *
+ * The secure path differs from {@link OxDeAIGuard} in exactly one respect: how
+ * the evaluated intent's provenance is established. Everything after that —
+ * state read, evaluation, authorization verification, replay consumption,
+ * intent/state hash binding, CAS, execution ordering — is the SAME enforcement
+ * body, reached by delegating to `OxDeAIGuard` rather than by reimplementing
+ * it. Two entry points that share one body cannot drift apart.
+ *
+ * ```text
+ * authenticate                       (caller, before this function)
+ * → resolve trusted context          (createTrustedExecutionContext)
+ * → normalize proposal → reconcile   (here; conflicts fail closed)
+ * → read state → evaluate → verify → CAS → execute   (shared body)
+ * ```
+ *
+ * Trusted context is a separate positional argument and never a field on
+ * {@link ProposedAction}: there is no place to put it in the request payload,
+ * so "trusted context is not accepted from request JSON" holds structurally
+ * rather than by convention.
+ *
+ * ⚠️ Only this path, or an integration independently enforcing the same
+ * boundary, may claim Tier 1 evaluator-input provenance. `OxDeAIGuard` remains
+ * available and unchanged, and carries no such guarantee.
+ *
+ * SCOPE — this entry point establishes trusted *evaluator inputs* only. It does
+ * NOT make state or policy authoritative: `getState` / `setState` and the
+ * engine's policy configuration are still supplied by the deployment. An
+ * authoritative versioned StateProvider and PolicyProvider are separate work.
+ *
+ * @public
+ */
+export function createSecureGuard(config: OxDeAIGuardConfig) {
+  const baseNormalize: (action: ProposedAction) => Intent =
+    config.mapActionToIntent ?? defaultNormalizeAction;
+
+  // Resolve the replay store ONCE. The guard closure is rebuilt per call so
+  // that each call's provenance capture is isolated, and a per-call default
+  // store would otherwise give every call a fresh replay namespace — silently
+  // disabling replay protection across calls.
+  const replayStore = config.replayStore ?? createInMemoryReplayStore();
+
+  return async function secureGuard(
+    trustedContext: TrustedExecutionContext,
+    action: ProposedAction,
+    execute: () => Promise<unknown>,
+    opts?: GuardCallOptions
+  ): Promise<unknown> {
+    if (!isTrustedExecutionContext(trustedContext)) {
+      throw new OxDeAIAuthorizationError(
+        "Secure guard requires a TrustedExecutionContext built by createTrustedExecutionContext(). " +
+          "A plain object — including one deserialized from request JSON — is not accepted. Execution blocked."
+      );
+    }
+
+    let provenance: ProvenanceRecord | undefined;
+
+    const secureConfig: OxDeAIGuardConfig = {
+      ...config,
+      replayStore,
+      // Reconciliation runs on the OUTPUT of the deployment's normalizer, so a
+      // custom mapActionToIntent cannot overwrite a trusted premise.
+      mapActionToIntent: (a: ProposedAction): Intent => {
+        const proposed = baseNormalize(a);
+        const reconciled = reconcileWithTrustedContext(proposed, trustedContext, a.context);
+        provenance = reconciled.provenance;
+        return reconciled.intent;
+      },
+      onDecision: config.onDecision
+        ? (record) => config.onDecision!({ ...record, ...(provenance ? { provenance } : {}) })
+        : undefined,
+    };
+
+    return OxDeAIGuard(secureConfig)(action, execute, opts);
+  };
+}

--- a/packages/guard/src/secureGuard.ts
+++ b/packages/guard/src/secureGuard.ts
@@ -3,10 +3,33 @@ import type { Intent } from "@oxdeai/core";
 import { OxDeAIGuard } from "./guard.js";
 import { defaultNormalizeAction } from "./normalizeAction.js";
 import { createInMemoryReplayStore } from "./replayStore.js";
-import { OxDeAIAuthorizationError } from "./errors.js";
+import { OxDeAIAuthorizationError, OxDeAIGuardConfigurationError } from "./errors.js";
 import { isTrustedExecutionContext, type TrustedExecutionContext } from "./trustedContext.js";
 import { reconcileWithTrustedContext, type ProvenanceRecord } from "./provenance.js";
 import type { OxDeAIGuardConfig, ProposedAction, GuardCallOptions } from "./types.js";
+
+/**
+ * Deployment-level configuration for the Tier 1 secure path.
+ *
+ * @public
+ */
+export type SecureGuardOptions = {
+  /**
+   * Whether this deployment serves one tenant or many.
+   *
+   * REQUIRED and never defaulted. Tier 1 permits an absent `tenantId` only when
+   * the deployment is explicitly single-tenant; without a declared posture a
+   * multi-tenant integration whose route has not been wired for tenant identity
+   * is indistinguishable from a legitimate single-tenant one, and would silently
+   * evaluate in an ambiguous namespace.
+   *
+   *  - `"single-tenant"` — a context without `tenantId` is valid.
+   *  - `"multi-tenant"`  — a context without `tenantId` fails closed before
+   *                        evaluation; a proposer tenant claim that conflicts
+   *                        with the trusted one is a provenance conflict.
+   */
+  readonly tenancy: "single-tenant" | "multi-tenant";
+};
 
 /**
  * Tier 1 secure guard entry point.
@@ -39,9 +62,35 @@ import type { OxDeAIGuardConfig, ProposedAction, GuardCallOptions } from "./type
  * engine's policy configuration are still supplied by the deployment. An
  * authoritative versioned StateProvider and PolicyProvider are separate work.
  *
+ * ⚠️ AUDIT CONTRACT — where provenance appears:
+ *
+ * ```text
+ * ALLOW / evaluated paths      → provenance on GuardDecisionRecord (onDecision)
+ * pre-evaluation conflict      → provenance on OxDeAIProvenanceConflictError,
+ *                                NOT on onDecision
+ * ```
+ *
+ * A provenance conflict is rejected before the shared enforcement body reaches
+ * a policy decision, so there is no decision record to attach it to. It is
+ * deliberately NOT emitted through `onDecision` as a synthetic DENY: that hook
+ * reports `PolicyEngine` decisions, and manufacturing one would misreport a
+ * boundary rejection as a policy outcome. **A deployment using `onDecision` as
+ * its only audit sink will therefore not see attempted identity or tool
+ * substitutions** — it must also record `OxDeAIProvenanceConflictError`, which
+ * carries the conflicting fields and the full provenance map. Unified
+ * guard-boundary audit emission is separate work.
+ *
  * @public
  */
-export function createSecureGuard(config: OxDeAIGuardConfig) {
+export function createSecureGuard(config: OxDeAIGuardConfig, options: SecureGuardOptions) {
+  const tenancy = options?.tenancy;
+  if (tenancy !== "single-tenant" && tenancy !== "multi-tenant") {
+    throw new OxDeAIGuardConfigurationError(
+      'Secure guard requires an explicit tenancy posture: "single-tenant" or "multi-tenant". ' +
+        "It is not defaulted, because a multi-tenant deployment that has not wired tenant identity " +
+        "would otherwise be indistinguishable from a legitimate single-tenant one."
+    );
+  }
   const baseNormalize: (action: ProposedAction) => Intent =
     config.mapActionToIntent ?? defaultNormalizeAction;
 
@@ -64,6 +113,18 @@ export function createSecureGuard(config: OxDeAIGuardConfig) {
       );
     }
 
+    // Deployment-level tenancy posture, enforced before evaluation, authorization
+    // issuance, state mutation or execution. A multi-tenant deployment whose
+    // route did not resolve a tenant fails closed rather than evaluating in an
+    // ambiguous namespace; treating the absence as "probably single tenant" is
+    // exactly the migration hazard this posture exists to remove.
+    if (tenancy === "multi-tenant" && trustedContext.tenantId === undefined) {
+      throw new OxDeAIAuthorizationError(
+        "Deployment is configured multi-tenant but the trusted execution context carries no tenantId. " +
+          "Execution blocked."
+      );
+    }
+
     let provenance: ProvenanceRecord | undefined;
 
     const secureConfig: OxDeAIGuardConfig = {
@@ -72,8 +133,27 @@ export function createSecureGuard(config: OxDeAIGuardConfig) {
       // Reconciliation runs on the OUTPUT of the deployment's normalizer, so a
       // custom mapActionToIntent cannot overwrite a trusted premise.
       mapActionToIntent: (a: ProposedAction): Intent => {
-        const proposed = baseNormalize(a);
-        const reconciled = reconcileWithTrustedContext(proposed, trustedContext, a.context);
+        // `defaultNormalizeAction` requires `context.agent_id` and throws before
+        // reconciliation could fill it, so an absent proposer identity would
+        // never reach the "absent claim → derived premise" rule. Supply the
+        // derived identity for normalization ONLY when the proposer omitted it,
+        // and reconcile against the ORIGINAL proposer claims so the fill is
+        // audited as `absent` rather than as a claim the proposer made.
+        const claimedAgentId = a.context?.["agent_id"];
+        const synthesizedFields = new Set<string>();
+        let forNormalization = a;
+        if (claimedAgentId === undefined || claimedAgentId === null) {
+          synthesizedFields.add("agent_id");
+          forNormalization = {
+            ...a,
+            context: { ...a.context, agent_id: trustedContext.agentId },
+          };
+        }
+
+        const proposed = baseNormalize(forNormalization);
+        const reconciled = reconcileWithTrustedContext(proposed, trustedContext, a.context, {
+          synthesized: synthesizedFields,
+        });
         provenance = reconciled.provenance;
         return reconciled.intent;
       },

--- a/packages/guard/src/test/guard.provenance.test.ts
+++ b/packages/guard/src/test/guard.provenance.test.ts
@@ -22,6 +22,13 @@
  *   P-16 a conflict blocks execution and state mutation
  *   P-17 the ALLOW path executes and reports provenance to the audit hook
  *   P-18 a custom mapActionToIntent cannot overwrite a trusted premise
+ *   P-19 an absent proposer agent_id is supplied from trusted context, audits absent
+ *   P-20 a matching proposer agent_id still audits as matched
+ *   P-21 a custom normalizer cannot substitute identity into a synthesized field
+ *   P-22 single-tenant deployment accepts a context without tenantId
+ *   P-23 multi-tenant fails closed when trusted tenantId is absent
+ *   P-24 multi-tenant matches a proposer tenant and rejects a conflicting one
+ *   P-25 a provenance conflict is NOT reported through onDecision
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -30,7 +37,7 @@ import type { Intent, State } from "@oxdeai/core";
 import { buildState } from "@oxdeai/sdk";
 import { TEST_KEYSET, TEST_KEYPAIR } from "./helpers/fixtures.js";
 
-import { createSecureGuard } from "../secureGuard.js";
+import { createSecureGuard, type SecureGuardOptions } from "../secureGuard.js";
 import {
   createTrustedExecutionContext,
   isTrustedExecutionContext,
@@ -100,6 +107,14 @@ function makeContext(overrides: Partial<TrustedExecutionContext> = {}): TrustedE
     depth: 0,
     ...overrides,
   });
+}
+
+const SINGLE_TENANT: SecureGuardOptions = { tenancy: "single-tenant" };
+const MULTI_TENANT: SecureGuardOptions = { tenancy: "multi-tenant" };
+
+/** Most scenarios are tenancy-agnostic; tenancy tests pass their own posture. */
+function makeSecure(config: OxDeAIGuardConfig, options: SecureGuardOptions = SINGLE_TENANT) {
+  return createSecureGuard(config, options);
 }
 
 function makeAction(context: Record<string, unknown> = {}): ProposedAction {
@@ -325,7 +340,7 @@ test("P-11 reconcile: multiple conflicts are collected in declaration order", ()
 
 test("P-12 attack L: privileged agent_id substitution is rejected by the secure path", async () => {
   let executed = false;
-  const secure = createSecureGuard(makeGuardConfig());
+  const secure = makeSecure(makeGuardConfig());
   const ctx = makeContext(); // authenticated principal maps to AGENT_ID
 
   await assert.rejects(
@@ -342,7 +357,7 @@ test("P-12 attack L: privileged agent_id substitution is rejected by the secure 
 
 test("P-13 attack M: tool rename is rejected where the route supplies tool identity", async () => {
   let executed = false;
-  const secure = createSecureGuard(makeGuardConfig());
+  const secure = makeSecure(makeGuardConfig());
   const ctx = makeContext({ tool: "provision_gpu" });
 
   await assert.rejects(
@@ -359,7 +374,7 @@ test("P-13 attack M: tool rename is rejected where the route supplies tool ident
 
 test("P-14 attack M: no closure is claimed where the route supplies no tool identity", async () => {
   const records: Array<Record<string, unknown>> = [];
-  const secure = createSecureGuard(
+  const secure = makeSecure(
     makeGuardConfig({ onDecision: (r) => { records.push(r as unknown as Record<string, unknown>); } })
   );
   const ctx = makeContext(); // no trusted tool
@@ -377,7 +392,7 @@ test("P-14 attack M: no closure is claimed where the route supplies no tool iden
 test("P-15 secure guard: an unbranded context is rejected before any side effect", async () => {
   let executed = false;
   let stateWritten = false;
-  const secure = createSecureGuard(
+  const secure = makeSecure(
     makeGuardConfig({
       setState: () => {
         stateWritten = true;
@@ -409,7 +424,7 @@ test("P-15 secure guard: an unbranded context is rejected before any side effect
 test("P-16 secure guard: a conflict blocks execution and state mutation", async () => {
   let executed = false;
   let stateWritten = false;
-  const secure = createSecureGuard(
+  const secure = makeSecure(
     makeGuardConfig({
       setState: () => {
         stateWritten = true;
@@ -433,7 +448,7 @@ test("P-16 secure guard: a conflict blocks execution and state mutation", async 
 
 test("P-17 secure guard: ALLOW executes and reports provenance to the audit hook", async () => {
   const records: Array<Record<string, unknown>> = [];
-  const secure = createSecureGuard(
+  const secure = makeSecure(
     makeGuardConfig({ onDecision: (r) => { records.push(r as unknown as Record<string, unknown>); } })
   );
 
@@ -459,7 +474,7 @@ test("P-18 secure guard: a custom mapActionToIntent cannot overwrite a trusted p
   // A deployment-supplied normalizer that returns a privileged agent_id.
   // Reconciliation runs on its OUTPUT, so this is a conflict rather than a
   // successful substitution.
-  const secure = createSecureGuard(
+  const secure = makeSecure(
     makeGuardConfig({
       mapActionToIntent: (action) => {
         const intent = defaultNormalizeAction({
@@ -482,4 +497,145 @@ test("P-18 secure guard: a custom mapActionToIntent cannot overwrite a trusted p
   );
 
   assert.equal(executed, false);
+});
+
+// ── P-19 .. P-24: review follow-ups on #234 ───────────────────────────────────
+
+test("P-19 secure guard: an absent proposer agent_id is supplied from trusted context", async () => {
+  const records: Array<Record<string, unknown>> = [];
+  const secure = makeSecure(
+    makeGuardConfig({ onDecision: (r) => { records.push(r as unknown as Record<string, unknown>); } })
+  );
+
+  // The proposal carries no agent_id at all. Before this fix the default
+  // normalizer threw on the missing context field, so "absent claim → derived
+  // premise" was unreachable end-to-end for identity.
+  const action: ProposedAction = {
+    name: "provision_gpu",
+    args: { asset: "a100" },
+    estimatedCost: 0.5,
+    resourceType: "gpu",
+    context: { target: "gpu-pool" },
+  };
+
+  const result = await secure(makeContext(), action, async () => "executed");
+
+  assert.equal(result, "executed");
+  const provenance = records[0]?.["provenance"] as Record<string, string> | undefined;
+  assert.equal(
+    provenance?.["agent_id"],
+    "absent",
+    "a guard-supplied identity must audit as absent, not as a claim the proposer made"
+  );
+});
+
+test("P-20 secure guard: a matching proposer agent_id still audits as matched", async () => {
+  const records: Array<Record<string, unknown>> = [];
+  const secure = makeSecure(
+    makeGuardConfig({ onDecision: (r) => { records.push(r as unknown as Record<string, unknown>); } })
+  );
+
+  await secure(makeContext(), makeAction({ agent_id: AGENT_ID }), async () => "ok");
+
+  const provenance = records[0]?.["provenance"] as Record<string, string> | undefined;
+  assert.equal(provenance?.["agent_id"], "matched");
+});
+
+test("P-21 secure guard: a custom normalizer cannot substitute identity into a synthesized field", async () => {
+  let executed = false;
+  // The proposer omits agent_id, so the guard supplies the trusted one for
+  // normalization — and the custom normalizer then returns a different identity.
+  // That must fail closed rather than being silently overwritten.
+  const secure = makeSecure(
+    makeGuardConfig({
+      mapActionToIntent: (action) => {
+        const intent = defaultNormalizeAction(action);
+        intent.agent_id = PRIVILEGED_AGENT_ID;
+        return intent;
+      },
+    })
+  );
+
+  const action: ProposedAction = {
+    name: "provision_gpu",
+    args: { asset: "a100" },
+    estimatedCost: 0.5,
+    resourceType: "gpu",
+    context: { target: "gpu-pool" },
+  };
+
+  await assert.rejects(
+    () => secure(makeContext(), action, async () => { executed = true; return "done"; }),
+    OxDeAIProvenanceConflictError
+  );
+  assert.equal(executed, false);
+});
+
+test("P-22 tenancy: single-tenant deployment accepts a context without tenantId", async () => {
+  const secure = makeSecure(makeGuardConfig(), SINGLE_TENANT);
+  const result = await secure(makeContext(), makeAction({ agent_id: AGENT_ID }), async () => "ok");
+  assert.equal(result, "ok");
+});
+
+test("P-23 tenancy: multi-tenant deployment fails closed when trusted tenantId is absent", async () => {
+  let executed = false;
+  let stateWritten = false;
+  const secure = makeSecure(
+    makeGuardConfig({ setState: () => { stateWritten = true; return true; } }),
+    MULTI_TENANT
+  );
+
+  await assert.rejects(
+    () =>
+      secure(makeContext(), makeAction({ agent_id: AGENT_ID }), async () => {
+        executed = true;
+        return "done";
+      }),
+    OxDeAIAuthorizationError
+  );
+
+  assert.equal(executed, false, "rejection precedes execution");
+  assert.equal(stateWritten, false, "rejection precedes state mutation");
+});
+
+test("P-24 tenancy: multi-tenant accepts a matching proposer tenant and rejects a conflicting one", async () => {
+  const records: Array<Record<string, unknown>> = [];
+  const secure = makeSecure(
+    makeGuardConfig({ onDecision: (r) => { records.push(r as unknown as Record<string, unknown>); } }),
+    MULTI_TENANT
+  );
+  const ctx = makeContext({ tenantId: "tenant-a" });
+
+  const result = await secure(
+    ctx,
+    makeAction({ agent_id: AGENT_ID, tenant_id: "tenant-a" }),
+    async () => "ok"
+  );
+  assert.equal(result, "ok");
+  const provenance = records[0]?.["provenance"] as Record<string, string> | undefined;
+  assert.equal(provenance?.["tenant_id"], "matched");
+
+  const secure2 = makeSecure(makeGuardConfig(), MULTI_TENANT);
+  await assert.rejects(
+    () =>
+      secure2(ctx, makeAction({ agent_id: AGENT_ID, tenant_id: "tenant-b" }), async () => "done"),
+    OxDeAIProvenanceConflictError
+  );
+});
+
+test("P-25 audit contract: a provenance conflict is NOT reported through onDecision", async () => {
+  const records: Array<Record<string, unknown>> = [];
+  const secure = makeSecure(
+    makeGuardConfig({ onDecision: (r) => { records.push(r as unknown as Record<string, unknown>); } })
+  );
+
+  await assert.rejects(
+    () => secure(makeContext(), makeAction({ agent_id: PRIVILEGED_AGENT_ID }), async () => "done"),
+    OxDeAIProvenanceConflictError
+  );
+
+  // Pinning the documented contract rather than a wish: rejection happens before
+  // the shared body reaches a policy decision, so there is no decision record.
+  // A deployment auditing only via onDecision does NOT see this attempt.
+  assert.equal(records.length, 0);
 });

--- a/packages/guard/src/test/guard.provenance.test.ts
+++ b/packages/guard/src/test/guard.provenance.test.ts
@@ -1,0 +1,485 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Tier 1 secure guard: trusted execution context and trusted-vs-proposer
+ * provenance reconciliation (#233).
+ *
+ * Scenarios:
+ *   P-1  depth is required and never defaulted to 0
+ *   P-2  context construction validates identity and routing fields
+ *   P-3  the runtime brand rejects plain and JSON-round-tripped objects
+ *   P-4  TrustedExecutionContext deliberately carries no evaluationTime
+ *   P-5  absent proposer claim is filled from trusted context
+ *   P-6  present-and-matching claim is recorded distinctly from an absent one
+ *   P-7  conflicting claim fails closed with the conflicting fields listed
+ *   P-8  comparison is exact: no case folding or trimming
+ *   P-9  a route without trusted tool identity records "unverified", not "matched"
+ *   P-10 context-only claims (principal_id, adapter_id) are conflict-checked
+ *   P-11 multiple conflicts are collected deterministically in declaration order
+ *   P-12 attack L: privileged agent_id substitution is rejected by the secure path
+ *   P-13 attack M: tool rename is rejected where the route supplies tool identity
+ *   P-14 attack M: no closure is claimed where the route supplies no tool identity
+ *   P-15 the secure path rejects an unbranded context before any side effect
+ *   P-16 a conflict blocks execution and state mutation
+ *   P-17 the ALLOW path executes and reports provenance to the audit hook
+ *   P-18 a custom mapActionToIntent cannot overwrite a trusted premise
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { PolicyEngine, RECOMMENDED_TRUSTED_TIME_PROFILE } from "@oxdeai/core";
+import type { Intent, State } from "@oxdeai/core";
+import { buildState } from "@oxdeai/sdk";
+import { TEST_KEYSET, TEST_KEYPAIR } from "./helpers/fixtures.js";
+
+import { createSecureGuard } from "../secureGuard.js";
+import {
+  createTrustedExecutionContext,
+  isTrustedExecutionContext,
+  type TrustedExecutionContext,
+} from "../trustedContext.js";
+import { reconcileWithTrustedContext } from "../provenance.js";
+import { defaultNormalizeAction } from "../normalizeAction.js";
+import {
+  OxDeAIProvenanceConflictError,
+  OxDeAIAuthorizationError,
+  OxDeAIGuardConfigurationError,
+} from "../errors.js";
+import type { ProposedAction, OxDeAIGuardConfig } from "../types.js";
+
+const ENGINE_SECRET = "test-secret-must-be-at-least-32-chars!!";
+const AGENT_ID = "agent-test-001";
+const PRIVILEGED_AGENT_ID = "agent-admin-root";
+
+function makeEngine(): PolicyEngine {
+  return new PolicyEngine({
+    policy_version: "v1",
+    engine_secret: ENGINE_SECRET,
+    authorization_signing_alg: "Ed25519",
+    authorization_signing_kid: "k1",
+    authorization_issuer: TEST_KEYSET.issuer,
+    authorization_audience: "aud-test",
+    authorization_ttl_seconds: 600,
+    authorization_private_key_pem: TEST_KEYPAIR.privateKey.toString(),
+    ...RECOMMENDED_TRUSTED_TIME_PROFILE,
+  });
+}
+
+function makeState(): State {
+  return buildState({
+    agent_id: AGENT_ID,
+    allow_action_types: ["PROVISION", "PAYMENT", "PURCHASE", "ONCHAIN_TX"],
+    budget_limit: 1_000_000_000n,
+    max_amount_per_action: 1_000_000_000n,
+    velocity_max_actions: 1000,
+    max_concurrent: 16,
+  });
+}
+
+function makeGuardConfig(overrides: Partial<OxDeAIGuardConfig> = {}): OxDeAIGuardConfig {
+  let currentState = makeState();
+  let currentVersion = 0;
+  return {
+    engine: makeEngine(),
+    getState: () => ({ state: currentState, version: currentVersion }),
+    setState: (s, v) => {
+      if (v !== currentVersion) return false;
+      currentState = s;
+      currentVersion++;
+      return true;
+    },
+    trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
+    ...overrides,
+  };
+}
+
+function makeContext(overrides: Partial<TrustedExecutionContext> = {}): TrustedExecutionContext {
+  return createTrustedExecutionContext({
+    principalId: "principal-1",
+    agentId: AGENT_ID,
+    adapterId: "adapter-http",
+    depth: 0,
+    ...overrides,
+  });
+}
+
+function makeAction(context: Record<string, unknown> = {}): ProposedAction {
+  return {
+    name: "provision_gpu",
+    args: { asset: "a100" },
+    estimatedCost: 0.5,
+    resourceType: "gpu",
+    context: { target: "gpu-pool", ...context },
+  };
+}
+
+// ── P-1 / P-2: context construction ───────────────────────────────────────────
+
+test("P-1 createTrustedExecutionContext: depth is required and never defaults to 0", () => {
+  assert.throws(
+    () =>
+      createTrustedExecutionContext({
+        principalId: "p",
+        agentId: "a",
+        adapterId: "ad",
+      } as unknown as TrustedExecutionContext),
+    OxDeAIGuardConfigurationError
+  );
+
+  // Explicit 0 is legitimate — the rejection is of a MISSING depth, not of a
+  // root call. This is what stops "required" from being read as "non-zero".
+  const ctx = createTrustedExecutionContext({
+    principalId: "p",
+    agentId: "a",
+    adapterId: "ad",
+    depth: 0,
+  });
+  assert.equal(ctx.depth, 0);
+});
+
+test("P-1b createTrustedExecutionContext: rejects negative and non-integer depth", () => {
+  for (const depth of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.throws(
+      () => createTrustedExecutionContext({ principalId: "p", agentId: "a", adapterId: "ad", depth }),
+      OxDeAIGuardConfigurationError,
+      `depth ${String(depth)} must be rejected`
+    );
+  }
+});
+
+test("P-2 createTrustedExecutionContext: identity and routing fields must be non-empty strings", () => {
+  const base = { principalId: "p", agentId: "a", adapterId: "ad", depth: 0 };
+  for (const field of ["principalId", "agentId", "adapterId"] as const) {
+    assert.throws(
+      () => createTrustedExecutionContext({ ...base, [field]: "" }),
+      OxDeAIGuardConfigurationError,
+      `empty ${field} must be rejected`
+    );
+  }
+});
+
+// ── P-3: the brand ────────────────────────────────────────────────────────────
+
+test("P-3 brand: a plain object with identical fields is not a trusted context", () => {
+  const real = makeContext();
+  assert.equal(isTrustedExecutionContext(real), true);
+
+  const lookalike = {
+    principalId: "principal-1",
+    agentId: AGENT_ID,
+    adapterId: "adapter-http",
+    depth: 0,
+  };
+  assert.equal(isTrustedExecutionContext(lookalike), false);
+
+  // A context that has been through request JSON loses the brand: the brand is
+  // a non-enumerable symbol, so it does not survive serialization. This is the
+  // property that makes "not constructed from request JSON" checkable.
+  const roundTripped = JSON.parse(JSON.stringify(real)) as unknown;
+  assert.equal(isTrustedExecutionContext(roundTripped), false);
+});
+
+// ── P-4: evaluationTime is deliberately absent ────────────────────────────────
+
+test("P-4 TrustedExecutionContext carries no evaluationTime", () => {
+  const ctx = makeContext();
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(ctx, "evaluationTime"),
+    false,
+    "trusted time is captured at the evaluation boundary, not carried on the context; " +
+      "a context that carried a timestamp could be reused as a time capsule"
+  );
+});
+
+// ── P-5 .. P-11: reconciliation ───────────────────────────────────────────────
+
+function normalized(context: Record<string, unknown> = {}): Intent {
+  return defaultNormalizeAction(makeAction({ agent_id: AGENT_ID, ...context }));
+}
+
+test("P-5 reconcile: absent proposer claim is filled from trusted context", () => {
+  const intent = defaultNormalizeAction(makeAction({ agent_id: AGENT_ID }));
+  delete (intent as unknown as Record<string, unknown>)["tool"];
+  const ctx = makeContext({ tool: "provision_gpu" });
+
+  const { intent: merged, provenance } = reconcileWithTrustedContext(intent, ctx, {
+    target: "gpu-pool",
+  });
+
+  assert.equal(merged.tool, "provision_gpu");
+  assert.equal(provenance["tool"], "absent");
+});
+
+test("P-6 reconcile: a matching claim is recorded distinctly from an absent one", () => {
+  const ctx = makeContext({ tool: "provision_gpu" });
+  const intent = normalized({ tool: "provision_gpu" });
+  intent.tool = "provision_gpu";
+
+  const { intent: merged, provenance } = reconcileWithTrustedContext(intent, ctx, {
+    target: "gpu-pool",
+    tool: "provision_gpu",
+  });
+
+  assert.equal(merged.tool, "provision_gpu");
+  assert.equal(
+    provenance["tool"],
+    "matched",
+    "a trusted fill and a correct proposer assertion must not be indistinguishable"
+  );
+  assert.equal(provenance["agent_id"], "matched");
+});
+
+test("P-7 reconcile: a conflicting claim fails closed and names the field", () => {
+  const ctx = makeContext();
+  const intent = normalized();
+  intent.agent_id = PRIVILEGED_AGENT_ID;
+
+  let caught: unknown;
+  try {
+    reconcileWithTrustedContext(intent, ctx, { target: "gpu-pool" });
+  } catch (e) {
+    caught = e;
+  }
+
+  assert.ok(caught instanceof OxDeAIProvenanceConflictError);
+  assert.deepEqual(caught.fields, ["agent_id"]);
+  assert.equal(caught.provenance["agent_id"], "conflict");
+});
+
+test("P-8 reconcile: comparison is exact — case differences are conflicts", () => {
+  const ctx = makeContext({ tool: "provision_gpu" });
+  const intent = normalized();
+  intent.tool = "PROVISION_GPU";
+
+  assert.throws(
+    () => reconcileWithTrustedContext(intent, ctx, { target: "gpu-pool" }),
+    OxDeAIProvenanceConflictError,
+    "no case folding: a near-match is how a rename bypass re-enters"
+  );
+});
+
+test("P-9 reconcile: no trusted tool identity records unverified, not matched", () => {
+  const ctx = makeContext(); // route supplies no tool
+  const intent = normalized();
+  intent.tool = "attacker_chosen_name";
+
+  const { intent: merged, provenance } = reconcileWithTrustedContext(intent, ctx, {
+    target: "gpu-pool",
+  });
+
+  assert.equal(merged.tool, "attacker_chosen_name", "the claim is retained, not overwritten");
+  assert.equal(
+    provenance["tool"],
+    "unverified",
+    "a route with no tool identity must not look like a verified match"
+  );
+});
+
+test("P-10 reconcile: context-only claims are conflict-checked", () => {
+  const ctx = makeContext();
+  const intent = normalized();
+
+  assert.throws(
+    () =>
+      reconcileWithTrustedContext(intent, ctx, {
+        target: "gpu-pool",
+        principal_id: "principal-someone-else",
+      }),
+    OxDeAIProvenanceConflictError
+  );
+
+  assert.throws(
+    () =>
+      reconcileWithTrustedContext(intent, ctx, {
+        target: "gpu-pool",
+        adapter_id: "adapter-other",
+      }),
+    OxDeAIProvenanceConflictError
+  );
+});
+
+test("P-11 reconcile: multiple conflicts are collected in declaration order", () => {
+  const ctx = makeContext({ tool: "provision_gpu" });
+  const intent = normalized();
+  intent.agent_id = PRIVILEGED_AGENT_ID;
+  intent.tool = "other_tool";
+
+  let caught: unknown;
+  try {
+    reconcileWithTrustedContext(intent, ctx, {
+      target: "gpu-pool",
+      adapter_id: "adapter-other",
+    });
+  } catch (e) {
+    caught = e;
+  }
+
+  assert.ok(caught instanceof OxDeAIProvenanceConflictError);
+  assert.deepEqual(
+    caught.fields,
+    ["agent_id", "tool", "adapter_id"],
+    "the same conflicting request must always report the same ordered set"
+  );
+});
+
+// ── P-12 .. P-18: secure guard end to end ─────────────────────────────────────
+
+test("P-12 attack L: privileged agent_id substitution is rejected by the secure path", async () => {
+  let executed = false;
+  const secure = createSecureGuard(makeGuardConfig());
+  const ctx = makeContext(); // authenticated principal maps to AGENT_ID
+
+  await assert.rejects(
+    () =>
+      secure(ctx, makeAction({ agent_id: PRIVILEGED_AGENT_ID }), async () => {
+        executed = true;
+        return "done";
+      }),
+    OxDeAIProvenanceConflictError
+  );
+
+  assert.equal(executed, false, "L: execution must not occur on a substituted agent_id");
+});
+
+test("P-13 attack M: tool rename is rejected where the route supplies tool identity", async () => {
+  let executed = false;
+  const secure = createSecureGuard(makeGuardConfig());
+  const ctx = makeContext({ tool: "provision_gpu" });
+
+  await assert.rejects(
+    () =>
+      secure(ctx, makeAction({ agent_id: AGENT_ID, tool: "unlisted_tool_name" }), async () => {
+        executed = true;
+        return "done";
+      }),
+    OxDeAIProvenanceConflictError
+  );
+
+  assert.equal(executed, false, "M: a renamed tool must not reach execution");
+});
+
+test("P-14 attack M: no closure is claimed where the route supplies no tool identity", async () => {
+  const records: Array<Record<string, unknown>> = [];
+  const secure = createSecureGuard(
+    makeGuardConfig({ onDecision: (r) => { records.push(r as unknown as Record<string, unknown>); } })
+  );
+  const ctx = makeContext(); // no trusted tool
+
+  await secure(ctx, makeAction({ agent_id: AGENT_ID, tool: "attacker_chosen_name" }), async () => "ok");
+
+  const provenance = records[0]?.["provenance"] as Record<string, string> | undefined;
+  assert.equal(
+    provenance?.["tool"],
+    "unverified",
+    "M is closed only for routes with authoritative tool identity; this route has none"
+  );
+});
+
+test("P-15 secure guard: an unbranded context is rejected before any side effect", async () => {
+  let executed = false;
+  let stateWritten = false;
+  const secure = createSecureGuard(
+    makeGuardConfig({
+      setState: () => {
+        stateWritten = true;
+        return true;
+      },
+    })
+  );
+
+  const forged = {
+    principalId: "principal-1",
+    agentId: AGENT_ID,
+    adapterId: "adapter-http",
+    depth: 0,
+  } as unknown as TrustedExecutionContext;
+
+  await assert.rejects(
+    () =>
+      secure(forged, makeAction({ agent_id: AGENT_ID }), async () => {
+        executed = true;
+        return "done";
+      }),
+    OxDeAIAuthorizationError
+  );
+
+  assert.equal(executed, false);
+  assert.equal(stateWritten, false);
+});
+
+test("P-16 secure guard: a conflict blocks execution and state mutation", async () => {
+  let executed = false;
+  let stateWritten = false;
+  const secure = createSecureGuard(
+    makeGuardConfig({
+      setState: () => {
+        stateWritten = true;
+        return true;
+      },
+    })
+  );
+
+  await assert.rejects(
+    () =>
+      secure(makeContext(), makeAction({ agent_id: PRIVILEGED_AGENT_ID }), async () => {
+        executed = true;
+        return "done";
+      }),
+    OxDeAIProvenanceConflictError
+  );
+
+  assert.equal(executed, false, "rejection precedes execution");
+  assert.equal(stateWritten, false, "rejection precedes state mutation");
+});
+
+test("P-17 secure guard: ALLOW executes and reports provenance to the audit hook", async () => {
+  const records: Array<Record<string, unknown>> = [];
+  const secure = createSecureGuard(
+    makeGuardConfig({ onDecision: (r) => { records.push(r as unknown as Record<string, unknown>); } })
+  );
+
+  const result = await secure(
+    makeContext({ tool: "provision_gpu" }),
+    makeAction({ agent_id: AGENT_ID }),
+    async () => "executed"
+  );
+
+  assert.equal(result, "executed");
+  assert.equal(records.length, 1);
+  assert.equal(records[0]?.["decision"], "ALLOW");
+
+  const provenance = records[0]?.["provenance"] as Record<string, string> | undefined;
+  assert.ok(provenance, "the secure path must report provenance");
+  assert.equal(provenance["agent_id"], "matched");
+  assert.equal(provenance["tool"], "absent", "tool was filled from the trusted route");
+  assert.equal(provenance["depth"], "absent");
+});
+
+test("P-18 secure guard: a custom mapActionToIntent cannot overwrite a trusted premise", async () => {
+  let executed = false;
+  // A deployment-supplied normalizer that returns a privileged agent_id.
+  // Reconciliation runs on its OUTPUT, so this is a conflict rather than a
+  // successful substitution.
+  const secure = createSecureGuard(
+    makeGuardConfig({
+      mapActionToIntent: (action) => {
+        const intent = defaultNormalizeAction({
+          ...action,
+          context: { ...action.context, agent_id: AGENT_ID },
+        });
+        intent.agent_id = PRIVILEGED_AGENT_ID;
+        return intent;
+      },
+    })
+  );
+
+  await assert.rejects(
+    () =>
+      secure(makeContext(), makeAction({ agent_id: AGENT_ID }), async () => {
+        executed = true;
+        return "done";
+      }),
+    OxDeAIProvenanceConflictError
+  );
+
+  assert.equal(executed, false);
+});

--- a/packages/guard/src/trustedContext.ts
+++ b/packages/guard/src/trustedContext.ts
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+import { OxDeAIGuardConfigurationError } from "./errors.js";
+
+/**
+ * Runtime brand for a guard-constructed trusted execution context.
+ *
+ * ⚠️ MISUSE RESISTANCE ONLY — NOT AUTHENTICATION.
+ *
+ * The brand proves that a context object was produced by
+ * {@link createTrustedExecutionContext} inside this process, and nothing more.
+ * It exists so that a value deserialized from request JSON cannot be passed to
+ * the secure guard as if it were trusted context: a type-only brand is erased
+ * at compile time and would let `JSON.parse(body).ctx` through unnoticed.
+ *
+ * It is NOT cryptographic provenance and it is NOT a caller credential. A
+ * privileged in-process caller that can reach the builder can still manufacture
+ * a branded context. The real trust root is the authenticated principal and the
+ * protected routing data used to construct the context — the brand only ensures
+ * that construction actually happened.
+ */
+const TRUSTED_CONTEXT_BRAND: unique symbol = Symbol("oxdeai.guard.trustedExecutionContext");
+
+/**
+ * Server-created execution context for the Tier 1 secure guard path.
+ *
+ * Constructed by the PEP *after* authentication and protected route resolution.
+ * It must never be deserialized from proposer-controlled request JSON; see
+ * `docs/architecture/decisions/tier1-evaluator-input-provenance.md`.
+ *
+ * ⚠️ `evaluationTime` is deliberately ABSENT from this type.
+ *
+ * The Tier 1 ADR's illustrative context shape lists `evaluationTime` alongside
+ * the identity and routing fields. That is superseded here on purpose: trusted
+ * time is captured by the secure guard at the actual evaluation boundary,
+ * immediately before evaluation, rather than carried on the context.
+ *
+ * Authentication establishes *who* and *where*; `evaluationTime` establishes
+ * *when this specific decision is being made*. If the context carried a
+ * timestamp, a context constructed once could be reused as a time capsule for
+ * later decisions, and freshness would silently describe context construction
+ * rather than the evaluation it gates. **Do not add `evaluationTime` to this
+ * type** — capture it at the evaluation boundary instead.
+ *
+ * @public
+ */
+export type TrustedExecutionContext = {
+  /** Authenticated, deployment-local principal identifier. */
+  readonly principalId: string;
+  /** Authenticated tenant namespace. Required when the deployment is multi-tenant. */
+  readonly tenantId?: string;
+  /** Effective agent identity, mapped from the authenticated principal. */
+  readonly agentId: string;
+  /** Execution adapter fixed before authorization; the same adapter must execute. */
+  readonly adapterId: string;
+  /**
+   * Tool identity derived from the trusted route.
+   *
+   * Optional because not every route can supply an authoritative tool identity
+   * yet. When absent, a proposer-supplied tool name is retained but is NOT
+   * verified — see {@link ClaimProvenance} `"unverified"`.
+   */
+  readonly tool?: string;
+  /**
+   * Security-relevant action classification derived from the trusted route.
+   *
+   * Carried and conflict-checked as trusted routing context. It is deliberately
+   * NOT wired into policy-module evaluation: making this classification
+   * load-bearing is a separate reviewed decision. `intent.action_type` remains
+   * a separate, proposer-controlled concept.
+   */
+  readonly routeClassification?: string;
+  /** Recursion depth derived from the protected execution chain. Never defaulted. */
+  readonly depth: number;
+};
+
+type BrandedTrustedExecutionContext = TrustedExecutionContext & {
+  readonly [TRUSTED_CONTEXT_BRAND]: true;
+};
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new OxDeAIGuardConfigurationError(
+      `TrustedExecutionContext.${field} must be a non-empty string. Context construction failed.`
+    );
+  }
+  return value;
+}
+
+function optionalString(value: unknown, field: string): string | undefined {
+  if (value === undefined) return undefined;
+  return requireString(value, field);
+}
+
+/**
+ * Construct a branded {@link TrustedExecutionContext}.
+ *
+ * Every field is validated at construction so that an invalid context fails
+ * here — before evaluation, authorization issuance, state mutation, or
+ * execution — rather than producing a weaker decision later.
+ *
+ * `depth` is REQUIRED and is never defaulted. A missing trusted depth fails
+ * context construction rather than silently representing the call as a root
+ * call: defaulting to `0` would hand every nested call the recursion budget of
+ * a root call while looking like trusted depth.
+ *
+ * @public
+ */
+export function createTrustedExecutionContext(
+  input: TrustedExecutionContext
+): TrustedExecutionContext {
+  if (typeof input !== "object" || input === null) {
+    throw new OxDeAIGuardConfigurationError(
+      "TrustedExecutionContext input must be an object. Context construction failed."
+    );
+  }
+
+  const principalId = requireString(input.principalId, "principalId");
+  const agentId = requireString(input.agentId, "agentId");
+  const adapterId = requireString(input.adapterId, "adapterId");
+  const tenantId = optionalString(input.tenantId, "tenantId");
+  const tool = optionalString(input.tool, "tool");
+  const routeClassification = optionalString(input.routeClassification, "routeClassification");
+
+  const depth = input.depth;
+  if (typeof depth !== "number" || !Number.isSafeInteger(depth) || depth < 0) {
+    throw new OxDeAIGuardConfigurationError(
+      "TrustedExecutionContext.depth is required and must be a non-negative safe integer " +
+        "derived from the protected execution chain. It is never defaulted: a missing depth " +
+        "would silently represent a nested call as a root call. Context construction failed."
+    );
+  }
+
+  const context: TrustedExecutionContext = {
+    principalId,
+    agentId,
+    adapterId,
+    depth,
+    ...(tenantId === undefined ? {} : { tenantId }),
+    ...(tool === undefined ? {} : { tool }),
+    ...(routeClassification === undefined ? {} : { routeClassification }),
+  };
+
+  Object.defineProperty(context, TRUSTED_CONTEXT_BRAND, {
+    value: true,
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+
+  return Object.freeze(context);
+}
+
+/**
+ * True only for a context produced by {@link createTrustedExecutionContext}.
+ *
+ * Non-enumerable, so the brand does not appear in JSON, `Object.keys`, or
+ * structured clones — a round-tripped context loses its brand and is rejected.
+ */
+export function isTrustedExecutionContext(
+  value: unknown
+): value is TrustedExecutionContext {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as Partial<BrandedTrustedExecutionContext>)[TRUSTED_CONTEXT_BRAND] === true
+  );
+}

--- a/packages/guard/src/types.ts
+++ b/packages/guard/src/types.ts
@@ -61,6 +61,12 @@ export type GuardDecisionRecord = {
   /** Present when the decision was made via the delegation verification path. */
   delegation?: DelegationV1;
   reasons?: string[];
+  /**
+   * Per-field trusted-vs-proposer outcome. Present only on the Tier 1 secure
+   * guard path, so that an audit reader can tell a guard-filled premise apart
+   * from a proposer assertion that happened to be correct.
+   */
+  provenance?: Readonly<Record<string, string>>;
 };
 
 /**


### PR DESCRIPTION
Implements #233, the first bounded step of #197. Shape and first diff were reviewed on the issue before this branch existed.

## What this adds

A second entry point in `@oxdeai/guard` that establishes trusted evaluator inputs before evaluation. `OxDeAIGuard` keeps its signature and behavior and remains the legacy/low-level path with no Tier 1 provenance guarantee.

`createSecureGuard` **delegates to `OxDeAIGuard`** rather than reimplementing enforcement, so state read, evaluation, authorization verification, replay consumption, intent/state hash binding, CAS and execution ordering are the same code on both paths and cannot drift.

Trusted context is a **separate positional argument**, never a field on `ProposedAction` — so "trusted context is not accepted from request JSON" holds structurally rather than by convention. `createTrustedExecutionContext` is the only constructor and sets a non-enumerable runtime brand; a type-only brand is erased at runtime and would let `JSON.parse(body).ctx` through.

The concrete gap this closes is present today: `defaultNormalizeAction` reads `agent_id` out of proposer-supplied `action.context`.

## Rulings from the issue, as implemented

- **Missing claims** — `absent → fill from the derived premise`, `present-and-equal → use the premise`, `conflict → fail closed`. Per-field outcomes surface on `GuardDecisionRecord.provenance`, so a derived fill and a correct proposer assertion are distinguishable in audit.
- **`unverified`** — a fourth outcome for a claim with no non-declared premise. Without it, a tool claim on a route with no tool identity would record identically to a verified match. `P-14` pins it.
- **Reason codes** — guard-layer only. `OxDeAIProvenanceConflictError extends OxDeAIAuthorizationError`. Core `ReasonCode`, the conformance registries and the API fingerprint are untouched.
- **Route classification** — carried and conflict-checked, deliberately not wired into policy-module evaluation. `intent.action_type` stays separate and #215 independent.
- **Depth** — required, validated, never defaulted. A test asserts `depth: 0` is still accepted, so "required" cannot later be misread as "non-zero".
- **`evaluationTime`** — not on the context; captured at the evaluation boundary. The ADR's illustrative shape is corrected in this PR, narrowly and with no other ADR change.
- **Brand** — documented as misuse resistance, explicitly not authentication. A privileged in-process caller reaching the builder can still manufacture a branded context.
- **Exact equality** — no case folding or normalization; a case-only difference is a conflict, with a test pinning it.
- **Extensibility** — the seam is named and structured in terms of provenance modes. `declared` and `derived` are implemented; `read` and `attested` attach later as sibling resolvers without restructuring, under `declared never overrides derived, read, or attested`.

## Attack coverage

`L` (privileged `agent_id` substitution) is closed on the secure path. `M` (tool rename) is closed **only** for routes supplying authoritative tool identity; where the route has none, the claim records `unverified` and no closure is claimed. Default-deny tool semantics remain #214.

## Verification

- **Control first:** `packages/guard` on `main` (`bb5ae92`) = **145 tests, 145 pass**.
- **After:** **164 tests, 164 pass** — 19 added, none of the 145 broken.
- **Neutralized and re-ran**, since tests that pass against the old code prove nothing: disabling conflict detection fails **8** tests including the L and M cases; disabling the derived fill fails **P-5**. Probes removed and green re-confirmed.
- `packages/core` **356/356**; `scripts/check-api-fingerprint.sh` passes unchanged.

## Out of scope

Authoritative StateProvider/CAS, PolicyProvider, credential and argument provenance, `tool_call` hardening, default-deny tool semantics, `AuthorizationV1` and canonicalization. The stale lease-reclamation wording in the ADR is left for the separate #197 documentation pass.

## One naming question

I kept the exported `reconcileWithTrustedContext` name as reviewed, since the enforcement context is the only non-declared source today. If you would rather generalise it now that `read` and `attested` are on the roadmap, say the word and I will rename it in place.
