### PR TITLE
feat(guard): add unified guard-boundary audit emission

### DIFF
--- a/packages/guard/package.json
+++ b/packages/guard/package.json
@@ -32,7 +32,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "rm -rf dist && tsc -p tsconfig.json",
     "build:test": "rm -rf dist && tsc -p tsconfig.test.json",
-    "test": "pnpm build:test && node --test \"dist/test/guard.test.js\" \"dist/test/guard.property.test.js\" \"dist/test/guard.delegation.test.js\" \"dist/test/guard.delegation.matrix.test.js\" \"dist/test/guard.delegation.property.test.js\" \"dist/test/guard.toctou.test.js\" \"dist/test/guard.boundary.test.js\" \"dist/test/guard.replay-store.test.js\" \"dist/test/guard.replay-store.redis.test.js\" \"dist/test/guard.authorization.test.js\" \"dist/test/guard.state-binding.test.js\" \"dist/test/guard.cas.test.js\" \"dist/test/guard.pep-conformance.test.js\" \"dist/test/guard.intent-binding.test.js\" \"dist/test/guard.provenance.test.js\""
+    "test": "pnpm build:test && node --test \"dist/test/guard.test.js\" \"dist/test/guard.property.test.js\" \"dist/test/guard.delegation.test.js\" \"dist/test/guard.delegation.matrix.test.js\" \"dist/test/guard.delegation.property.test.js\" \"dist/test/guard.toctou.test.js\" \"dist/test/guard.boundary.test.js\" \"dist/test/guard.replay-store.test.js\" \"dist/test/guard.replay-store.redis.test.js\" \"dist/test/guard.authorization.test.js\" \"dist/test/guard.state-binding.test.js\" \"dist/test/guard.cas.test.js\" \"dist/test/guard.pep-conformance.test.js\" \"dist/test/guard.intent-binding.test.js\" \"dist/test/guard.provenance.test.js\" \"dist/test/guard.boundary-audit.test.js\""
   },
   "files": [
   "dist",

--- a/packages/guard/src/boundaryEvent.ts
+++ b/packages/guard/src/boundaryEvent.ts
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Unified guard-boundary audit emission (#235).
+ *
+ * `onDecision` reports a completed `GuardDecisionRecord`. It therefore cannot
+ * report a request the guard refused without emitting one — an unbranded
+ * trusted context, a provenance conflict, a delegation replay, a state-hash
+ * mismatch, a CAS conflict. Those rejections were previously visible only as a
+ * thrown error, so a deployment whose only audit sink was `onDecision` could
+ * not see attempted identity or tool substitutions at all.
+ *
+ * "No decision record" is not the same as "no decision". A boundary rejection
+ * may occur before the engine ran (`policyEvaluated === false`), or after it
+ * returned a valid ALLOW (`policyEvaluated === true`): authorization
+ * verification, replay consumption, hash binding and the CAS commit all run
+ * after the ALLOW and before `execute()`. On the ALLOW path `onDecision` fires
+ * only once the protected callback has returned, so a rejection anywhere in
+ * that window yields a boundary event and no decision record at all.
+ *
+ * This module carries the second stream. Every rejection raised at the guard
+ * boundary is emitted once, as a structured {@link GuardBoundaryAuditEvent},
+ * to the optional `onBoundaryEvent` hook — without changing any error type,
+ * message, or control flow.
+ *
+ * ## Stream semantics (disjoint by construction)
+ *
+ * ```text
+ * valid DENY                              → onDecision only      (decision record emitted)
+ * guard rejection before execute() starts → onBoundaryEvent only (no decision record)
+ * ALLOW, execute() starts, callback threw → neither              (current contract, #238)
+ * ```
+ *
+ * The invariant is that no single rejection is ever reported on both streams.
+ * A valid `OxDeAIDenyError` is the engine's decision, is reported to
+ * `onDecision`, and returns early here; every other guard-boundary rejection
+ * emits no decision record, whether or not the engine had already returned an
+ * ALLOW. A malformed DENY — one whose `reasons` are invalid, so the engine
+ * throws before `OxDeAIDenyError` is constructed — is not a decision and is
+ * not covered by this statement; it surfaces as an engine-contract violation
+ * and is out of scope here.
+ *
+ * ## Failure contract
+ *
+ * `onBoundaryEvent` is a best-effort audit sink. A hook that throws, rejects,
+ * or hangs on a rejected promise must never change what the caller sees: the
+ * ORIGINAL error is always re-thrown, unwrapped and unreplaced. A deployment
+ * that needs delivery guarantees must provide them inside the hook.
+ */
+import { OxDeAIDenyError } from "./errors.js";
+import type { ProvenanceRecord } from "./provenance.js";
+
+/**
+ * The enforcement stage a request was rejected at.
+ *
+ * Ordered the way a request traverses the boundary. `TRUSTED_CONTEXT` is
+ * reachable only on the Tier 1 secure path; every other stage is shared.
+ *
+ * @public
+ */
+export type GuardBoundaryStage =
+  | "TRUSTED_CONTEXT"
+  | "STATE_LOAD"
+  | "NORMALIZATION"
+  | "PROVENANCE"
+  | "DELEGATION"
+  | "POLICY_EVALUATION"
+  | "AUTHORIZATION_VERIFICATION"
+  | "REPLAY"
+  | "STATE_COMMIT"
+  | "EXECUTION_GATE";
+
+/**
+ * Why the request was rejected, as a stable machine-readable category.
+ *
+ * Categories are deliberately coarser than the error messages: a message is
+ * free to change wording, a category is what an audit pipeline groups on.
+ * `UNCLASSIFIED` is the honest fallback for a rejection that escaped an
+ * unannotated throw site (typically a deployment-supplied `getState`,
+ * `setState`, or `beforeExecute` callback failing) — it is never a synonym for
+ * "allowed".
+ *
+ * @public
+ */
+export type GuardBoundaryFailure =
+  | "UNTRUSTED_CONTEXT"
+  | "MISSING_TENANT_ID"
+  | "STATE_VERSION_MISSING"
+  | "NORMALIZATION_FAILURE"
+  | "PROVENANCE_CONFLICT"
+  | "DELEGATION_INPUT_INVALID"
+  | "DELEGATION_VERIFICATION_FAILED"
+  | "DELEGATION_REPLAY"
+  | "AUTHORIZATION_MISSING"
+  | "AUTHORIZATION_VERIFICATION_FAILED"
+  | "AUTHORIZATION_REPLAY"
+  | "REPLAY_STORE_UNAVAILABLE"
+  | "INTENT_HASH_MISMATCH"
+  | "STATE_HASH_MISMATCH"
+  | "CAS_CONFLICT"
+  | "ENGINE_FAILURE"
+  | "UNCLASSIFIED";
+
+/**
+ * One guard-boundary rejection, as seen by an audit sink.
+ *
+ * The boolean block is the point of the record: it states exactly how far the
+ * request got before it was refused, so that a reader can tell a request that
+ * never reached the engine from one that was authorized and then failed its
+ * state binding. Every flag is reported for every event — a rejection is
+ * described by the flags that are `false` as much as by the ones that are
+ * `true`.
+ *
+ * There is deliberately no `policyDecision` field. A valid `DENY` is not
+ * reachable here: it is an `OxDeAIDenyError`, which is reported on
+ * `onDecision` and returns early from emission. That leaves `ALLOW` as the only value the
+ * field could ever carry, and it would carry it exactly when
+ * `policyEvaluated` is already `true` — no information that
+ * {@link GuardBoundaryAuditEvent.policyEvaluated} does not already give.
+ *
+ * @public
+ */
+export type GuardBoundaryAuditEvent = {
+  /** Stage the request was refused at. */
+  readonly stage: GuardBoundaryStage;
+  /** Category of the refusal. */
+  readonly boundaryFailure: GuardBoundaryFailure;
+  /** `true` once `engine.evaluatePure` has returned. Always `false` on the delegation path, which does not call the engine. */
+  readonly policyEvaluated: boolean;
+  /** `true` once the engine has returned an ALLOW carrying an authorization artifact. */
+  readonly authorizationIssued: boolean;
+  /** `true` once an `auth_id` was consumed from the replay store by this request. */
+  readonly authorizationConsumed: boolean;
+  /** `true` once a `delegation_id` was consumed from the replay store by this request. */
+  readonly delegationConsumed: boolean;
+  /** `true` once the CAS `setState` commit succeeded. */
+  readonly stateCommitted: boolean;
+  /**
+   * `true` once control has been handed to the protected callback.
+   *
+   * An event is never emitted with this flag set: past this point the guard has
+   * permitted the action, so a later failure belongs to the callback and is not
+   * a guard-boundary rejection. The flag is on the record so that the invariant
+   * is legible to an audit reader rather than implicit.
+   */
+  readonly executionStarted: boolean;
+  /** `intent_id` of the normalized intent, once normalization has succeeded. */
+  readonly intentId?: string;
+  /**
+   * Per-field trusted-vs-proposer outcome, on a provenance conflict.
+   *
+   * Reuses the type the reconciliation boundary already exports, so an audit
+   * reader parses one provenance vocabulary rather than an opaque string map.
+   */
+  readonly provenance?: ProvenanceRecord;
+  /** Conflicting fields, in declaration order, on a provenance conflict. */
+  readonly conflictingFields?: readonly string[];
+};
+
+/**
+ * Audit sink for guard-boundary rejections.
+ *
+ * Disjoint from `onDecision`: a valid policy `DENY` is reported there and
+ * never here, and a guard rejection that emits no decision record is reported
+ * here and never there — whether it happened before the engine ran or after a
+ * valid ALLOW. A failure thrown by the protected callback after the guard
+ * permitted execution is reported on neither — the guard's answer was ALLOW,
+ * and the callback's outcome belongs to the caller (#238).
+ *
+ * Best effort. Anything this hook throws or rejects with is swallowed; the
+ * caller always receives the original guard error, unwrapped and unreplaced.
+ * A slow hook does delay the rejection, because the guard awaits it before
+ * re-throwing — return promptly and do durable work out of band.
+ *
+ * @public
+ */
+export type GuardBoundaryEventHook = (event: GuardBoundaryAuditEvent) => void | Promise<void>;
+
+// ── internal: per-request lifecycle ───────────────────────────────────────────
+
+/**
+ * Mutable per-request progress record. Internal: it is written as the request
+ * advances and read only when building an event.
+ */
+export type GuardLifecycle = {
+  /** Stage currently being executed; the fallback stage for an unannotated throw. */
+  stage: GuardBoundaryStage;
+  policyEvaluated: boolean;
+  authorizationIssued: boolean;
+  authorizationConsumed: boolean;
+  delegationConsumed: boolean;
+  stateCommitted: boolean;
+  executionStarted: boolean;
+  intentId?: string;
+  /**
+   * Set once control has been handed to the shared enforcement body, which
+   * runs its own catch and has therefore already accounted for anything raised
+   * beyond this point.
+   *
+   * The {@link EMITTED} set covers that case for thrown objects; this flag
+   * covers it for a non-object throw, which cannot be tracked in a WeakSet. It
+   * is what stops the secure path's outer catch from re-reporting a callback
+   * failure — the inner body's `executionStarted` short-circuit is invisible to
+   * the outer lifecycle.
+   */
+  sharedBodyEntered: boolean;
+};
+
+/** Start a lifecycle at the stage the enclosing layer begins with. */
+export function createLifecycle(stage: GuardBoundaryStage): GuardLifecycle {
+  return {
+    stage,
+    policyEvaluated: false,
+    authorizationIssued: false,
+    authorizationConsumed: false,
+    delegationConsumed: false,
+    stateCommitted: false,
+    executionStarted: false,
+    sharedBodyEntered: false,
+  };
+}
+
+// ── internal: classification ──────────────────────────────────────────────────
+
+/** Extra evidence a throw site can attach to its rejection. */
+type BoundaryDetails = {
+  readonly conflictingFields?: readonly string[];
+  readonly provenance?: ProvenanceRecord;
+};
+
+type BoundaryAnnotation = {
+  readonly stage: GuardBoundaryStage;
+  readonly failure: GuardBoundaryFailure;
+  readonly details?: BoundaryDetails;
+};
+
+/**
+ * Classification is held beside the error, never on it: attaching properties to
+ * the error would change a public error shape that callers already match on.
+ */
+const ANNOTATIONS = new WeakMap<object, BoundaryAnnotation>();
+
+/**
+ * Errors already accounted for, so that two nested catches (secure wrapper and
+ * shared body) report one event rather than two.
+ *
+ * A WeakSet, not a Set: entries must not keep a rejected request's error — and
+ * everything it retains — alive for the lifetime of the process.
+ */
+const EMITTED = new WeakSet<object>();
+
+/**
+ * Whether a thrown value can key a WeakMap/WeakSet.
+ *
+ * `throw "boom"` is legal, and a third-party normalizer or callback may do it.
+ * Every weak-collection operation is guarded by this, so a non-object rejection
+ * still surfaces unchanged instead of being replaced by a `TypeError` raised
+ * inside the audit path. It loses only cross-layer de-duplication.
+ */
+function isWeakKey(value: unknown): value is object {
+  return (typeof value === "object" && value !== null) || typeof value === "function";
+}
+
+/**
+ * Classify a rejection at its throw site and return it unchanged, so a call
+ * site reads `throw reject(STAGE, CATEGORY, new SomeError(...))`.
+ *
+ * The error's type and message are untouched — this only records how the
+ * rejection should be described to an audit sink. The first annotation wins:
+ * an inner layer that knows more about the rejection than an outer one keeps
+ * its classification.
+ */
+export function reject<E>(
+  stage: GuardBoundaryStage,
+  failure: GuardBoundaryFailure,
+  error: E,
+  details?: BoundaryDetails
+): E {
+  if (isWeakKey(error) && !ANNOTATIONS.has(error)) {
+    ANNOTATIONS.set(error, details ? { stage, failure, details } : { stage, failure });
+  }
+  return error;
+}
+
+function buildEvent(
+  annotation: BoundaryAnnotation | undefined,
+  lifecycle: GuardLifecycle
+): GuardBoundaryAuditEvent {
+  const details = annotation?.details;
+  return Object.freeze({
+    stage: annotation?.stage ?? lifecycle.stage,
+    boundaryFailure: annotation?.failure ?? "UNCLASSIFIED",
+    policyEvaluated: lifecycle.policyEvaluated,
+    authorizationIssued: lifecycle.authorizationIssued,
+    authorizationConsumed: lifecycle.authorizationConsumed,
+    delegationConsumed: lifecycle.delegationConsumed,
+    stateCommitted: lifecycle.stateCommitted,
+    executionStarted: lifecycle.executionStarted,
+    ...(lifecycle.intentId !== undefined ? { intentId: lifecycle.intentId } : {}),
+    ...(details?.provenance ? { provenance: details.provenance } : {}),
+    ...(details?.conflictingFields
+      ? { conflictingFields: Object.freeze([...details.conflictingFields]) }
+      : {}),
+  });
+}
+
+/**
+ * Emit one guard-boundary audit event for a rejection, if it is one.
+ *
+ * Every emission rule lives here, so both catch sites are identical and
+ * unconditional and neither can drift into deciding policy of its own:
+ *
+ *  1. no hook          → nothing to do;
+ *  2. valid `OxDeAIDenyError` → a policy decision; `onDecision` reported it;
+ *  3. execution began  → the guard permitted the action, so this is a callback
+ *                        failure, not a boundary rejection;
+ *  4. already handled  → a nested catch one layer down accounted for it.
+ *
+ * The caller re-throws the ORIGINAL error regardless of what happens here.
+ */
+export async function emitBoundaryEvent(
+  hook: GuardBoundaryEventHook | undefined,
+  err: unknown,
+  lifecycle: GuardLifecycle
+): Promise<void> {
+  if (!hook) return;
+
+  // A valid denial is a decision, not a boundary rejection: it is reported on
+  // onDecision, and reporting it here as well would double-count every DENY.
+  if (err instanceof OxDeAIDenyError) return;
+
+  if (lifecycle.executionStarted) {
+    // Past the execution gate the guard has already permitted the action. Mark
+    // the error handled so an OUTER catch, whose lifecycle never saw the gate
+    // open, cannot re-report a callback failure as a guard rejection.
+    if (isWeakKey(err)) EMITTED.add(err);
+    return;
+  }
+
+  // Already accounted for one layer down — by identity for a thrown object, and
+  // by the shared-body flag for a non-object throw that cannot be tracked.
+  if (lifecycle.sharedBodyEntered) return;
+  if (isWeakKey(err)) {
+    if (EMITTED.has(err)) return;
+    EMITTED.add(err);
+  }
+
+  const event = buildEvent(isWeakKey(err) ? ANNOTATIONS.get(err) : undefined, lifecycle);
+
+  try {
+    await hook(event);
+  } catch {
+    // Best effort: an audit sink failure must never change what the caller
+    // sees, and must never mask the rejection it was reporting.
+  }
+}

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -110,9 +110,10 @@ async function fireDecision(
  * Audit streams (disjoint — no rejection appears on both):
  *
  * ```text
- * policy DENY                → onDecision only        (a decision was reached)
- * pre-execution rejection    → onBoundaryEvent only   (no decision to report)
- * ALLOW, callback then threw → neither                (not a guard rejection)
+ * policy DENY                -> onDecision only        (decision record emitted)
+ * guard rejection before execute() starts
+ *                            -> onBoundaryEvent only   (no decision record emitted)
+ * ALLOW, callback then threw -> neither                (current contract, #238)
  * ```
  *
  * Both hooks are best effort: whatever they throw is swallowed, and the caller

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -5,6 +5,9 @@ import type { OxDeAIGuardConfig, ProposedAction, GuardDecisionRecord, GuardCallO
 import { defaultNormalizeAction } from "./normalizeAction.js";
 import { createInMemoryReplayStore } from "./replayStore.js";
 import type { ReplayStore } from "./replayStore.js";
+import { createLifecycle, emitBoundaryEvent, reject } from "./boundaryEvent.js";
+import type { GuardLifecycle } from "./boundaryEvent.js";
+import type { ProvenanceRecord } from "./provenance.js";
 import {
   OxDeAIDenyError,
   OxDeAIAuthorizationError,
@@ -103,6 +106,17 @@ async function fireDecision(
  *   - Scope violation             → OxDeAIDelegationError (no execution).
  *   - Normalization failure       → OxDeAINormalizationError (no execution).
  *   - Evaluation / state errors   → re-thrown (fail-closed).
+ *
+ * Audit streams (disjoint — no rejection appears on both):
+ *
+ * ```text
+ * policy DENY                → onDecision only        (a decision was reached)
+ * pre-execution rejection    → onBoundaryEvent only   (no decision to report)
+ * ALLOW, callback then threw → neither                (not a guard rejection)
+ * ```
+ *
+ * Both hooks are best effort: whatever they throw is swallowed, and the caller
+ * always receives the original guard error, unwrapped and unreplaced.
  */
 export function OxDeAIGuard(config: OxDeAIGuardConfig) {
   validateConfig(config);
@@ -125,10 +139,16 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
   // Replace with a durable backend for multi-process / restart-durable deployments.
   const replayStore: ReplayStore = config.replayStore ?? createInMemoryReplayStore();
 
-  return async function guard(
+  /**
+   * The enforcement body. Extracted so that every rejection leaves through one
+   * catch in `guard` below, rather than each throw site having to remember to
+   * report itself.
+   */
+  async function runRequest(
     action: ProposedAction,
     execute: () => Promise<unknown>,
-    opts?: GuardCallOptions
+    opts: GuardCallOptions | undefined,
+    lifecycle: GuardLifecycle
   ): Promise<unknown> {
     // ── 1. Load state + version ────────────────────────────────────────────
     const versioned = await config.getState();
@@ -137,35 +157,60 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
 
     // Fail closed if the store did not return a version.
     if (version === undefined || version === null) {
-      throw new OxDeAIAuthorizationError(
-        "State store returned no version. Cannot enforce CAS invariant. Execution blocked."
+      throw reject(
+        "STATE_LOAD",
+        "STATE_VERSION_MISSING",
+        new OxDeAIAuthorizationError(
+          "State store returned no version. Cannot enforce CAS invariant. Execution blocked."
+        )
       );
     }
 
     // ── 2. Normalize action → intent ───────────────────────────────────────
+    lifecycle.stage = "NORMALIZATION";
     let intent: Intent;
     try {
       intent = normalize(action);
     } catch (err) {
-      if (err instanceof OxDeAINormalizationError) throw err;
+      if (err instanceof OxDeAINormalizationError) {
+        throw reject("NORMALIZATION", "NORMALIZATION_FAILURE", err);
+      }
       // The secure path performs trusted-vs-proposer reconciliation inside the
       // normalizer, so a provenance conflict surfaces here. It is an
       // authorization boundary failure, not a normalization failure, and must
       // reach the caller with its own type and conflicting-field list intact.
-      if (err instanceof OxDeAIProvenanceConflictError) throw err;
+      if (err instanceof OxDeAIProvenanceConflictError) {
+        throw reject("PROVENANCE", "PROVENANCE_CONFLICT", err, {
+          conflictingFields: err.fields,
+          // The error predates the boundary event and types its record as a
+          // plain string map; every value in it is a ClaimProvenance by
+          // construction (provenance.ts builds it from that union).
+          provenance: err.provenance as ProvenanceRecord,
+        });
+      }
       // Custom mapActionToIntent threw something unexpected — fail closed.
-      throw new OxDeAINormalizationError(
-        `mapActionToIntent threw an unexpected error: ${err instanceof Error ? err.message : String(err)}`
+      throw reject(
+        "NORMALIZATION",
+        "NORMALIZATION_FAILURE",
+        new OxDeAINormalizationError(
+          `mapActionToIntent threw an unexpected error: ${err instanceof Error ? err.message : String(err)}`
+        )
       );
     }
+    lifecycle.intentId = intent.intent_id;
 
     // ── 3. Delegation path ─────────────────────────────────────────────────
     if (opts?.delegation) {
+      lifecycle.stage = "DELEGATION";
       const { delegation, parentAuth } = opts.delegation;
 
       if (!delegation || !parentAuth) {
-        throw new OxDeAIAuthorizationError(
-          "Delegation input is incomplete: both delegation and parentAuth are required. Execution blocked."
+        throw reject(
+          "DELEGATION",
+          "DELEGATION_INPUT_INVALID",
+          new OxDeAIAuthorizationError(
+            "Delegation input is incomplete: both delegation and parentAuth are required. Execution blocked."
+          )
         );
       }
 
@@ -179,13 +224,24 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
           ? await replayStore.consumeDelegationId(delegation.delegation_id, { expiry: delegation.expiry })
           : true;
       } catch (err) {
-        throw new OxDeAIAuthorizationError(
-          `Replay store unavailable for delegation_id: ${err instanceof Error ? err.message : String(err)}. Execution blocked.`
+        throw reject(
+          "REPLAY",
+          "REPLAY_STORE_UNAVAILABLE",
+          new OxDeAIAuthorizationError(
+            `Replay store unavailable for delegation_id: ${err instanceof Error ? err.message : String(err)}. Execution blocked.`
+          )
         );
       }
       if (!delegConsumed) {
-        throw new OxDeAIAuthorizationError("Delegation replay detected. Execution blocked.");
+        throw reject(
+          "REPLAY",
+          "DELEGATION_REPLAY",
+          new OxDeAIAuthorizationError("Delegation replay detected. Execution blocked.")
+        );
       }
+      // Only a store that implements the optional check-and-consume actually
+      // consumed anything; the fallback above assumes success without a store.
+      lifecycle.delegationConsumed = replayStore.consumeDelegationId !== undefined;
 
       // Verify delegation chain:
       //   - parent hash binding
@@ -200,8 +256,12 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
       // Validate parentScope before chain verification. Fail closed on missing or malformed scope.
       const { parentScope } = opts.delegation;
       if (!isValidDelegationScope(parentScope)) {
-        throw new OxDeAIAuthorizationError(
-          "Parent authorization scope is missing or malformed. Execution blocked."
+        throw reject(
+          "DELEGATION",
+          "DELEGATION_INPUT_INVALID",
+          new OxDeAIAuthorizationError(
+            "Parent authorization scope is missing or malformed. Execution blocked."
+          )
         );
       }
 
@@ -238,7 +298,11 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
       }
 
       if (violationMessages.length > 0) {
-        throw new OxDeAIDelegationError(violationMessages);
+        throw reject(
+          "DELEGATION",
+          "DELEGATION_VERIFICATION_FAILED",
+          new OxDeAIDelegationError(violationMessages)
+        );
       }
 
       // Enforce strict verification on the parent Authorization as well.
@@ -249,15 +313,24 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
           parentAuth.auth_id, { expiry: parentAuth.expiry }
         );
       } catch (err) {
-        throw new OxDeAIAuthorizationError(
-          `Replay store unavailable for parentAuth auth_id: ${err instanceof Error ? err.message : String(err)}. Execution blocked.`
+        throw reject(
+          "REPLAY",
+          "REPLAY_STORE_UNAVAILABLE",
+          new OxDeAIAuthorizationError(
+            `Replay store unavailable for parentAuth auth_id: ${err instanceof Error ? err.message : String(err)}. Execution blocked.`
+          )
         );
       }
       if (!parentAuthConsumed) {
-        throw new OxDeAIAuthorizationError(
-          "Authorization replay detected on parentAuth: auth_id already consumed. Execution blocked."
+        throw reject(
+          "REPLAY",
+          "AUTHORIZATION_REPLAY",
+          new OxDeAIAuthorizationError(
+            "Authorization replay detected on parentAuth: auth_id already consumed. Execution blocked."
+          )
         );
       }
+      lifecycle.authorizationConsumed = true;
 
       const parentAuthResult = strictVerifyAuthorization(parentAuth as AuthorizationV1, {
         now,
@@ -274,7 +347,11 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
           parentAuthResult.violations?.map((v) => v.code).join(", ") ||
           parentAuthResult.status ||
           "unknown reason";
-        throw new OxDeAIAuthorizationError(`Parent authorization verification failed: ${reasons}. Execution blocked.`);
+        throw reject(
+          "AUTHORIZATION_VERIFICATION",
+          "AUTHORIZATION_VERIFICATION_FAILED",
+          new OxDeAIAuthorizationError(`Parent authorization verification failed: ${reasons}. Execution blocked.`)
+        );
       }
 
       // parentAuth is AuthorizationV1; cast to Authorization for hook/audit
@@ -283,11 +360,18 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
       const parentAuthCompat = parentAuth as unknown as Authorization;
 
       // ── Delegation: beforeExecute hook ────────────────────────────────
+      lifecycle.stage = "EXECUTION_GATE";
       if (config.beforeExecute) {
         await config.beforeExecute(action, parentAuthCompat);
       }
 
       // ── Delegation: execute ───────────────────────────────────────────
+      // Marked BEFORE control enters the callback, not after it returns: a
+      // failure raised inside the callback is not a guard-boundary rejection,
+      // and the guard has already permitted the action by this line. Moving
+      // this assignment below the await would silently re-classify every
+      // callback failure as a guard refusal.
+      lifecycle.executionStarted = true;
       const result = await execute();
 
       // ── Delegation: audit hook (no setState — parent state is authoritative) ──
@@ -308,16 +392,22 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
     // just the existing one applied to the now-mandatory evaluatePure
     // parameter. It is not independently trusted or monotonic; reliable
     // PEP-side clock capture remains deferred.
+    lifecycle.stage = "POLICY_EVALUATION";
     const evaluationTime = Math.floor(Date.now() / 1000);
     let evalResult: ReturnType<typeof config.engine.evaluatePure>;
     try {
       evalResult = config.engine.evaluatePure(intent, state, evaluationTime);
     } catch (err) {
       // Engine errors are never swallowed — callers must handle them.
-      throw new OxDeAIAuthorizationError(
-        `PolicyEngine.evaluatePure threw: ${err instanceof Error ? err.message : String(err)}`
+      throw reject(
+        "POLICY_EVALUATION",
+        "ENGINE_FAILURE",
+        new OxDeAIAuthorizationError(
+          `PolicyEngine.evaluatePure threw: ${err instanceof Error ? err.message : String(err)}`
+        )
       );
     }
+    lifecycle.policyEvaluated = true;
 
     // ── 5. DENY path ───────────────────────────────────────────────────────
     if (evalResult.decision === "DENY") {
@@ -332,19 +422,31 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
 
     // ── 6. ALLOW: require authorization artifact and nextState ─────────────
     if (!evalResult.authorization) {
-      throw new OxDeAIAuthorizationError(
-        "PolicyEngine returned ALLOW without an authorization artifact. Execution blocked."
+      throw reject(
+        "POLICY_EVALUATION",
+        "AUTHORIZATION_MISSING",
+        new OxDeAIAuthorizationError(
+          "PolicyEngine returned ALLOW without an authorization artifact. Execution blocked."
+        )
       );
     }
     if (!evalResult.nextState) {
-      throw new OxDeAIAuthorizationError(
-        "PolicyEngine returned ALLOW without a nextState. Execution blocked."
+      // An ALLOW with no next state is an engine contract violation, not a
+      // missing artifact: the artifact is present and the result is unusable.
+      throw reject(
+        "POLICY_EVALUATION",
+        "ENGINE_FAILURE",
+        new OxDeAIAuthorizationError(
+          "PolicyEngine returned ALLOW without a nextState. Execution blocked."
+        )
       );
     }
+    lifecycle.authorizationIssued = true;
 
     const { authorization, nextState } = evalResult;
 
     // ── 6b. Verify the authorization artifact (strict verifier, fail-closed) ─
+    lifecycle.stage = "AUTHORIZATION_VERIFICATION";
     const now = Math.floor(Date.now() / 1000);
 
     // Atomically check-and-consume the auth_id before execution. Fail closed on store errors.
@@ -354,13 +456,22 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
         authorization.auth_id, { expiry: (authorization as AuthorizationV1).expiry ?? 0 }
       );
     } catch (err) {
-      throw new OxDeAIAuthorizationError(
-        `Replay store unavailable: ${err instanceof Error ? err.message : String(err)}. Execution blocked.`
+      throw reject(
+        "REPLAY",
+        "REPLAY_STORE_UNAVAILABLE",
+        new OxDeAIAuthorizationError(
+          `Replay store unavailable: ${err instanceof Error ? err.message : String(err)}. Execution blocked.`
+        )
       );
     }
     if (!authConsumed) {
-      throw new OxDeAIAuthorizationError("Authorization replay detected: auth_id already consumed. Execution blocked.");
+      throw reject(
+        "REPLAY",
+        "AUTHORIZATION_REPLAY",
+        new OxDeAIAuthorizationError("Authorization replay detected: auth_id already consumed. Execution blocked.")
+      );
     }
+    lifecycle.authorizationConsumed = true;
 
     const authResult = strictVerifyAuthorization(authorization as AuthorizationV1, {
       now,
@@ -375,7 +486,11 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
     if (authResult.status !== "ok") {
       const reasons =
         authResult.violations?.map((v) => v.code).join(", ") || authResult.status || "unknown reason";
-      throw new OxDeAIAuthorizationError(`Authorization verification failed: ${reasons}. Execution blocked.`);
+      throw reject(
+        "AUTHORIZATION_VERIFICATION",
+        "AUTHORIZATION_VERIFICATION_FAILED",
+        new OxDeAIAuthorizationError(`Authorization verification failed: ${reasons}. Execution blocked.`)
+      );
     }
 
     // ── 6d. Enforce intent_hash binding ──────────────────────────────────────
@@ -387,13 +502,23 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
     try {
       computedIntentHash = intentHash(intent);
     } catch (err) {
-      throw new OxDeAIAuthorizationError(
-        `Intent canonicalization failed: ${err instanceof Error ? err.message : String(err)}. Execution blocked.`
+      // A canonicalization failure and a computed mismatch are the same audit
+      // fact: the intent binding could not be established, so nothing may run.
+      throw reject(
+        "AUTHORIZATION_VERIFICATION",
+        "INTENT_HASH_MISMATCH",
+        new OxDeAIAuthorizationError(
+          `Intent canonicalization failed: ${err instanceof Error ? err.message : String(err)}. Execution blocked.`
+        )
       );
     }
     if (computedIntentHash !== (authorization as AuthorizationV1).intent_hash) {
-      throw new OxDeAIAuthorizationError(
-        "Intent hash mismatch: computed hash does not match authorization.intent_hash. Execution blocked."
+      throw reject(
+        "AUTHORIZATION_VERIFICATION",
+        "INTENT_HASH_MISMATCH",
+        new OxDeAIAuthorizationError(
+          "Intent hash mismatch: computed hash does not match authorization.intent_hash. Execution blocked."
+        )
       );
     }
 
@@ -409,8 +534,14 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
     // Using the wrong strategy produces a deterministic mismatch — fail-closed.
     const expectedStateHash = (authorization as AuthorizationV1).state_hash;
     if (!expectedStateHash) {
-      throw new OxDeAIAuthorizationError(
-        "Authorization is missing state_hash. Execution blocked."
+      // As with the intent binding: absent, uncomputable and unequal are one
+      // audit fact — the state binding does not hold.
+      throw reject(
+        "AUTHORIZATION_VERIFICATION",
+        "STATE_HASH_MISMATCH",
+        new OxDeAIAuthorizationError(
+          "Authorization is missing state_hash. Execution blocked."
+        )
       );
     }
     const computeHash = config.computeStateHash ?? ((s) => config.engine.computeStateHash(s));
@@ -418,13 +549,21 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
     try {
       actualStateHash = computeHash(state);
     } catch (err) {
-      throw new OxDeAIAuthorizationError(
-        `State canonicalization failed: ${err instanceof Error ? err.message : String(err)}. Execution blocked.`
+      throw reject(
+        "AUTHORIZATION_VERIFICATION",
+        "STATE_HASH_MISMATCH",
+        new OxDeAIAuthorizationError(
+          `State canonicalization failed: ${err instanceof Error ? err.message : String(err)}. Execution blocked.`
+        )
       );
     }
     if (actualStateHash !== expectedStateHash) {
-      throw new OxDeAIAuthorizationError(
-        "Authorization state_hash does not match the current execution-time state snapshot. Execution blocked."
+      throw reject(
+        "AUTHORIZATION_VERIFICATION",
+        "STATE_HASH_MISMATCH",
+        new OxDeAIAuthorizationError(
+          "Authorization state_hash does not match the current execution-time state snapshot. Execution blocked."
+        )
       );
     }
 
@@ -432,19 +571,32 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
     // Commit the new state atomically. This must happen before execute() so
     // that a version mismatch (concurrent modification) blocks execution
     // without committing any side effects.
+    lifecycle.stage = "STATE_COMMIT";
     const casOk = await config.setState(nextState, version);
     if (!casOk) {
-      throw new OxDeAIConflictError(
-        "State version mismatch: concurrent modification detected. Execution blocked."
+      throw reject(
+        "STATE_COMMIT",
+        "CAS_CONFLICT",
+        new OxDeAIConflictError(
+          "State version mismatch: concurrent modification detected. Execution blocked."
+        )
       );
     }
+    lifecycle.stateCommitted = true;
 
     // ── 8. beforeExecute hook ──────────────────────────────────────────────
+    lifecycle.stage = "EXECUTION_GATE";
     if (config.beforeExecute) {
       await config.beforeExecute(action, authorization);
     }
 
     // ── 9. Execute the side effect ─────────────────────────────────────────
+    // Marked BEFORE control enters the callback, not after it returns: a
+    // failure raised inside the callback is not a guard-boundary rejection,
+    // and the guard has already permitted the action by this line. Moving this
+    // assignment below the await would silently re-classify every callback
+    // failure as a guard refusal.
+    lifecycle.executionStarted = true;
     const result = await execute();
 
     // ── 10. Fire audit hook ────────────────────────────────────────────────
@@ -456,5 +608,22 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
 
     // ── 11. Return result ──────────────────────────────────────────────────
     return result;
+  }
+
+  return async function guard(
+    action: ProposedAction,
+    execute: () => Promise<unknown>,
+    opts?: GuardCallOptions
+  ): Promise<unknown> {
+    const lifecycle = createLifecycle("STATE_LOAD");
+    try {
+      return await runRequest(action, execute, opts, lifecycle);
+    } catch (err) {
+      // Unconditional: every emission rule lives in emitBoundaryEvent, so this
+      // catch cannot drift into deciding what counts as a rejection. The
+      // ORIGINAL error is re-thrown regardless of what the audit sink does.
+      await emitBoundaryEvent(config.onBoundaryEvent, err, lifecycle);
+      throw err;
+    }
   };
 }

--- a/packages/guard/src/index.ts
+++ b/packages/guard/src/index.ts
@@ -18,6 +18,12 @@ export {
 export type { TrustedExecutionContext } from "./trustedContext.js";
 export { reconcileWithTrustedContext } from "./provenance.js";
 export type { ClaimProvenance, ProvenanceRecord, ReconciliationResult, ReconciliationOptions } from "./provenance.js";
+export type {
+  GuardBoundaryStage,
+  GuardBoundaryFailure,
+  GuardBoundaryAuditEvent,
+  GuardBoundaryEventHook,
+} from "./boundaryEvent.js";
 export {
   INTERNAL_EXECUTOR_TOKEN_HEADER,
   createPepGatewayExecutor,

--- a/packages/guard/src/secureGuard.ts
+++ b/packages/guard/src/secureGuard.ts
@@ -6,6 +6,8 @@ import { createInMemoryReplayStore } from "./replayStore.js";
 import { OxDeAIAuthorizationError, OxDeAIGuardConfigurationError } from "./errors.js";
 import { isTrustedExecutionContext, type TrustedExecutionContext } from "./trustedContext.js";
 import { reconcileWithTrustedContext, type ProvenanceRecord } from "./provenance.js";
+import { createLifecycle, emitBoundaryEvent, reject } from "./boundaryEvent.js";
+import type { GuardLifecycle } from "./boundaryEvent.js";
 import type { OxDeAIGuardConfig, ProposedAction, GuardCallOptions } from "./types.js";
 
 /**
@@ -66,19 +68,21 @@ export type SecureGuardOptions = {
  *
  * ```text
  * ALLOW / evaluated paths      → provenance on GuardDecisionRecord (onDecision)
- * pre-evaluation conflict      → provenance on OxDeAIProvenanceConflictError,
- *                                NOT on onDecision
+ * pre-evaluation conflict      → provenance on GuardBoundaryAuditEvent
+ *                                (onBoundaryEvent) and on the thrown
+ *                                OxDeAIProvenanceConflictError, NOT on onDecision
  * ```
  *
  * A provenance conflict is rejected before the shared enforcement body reaches
  * a policy decision, so there is no decision record to attach it to. It is
  * deliberately NOT emitted through `onDecision` as a synthetic DENY: that hook
  * reports `PolicyEngine` decisions, and manufacturing one would misreport a
- * boundary rejection as a policy outcome. **A deployment using `onDecision` as
- * its only audit sink will therefore not see attempted identity or tool
- * substitutions** — it must also record `OxDeAIProvenanceConflictError`, which
- * carries the conflicting fields and the full provenance map. Unified
- * guard-boundary audit emission is separate work.
+ * boundary rejection as a policy outcome. It is instead emitted once on the
+ * disjoint guard-boundary stream — `config.onBoundaryEvent` — carrying the
+ * conflicting fields and the full provenance map, so a deployment no longer has
+ * to catch `OxDeAIProvenanceConflictError` itself to see attempted identity or
+ * tool substitutions. A deployment that wires NEITHER hook still sees only the
+ * thrown error.
  *
  * @public
  */
@@ -100,16 +104,26 @@ export function createSecureGuard(config: OxDeAIGuardConfig, options: SecureGuar
   // disabling replay protection across calls.
   const replayStore = config.replayStore ?? createInMemoryReplayStore();
 
-  return async function secureGuard(
+  /**
+   * The secure prelude plus delegation to the shared body. Extracted so that
+   * every rejection raised before the shared body is reached leaves through the
+   * one catch in `secureGuard` below.
+   */
+  async function runSecure(
     trustedContext: TrustedExecutionContext,
     action: ProposedAction,
     execute: () => Promise<unknown>,
-    opts?: GuardCallOptions
+    opts: GuardCallOptions | undefined,
+    lifecycle: GuardLifecycle
   ): Promise<unknown> {
     if (!isTrustedExecutionContext(trustedContext)) {
-      throw new OxDeAIAuthorizationError(
-        "Secure guard requires a TrustedExecutionContext built by createTrustedExecutionContext(). " +
-          "A plain object — including one deserialized from request JSON — is not accepted. Execution blocked."
+      throw reject(
+        "TRUSTED_CONTEXT",
+        "UNTRUSTED_CONTEXT",
+        new OxDeAIAuthorizationError(
+          "Secure guard requires a TrustedExecutionContext built by createTrustedExecutionContext(). " +
+            "A plain object — including one deserialized from request JSON — is not accepted. Execution blocked."
+        )
       );
     }
 
@@ -119,9 +133,13 @@ export function createSecureGuard(config: OxDeAIGuardConfig, options: SecureGuar
     // ambiguous namespace; treating the absence as "probably single tenant" is
     // exactly the migration hazard this posture exists to remove.
     if (tenancy === "multi-tenant" && trustedContext.tenantId === undefined) {
-      throw new OxDeAIAuthorizationError(
-        "Deployment is configured multi-tenant but the trusted execution context carries no tenantId. " +
-          "Execution blocked."
+      throw reject(
+        "TRUSTED_CONTEXT",
+        "MISSING_TENANT_ID",
+        new OxDeAIAuthorizationError(
+          "Deployment is configured multi-tenant but the trusted execution context carries no tenantId. " +
+            "Execution blocked."
+        )
       );
     }
 
@@ -162,6 +180,29 @@ export function createSecureGuard(config: OxDeAIGuardConfig, options: SecureGuar
         : undefined,
     };
 
-    return OxDeAIGuard(secureConfig)(action, execute, opts);
+    // Factory-time configuration errors are still this layer's to report; from
+    // the invocation onward the shared body runs its own catch, so anything it
+    // raises is already accounted for and must not be reported twice.
+    const sharedBody = OxDeAIGuard(secureConfig);
+    lifecycle.sharedBodyEntered = true;
+    return await sharedBody(action, execute, opts);
+  }
+
+  return async function secureGuard(
+    trustedContext: TrustedExecutionContext,
+    action: ProposedAction,
+    execute: () => Promise<unknown>,
+    opts?: GuardCallOptions
+  ): Promise<unknown> {
+    const outerLifecycle = createLifecycle("TRUSTED_CONTEXT");
+    try {
+      return await runSecure(trustedContext, action, execute, opts, outerLifecycle);
+    } catch (err) {
+      // Identical and unconditional to the shared body's catch: the rules for
+      // what is emitted live only in emitBoundaryEvent, and the ORIGINAL error
+      // is re-thrown regardless of what the audit sink does.
+      await emitBoundaryEvent(config.onBoundaryEvent, err, outerLifecycle);
+      throw err;
+    }
   };
 }

--- a/packages/guard/src/test/guard.boundary-audit.test.ts
+++ b/packages/guard/src/test/guard.boundary-audit.test.ts
@@ -1,0 +1,908 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Unified guard-boundary audit emission (#235).
+ *
+ * `onDecision` can only report what the engine decided, so a request refused
+ * before a decision existed was previously invisible to it. These tests pin the
+ * second stream — `onBoundaryEvent` — and, more importantly, pin the rules that
+ * keep the two streams disjoint and keep the audit path incapable of changing
+ * what a caller sees.
+ *
+ * Scenarios:
+ *   B-1  TRUSTED_CONTEXT / UNTRUSTED_CONTEXT, emitted by the outer catch only
+ *   B-2  TRUSTED_CONTEXT / MISSING_TENANT_ID
+ *   B-3  STATE_LOAD / STATE_VERSION_MISSING
+ *   B-4  NORMALIZATION / NORMALIZATION_FAILURE (thrown, and wrapped)
+ *   B-5  PROVENANCE / PROVENANCE_CONFLICT carries fields and provenance
+ *   B-6  DELEGATION / DELEGATION_INPUT_INVALID
+ *   B-7  DELEGATION / DELEGATION_VERIFICATION_FAILED
+ *   B-8  REPLAY / DELEGATION_REPLAY
+ *   B-9  REPLAY / AUTHORIZATION_REPLAY
+ *   B-10 REPLAY / REPLAY_STORE_UNAVAILABLE
+ *   B-11 POLICY_EVALUATION / ENGINE_FAILURE
+ *   B-12 POLICY_EVALUATION / AUTHORIZATION_MISSING
+ *   B-13 AUTHORIZATION_VERIFICATION / AUTHORIZATION_VERIFICATION_FAILED
+ *   B-14 AUTHORIZATION_VERIFICATION / INTENT_HASH_MISMATCH
+ *   B-15 AUTHORIZATION_VERIFICATION / STATE_HASH_MISMATCH
+ *   B-16 STATE_COMMIT / CAS_CONFLICT
+ *   B-17 EXECUTION_GATE / UNCLASSIFIED (a deployment hook failed)
+ *   B-18 main path: a callback failure is NOT a boundary rejection
+ *   B-19 delegation path: a callback failure is NOT a boundary rejection
+ *   B-20 a non-object throw surfaces unchanged, through the UNCLASSIFIED fallback
+ *   B-21 a policy DENY is reported on onDecision and NEVER on onBoundaryEvent
+ *   B-22 a conflict raised inside the normalizer emits once, not once per layer
+ *   B-23 a throwing audit sink does not change what the caller receives
+ *   B-24 the record carries no policyDecision; policyEvaluated carries the fact
+ *   B-25 the guard behaves identically with no boundary hook configured
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  PolicyEngine,
+  RECOMMENDED_TRUSTED_TIME_PROFILE,
+  createDelegation,
+  intentHash,
+  signAuthorizationEd25519,
+} from "@oxdeai/core";
+import type { AuthorizationV1, DelegationScope, DelegationV1, Intent, State } from "@oxdeai/core";
+import { buildState } from "@oxdeai/sdk";
+import { TEST_KEYSET, TEST_KEYPAIR, signAuth } from "./helpers/fixtures.js";
+
+import { OxDeAIGuard } from "../guard.js";
+import { createSecureGuard } from "../secureGuard.js";
+import { createTrustedExecutionContext } from "../trustedContext.js";
+import type { TrustedExecutionContext } from "../trustedContext.js";
+import { defaultNormalizeAction } from "../normalizeAction.js";
+import {
+  OxDeAIAuthorizationError,
+  OxDeAIDelegationError,
+  OxDeAIDenyError,
+  OxDeAINormalizationError,
+  OxDeAIProvenanceConflictError,
+} from "../errors.js";
+import type { GuardBoundaryAuditEvent } from "../boundaryEvent.js";
+import type { OxDeAIGuardConfig, ProposedAction, StateVersion } from "../types.js";
+import type { ReplayStore } from "../replayStore.js";
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+const ENGINE_SECRET = "test-secret-must-be-at-least-32-chars!!";
+const AGENT_ID = "agent-test-001";
+const PRIVILEGED_AGENT_ID = "agent-admin-root";
+
+function makeEngine(): PolicyEngine {
+  return new PolicyEngine({
+    policy_version: "v1",
+    engine_secret: ENGINE_SECRET,
+    authorization_signing_alg: "Ed25519",
+    authorization_signing_kid: "k1",
+    authorization_issuer: TEST_KEYSET.issuer,
+    authorization_audience: "aud-test",
+    authorization_ttl_seconds: 600,
+    authorization_private_key_pem: TEST_KEYPAIR.privateKey.toString(),
+    ...RECOMMENDED_TRUSTED_TIME_PROFILE,
+  });
+}
+
+function makeState(agentId: string = AGENT_ID): State {
+  return buildState({
+    agent_id: agentId,
+    allow_action_types: ["PROVISION", "PAYMENT", "PURCHASE", "ONCHAIN_TX"],
+    budget_limit: 1_000_000_000n,
+    max_amount_per_action: 1_000_000_000n,
+    velocity_max_actions: 1000,
+    max_concurrent: 16,
+  });
+}
+
+function makeGuardConfig(overrides: Partial<OxDeAIGuardConfig> = {}): OxDeAIGuardConfig {
+  let currentState = makeState();
+  let currentVersion = 0;
+  return {
+    engine: makeEngine(),
+    getState: () => ({ state: currentState, version: currentVersion }),
+    setState: (s, v) => {
+      if (v !== currentVersion) return false;
+      currentState = s;
+      currentVersion++;
+      return true;
+    },
+    trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "aud-test",
+    ...overrides,
+  };
+}
+
+const baseAction: ProposedAction = {
+  name: "provision_gpu",
+  args: { asset: "a100" },
+  estimatedCost: 0.5,
+  resourceType: "gpu",
+  context: { agent_id: AGENT_ID, target: "gpu-pool" },
+};
+
+function makeContext(overrides: Partial<TrustedExecutionContext> = {}): TrustedExecutionContext {
+  return createTrustedExecutionContext({
+    principalId: "principal-1",
+    agentId: AGENT_ID,
+    adapterId: "adapter-http",
+    depth: 0,
+    ...overrides,
+  });
+}
+
+/** A mock engine, for the result shapes a real PolicyEngine will not produce. */
+function mockEngine(
+  evaluatePure: (intent: Intent, state: State, at: number) => unknown,
+  computeStateHash: (state: State) => string = () => "0".repeat(64)
+): PolicyEngine {
+  return { evaluatePure, computeStateHash } as unknown as PolicyEngine;
+}
+
+// ── delegation fixtures (mirrors guard.delegation.test.ts) ────────────────────
+
+const T_NOW = Math.floor(Date.now() / 1000);
+const PARENT_SCOPE: DelegationScope = { tools: ["provision_gpu"], max_amount: 1_000_000n };
+
+function makeParentAuth(): AuthorizationV1 {
+  return signAuthorizationEd25519(
+    {
+      auth_id: "f".repeat(64),
+      issuer: TEST_KEYSET.issuer,
+      audience: "agent-A",
+      intent_hash: "a".repeat(64),
+      state_hash: "b".repeat(64),
+      policy_id: "policy-1",
+      decision: "ALLOW",
+      issued_at: T_NOW - 60,
+      expiry: T_NOW + 900,
+      kid: "k1",
+    },
+    TEST_KEYPAIR.privateKey.toString()
+  );
+}
+
+function makeDelegation(parentAuth: AuthorizationV1, expiry: number = T_NOW + 300): DelegationV1 {
+  return createDelegation(
+    parentAuth,
+    {
+      delegatee: "agent-B",
+      issuer: TEST_KEYSET.issuer,
+      scope: { tools: ["provision_gpu"], max_amount: 1_000_000n },
+      expiry,
+      kid: "k1",
+    },
+    TEST_KEYPAIR.privateKey.toString()
+  );
+}
+
+function makeDelegationConfig(overrides: Partial<OxDeAIGuardConfig> = {}): OxDeAIGuardConfig {
+  const state = makeState("agent-B");
+  return {
+    engine: makeEngine(),
+    getState: () => ({ state, version: 0 }),
+    setState: () => true,
+    trustedKeySets: [TEST_KEYSET],
+    expectedAudience: "agent-A",
+    ...overrides,
+  };
+}
+
+const delegatedAction: ProposedAction = {
+  name: "provision_gpu",
+  args: { asset: "a100" },
+  estimatedCost: 0,
+  context: { agent_id: "agent-B", target: "gpu-pool" },
+  timestampSeconds: T_NOW,
+};
+
+// ── collector ─────────────────────────────────────────────────────────────────
+
+type Collector = {
+  readonly events: GuardBoundaryAuditEvent[];
+  readonly hook: (event: GuardBoundaryAuditEvent) => void;
+};
+
+function collect(): Collector {
+  const events: GuardBoundaryAuditEvent[] = [];
+  return { events, hook: (event) => { events.push(event); } };
+}
+
+/** Asserts exactly one event was emitted and returns it. */
+function only(events: readonly GuardBoundaryAuditEvent[]): GuardBoundaryAuditEvent {
+  assert.equal(events.length, 1, `expected exactly one boundary event, got ${events.length}`);
+  return events[0]!;
+}
+
+/** Runs a call expected to reject and returns the thrown value. */
+async function caught(run: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await run();
+  } catch (err) {
+    return err;
+  }
+  assert.fail("expected the guard to reject");
+}
+
+// ── B-1 / B-2: the secure prelude, reported by the outer catch ────────────────
+
+test("B-1 an unbranded trusted context emits TRUSTED_CONTEXT / UNTRUSTED_CONTEXT", async () => {
+  const audit = collect();
+  const secure = createSecureGuard(
+    makeGuardConfig({ onBoundaryEvent: audit.hook }),
+    { tenancy: "single-tenant" }
+  );
+
+  const forged = {
+    principalId: "principal-1",
+    agentId: AGENT_ID,
+    adapterId: "adapter-http",
+    depth: 0,
+  } as unknown as TrustedExecutionContext;
+
+  const err = await caught(() => secure(forged, baseAction, async () => "done"));
+  assert.ok(err instanceof OxDeAIAuthorizationError);
+
+  const event = only(audit.events);
+  assert.equal(event.stage, "TRUSTED_CONTEXT");
+  assert.equal(event.boundaryFailure, "UNTRUSTED_CONTEXT");
+  // The shared body was never entered, so nothing downstream can have happened.
+  assert.equal(event.policyEvaluated, false);
+  assert.equal(event.authorizationIssued, false);
+  assert.equal(event.authorizationConsumed, false);
+  assert.equal(event.delegationConsumed, false);
+  assert.equal(event.stateCommitted, false);
+  assert.equal(event.executionStarted, false);
+  assert.equal(event.intentId, undefined);
+});
+
+test("B-2 a multi-tenant deployment without tenantId emits MISSING_TENANT_ID", async () => {
+  const audit = collect();
+  const secure = createSecureGuard(
+    makeGuardConfig({ onBoundaryEvent: audit.hook }),
+    { tenancy: "multi-tenant" }
+  );
+
+  const err = await caught(() => secure(makeContext(), baseAction, async () => "done"));
+  assert.ok(err instanceof OxDeAIAuthorizationError);
+
+  const event = only(audit.events);
+  assert.equal(event.stage, "TRUSTED_CONTEXT");
+  assert.equal(event.boundaryFailure, "MISSING_TENANT_ID");
+});
+
+// ── B-3 .. B-17: one per reachable stage / category pairing ───────────────────
+
+test("B-3 a state store returning no version emits STATE_LOAD / STATE_VERSION_MISSING", async () => {
+  const audit = collect();
+  const guard = OxDeAIGuard(
+    makeGuardConfig({
+      getState: () => ({ state: makeState(), version: undefined as unknown as StateVersion }),
+      onBoundaryEvent: audit.hook,
+    })
+  );
+
+  const err = await caught(() => guard(baseAction, async () => "done"));
+  assert.ok(err instanceof OxDeAIAuthorizationError);
+
+  const event = only(audit.events);
+  assert.equal(event.stage, "STATE_LOAD");
+  assert.equal(event.boundaryFailure, "STATE_VERSION_MISSING");
+  assert.equal(event.intentId, undefined, "normalization has not run yet");
+});
+
+test("B-4 a normalization failure emits NORMALIZATION / NORMALIZATION_FAILURE", async () => {
+  // (a) the default normalizer rejecting an incomplete action.
+  const thrown = collect();
+  const guard = OxDeAIGuard(makeGuardConfig({ onBoundaryEvent: thrown.hook }));
+  const err = await caught(() =>
+    guard({ name: "provision_gpu", args: {}, context: {} }, async () => "done")
+  );
+  assert.ok(err instanceof OxDeAINormalizationError);
+  const event = only(thrown.events);
+  assert.equal(event.stage, "NORMALIZATION");
+  assert.equal(event.boundaryFailure, "NORMALIZATION_FAILURE");
+
+  // (b) a custom normalizer throwing something unexpected, which the guard
+  //     wraps. The wrapper is what the caller sees, and it is what is reported.
+  const wrapped = collect();
+  const guard2 = OxDeAIGuard(
+    makeGuardConfig({
+      mapActionToIntent: () => { throw new Error("normalizer exploded"); },
+      onBoundaryEvent: wrapped.hook,
+    })
+  );
+  const err2 = await caught(() => guard2(baseAction, async () => "done"));
+  assert.ok(err2 instanceof OxDeAINormalizationError);
+  const event2 = only(wrapped.events);
+  assert.equal(event2.stage, "NORMALIZATION");
+  assert.equal(event2.boundaryFailure, "NORMALIZATION_FAILURE");
+});
+
+test("B-5 a provenance conflict emits PROVENANCE / PROVENANCE_CONFLICT with its evidence", async () => {
+  const audit = collect();
+  const secure = createSecureGuard(
+    makeGuardConfig({ onBoundaryEvent: audit.hook }),
+    { tenancy: "single-tenant" }
+  );
+
+  const substituted: ProposedAction = {
+    ...baseAction,
+    context: { ...baseAction.context, agent_id: PRIVILEGED_AGENT_ID },
+  };
+
+  const err = await caught(() => secure(makeContext(), substituted, async () => "done"));
+  assert.ok(err instanceof OxDeAIProvenanceConflictError);
+
+  const event = only(audit.events);
+  assert.equal(event.stage, "PROVENANCE");
+  assert.equal(event.boundaryFailure, "PROVENANCE_CONFLICT");
+  assert.deepEqual(event.conflictingFields, ["agent_id"]);
+  // The record reuses the reconciliation vocabulary, not an opaque string map:
+  // an audit reader parses one provenance type across both streams.
+  assert.equal(event.provenance?.["agent_id"], "conflict");
+  assert.equal(event.policyEvaluated, false, "a conflict is refused before evaluation");
+});
+
+test("B-6 incomplete delegation input emits DELEGATION / DELEGATION_INPUT_INVALID", async () => {
+  const audit = collect();
+  const guard = OxDeAIGuard(makeDelegationConfig({ onBoundaryEvent: audit.hook }));
+
+  const err = await caught(() =>
+    guard(delegatedAction, async () => "done", {
+      delegation: {
+        delegation: null as unknown as DelegationV1,
+        parentAuth: null as unknown as AuthorizationV1,
+        parentScope: {},
+      },
+    })
+  );
+  assert.ok(err instanceof OxDeAIAuthorizationError);
+
+  const event = only(audit.events);
+  assert.equal(event.stage, "DELEGATION");
+  assert.equal(event.boundaryFailure, "DELEGATION_INPUT_INVALID");
+});
+
+test("B-7 a failed delegation chain emits DELEGATION / DELEGATION_VERIFICATION_FAILED", async () => {
+  const audit = collect();
+  const guard = OxDeAIGuard(makeDelegationConfig({ onBoundaryEvent: audit.hook }));
+  const parentAuth = makeParentAuth();
+  const expired = makeDelegation(parentAuth, T_NOW - 1);
+
+  const err = await caught(() =>
+    guard(delegatedAction, async () => "done", {
+      delegation: { delegation: expired, parentAuth, parentScope: PARENT_SCOPE },
+    })
+  );
+  assert.ok(err instanceof OxDeAIDelegationError);
+
+  const event = only(audit.events);
+  assert.equal(event.stage, "DELEGATION");
+  assert.equal(event.boundaryFailure, "DELEGATION_VERIFICATION_FAILED");
+  assert.equal(event.policyEvaluated, false, "the delegation path never calls the engine");
+});
+
+test("B-8 a replayed delegation emits REPLAY / DELEGATION_REPLAY", async () => {
+  const audit = collect();
+  const guard = OxDeAIGuard(makeDelegationConfig({ onBoundaryEvent: audit.hook }));
+  const parentAuth = makeParentAuth();
+  const delegation = makeDelegation(parentAuth);
+  const input = { delegation: { delegation, parentAuth, parentScope: PARENT_SCOPE } };
+
+  await guard(delegatedAction, async () => "first", input);
+  assert.deepEqual(audit.events, [], "a permitted call is not a boundary rejection");
+
+  const err = await caught(() => guard(delegatedAction, async () => "second", input));
+  assert.ok(err instanceof OxDeAIAuthorizationError);
+
+  const event = only(audit.events);
+  assert.equal(event.stage, "REPLAY");
+  assert.equal(event.boundaryFailure, "DELEGATION_REPLAY");
+  assert.equal(
+    event.delegationConsumed,
+    false,
+    "the replayed id was consumed by the FIRST call, not by this one"
+  );
+});
+
+test("B-9 a replayed authorization emits REPLAY / AUTHORIZATION_REPLAY", async () => {
+  const audit = collect();
+  const store: ReplayStore = { consumeAuthId: async () => false };
+  const guard = OxDeAIGuard(makeGuardConfig({ replayStore: store, onBoundaryEvent: audit.hook }));
+
+  const err = await caught(() => guard(baseAction, async () => "done"));
+  assert.ok(err instanceof OxDeAIAuthorizationError);
+
+  const event = only(audit.events);
+  assert.equal(event.stage, "REPLAY");
+  assert.equal(event.boundaryFailure, "AUTHORIZATION_REPLAY");
+  assert.equal(event.policyEvaluated, true, "the engine ran before replay was checked");
+  assert.equal(event.authorizationIssued, true);
+  assert.equal(event.authorizationConsumed, false, "a replayed id is not consumed by this call");
+  assert.equal(event.stateCommitted, false);
+  assert.equal(event.executionStarted, false);
+  assert.ok(event.intentId, "the intent had been normalized by this point");
+});
+
+test("B-10 an unavailable replay store emits REPLAY / REPLAY_STORE_UNAVAILABLE", async () => {
+  const audit = collect();
+  const store: ReplayStore = {
+    consumeAuthId: async () => { throw new Error("redis down"); },
+  };
+  const guard = OxDeAIGuard(makeGuardConfig({ replayStore: store, onBoundaryEvent: audit.hook }));
+
+  const err = await caught(() => guard(baseAction, async () => "done"));
+  assert.ok(err instanceof OxDeAIAuthorizationError);
+
+  const event = only(audit.events);
+  assert.equal(event.stage, "REPLAY");
+  assert.equal(event.boundaryFailure, "REPLAY_STORE_UNAVAILABLE");
+});
+
+test("B-11 an engine that throws emits POLICY_EVALUATION / ENGINE_FAILURE", async () => {
+  const audit = collect();
+  const guard = OxDeAIGuard(
+    makeGuardConfig({
+      engine: mockEngine(() => { throw new Error("engine unavailable"); }),
+      onBoundaryEvent: audit.hook,
+    })
+  );
+
+  const err = await caught(() => guard(baseAction, async () => "done"));
+  assert.ok(err instanceof OxDeAIAuthorizationError);
+
+  const event = only(audit.events);
+  assert.equal(event.stage, "POLICY_EVALUATION");
+  assert.equal(event.boundaryFailure, "ENGINE_FAILURE");
+  assert.equal(
+    event.policyEvaluated,
+    false,
+    "an engine that threw did not evaluate; the flag must not claim it did"
+  );
+});
+
+test("B-12 ALLOW without an artifact emits POLICY_EVALUATION / AUTHORIZATION_MISSING", async () => {
+  const audit = collect();
+  const guard = OxDeAIGuard(
+    makeGuardConfig({
+      engine: mockEngine((_intent, state) => ({ decision: "ALLOW", reasons: [], nextState: state })),
+      onBoundaryEvent: audit.hook,
+    })
+  );
+
+  const err = await caught(() => guard(baseAction, async () => "done"));
+  assert.ok(err instanceof OxDeAIAuthorizationError);
+
+  const event = only(audit.events);
+  assert.equal(event.stage, "POLICY_EVALUATION");
+  assert.equal(event.boundaryFailure, "AUTHORIZATION_MISSING");
+  assert.equal(event.policyEvaluated, true);
+  assert.equal(event.authorizationIssued, false);
+});
+
+test("B-13 a failed verifier emits AUTHORIZATION_VERIFICATION / AUTHORIZATION_VERIFICATION_FAILED", async () => {
+  const audit = collect();
+  const guard = OxDeAIGuard(
+    makeGuardConfig({
+      // Correctly signed, but issued to a different audience than this guard
+      // instance protects.
+      engine: mockEngine((_intent, state) => ({
+        decision: "ALLOW",
+        reasons: [],
+        nextState: state,
+        authorization: signAuth({ audience: "aud-somebody-else" }),
+      })),
+      onBoundaryEvent: audit.hook,
+    })
+  );
+
+  const err = await caught(() => guard(baseAction, async () => "done"));
+  assert.ok(err instanceof OxDeAIAuthorizationError);
+
+  const event = only(audit.events);
+  assert.equal(event.stage, "AUTHORIZATION_VERIFICATION");
+  assert.equal(event.boundaryFailure, "AUTHORIZATION_VERIFICATION_FAILED");
+  assert.equal(event.authorizationIssued, true);
+  assert.equal(event.authorizationConsumed, true, "the id was consumed before verification");
+});
+
+test("B-14 an unbound intent emits AUTHORIZATION_VERIFICATION / INTENT_HASH_MISMATCH", async () => {
+  const audit = collect();
+  const guard = OxDeAIGuard(
+    makeGuardConfig({
+      // A verifiable authorization committing to some other intent.
+      engine: mockEngine((_intent, state) => ({
+        decision: "ALLOW",
+        reasons: [],
+        nextState: state,
+        authorization: signAuth({ intent_hash: "9".repeat(64) }),
+      })),
+      onBoundaryEvent: audit.hook,
+    })
+  );
+
+  const err = await caught(() => guard(baseAction, async () => "done"));
+  assert.ok(err instanceof OxDeAIAuthorizationError);
+
+  const event = only(audit.events);
+  assert.equal(event.stage, "AUTHORIZATION_VERIFICATION");
+  assert.equal(event.boundaryFailure, "INTENT_HASH_MISMATCH");
+});
+
+test("B-15 an unbound state emits AUTHORIZATION_VERIFICATION / STATE_HASH_MISMATCH", async () => {
+  const audit = collect();
+  const guard = OxDeAIGuard(
+    makeGuardConfig({
+      // Intent binding holds; the committed state snapshot does not.
+      engine: mockEngine((intent, state) => ({
+        decision: "ALLOW",
+        reasons: [],
+        nextState: state,
+        authorization: signAuth({ intent_hash: intentHash(intent), state_hash: "7".repeat(64) }),
+      })),
+      onBoundaryEvent: audit.hook,
+    })
+  );
+
+  const err = await caught(() => guard(baseAction, async () => "done"));
+  assert.ok(err instanceof OxDeAIAuthorizationError);
+
+  const event = only(audit.events);
+  assert.equal(event.stage, "AUTHORIZATION_VERIFICATION");
+  assert.equal(event.boundaryFailure, "STATE_HASH_MISMATCH");
+  assert.equal(event.stateCommitted, false, "the binding is checked before the commit");
+});
+
+test("B-16 a lost CAS race emits STATE_COMMIT / CAS_CONFLICT", async () => {
+  const audit = collect();
+  const guard = OxDeAIGuard(
+    makeGuardConfig({ setState: () => false, onBoundaryEvent: audit.hook })
+  );
+
+  const err = await caught(() => guard(baseAction, async () => "done"));
+  assert.ok(err instanceof OxDeAIAuthorizationError);
+
+  const event = only(audit.events);
+  assert.equal(event.stage, "STATE_COMMIT");
+  assert.equal(event.boundaryFailure, "CAS_CONFLICT");
+  assert.equal(event.authorizationConsumed, true);
+  assert.equal(event.stateCommitted, false);
+  assert.equal(event.executionStarted, false, "a lost race blocks side effects");
+});
+
+test("B-17 a failing deployment hook emits EXECUTION_GATE / UNCLASSIFIED", async () => {
+  const audit = collect();
+  const guard = OxDeAIGuard(
+    makeGuardConfig({
+      beforeExecute: () => { throw new Error("pre-flight check failed"); },
+      onBoundaryEvent: audit.hook,
+    })
+  );
+
+  const err = await caught(() => guard(baseAction, async () => "done"));
+  assert.equal((err as Error).message, "pre-flight check failed", "the hook's error is not wrapped");
+
+  const event = only(audit.events);
+  assert.equal(event.stage, "EXECUTION_GATE");
+  assert.equal(
+    event.boundaryFailure,
+    "UNCLASSIFIED",
+    "an unannotated escape is reported honestly, never silently dropped"
+  );
+  assert.equal(event.stateCommitted, true, "the commit had already happened");
+  assert.equal(event.executionStarted, false, "the gate never opened");
+});
+
+// ── B-18 / B-19: executionStarted precedes the callback, at BOTH sites ────────
+
+test("B-18 main path: a failure inside the protected callback is not a boundary rejection", async () => {
+  const audit = collect();
+  let commits = 0;
+  let currentState = makeState();
+  let currentVersion = 0;
+
+  const guard = OxDeAIGuard(
+    makeGuardConfig({
+      getState: () => ({ state: currentState, version: currentVersion }),
+      setState: (s, v) => {
+        commits++;
+        // The second call loses the CAS race — the control below.
+        if (commits > 1 || v !== currentVersion) return false;
+        currentState = s;
+        currentVersion++;
+        return true;
+      },
+      onBoundaryEvent: audit.hook,
+    })
+  );
+
+  const boom = new Error("the side effect failed");
+  const err = await caught(() => guard(baseAction, async () => { throw boom; }));
+
+  assert.equal(err, boom, "the callback's own error reaches the caller unchanged");
+  assert.deepEqual(
+    audit.events,
+    [],
+    "past the execution gate the guard has already permitted the action: a callback " +
+      "failure is the caller's, and reporting it would make the audit stream claim " +
+      "the guard refused something it allowed"
+  );
+
+  // Control, on the SAME guard instance and the SAME hook: a rejection raised
+  // before the gate still emits. Without this, the assertion above would also
+  // pass if the hook were simply never wired.
+  const err2 = await caught(() => guard(baseAction, async () => "done"));
+  assert.ok(err2 instanceof OxDeAIAuthorizationError);
+  const event = only(audit.events);
+  assert.equal(event.boundaryFailure, "CAS_CONFLICT");
+  assert.equal(event.executionStarted, false);
+});
+
+test("B-19 delegation path: a failure inside the protected callback is not a boundary rejection", async () => {
+  const audit = collect();
+  const guard = OxDeAIGuard(makeDelegationConfig({ onBoundaryEvent: audit.hook }));
+  const parentAuth = makeParentAuth();
+  const delegation = makeDelegation(parentAuth);
+  const input = { delegation: { delegation, parentAuth, parentScope: PARENT_SCOPE } };
+
+  const boom = new Error("the delegated side effect failed");
+  const err = await caught(() => guard(delegatedAction, async () => { throw boom; }, input));
+
+  assert.equal(err, boom, "the callback's own error reaches the caller unchanged");
+  assert.deepEqual(
+    audit.events,
+    [],
+    "the delegation path opens its own execution gate and must honour it identically"
+  );
+
+  // Control, on the SAME guard instance and the SAME hook: replaying the now
+  // consumed delegation is refused before the gate, and does emit.
+  const err2 = await caught(() => guard(delegatedAction, async () => "done", input));
+  assert.ok(err2 instanceof OxDeAIAuthorizationError);
+  const event = only(audit.events);
+  assert.equal(event.boundaryFailure, "DELEGATION_REPLAY");
+  assert.equal(event.executionStarted, false);
+});
+
+// ── B-20: non-object throws ──────────────────────────────────────────────────
+
+test("B-20 a non-object throw surfaces unchanged and reports UNCLASSIFIED", async () => {
+  const audit = collect();
+  const guard = OxDeAIGuard(
+    makeGuardConfig({
+      // `throw "boom"` is legal, and a third-party callback may do it. The
+      // audit path keys de-duplication on the thrown value, so it must not
+      // assume that value can key a WeakSet.
+      getState: () => { throw "boom"; },
+      onBoundaryEvent: audit.hook,
+    })
+  );
+
+  const err = await caught(() => guard(baseAction, async () => "done"));
+  assert.equal(err instanceof Error, false, "it is not replaced by a TypeError from the audit path");
+  assert.equal(err, "boom", "and the original rejection reaches the caller");
+
+  const event = only(audit.events);
+  assert.equal(event.stage, "STATE_LOAD");
+  assert.equal(event.boundaryFailure, "UNCLASSIFIED");
+});
+
+test("B-20b a non-object throw on the secure path is still reported exactly once", async () => {
+  const audit = collect();
+  const secure = createSecureGuard(
+    makeGuardConfig({
+      getState: () => { throw "boom"; },
+      onBoundaryEvent: audit.hook,
+    }),
+    { tenancy: "single-tenant" }
+  );
+
+  const err = await caught(() => secure(makeContext(), baseAction, async () => "done"));
+  assert.equal(err, "boom");
+
+  // Two nested catches see this rejection and it cannot be tracked by identity,
+  // so only the lifecycle can stop the outer one from reporting it a second time.
+  const event = only(audit.events);
+  assert.equal(event.boundaryFailure, "UNCLASSIFIED");
+});
+
+test("B-20c a normalizer that throws a string still yields the guard's own error", async () => {
+  const audit = collect();
+  const guard = OxDeAIGuard(
+    makeGuardConfig({
+      mapActionToIntent: () => { throw "boom"; },
+      onBoundaryEvent: audit.hook,
+    })
+  );
+
+  const err = await caught(() => guard(baseAction, async () => "done"));
+  assert.ok(err instanceof OxDeAINormalizationError, "the pre-existing wrapping is unchanged");
+  assert.match((err as Error).message, /boom/);
+
+  const event = only(audit.events);
+  assert.equal(event.boundaryFailure, "NORMALIZATION_FAILURE");
+});
+
+// ── B-21: DENY belongs to the other stream ───────────────────────────────────
+
+test("B-21 a policy DENY is reported on onDecision and never on onBoundaryEvent", async () => {
+  const audit = collect();
+  const decisions: string[] = [];
+  const denied: State = { ...makeState(), kill_switch: { global: true, agents: {} } };
+
+  const guard = OxDeAIGuard(
+    makeGuardConfig({
+      getState: () => ({ state: denied, version: 0 }),
+      onDecision: ({ decision }) => { decisions.push(decision); },
+      onBoundaryEvent: audit.hook,
+    })
+  );
+
+  const err = await caught(() => guard(baseAction, async () => "done"));
+  assert.ok(err instanceof OxDeAIDenyError);
+
+  assert.deepEqual(decisions, ["DENY"]);
+  assert.deepEqual(
+    audit.events,
+    [],
+    "a denial is a decision, not a boundary rejection: reporting it on both " +
+      "streams would double-count every DENY in an audit pipeline"
+  );
+});
+
+// ── B-22: one rejection, one event, however many layers see it ───────────────
+
+test("B-22 a conflict raised inside the normalizer is emitted once, not once per layer", async () => {
+  const audit = collect();
+  const secure = createSecureGuard(
+    makeGuardConfig({ onBoundaryEvent: audit.hook }),
+    { tenancy: "single-tenant" }
+  );
+
+  const substituted: ProposedAction = {
+    ...baseAction,
+    context: { ...baseAction.context, agent_id: PRIVILEGED_AGENT_ID },
+  };
+
+  await caught(() => secure(makeContext(), substituted, async () => "done"));
+
+  // The conflict is raised inside the injected normalizer, so the shared body's
+  // catch and the secure wrapper's catch both see the same error object.
+  assert.equal(audit.events.length, 1, "two nested catches must not double-report");
+  assert.equal(audit.events[0]!.boundaryFailure, "PROVENANCE_CONFLICT");
+});
+
+test("B-22b a custom normalizer's own provenance conflict is classified the same way", async () => {
+  // The classification lives at the shared body's throw site, so it does not
+  // depend on the secure wrapper having produced the conflict.
+  const audit = collect();
+  const guard = OxDeAIGuard(
+    makeGuardConfig({
+      mapActionToIntent: () => {
+        throw new OxDeAIProvenanceConflictError(["tool"], { tool: "conflict" });
+      },
+      onBoundaryEvent: audit.hook,
+    })
+  );
+
+  const err = await caught(() => guard(baseAction, async () => "done"));
+  assert.ok(err instanceof OxDeAIProvenanceConflictError);
+
+  const event = only(audit.events);
+  assert.equal(event.stage, "PROVENANCE");
+  assert.equal(event.boundaryFailure, "PROVENANCE_CONFLICT");
+  assert.deepEqual(event.conflictingFields, ["tool"]);
+});
+
+// ── B-23: the audit sink cannot change the outcome ───────────────────────────
+
+test("B-23 a throwing audit sink does not change what the caller receives", async () => {
+  const guard = OxDeAIGuard(
+    makeGuardConfig({
+      setState: () => false,
+      onBoundaryEvent: () => { throw new Error("audit sink is down"); },
+    })
+  );
+
+  const err = await caught(() => guard(baseAction, async () => "done"));
+  assert.ok(err instanceof OxDeAIAuthorizationError, "the ORIGINAL guard error, not the sink's");
+  assert.match((err as Error).message, /concurrent modification/);
+});
+
+test("B-23b a rejecting async audit sink does not change what the caller receives", async () => {
+  const secure = createSecureGuard(
+    makeGuardConfig({
+      onBoundaryEvent: async () => { throw new Error("audit sink is down"); },
+    }),
+    { tenancy: "multi-tenant" }
+  );
+
+  const err = await caught(() => secure(makeContext(), baseAction, async () => "done"));
+  assert.ok(err instanceof OxDeAIAuthorizationError);
+  assert.match((err as Error).message, /multi-tenant/);
+});
+
+// ── B-24: what the record deliberately does not carry ────────────────────────
+
+test("B-24 the record carries no policyDecision; policyEvaluated carries the fact", async () => {
+  // A boundary event never carries a DENY: a denial is an OxDeAIDenyError, which
+  // is reported on onDecision and returns early from emission (pinned by B-21).
+  // "ALLOW" would therefore be the only value the field could ever hold, and it
+  // would hold it exactly when policyEvaluated is already true — so the field is
+  // omitted rather than frozen into the public shape carrying one value.
+  const after = collect();
+  const guard = OxDeAIGuard(makeGuardConfig({ setState: () => false, onBoundaryEvent: after.hook }));
+  await caught(() => guard(baseAction, async () => "done"));
+  const afterAllow = only(after.events);
+
+  assert.equal(Object.prototype.hasOwnProperty.call(afterAllow, "policyDecision"), false);
+  assert.equal(afterAllow.policyEvaluated, true);
+  assert.equal(afterAllow.authorizationIssued, true);
+
+  const before = collect();
+  const guard2 = OxDeAIGuard(
+    makeGuardConfig({
+      getState: () => ({ state: makeState(), version: undefined as unknown as StateVersion }),
+      onBoundaryEvent: before.hook,
+    })
+  );
+  await caught(() => guard2(baseAction, async () => "done"));
+  const beforeEvaluation = only(before.events);
+
+  assert.equal(Object.prototype.hasOwnProperty.call(beforeEvaluation, "policyDecision"), false);
+  assert.equal(
+    beforeEvaluation.policyEvaluated,
+    false,
+    "policyEvaluated is what separates a pre-evaluation refusal from a post-ALLOW one"
+  );
+});
+
+// ── B-25: the hook is optional ───────────────────────────────────────────────
+
+test("B-25 the guard behaves identically with no boundary hook configured", async () => {
+  const guard = OxDeAIGuard(makeGuardConfig({ setState: () => false }));
+  const err = await caught(() => guard(baseAction, async () => "done"));
+  assert.ok(err instanceof OxDeAIAuthorizationError);
+
+  const permitting = OxDeAIGuard(makeGuardConfig());
+  assert.equal(await permitting(baseAction, async () => "executed"), "executed");
+});
+
+test("B-25b a permitted call emits nothing on the boundary stream", async () => {
+  const audit = collect();
+  const guard = OxDeAIGuard(makeGuardConfig({ onBoundaryEvent: audit.hook }));
+
+  const result = await guard(baseAction, async () => "executed");
+
+  assert.equal(result, "executed");
+  assert.deepEqual(audit.events, [], "the boundary stream reports rejections only");
+});
+
+// ── the reconciliation path still behaves as before ──────────────────────────
+
+test("B-26 the secure path still reports provenance on onDecision for an ALLOW", async () => {
+  const audit = collect();
+  const records: Array<Record<string, unknown>> = [];
+  const secure = createSecureGuard(
+    makeGuardConfig({
+      onDecision: (r) => { records.push(r as unknown as Record<string, unknown>); },
+      onBoundaryEvent: audit.hook,
+    }),
+    { tenancy: "single-tenant" }
+  );
+
+  const result = await secure(makeContext({ tool: "provision_gpu" }), baseAction, async () => "ok");
+
+  assert.equal(result, "ok");
+  assert.equal(records.length, 1, "the decision stream is unchanged");
+  assert.deepEqual(audit.events, []);
+  const provenance = records[0]?.["provenance"] as Record<string, string> | undefined;
+  assert.equal(provenance?.["agent_id"], "matched");
+});
+
+test("B-27 defaultNormalizeAction is unchanged by the audit wiring", () => {
+  const intent: Intent = defaultNormalizeAction(baseAction);
+  assert.equal(intent.agent_id, AGENT_ID);
+  assert.equal(intent.amount, 500_000n);
+});

--- a/packages/guard/src/types.ts
+++ b/packages/guard/src/types.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { AuthorizationV1, DelegationScope, DelegationV1, Intent, KeySet, PolicyEngine, State } from "@oxdeai/core";
 import type { ReplayStore } from "./replayStore.js";
+import type { GuardBoundaryEventHook } from "./boundaryEvent.js";
 
 /**
  * A runtime-agnostic description of an action an agent wants to perform.
@@ -125,6 +126,39 @@ export type OxDeAIGuardConfig = {
    * Errors thrown here are swallowed so they cannot block execution.
    */
   onDecision?: (result: GuardDecisionRecord) => void | Promise<void>;
+
+  /**
+   * Optional audit hook for rejections raised at the guard boundary — an
+   * unbranded trusted context, a provenance conflict, a delegation replay, a
+   * hash-binding failure, a CAS conflict.
+   *
+   * Disjoint from {@link OxDeAIGuardConfig.onDecision}, by construction:
+   *
+   * ```text
+   * valid DENY                              → onDecision only      (decision record emitted)
+   * guard rejection before execute() starts → onBoundaryEvent only (no decision record)
+   * ALLOW, execute() starts, callback threw → neither              (current contract, #238)
+   * ```
+   *
+   * No rejection is reported on both streams. A valid denial is the engine's
+   * decision and is reported to `onDecision`; every other guard-boundary
+   * rejection emits no decision record, which is precisely why a deployment
+   * auditing only `onDecision` could not see attempted identity or tool
+   * substitutions.
+   *
+   * A boundary rejection is not necessarily pre-decision: it may occur before
+   * the engine ran (`policyEvaluated === false`) or after a valid ALLOW
+   * (`policyEvaluated === true`), because authorization verification, replay
+   * consumption, hash binding and the CAS commit all run after the ALLOW and
+   * before `execute()`, while the ALLOW record is only emitted once the
+   * protected callback has returned.
+   *
+   * Best effort, exactly like `onDecision`: anything this hook throws or
+   * rejects with is swallowed, and the caller always receives the original
+   * guard error, unwrapped and unreplaced. It is awaited before the rejection
+   * propagates, so a slow hook delays the caller — do durable work out of band.
+   */
+  onBoundaryEvent?: GuardBoundaryEventHook;
 
   /**
    * The audience this guard instance expects in every AuthorizationV1 artifact.


### PR DESCRIPTION
Closes #235.

This is the exact diff reviewed and approved in https://github.com/oxdeai/oxdeai/issues/235#issuecomment-5395259723 — no implementation changes since, only the JSDoc corrections you asked for.

## What this adds

A single `onBoundaryEvent` channel for guard-boundary rejections that happen outside the policy engine. Previously those left no audit trail at all: the request was refused with no `GuardDecisionRecord` and no other signal.

- `boundaryEvent.ts` — emission helper, stage taxonomy, redaction path
- `guard.ts` — fires at the pre-engine stages plus authorization verification, replay, CAS and state commit; execution-start boundary added
- `secureGuard.ts` — same coverage for the secure wrapper, including the primitive-throw fallback
- `types.ts` / `index.ts` — public surface for the event and its stages
- WeakMap/WeakSet tracking so a shared body entered once is not double-counted

## Semantics (the never-both invariant)

| case | emits |
|---|---|
| valid DENY | `onDecision` only |
| guard rejection before `execute()` starts | `onBoundaryEvent` only |
| callback throws after `execute()` started | neither — tracked in #238 |

A boundary event may carry `policyEvaluated: false`, **or** `true` where a valid ALLOW was already returned but no final decision record is produced (authorization verification, replay, CAS). That correction came from your review — I checked it against the control flow in `guard.ts` before changing the wording: the DENY path fires `fireDecision` at :415 before the throw at :421, whereas the ALLOW path only fires at :603, after `execute()` at :600.

`policyDecision` was not reintroduced, and malformed engine output is untouched.

## Verification

- guard **203/203**
- core **356/356**
- `pnpm typecheck` exit 0
- supplemental API report fingerprint **OK**

Happy to bring any further implementation change back for review before pushing it here.