### PR TITLE
ci(security): enforce policy-boundary repro harness

### DIFF
--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -20,8 +20,16 @@ jobs:
           node-version: "22"
           cache: "pnpm"
 
-      - name: Install
-        run: pnpm install --frozen-lockfile
+      - name: Install security-gate dependencies
+        run: >-
+          pnpm install --frozen-lockfile
+          --filter .
+          --filter @oxdeai/core...
+          --filter @oxdeai/sdk...
+          --filter @oxdeai/guard...
+
+      - name: Build protocol packages
+        run: pnpm build:protocol
 
       - name: Audit
         run: pnpm audit --json > audit.json || true

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "run:bench": "pnpm --filter oxdeai-bench run run",
     "security:audit": "pnpm audit --json > audit.json || true",
     "security:gate": "node scripts/security-gate.mjs audit.json security/vuln-policy.json",
+    "security:policy-boundary": "tsx scripts/security/repro-policy-boundary-attacks.ts",
     "tags:audit": "node scripts/audit-tags.mjs",
     "tags:cleanup:dry": "node scripts/cleanup-legacy-tags.mjs",
     "tags:cleanup:local": "node scripts/cleanup-legacy-tags.mjs --apply-local --confirm=DELETE_LEGACY_TAGS",

--- a/scripts/security-gate.mjs
+++ b/scripts/security-gate.mjs
@@ -7,6 +7,7 @@
  */
 import fs from "node:fs";
 import crypto from "node:crypto";
+import { spawnSync } from "node:child_process";
 
 const args = process.argv.slice(2);
 const [auditPath, policyPath] = args.filter((a) => !a.startsWith("--"));
@@ -206,4 +207,11 @@ if (artifactOut) {
   console.log(`Artifact written to ${artifactOut}`);
 }
 
-process.exit(ok ? 0 : 1);
+console.log("\n== Policy-Boundary Repro Harness ==");
+const harness = spawnSync("pnpm", ["run", "security:policy-boundary"], { stdio: "inherit" });
+const harnessOk = harness.status === 0;
+if (!harnessOk) {
+  console.log(`\nPolicy-boundary repro harness failed (exit code ${harness.status ?? "unknown"}).`);
+}
+
+process.exit(ok && harnessOk ? 0 : 1);

--- a/scripts/security/repro-policy-boundary-attacks.ts
+++ b/scripts/security/repro-policy-boundary-attacks.ts
@@ -171,6 +171,13 @@ function toolIntent(nonce: number): Partial<Intent> {
 // changing what these cases mean.
 const LEGACY_PROFILE_LABEL = "LEGACY PROFILE";
 
+// Structured pass/fail state for CI. Only invariants that are expected to
+// hold today (Tier 1 secure-profile protections, plus the legacy attacks
+// that are already fixed) are pushed here on violation. Intentional
+// legacy-profile residuals (G/L/M) are logged for diagnostics only and never
+// push a failure — see the individual call sites below.
+const failures: string[] = [];
+
 function print(name: string, out: Outcome): void {
   console.log(`\n=== [${LEGACY_PROFILE_LABEL}] ${name} ===`);
   console.log("decision:", out.decision);
@@ -181,9 +188,23 @@ function print(name: string, out: Outcome): void {
   }
 }
 
-function assertSignal(name: string, condition: boolean, vulnerable: string, resisted: string): void {
+// `blocking: true` marks a case where `condition` (vulnerable/signal
+// detected) must NOT hold today; a regression pushes a CI failure. Omitted
+// (or false) for cases that are intentionally still reproducible (legacy
+// G/L/M) — those remain diagnostic-only, matching the requirement that
+// expected legacy-profile residuals must not fail CI.
+function assertSignal(
+  name: string,
+  condition: boolean,
+  vulnerable: string,
+  resisted: string,
+  opts?: { blocking?: boolean },
+): void {
   if (condition) {
     console.log(`[${LEGACY_PROFILE_LABEL}] SECURITY SIGNAL: ${vulnerable}`);
+    if (opts?.blocking) {
+      failures.push(`${name}: ${vulnerable}`);
+    }
   } else {
     console.log(`[${LEGACY_PROFILE_LABEL}] RESISTED / FIXED: ${resisted}`);
   }
@@ -214,6 +235,7 @@ function attackF_killSwitchTypeConfusion(): void {
     out.decision === "ALLOW",
     "VULNERABLE: truthy non-boolean per-agent kill-switch produced ALLOW",
     "per-agent kill-switch type confusion rejected or denied",
+    { blocking: true },
   );
 }
 
@@ -250,6 +272,7 @@ function attackC_futureDatedAuthorization(): void {
     out.decision === "ALLOW" && typeof expiry === "number" && expiry > BASE_TS + 99 * 365 * 24 * 60 * 60,
     "VULNERABLE: engine emitted far-future authorization from intent.timestamp",
     "future-dated authorization rejected or bounded",
+    { blocking: true },
   );
 }
 
@@ -285,6 +308,7 @@ function attackK_replayFutureDating(): void {
       futureReplay.decision === "ALLOW",
     "VULNERABLE: replay protection bypassed by attacker-controlled future timestamp",
     "future-dated replay rejected",
+    { blocking: true },
   );
 }
 
@@ -335,6 +359,7 @@ function attackJ_velocityFutureDating(): void {
     outs.every((o) => o.decision === "ALLOW"),
     "VULNERABLE: velocity limit reset by attacker-controlled future timestamps",
     "freshness-valid caller timestamps cannot reset trusted velocity quota",
+    { blocking: true },
   );
 }
 
@@ -390,6 +415,7 @@ function attackI_toolWindowFutureDating(): void {
       outs[3]?.decision === "ALLOW"),
     "VULNERABLE: tool-call limit reset by attacker-controlled future timestamps",
     "caller timestamps cannot reset quota; trusted exact-boundary progression can",
+    { blocking: true },
   );
 }
 
@@ -514,6 +540,7 @@ function attackH_toolCallOptIn(): void {
     omittedBypassed || !controlEnforced || !mixedSharesOneBudget,
     "VULNERABLE: omitting or falsifying self-declared tool_call bypasses tool limit",
     "tool limit enforced identically regardless of tool_call value or presence",
+    { blocking: true },
   );
 }
 
@@ -797,6 +824,7 @@ async function runProvenanceConflictCase(
       `[${TIER1_PROFILE_LABEL}] SECURITY SIGNAL: expected a deterministic OxDeAIProvenanceConflictError ` +
         `on '${expectedField}' with the protected execute() callback never invoked, but did not observe it.`,
     );
+    failures.push(`${name}: expected a deterministic provenance conflict on '${expectedField}'`);
   }
 }
 
@@ -946,10 +974,17 @@ async function attackMSecure_toolUnverifiedWithoutRoutePremise(): Promise<void> 
       `[${TIER1_PROFILE_LABEL}] SECURITY SIGNAL: proposer tool claim was recorded as 'matched' with no trusted tool ` +
         `premise to match against — this misreports an unverified claim as verified.`,
     );
+    failures.push(
+      "M-secure (no trusted tool): proposer tool claim misreported as 'matched' with no trusted tool premise",
+    );
   } else {
     console.log(
       `[${TIER1_PROFILE_LABEL}] SECURITY SIGNAL: expected provenance.tool === 'unverified' with execution proceeding, ` +
         `observed tool='${String(toolOutcome)}', executed=${executed}, error=${caught ? String(caught) : "none"}.`,
+    );
+    failures.push(
+      `M-secure (no trusted tool): expected residual/unverified state, observed tool='${String(toolOutcome)}', ` +
+        `executed=${executed}, error=${caught ? String(caught) : "none"}`,
     );
   }
 }
@@ -978,6 +1013,14 @@ async function main(): Promise<void> {
   await attackMSecure_toolUnverifiedWithoutRoutePremise();
 
   console.log("\nDone.");
+
+  if (failures.length > 0) {
+    console.error(`\n${failures.length} required policy-boundary invariant(s) failed:`);
+    for (const f of failures) console.error(` - ${f}`);
+    process.exitCode = 1;
+  } else {
+    console.log("\nAll required policy-boundary invariants held.");
+  }
 }
 
 main();


### PR DESCRIPTION
## Summary

Closes #239.

Run the policy-boundary attack repro harness as part of the required `security` CI check.

The harness previously existed as a manual security regression tool, but CI did not execute it and regressions in required policy-boundary invariants could therefore merge without failing the branch-protection security gate.

This PR wires the harness into the existing security gate without introducing a second required GitHub check.

## What changed

- add `security:policy-boundary` root package script
- make `scripts/security/repro-policy-boundary-attacks.ts` expose structured blocking failures
- run the harness from `scripts/security-gate.mjs`
- combine dependency-audit and policy-boundary results into the existing security gate exit status
- build protocol packages in the security workflow before running the harness, because the repro imports built `@oxdeai/core`, `@oxdeai/sdk`, and `@oxdeai/guard` output

## Security semantics

Required invariants now fail CI if they regress.

Blocking cases include:

- F: kill-switch type confusion
- C: future-dated authorization
- K: replay protection under future dating
- J: velocity-window timestamp noninterference
- I: tool-call window timestamp noninterference
- H: `tool_call` opt-in bypass
- G-secure: trusted depth vs proposer depth conflict
- L-secure: trusted agent identity vs proposer `agent_id` conflict
- M-secure with trusted tool: trusted tool identity vs proposer rename conflict

Expected legacy-profile residuals remain diagnostic-only and do not fail CI:

- G legacy: self-declared depth
- L legacy: self-declared `agent_id`
- M legacy: self-declared tool name

The Tier 1 case with no trusted tool premise also remains explicitly residual:

- proposer tool provenance must remain `unverified`
- it must not be reported as `matched`
- this is not treated as globally fixed

CI correctness does not depend on parsing human-readable strings such as `RESISTED`, `SECURITY SIGNAL`, or `RESIDUAL`. The harness tracks required invariant failures structurally and returns a non-zero process status when one breaks.

## Validation

Clean run:

- `pnpm install --frozen-lockfile`
- `pnpm build:protocol`
- `pnpm run security:policy-boundary`
- `pnpm run security:audit`
- `node scripts/security-gate.mjs audit.json security/vuln-policy.json`
- `pnpm --filter @oxdeai/guard test`
- `pnpm --filter @oxdeai/core test`
- `pnpm typecheck`

Results:

- dependency security gate: `ALLOW`
- policy-boundary harness: all required invariants held
- final security gate exit code: `0`
- guard tests: 171/171 pass
- core tests: 356/356 pass
- workspace typecheck: clean

Neutralization testing also confirmed that forcing a Tier 1 secure provenance case to fail causes:

- the standalone harness to exit non-zero
- the required security gate to exit non-zero

Intentional legacy residual findings continue to exit successfully.

## Scope

No changes to:

- `PolicyEngine`
- secure-guard authorization semantics
- `AuthorizationV1`
- canonicalization
- core `ReasonCode`
- default-deny tool policy

The existing required `security` check remains the single branch-protection integration point.