### PR TITLE
release: align 2.0 package metadata and adapter release plumbing

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,26 +54,28 @@ Remaining standardization gates include:
 ## Version Snapshot
 
 > Verify exact package versions against `package.json` before release publication.
+> These are the prepared versions for the next 2.0 release line. None of them is published yet;
+> the npm registry still serves the pre-2.0 line.
 
 ### Protocol / Core
 
-- `@oxdeai/core`: 1.7.0
-- `@oxdeai/conformance`: 1.5.0
-- `@oxdeai/sdk`: 1.3.3
+- `@oxdeai/core`: 2.0.0
+- `@oxdeai/conformance`: 2.0.0
+- `@oxdeai/sdk`: 2.0.0
 
 ### Enforcement / Adapters
 
-- `@oxdeai/guard`: 1.0.3
+- `@oxdeai/guard`: 2.0.0
 - `@oxdeai/sift`: 0.0.1
-- `@oxdeai/langgraph`: 1.0.1
-- `@oxdeai/openai-agents`: 1.0.1
-- `@oxdeai/crewai`: 1.0.1
-- `@oxdeai/autogen`: 1.0.1
-- `@oxdeai/openclaw`: 1.0.1
+- `@oxdeai/langgraph`: 2.0.0
+- `@oxdeai/openai-agents`: 2.0.0
+- `@oxdeai/crewai`: 2.0.0
+- `@oxdeai/autogen`: 2.0.0
+- `@oxdeai/openclaw`: 2.0.0
 
 ### Tooling
 
-- `@oxdeai/cli`: 0.2.4
+- `@oxdeai/cli`: 0.3.0
 
 ### Compatibility
 

--- a/docs/release/RELEASE.md
+++ b/docs/release/RELEASE.md
@@ -20,7 +20,7 @@ A coordinated release commit does not create a shared package version line.
 
 ## 2. Released Packages
 
-Currently released package tag prefixes:
+Supported package-scoped release tag prefixes:
 
 | npm package | package path | tag prefix |
 |---|---|---|
@@ -29,6 +29,11 @@ Currently released package tag prefixes:
 | `@oxdeai/conformance` | `packages/conformance` | `conformance-vX.Y.Z` |
 | `@oxdeai/guard` | `packages/guard` | `guard-vX.Y.Z` |
 | `@oxdeai/cli` | `packages/cli` | `cli-vX.Y.Z` |
+| `@oxdeai/langgraph` | `packages/langgraph` | `langgraph-vX.Y.Z` |
+| `@oxdeai/crewai` | `packages/crewai` | `crewai-vX.Y.Z` |
+| `@oxdeai/autogen` | `packages/autogen` | `autogen-vX.Y.Z` |
+| `@oxdeai/openai-agents` | `packages/openai-agents` | `openai-agents-vX.Y.Z` |
+| `@oxdeai/openclaw` | `packages/openclaw` | `openclaw-vX.Y.Z` |
 
 Other packages in `packages/` must not be released publicly unless their package-scoped tag prefix, changelog requirement, validation gates, and npm publish target are added to this policy first.
 
@@ -50,6 +55,11 @@ sdk-vX.Y.Z
 conformance-vX.Y.Z
 guard-vX.Y.Z
 cli-vX.Y.Z
+langgraph-vX.Y.Z
+crewai-vX.Y.Z
+autogen-vX.Y.Z
+openai-agents-vX.Y.Z
+openclaw-vX.Y.Z
 ```
 
 Rules:
@@ -64,7 +74,13 @@ Global `vX.Y.Z` tags are legacy. Do not create new global `vX.Y.Z` tags for pack
 
 Global tags may only be introduced for a separately documented compatibility bundle or top-level announcement. Such a bundle tag must not replace package-scoped release tags and must include an explicit manifest mapping package names, package versions, package tags, npm versions, and the Git commit.
 
-Historical or suspicious prefixes such as `adapters-vX.Y.Z` must not be reused unless this policy is updated first.
+The historical shared prefix `adapters-vX.Y.Z` is retired. A single tag covering all five adapter
+packages cannot satisfy the rule that a tag version exactly matches one package's `package.json`
+version, so it must not be created again. The existing `adapters-v1.0.0` and `adapters-v1.0.1`
+tags are retained as historical record and must not be moved or deleted. From the 2.0 line onward,
+each adapter uses its own package-scoped prefix as listed above.
+
+Any other historical or suspicious prefix must not be reused unless this policy is updated first.
 
 Historical documentation and changelog entries may mention coordinated global `vX.Y.Z` releases or shared protocol-stack version lines. Those entries explain past releases only. They are not current release policy.
 

--- a/docs/release/RELEASING.md
+++ b/docs/release/RELEASING.md
@@ -18,6 +18,11 @@ sdk-vX.Y.Z
 conformance-vX.Y.Z
 guard-vX.Y.Z
 cli-vX.Y.Z
+langgraph-vX.Y.Z
+crewai-vX.Y.Z
+autogen-vX.Y.Z
+openai-agents-vX.Y.Z
+openclaw-vX.Y.Z
 ```
 
 Global `vX.Y.Z` tags are legacy for package releases. Do not create them for normal package releases.

--- a/docs/release/release-checklist.md
+++ b/docs/release/release-checklist.md
@@ -30,6 +30,11 @@ sdk-vX.Y.Z
 conformance-vX.Y.Z
 guard-vX.Y.Z
 cli-vX.Y.Z
+langgraph-vX.Y.Z
+crewai-vX.Y.Z
+autogen-vX.Y.Z
+openai-agents-vX.Y.Z
+openclaw-vX.Y.Z
 ```
 
 For coordinated releases, repeat the mapping for every package. Multiple tags may point to the same commit, but package versions remain independent.

--- a/packages/autogen/CHANGELOG.md
+++ b/packages/autogen/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog
+
+All notable changes to `@oxdeai/autogen` will be documented in this file.
+
+The format is based on Keep a Changelog.
+This project follows Semantic Versioning.
+
+> This file starts at 2.0.0. Versions 1.0.0 and 1.0.1 were published without a
+> changelog; the 2.0.0 entry below reconstructs the delta from the published
+> `@oxdeai/autogen@1.0.1` npm artifact.
+
+---
+
+## [2.0.0] - Unreleased
+
+**Baseline for this entry:** the published `@oxdeai/autogen@1.0.1` npm artifact
+(2026-03-19). The version was set to `1.0.1` at `8797931`; the packed
+`dist/types.d.ts` of that artifact is used as the authoritative comparison surface.
+
+> ⚠️ The published `1.0.1` artifact declares `"@oxdeai/core": "workspace:*"` and
+> `"@oxdeai/guard": "workspace:*"`, so **it cannot be installed standalone from the
+> public registry**. That is a defect of the historical release process, not of the
+> source. See **Packaging** below.
+
+### Breaking
+
+- **Requires `@oxdeai/core` 2.0 and `@oxdeai/guard` 2.0.** Both dependencies move
+  to a major line with breaking API and runtime-semantic changes; see those packages'
+  changelogs.
+- **`getState` now returns versioned state** — `{ state, version }` rather than
+  `State`. A store returning no version fails closed.
+- **`setState` is now compare-and-set** — `(state, expectedVersion) => boolean`
+  rather than `(state) => void`. Returning `false` blocks execution.
+- **`strict?: boolean` removed from `AutoGenGuardConfig`.** The field was declared but never
+  read, and never reached the guard. It was inherited from the `@oxdeai/guard@1.0.1`
+  config shape, where it was also inert. Nothing replaces it — it was not a security
+  control, and presenting it as one was the problem.
+- **`expectedAudience` is enforced by the guard.** The adapter derives it from
+  `config.agentId`, so no caller change is required, but an authorization whose
+  audience does not match that agent identity now fails closed.
+
+### Added
+
+Configuration forwarded through to `OxDeAIGuard`. These were supported by the guard
+but unreachable through this adapter:
+
+- **`replayStore`** — durable `auth_id` / `delegation_id` tracking. Without it the
+  guard creates a per-instance in-memory store, so in a horizontally scaled or
+  restart-prone deployment replay protection did not hold across processes and the
+  adapter offered no way to fix that.
+- **`onBoundaryEvent`** — the guard-boundary audit stream. It is disjoint from
+  `onDecision`, so replay rejections, CAS conflicts and hash-binding failures
+  previously produced **no audit record at all** for adapter consumers.
+- **`computeStateHash`** — custom live-state hash strategy, required when
+  authorizations are issued by an external provider whose state canonicalization
+  differs from the core engine's.
+- `trustedKeySets` is exposed on the adapter config for strict authorization
+  verification.
+
+### Trust profile
+
+Unchanged and now documented explicitly in the README: **declared**.
+
+This adapter integrates the lower-level `OxDeAIGuard` boundary. `agent_id` is fixed
+by deployment configuration and is not proposer-controlled. Tool identity and
+recursion depth are **not** established from a `TrustedExecutionContext`:
+`intent.tool` and `intent.depth` are not populated by the default normalization, so
+`ToolAmplificationModule` and `RecursionDepthModule` do not constrain this path.
+
+This release makes **no Tier 1 evaluator-input provenance claim**. Deployments
+requiring it should establish trusted execution context at an authenticating PEP and
+integrate `createSecureGuard` from `@oxdeai/guard` there. A `createSecureGuard`
+adapter entry point is tracked as future work; a framework adapter has no
+authenticated principal of its own and cannot construct that context honestly.
+
+### Packaging
+
+- **Workspace dependencies now use `workspace:^`**, so the packed artifact declares
+  `^2.0.0` ranges instead of the exact pin `workspace:*` resolves to. This fixes
+  standalone installation and lets the adapter tolerate a compatible guard or core
+  patch without a republish.
+- An explicit `files` field is declared. The artifact no longer ships `src/`,
+  `tsconfig.json` or compiled test files.
+- `prepack` now rebuilds before packing, so a stale `dist/` cannot be published.
+- `repository` (with `directory`), `homepage` and `bugs` are declared for npm
+  provenance.
+- This changelog file was added; the package previously shipped none.

--- a/packages/autogen/README.md
+++ b/packages/autogen/README.md
@@ -33,8 +33,8 @@ import { createAutoGenGuard } from "@oxdeai/autogen";
 
 const guard = createAutoGenGuard({
   engine,      // PolicyEngine from @oxdeai/core
-  getState,    // () => State | Promise<State>
-  setState,    // (state: State) => void | Promise<void>
+  getState,    // () => { state, version } | Promise<{ state, version }>
+  setState,    // (state, expectedVersion) => boolean | Promise<boolean>  (CAS)
   agentId: "gpu-agent-1",
 });
 
@@ -106,6 +106,39 @@ semantics as every other OxDeAI protocol demo:
 - **Envelope verification** remains offline and deterministic
 
 All of this is guaranteed by `@oxdeai/guard` - this package adds nothing on top.
+
+---
+
+## Trust profile
+
+**Declared.**
+
+This adapter integrates the lower-level `OxDeAIGuard` boundary. `agent_id` is
+fixed by deployment configuration (`config.agentId`) and is not proposer-controlled;
+the same value is bound as `expectedAudience`, so an authorization issued for a
+different audience fails closed.
+
+Tool identity and recursion depth are **not** established from a
+`TrustedExecutionContext` on this path. The default adapter normalization does not
+populate `intent.tool` or `intent.depth`, so `ToolAmplificationModule` and
+`RecursionDepthModule` do not constrain execution here. The adapter deliberately
+does not derive `intent.tool` from the proposer-supplied tool-call name: doing so
+would activate the module against a value the caller controls, which is weaker than
+leaving it unset.
+
+Deployments that require authenticated Tier 1 evaluator-input provenance should
+establish trusted execution context at an authenticating PEP — where a principal is
+actually authenticated and the route is resolved — and integrate `createSecureGuard`
+from `@oxdeai/guard` there. A framework adapter has no authenticated principal of its
+own, so it cannot construct that context honestly.
+
+Replay protection defaults to a per-guard in-memory store. Multi-process or
+restart-durable deployments must pass an explicit `replayStore`; see
+`createRedisReplayStore` in `@oxdeai/guard`.
+
+Wire `onBoundaryEvent` alongside `onDecision` to observe guard-boundary rejections
+(replay, CAS conflict, hash-binding failure). The two streams are disjoint: a
+boundary rejection produces no decision record.
 
 ---
 

--- a/packages/autogen/package.json
+++ b/packages/autogen/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@oxdeai/autogen",
-  "version": "1.0.1",
-  "license": "Apache-2.0",
+  "version": "2.0.0",
   "description": "Thin AutoGen adapter for the OxDeAI universal execution guard",
+  "license": "Apache-2.0",
   "keywords": [
     "oxdeai",
     "autogen",
@@ -20,9 +20,25 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/oxdeai/oxdeai.git",
+    "directory": "packages/autogen"
+  },
+  "homepage": "https://github.com/oxdeai/oxdeai",
+  "bugs": {
+    "url": "https://github.com/oxdeai/oxdeai/issues"
+  },
+  "files": [
+    "dist",
+    "!dist/test",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "dependencies": {
-    "@oxdeai/core": "workspace:*",
-    "@oxdeai/guard": "workspace:*"
+    "@oxdeai/core": "workspace:^",
+    "@oxdeai/guard": "workspace:^"
   },
   "devDependencies": {
     "@oxdeai/sdk": "workspace:*"
@@ -30,6 +46,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "rm -rf dist && tsc -p tsconfig.json",
+    "prepack": "pnpm build",
     "test": "pnpm build && node --test \"dist/test/adapter.test.js\""
   }
 }

--- a/packages/autogen/src/adapter.ts
+++ b/packages/autogen/src/adapter.ts
@@ -52,8 +52,11 @@ export function createAutoGenGuard(config: AutoGenGuardConfig): AutoGenGuardFn {
     mapActionToIntent: config.mapActionToIntent,
     beforeExecute: config.beforeExecute,
     onDecision: config.onDecision,
+    onBoundaryEvent: config.onBoundaryEvent,
     expectedAudience: config.agentId,
     trustedKeySets: config.trustedKeySets,
+    replayStore: config.replayStore,
+    computeStateHash: config.computeStateHash,
   });
 
   return async function autoGenGuard<T>(

--- a/packages/autogen/src/types.ts
+++ b/packages/autogen/src/types.ts
@@ -70,11 +70,34 @@ export type AutoGenGuardConfig = {
    */
   onDecision?: OxDeAIGuardConfig["onDecision"];
 
-  /** When true, missing optional normalizer fields cause hard failures. */
-  strict?: boolean;
+  /**
+   * Audit hook for guard-boundary rejections raised before `execute()` starts —
+   * provenance conflicts, replay rejections, hash-binding failures, CAS conflicts.
+   *
+   * Disjoint from {@link onDecision}: a boundary rejection produces no decision
+   * record, so a deployment wiring only `onDecision` cannot observe one.
+   */
+  onBoundaryEvent?: OxDeAIGuardConfig["onBoundaryEvent"];
 
   /** Trusted keysets required for strict authorization verification. */
   trustedKeySets?: OxDeAIGuardConfig["trustedKeySets"];
+
+  /**
+   * Replay store used for durable `auth_id` / `delegation_id` tracking.
+   *
+   * When omitted the guard creates a per-instance in-memory store, which is
+   * single-process only. Multi-process or restart-durable deployments must
+   * supply a shared backend such as `createRedisReplayStore` from `@oxdeai/guard`.
+   */
+  replayStore?: OxDeAIGuardConfig["replayStore"];
+
+  /**
+   * Custom live-state hash strategy used for `state_hash` binding verification.
+   *
+   * Required when authorizations are issued by an external provider whose state
+   * canonicalization differs from the core PolicyEngine's.
+   */
+  computeStateHash?: OxDeAIGuardConfig["computeStateHash"];
 };
 
 /**

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,39 @@ This project follows Semantic Versioning.
 
 ---
 
+## [0.3.0] - Unreleased
+
+**Baseline for this entry:** the published `@oxdeai/cli@0.2.4` npm artifact
+(2026-03-12). The Git tag `cli-v0.2.4` (`3614d94`) carries the same date, so the
+baseline is provable for this package.
+
+Pre-1.0, so a minor bump carries the breaking change.
+
+### Breaking
+
+- **Depends on the `@oxdeai/core` 2.0 line.** Behaviour that follows from core's
+  trusted-time work is inherited by the CLI's build/verify/replay paths.
+- **A valid `engine_secret` is enforced on the validation path.** Insecure defaults
+  were removed; a run that previously succeeded with an absent or too-short secret
+  now fails with an actionable error rather than proceeding.
+- **Strict-mode verification requires an explicit trust anchor.** The four strict
+  `verify` entry points require `--trusted-keyset`, or an explicit
+  `--mode best-effort`. A missing keyset produces an actionable error instead of a
+  silent inconclusive result.
+
+### Fixed
+
+- Deterministic `init` behaviour restored.
+- `oxdeai` with no command exits 0 and prints usage to stdout.
+
+### Packaging
+
+- `license`, `repository` (with `directory`), `homepage` and `bugs` are now declared;
+  the published `0.2.4` artifact carried none of them, which blocks npm provenance.
+- The existing `prepack` build step is unchanged.
+
+---
+
 ## [0.2.4] - 2026-03-19
 
 ### Fixed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,15 +1,27 @@
 {
   "name": "@oxdeai/cli",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "Protocol-focused CLI tooling for OxDeAI artifact build/verify/replay workflows",
+  "license": "Apache-2.0",
   "type": "module",
   "bin": {
     "oxdeai": "dist/main.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/oxdeai/oxdeai.git",
+    "directory": "packages/cli"
+  },
+  "homepage": "https://github.com/oxdeai/oxdeai",
+  "bugs": {
+    "url": "https://github.com/oxdeai/oxdeai/issues"
+  },
   "files": [
     "dist",
+    "!dist/**/*.test.*",
     "README.md",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "LICENSE"
   ],
   "dependencies": {
     "@oxdeai/core": "workspace:*"

--- a/packages/conformance/CHANGELOG.md
+++ b/packages/conformance/CHANGELOG.md
@@ -7,6 +7,64 @@ This project follows Semantic Versioning.
 
 ---
 
+## [2.0.0] - Unreleased
+
+**Baseline for this entry:** the published `@oxdeai/conformance@1.3.1` npm artifact
+(2026-03-08).
+
+> ⚠️ `1.5.0` appears in this changelog and as the Git tag `conformance-v1.5.0` but
+> **was never published to npm**. `1.3.1` is the last released artifact and is the
+> baseline used here. The `1.5.0` entry below is retained as historical record of
+> the source change, not of a release.
+
+The vector corpus is this package's public contract, and it has roughly doubled
+since the last published artifact.
+
+### Breaking
+
+- **The suite now targets the `@oxdeai/core` 2.0 line.** The dependency is an exact
+  pin, so a build of this package validates the 2.0 protocol surface and cannot be
+  used to validate a `core@1.x` implementation. Implementers tracking the 1.x line
+  must stay on `@oxdeai/conformance@1.3.1`.
+- Vector regeneration under the trusted-time engine changed expected values wherever
+  a vector's evaluation depended on time. Existing vector expectations captured
+  against the 1.3.1 engine will not match.
+
+### Added
+
+Nine vector families that did not exist in the published `1.3.1` artifact:
+
+- `trusted-time.json` — trusted-time freshness semantics
+- `clock-semantics-verification.json`
+- `delegation-verification.json`, `delegation-chain-verification.json`,
+  `delegation-parent-hash.json`, `delegation-signature-verification.json`
+- `signed-krl-verification.json` — `SignedKRLV1`
+- `key-lifecycle-verification.json`
+- `profile-c-state-verification.json`
+
+Also added: the `validate:trusted-time` entry point and the trusted-time conformance
+runner.
+
+### Changed
+
+- The validator no longer reads `OXDEAI_ENGINE_SECRET` from the environment; both
+  `extract-vectors` and `validate` use `CONFORMANCE_ENGINE_SECRET` unconditionally,
+  so the suite is deterministic regardless of shell environment.
+- Delegation chain and signature verification run on an independent recomputation
+  path rather than through an engine call.
+
+### Packaging
+
+- An explicit `files` field is declared. The artifact now ships `vectors/`, the
+  compiled validator, README, CHANGELOG and LICENSE only. It no longer ships
+  TypeScript sources, `tsconfig.json`, the Go/Python harness directory, or compiled
+  test files — the harnesses remain in the repository and are run from source.
+- `prepack` now rebuilds before packing.
+- `repository` (with `directory`), `homepage` and `bugs` are declared for npm
+  provenance.
+
+---
+
 ## [1.5.0] - 2026-03-30
 
 ### Changed

--- a/packages/conformance/README.md
+++ b/packages/conformance/README.md
@@ -8,7 +8,7 @@ Ensures implementations reproduce deterministic AuthorizationV1 artifacts and bo
 Passing validation means the implementation reproduces expected deterministic artifacts (hashes, statuses, and verification outputs) from frozen vectors.
 
 ## Version Coupling
-- `@oxdeai/conformance@1.5.0` targets `@oxdeai/core@1.7.0` behavior.
+- `@oxdeai/conformance@2.0.0` targets `@oxdeai/core@2.0.0` behavior.
 - Use matching major/minor protocol versions when validating.
 
 ## Included Vector Sets

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxdeai/conformance",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "Conformance test suite for OxDeAI Core implementations, ensuring compliance with the deterministic policy engine protocol through standardized test cases and validation tools.",
   "license": "Apache-2.0",
   "keywords": [
@@ -16,13 +16,23 @@
     "envelope"
   ],
   "type": "module",
-  "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "extract": "pnpm -C ../core build && pnpm build && node dist/scripts/extract-vectors.js",
-    "validate": "pnpm -C ../core build && pnpm build && node dist/src/validate.js",
-    "validate:trusted-time": "pnpm -C ../core build && pnpm build && node dist/src/validate-trusted-time.js",
-    "test": "pnpm -C ../core build && pnpm build && node --test dist/src/trustedTimeConformance.test.js"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/oxdeai/oxdeai.git",
+    "directory": "packages/conformance"
   },
+  "homepage": "https://github.com/oxdeai/oxdeai",
+  "bugs": {
+    "url": "https://github.com/oxdeai/oxdeai/issues"
+  },
+  "files": [
+    "dist",
+    "!dist/**/*.test.*",
+    "vectors",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "dependencies": {
     "@oxdeai/core": "workspace:*"
   },
@@ -30,5 +40,13 @@
     "ts-node": "^10.9.0",
     "tsx": "^4.23.1",
     "typescript": "^5.0.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepack": "pnpm build",
+    "extract": "pnpm -C ../core build && pnpm build && node dist/scripts/extract-vectors.js",
+    "validate": "pnpm -C ../core build && pnpm build && node dist/src/validate.js",
+    "validate:trusted-time": "pnpm -C ../core build && pnpm build && node dist/src/validate-trusted-time.js",
+    "test": "pnpm -C ../core build && pnpm build && node --test dist/src/trustedTimeConformance.test.js"
   }
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,6 +7,116 @@ This project follows Semantic Versioning.
 
 ---
 
+## [2.0.0] - Unreleased
+
+**Baseline for this entry:** the published `@oxdeai/core@1.7.0` npm artifact
+(2026-04-01). Its packed public surface matches the source at tag `core-v1.7.0`
+(`409ff44`), so that commit is used as the provable comparison point. Entries below
+describe the consumer-visible delta between that artifact and the current candidate.
+
+> ⚠️ `1.7.0` was published and then further modified on `main` without a version
+> bump, so the version number `1.7.0` no longer uniquely identifies an artifact.
+> `2.0.0` re-establishes that guarantee. Nothing between the published `1.7.0` and
+> this release should be treated as a released version.
+
+### Breaking
+
+- **`evaluationTime` is now a required argument on every evaluation entry point.**
+  There is no implicit wall-clock fallback and no derivation from `intent.timestamp`.
+  ```diff
+  - engine.evaluate(intent, state)
+  + engine.evaluate(intent, state, evaluationTime)
+
+  - engine.evaluatePure(intent, state, opts?)
+  + engine.evaluatePure(intent, state, evaluationTime, opts?)
+
+  - engine.simulateSequence(intents, opts?)
+  + engine.simulateSequence(intents, evaluationTime, opts?)
+  ```
+  Note that `opts` moved from the third to the fourth positional parameter on
+  `evaluatePure`, and from the second to the third on `simulateSequence`. A call
+  site that passes `opts` in the old position now passes it as `evaluationTime`
+  and fails validation rather than silently misbehaving.
+- **`EngineOptions.maxClockSkewSeconds` and `EngineOptions.maxIntentAgeSeconds` are
+  now required.** A `PolicyEngine` constructed without an explicit trusted-time
+  policy no longer starts. `RECOMMENDED_TRUSTED_TIME_PROFILE` supplies conformant
+  values, but a deployment must opt into it explicitly — it is a recommended
+  profile, not a default.
+- **`evaluationTime` is validated, not coerced.** `NaN`, `Infinity`, non-integers
+  and out-of-range values are rejected via `assertProtocolSeconds` instead of being
+  normalized.
+- **`PolicyEngine.verifyAuthorization` now returns the named type
+  `EngineAuthorizationVerificationResult`.** The result gained `signatureVerified`,
+  `verificationMode` and `verificationCoverage` alongside `valid` / `reason`. Code
+  that structurally matched the previous anonymous return type still compiles;
+  code that re-declared it will not.
+- **The public `AuthorizationV1` artifact boundary is separated from the engine's
+  internal representation.** Internal HMAC-binding fields are no longer part of the
+  published artifact surface; use `toPublicAuthorizationV1` to obtain the wire form.
+- **`auth_id` is the canonical authorization identifier.** Reads are reconciled with
+  the legacy `authorization_id` field rather than the two being treated as
+  interchangeable.
+
+### Security hardening
+
+- Replay-window eviction, velocity windows and tool-call windows are all driven from
+  the trusted `evaluationTime` rather than from proposer-supplied `intent.timestamp`.
+  A caller can no longer reset its own quota by choosing a favourable timestamp that
+  still passes freshness.
+- Authorization `issued_at` / `expiry` are minted from the trusted evaluation time.
+- Implausible future authorization issuance is rejected; the bound is exported as
+  `DEFAULT_MAX_FUTURE_ISSUED_AT_SKEW_SECONDS`.
+- Tool-call enforcement is derived from trusted policy state. `intent.tool_call` is
+  explicitly treated as a self-declared, agent-controlled field and does not
+  influence the decision; `intent.tool` is used only as a lookup key that must
+  resolve against trusted state.
+- Negative `intent.amount` values are rejected instead of flowing into budget and
+  velocity arithmetic.
+- Expired concurrency leases are reclaimed and released leases removed, so a crashed
+  or abandoned execution no longer consumes concurrency budget indefinitely.
+- Runtime state numeric-leaf validation was hardened; malformed or type-confused
+  state leaves produce a deterministic `STATE_INVALID` denial rather than being
+  coerced.
+- `canonicalization-v1` and normative `AuthorizationV1` verification are enforced at
+  the verification boundary.
+
+### Added
+
+- `RECOMMENDED_TRUSTED_TIME_PROFILE` — conformant `maxClockSkewSeconds` /
+  `maxIntentAgeSeconds` values matching `docs/spec/core/trusted-time-v1.md` §5.
+- Deterministic trusted-time freshness verifier and its dedicated reason codes.
+- `SignedKRLV1` protocol artifact, with `verifySignedKrl` and
+  `signedKrlSigningPayload`, plus the `signed-krl` type exports.
+- `toPublicAuthorizationV1` and `DEFAULT_MAX_FUTURE_ISSUED_AT_SKEW_SECONDS`.
+- Signature-verification status and coverage are surfaced on authorization results
+  (`signatureVerified`, `verificationMode`, `verificationCoverage`), so a caller can
+  distinguish "verified and valid" from "valid under a weaker coverage mode".
+- `EngineAuthorizationVerificationResult` is exported.
+
+### Changed
+
+- `PolicyEngine.verifyAuthorization` is documented as **limited scope**: it
+  authenticates only the engine-HMAC field subset. Relying parties enforcing an
+  authorization issued by another party must use the standalone strict verifier with
+  explicit `trustedKeySets`.
+- HMAC-SHA256 authorization verification is deprecated in favour of Ed25519.
+- The Sift `AuthorizationV1` wire encoding is accepted at the verification boundary.
+- Audit-chain genesis was aligned and conformance vectors refrozen accordingly.
+
+### Fixed
+
+- Core public-API surface is shape-aware at the guard boundary, so an incompatible
+  engine shape is rejected at construction rather than at first evaluation.
+
+### Packaging
+
+- The published tarball no longer ships `dist/test` or `dist/dev`. The `1.7.0`
+  artifact shipped 102 compiled test files and a development subprocess helper.
+- `prepack` now rebuilds before packing, so a stale `dist/` cannot be published.
+- `repository.directory` is declared for npm provenance.
+
+---
+
 ## [1.7.0] - 2026-03-29
 
 ### Added

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,8 +1,26 @@
 {
   "name": "@oxdeai/core",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "description": "Deterministic execution-time authorization engine for AI agents. Evaluates proposed actions against intent, state, and policy before execution and emits cryptographically verifiable authorization artifacts.",
   "license": "Apache-2.0",
+  "keywords": [
+    "ai-agents",
+    "agent-security",
+    "agent-authorization",
+    "execution-time-authorization",
+    "pre-execution-authorization",
+    "policy-engine",
+    "policy-enforcement-point",
+    "execution-authorization",
+    "authorization-artifact",
+    "authorization-protocol",
+    "verification-protocol",
+    "deterministic-verification",
+    "fail-closed",
+    "autonomous-systems",
+    "agent-safety",
+    "deterministic"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -41,33 +59,22 @@
   "bugs": {
     "url": "https://github.com/oxdeai/oxdeai/issues"
   },
-  "keywords": [
-    "ai-agents",
-    "agent-security",
-    "agent-authorization",
-    "execution-time-authorization",
-    "pre-execution-authorization",
-    "policy-engine",
-    "policy-enforcement-point",
-    "execution-authorization",
-    "authorization-artifact",
-    "authorization-protocol",
-    "verification-protocol",
-    "deterministic-verification",
-    "fail-closed",
-    "autonomous-systems",
-    "agent-safety",
-    "deterministic"
-  ],
   "files": [
     "dist",
+    "!dist/test",
+    "!dist/dev",
     "schemas",
     "README.md",
     "LICENSE",
     "CHANGELOG.md"
   ],
+  "devDependencies": {
+    "@microsoft/api-extractor": "^7.57.6",
+    "fast-check": "^4.6.0"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "prepack": "pnpm build",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test:node": "node --test \"dist/test/*.test.js\"",
     "test": "pnpm build && pnpm test:node",
@@ -77,9 +84,5 @@
     "schema:validate": "node scripts/schema-validate.mjs",
     "api:fingerprint": "../../scripts/api-fingerprint.sh",
     "api:fingerprint:check": "../../scripts/check-api-fingerprint.sh"
-  },
-  "devDependencies": {
-    "@microsoft/api-extractor": "^7.57.6",
-    "fast-check": "^4.6.0"
   }
 }

--- a/packages/crewai/CHANGELOG.md
+++ b/packages/crewai/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog
+
+All notable changes to `@oxdeai/crewai` will be documented in this file.
+
+The format is based on Keep a Changelog.
+This project follows Semantic Versioning.
+
+> This file starts at 2.0.0. Versions 1.0.0 and 1.0.1 were published without a
+> changelog; the 2.0.0 entry below reconstructs the delta from the published
+> `@oxdeai/crewai@1.0.1` npm artifact.
+
+---
+
+## [2.0.0] - Unreleased
+
+**Baseline for this entry:** the published `@oxdeai/crewai@1.0.1` npm artifact
+(2026-03-19). The version was set to `1.0.1` at `8797931`; the packed
+`dist/types.d.ts` of that artifact is used as the authoritative comparison surface.
+
+> ⚠️ The published `1.0.1` artifact declares `"@oxdeai/core": "workspace:*"` and
+> `"@oxdeai/guard": "workspace:*"`, so **it cannot be installed standalone from the
+> public registry**. That is a defect of the historical release process, not of the
+> source. See **Packaging** below.
+
+### Breaking
+
+- **Requires `@oxdeai/core` 2.0 and `@oxdeai/guard` 2.0.** Both dependencies move
+  to a major line with breaking API and runtime-semantic changes; see those packages'
+  changelogs.
+- **`getState` now returns versioned state** — `{ state, version }` rather than
+  `State`. A store returning no version fails closed.
+- **`setState` is now compare-and-set** — `(state, expectedVersion) => boolean`
+  rather than `(state) => void`. Returning `false` blocks execution.
+- **`strict?: boolean` removed from `CrewAIGuardConfig`.** The field was declared but never
+  read, and never reached the guard. It was inherited from the `@oxdeai/guard@1.0.1`
+  config shape, where it was also inert. Nothing replaces it — it was not a security
+  control, and presenting it as one was the problem.
+- **`expectedAudience` is enforced by the guard.** The adapter derives it from
+  `config.agentId`, so no caller change is required, but an authorization whose
+  audience does not match that agent identity now fails closed.
+
+### Added
+
+Configuration forwarded through to `OxDeAIGuard`. These were supported by the guard
+but unreachable through this adapter:
+
+- **`replayStore`** — durable `auth_id` / `delegation_id` tracking. Without it the
+  guard creates a per-instance in-memory store, so in a horizontally scaled or
+  restart-prone deployment replay protection did not hold across processes and the
+  adapter offered no way to fix that.
+- **`onBoundaryEvent`** — the guard-boundary audit stream. It is disjoint from
+  `onDecision`, so replay rejections, CAS conflicts and hash-binding failures
+  previously produced **no audit record at all** for adapter consumers.
+- **`computeStateHash`** — custom live-state hash strategy, required when
+  authorizations are issued by an external provider whose state canonicalization
+  differs from the core engine's.
+- `trustedKeySets` is exposed on the adapter config for strict authorization
+  verification.
+
+### Trust profile
+
+Unchanged and now documented explicitly in the README: **declared**.
+
+This adapter integrates the lower-level `OxDeAIGuard` boundary. `agent_id` is fixed
+by deployment configuration and is not proposer-controlled. Tool identity and
+recursion depth are **not** established from a `TrustedExecutionContext`:
+`intent.tool` and `intent.depth` are not populated by the default normalization, so
+`ToolAmplificationModule` and `RecursionDepthModule` do not constrain this path.
+
+This release makes **no Tier 1 evaluator-input provenance claim**. Deployments
+requiring it should establish trusted execution context at an authenticating PEP and
+integrate `createSecureGuard` from `@oxdeai/guard` there. A `createSecureGuard`
+adapter entry point is tracked as future work; a framework adapter has no
+authenticated principal of its own and cannot construct that context honestly.
+
+### Packaging
+
+- **Workspace dependencies now use `workspace:^`**, so the packed artifact declares
+  `^2.0.0` ranges instead of the exact pin `workspace:*` resolves to. This fixes
+  standalone installation and lets the adapter tolerate a compatible guard or core
+  patch without a republish.
+- An explicit `files` field is declared. The artifact no longer ships `src/`,
+  `tsconfig.json` or compiled test files.
+- `prepack` now rebuilds before packing, so a stale `dist/` cannot be published.
+- `repository` (with `directory`), `homepage` and `bugs` are declared for npm
+  provenance.
+- This changelog file was added; the package previously shipped none.

--- a/packages/crewai/README.md
+++ b/packages/crewai/README.md
@@ -33,8 +33,8 @@ import { createCrewAIGuard } from "@oxdeai/crewai";
 
 const guard = createCrewAIGuard({
   engine,      // PolicyEngine from @oxdeai/core
-  getState,    // () => State | Promise<State>
-  setState,    // (state: State) => void | Promise<void>
+  getState,    // () => { state, version } | Promise<{ state, version }>
+  setState,    // (state, expectedVersion) => boolean | Promise<boolean>  (CAS)
   agentId: "gpu-agent-1",
 });
 
@@ -106,6 +106,39 @@ semantics as every other OxDeAI protocol demo:
 - **Envelope verification** remains offline and deterministic
 
 All of this is guaranteed by `@oxdeai/guard` — this package adds nothing on top.
+
+---
+
+## Trust profile
+
+**Declared.**
+
+This adapter integrates the lower-level `OxDeAIGuard` boundary. `agent_id` is
+fixed by deployment configuration (`config.agentId`) and is not proposer-controlled;
+the same value is bound as `expectedAudience`, so an authorization issued for a
+different audience fails closed.
+
+Tool identity and recursion depth are **not** established from a
+`TrustedExecutionContext` on this path. The default adapter normalization does not
+populate `intent.tool` or `intent.depth`, so `ToolAmplificationModule` and
+`RecursionDepthModule` do not constrain execution here. The adapter deliberately
+does not derive `intent.tool` from the proposer-supplied tool-call name: doing so
+would activate the module against a value the caller controls, which is weaker than
+leaving it unset.
+
+Deployments that require authenticated Tier 1 evaluator-input provenance should
+establish trusted execution context at an authenticating PEP — where a principal is
+actually authenticated and the route is resolved — and integrate `createSecureGuard`
+from `@oxdeai/guard` there. A framework adapter has no authenticated principal of its
+own, so it cannot construct that context honestly.
+
+Replay protection defaults to a per-guard in-memory store. Multi-process or
+restart-durable deployments must pass an explicit `replayStore`; see
+`createRedisReplayStore` in `@oxdeai/guard`.
+
+Wire `onBoundaryEvent` alongside `onDecision` to observe guard-boundary rejections
+(replay, CAS conflict, hash-binding failure). The two streams are disjoint: a
+boundary rejection produces no decision record.
 
 ---
 

--- a/packages/crewai/package.json
+++ b/packages/crewai/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@oxdeai/crewai",
-  "version": "1.0.1",
-  "license": "Apache-2.0",
+  "version": "2.0.0",
   "description": "Thin CrewAI adapter for the OxDeAI universal execution guard",
+  "license": "Apache-2.0",
   "keywords": [
     "oxdeai",
     "crewai",
@@ -20,9 +20,25 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/oxdeai/oxdeai.git",
+    "directory": "packages/crewai"
+  },
+  "homepage": "https://github.com/oxdeai/oxdeai",
+  "bugs": {
+    "url": "https://github.com/oxdeai/oxdeai/issues"
+  },
+  "files": [
+    "dist",
+    "!dist/test",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "dependencies": {
-    "@oxdeai/core": "workspace:*",
-    "@oxdeai/guard": "workspace:*"
+    "@oxdeai/core": "workspace:^",
+    "@oxdeai/guard": "workspace:^"
   },
   "devDependencies": {
     "@oxdeai/sdk": "workspace:*"
@@ -30,6 +46,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "rm -rf dist && tsc -p tsconfig.json",
+    "prepack": "pnpm build",
     "test": "pnpm build && node --test \"dist/test/adapter.test.js\""
   }
 }

--- a/packages/crewai/src/adapter.ts
+++ b/packages/crewai/src/adapter.ts
@@ -52,8 +52,11 @@ export function createCrewAIGuard(config: CrewAIGuardConfig): CrewAIGuardFn {
     mapActionToIntent: config.mapActionToIntent,
     beforeExecute: config.beforeExecute,
     onDecision: config.onDecision,
+    onBoundaryEvent: config.onBoundaryEvent,
     expectedAudience: config.agentId,
     trustedKeySets: config.trustedKeySets,
+    replayStore: config.replayStore,
+    computeStateHash: config.computeStateHash,
   });
 
   return async function crewAIGuard<T>(

--- a/packages/crewai/src/types.ts
+++ b/packages/crewai/src/types.ts
@@ -70,11 +70,34 @@ export type CrewAIGuardConfig = {
    */
   onDecision?: OxDeAIGuardConfig["onDecision"];
 
-  /** When true, missing optional normalizer fields cause hard failures. */
-  strict?: boolean;
+  /**
+   * Audit hook for guard-boundary rejections raised before `execute()` starts —
+   * provenance conflicts, replay rejections, hash-binding failures, CAS conflicts.
+   *
+   * Disjoint from {@link onDecision}: a boundary rejection produces no decision
+   * record, so a deployment wiring only `onDecision` cannot observe one.
+   */
+  onBoundaryEvent?: OxDeAIGuardConfig["onBoundaryEvent"];
 
   /** Trusted keysets required for strict authorization verification. */
   trustedKeySets?: OxDeAIGuardConfig["trustedKeySets"];
+
+  /**
+   * Replay store used for durable `auth_id` / `delegation_id` tracking.
+   *
+   * When omitted the guard creates a per-instance in-memory store, which is
+   * single-process only. Multi-process or restart-durable deployments must
+   * supply a shared backend such as `createRedisReplayStore` from `@oxdeai/guard`.
+   */
+  replayStore?: OxDeAIGuardConfig["replayStore"];
+
+  /**
+   * Custom live-state hash strategy used for `state_hash` binding verification.
+   *
+   * Required when authorizations are issued by an external provider whose state
+   * canonicalization differs from the core PolicyEngine's.
+   */
+  computeStateHash?: OxDeAIGuardConfig["computeStateHash"];
 };
 
 /**

--- a/packages/guard/CHANGELOG.md
+++ b/packages/guard/CHANGELOG.md
@@ -7,6 +7,143 @@ This project follows Semantic Versioning.
 
 ---
 
+## [2.0.0] - Unreleased
+
+**Baseline for this entry:** the published `@oxdeai/guard@1.0.1` npm artifact
+(2026-03-19). The version was set to `1.0.1` at `8797931` and remained so until
+`273f3ba`, so the published artifact originates in that range; its packed
+`dist/types.d.ts` is used as the authoritative comparison surface.
+
+> ⚠️ `1.0.2` and `1.0.3` appear in this changelog and in Git tags but **were never
+> published to npm**. `1.0.1` is the last released artifact, and it is the baseline
+> used here. The `guard-v1.0.3` tag is retained as historical record and is not a
+> release.
+>
+> ⚠️ The published `1.0.1` artifact also declares `"@oxdeai/core": "workspace:*"`
+> and therefore cannot be installed standalone from the public registry. That is a
+> defect of the historical release process, not of the source; see **Packaging**.
+
+### Breaking
+
+- **`getState` now returns versioned state.**
+  ```diff
+  - getState: () => State | Promise<State>
+  + getState: () => VersionedState | Promise<VersionedState>   // { state, version }
+  ```
+  A store that returns no `version` fails closed before evaluation — the CAS
+  invariant cannot be enforced without one.
+- **`setState` is now compare-and-set and must report success.**
+  ```diff
+  - setState: (state: State) => void | Promise<void>
+  + setState: (state: State, expectedVersion: StateVersion) => boolean | Promise<boolean>
+  ```
+  It must atomically verify that the persisted version still equals
+  `expectedVersion` before committing. Returning `false` raises
+  `OxDeAIConflictError` and blocks execution. An implementation that ignores
+  `expectedVersion` and always returns `true` silently removes the protection.
+- **`expectedAudience` is required.** Construction throws
+  `OxDeAIGuardConfigurationError` when it is absent. There is no default and no
+  fallback. It must equal the engine's `authorization_audience`.
+- **`trustedKeySets` is required for the verification path.** Construction throws
+  when absent or empty. A valid signature from an unconfigured issuer still fails
+  closed.
+- **`strict?: boolean` was removed from `OxDeAIGuardConfig`.** It had no effect.
+- **`beforeExecute` and `GuardDecisionRecord` now carry `AuthorizationV1`** rather
+  than the internal `Authorization` shape.
+
+### Added
+
+- **`createSecureGuard`** — the Tier 1 secure entry point. It differs from
+  `OxDeAIGuard` in exactly one respect: how the evaluated intent's provenance is
+  established. Everything after that — state read, evaluation, verification, replay
+  consumption, hash binding, CAS, execution ordering — is the same enforcement body,
+  reached by delegation rather than reimplementation.
+- **`createTrustedExecutionContext`** / `isTrustedExecutionContext` /
+  `TrustedExecutionContext`. The returned context carries a non-enumerable runtime
+  brand, so a value deserialized from request JSON is rejected. The brand is
+  **misuse resistance, not authentication**: it proves construction happened, not
+  that the caller was authorized. `depth` is required and never defaulted.
+- **Provenance reconciliation** — `reconcileWithTrustedContext`, `ClaimProvenance`,
+  `ProvenanceRecord`, `ReconciliationResult`, `ReconciliationOptions`. Proposer
+  claims never override derived premises; a conflict fails closed before evaluation
+  with `OxDeAIProvenanceConflictError`, and per-field outcomes (`absent`, `matched`,
+  `conflict`, `unverified`) are recorded for audit.
+- **Explicit tenancy posture** — `SecureGuardOptions.tenancy` is required and never
+  defaulted. A `multi-tenant` deployment whose route did not resolve a `tenantId`
+  fails closed rather than evaluating in an ambiguous namespace.
+- **`onBoundaryEvent`** — an audit stream for guard-boundary rejections raised
+  before `execute()` starts, with `GuardBoundaryStage`, `GuardBoundaryFailure`,
+  `GuardBoundaryAuditEvent` and `GuardBoundaryEventHook`. It is **disjoint** from
+  `onDecision`: a valid policy DENY is reported to `onDecision` only, every other
+  boundary rejection to `onBoundaryEvent` only, and no rejection appears on both.
+  A deployment auditing only `onDecision` cannot see attempted identity or tool
+  substitutions.
+- **Delegation enforcement** — `GuardDelegationInput`, `GuardCallOptions`,
+  `OxDeAIDelegationError`. Full chain verification before execution: parent hash
+  binding, scope narrowing, expiry ceiling, delegator identity, policy binding and
+  signature verification. `parentScope` is required; a missing or malformed scope
+  fails closed before chain verification.
+- **Pluggable replay store** — `ReplayStore`, `createInMemoryReplayStore`,
+  `createRedisReplayStore`. The default in-memory store is single-process only.
+  Stores must be fail-closed: throw rather than return a permissive result.
+- **Pluggable state-hash strategy** — `computeStateHash`, for authorizations issued
+  by a provider whose state canonicalization differs from the core engine's.
+- **PEP gateway surface** — `createPepGatewayExecutor`,
+  `createPepGatewayHttpServer`, `createHttpUpstreamExecutor`,
+  `createProtectedUpstreamHttpServer`, `protectUpstreamExecution`,
+  `hasValidInternalExecutorToken`, `INTERNAL_EXECUTOR_TOKEN_HEADER`.
+- `defaultNormalizeAction`, `StateVersion`, `VersionedState`, `OxDeAIConflictError`.
+
+### Security hardening
+
+- Execution is gated on an ordered fail-closed sequence: state load → normalize →
+  evaluate → require authorization and `nextState` → consume `auth_id` → strict
+  verification → `intent_hash` binding → `state_hash` binding → CAS commit →
+  `beforeExecute` → `execute()`. Any failure blocks execution with no side effects
+  committed.
+- `intent_hash` is recomputed from the normalized intent and compared with the
+  artifact commitment. A canonicalization failure and a computed mismatch are
+  treated as the same audit fact.
+- `state_hash` is verified against the live execution-time snapshot; absent,
+  uncomputable and unequal are all a binding failure.
+- CAS commit happens **before** `execute()`, so a concurrent state change blocks the
+  side effect rather than being detected after it.
+- `auth_id` and `delegation_id` are consumed atomically before execution; a replay
+  store that is unavailable throws and the guard denies.
+- Authorization verification runs in strict mode with
+  `requireSignatureVerification`, bound to `expectedAudience`, `expectedIssuer` and
+  `expectedPolicyId`.
+
+### Trust-profile note
+
+`OxDeAIGuard` remains a supported lower-level API and is **not** deprecated. It
+carries no Tier 1 evaluator-input provenance guarantee: `agent_id`, `depth` and
+`tool` are whatever the caller supplies. Only `createSecureGuard` — or an
+integration independently enforcing the same boundary — may claim Tier 1 provenance.
+
+`createSecureGuard` establishes trusted evaluator **inputs** only. It does not make
+state or policy authoritative: `getState` / `setState` and the engine's policy
+configuration are still supplied by the deployment. An authoritative versioned state
+provider is separate work (#197).
+
+### Known scope limits
+
+- The `evaluationTime` passed to the engine is sampled from the process wall clock
+  at the evaluation boundary. It is not independently trusted or monotonic;
+  reliable PEP-side clock capture remains deferred.
+- Guard state CAS protects OxDeAI policy state. It does **not** provide TOCTOU
+  safety for mutations of arbitrary external resources inside `execute()`; that
+  requires a resource-side atomic version precondition (#253).
+- A protected callback that throws after `execute()` has started currently produces
+  neither a decision record nor a boundary event (#238).
+
+### Packaging
+
+- `prepack` now rebuilds before packing.
+- `repository.directory` is declared for npm provenance.
+
+---
+
 ## [1.0.2] - 2026-03-20
 
 ### Added

--- a/packages/guard/README.md
+++ b/packages/guard/README.md
@@ -38,8 +38,8 @@ import { OxDeAIGuard } from "@oxdeai/guard";
 // Build the guard once per agent session.
 const guard = OxDeAIGuard({
   engine,      // PolicyEngine from @oxdeai/core
-  getState,    // () => State | Promise<State>
-  setState,    // (state: State) => void | Promise<void>
+  getState,    // () => { state, version } | Promise<{ state, version }>
+  setState,    // (state, expectedVersion) => boolean | Promise<boolean>  (CAS)
 });
 
 // Call it before every tool execution.

--- a/packages/guard/package.json
+++ b/packages/guard/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@oxdeai/guard",
-  "version": "1.0.3",
-  "license": "Apache-2.0",
+  "version": "2.0.0",
   "description": "Universal execution authorization guard (PEP boundary) for OxDeAI",
+  "license": "Apache-2.0",
   "keywords": [
     "oxdeai",
     "ai-agents",
@@ -21,24 +21,33 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/oxdeai/oxdeai.git",
+    "directory": "packages/guard"
+  },
+  "homepage": "https://github.com/oxdeai/oxdeai",
+  "bugs": {
+    "url": "https://github.com/oxdeai/oxdeai/issues"
+  },
+  "files": [
+    "dist",
+    "!dist/test",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "dependencies": {
-  "@oxdeai/core": "workspace:*"
+    "@oxdeai/core": "workspace:*"
   },
   "devDependencies": {
     "@oxdeai/sdk": "workspace:*"
   },
-
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "rm -rf dist && tsc -p tsconfig.json",
+    "prepack": "pnpm build",
     "build:test": "rm -rf dist && tsc -p tsconfig.test.json",
     "test": "pnpm build:test && node --test \"dist/test/guard.test.js\" \"dist/test/guard.property.test.js\" \"dist/test/guard.delegation.test.js\" \"dist/test/guard.delegation.matrix.test.js\" \"dist/test/guard.delegation.property.test.js\" \"dist/test/guard.toctou.test.js\" \"dist/test/guard.boundary.test.js\" \"dist/test/guard.replay-store.test.js\" \"dist/test/guard.replay-store.redis.test.js\" \"dist/test/guard.authorization.test.js\" \"dist/test/guard.state-binding.test.js\" \"dist/test/guard.cas.test.js\" \"dist/test/guard.pep-conformance.test.js\" \"dist/test/guard.intent-binding.test.js\" \"dist/test/guard.provenance.test.js\" \"dist/test/guard.boundary-audit.test.js\""
-  },
-  "files": [
-  "dist",
-  "!dist/test",
-  "README.md",
-  "CHANGELOG.md",
-  "LICENSE"
- ]
+  }
 }

--- a/packages/langgraph/CHANGELOG.md
+++ b/packages/langgraph/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog
+
+All notable changes to `@oxdeai/langgraph` will be documented in this file.
+
+The format is based on Keep a Changelog.
+This project follows Semantic Versioning.
+
+> This file starts at 2.0.0. Versions 1.0.0 and 1.0.1 were published without a
+> changelog; the 2.0.0 entry below reconstructs the delta from the published
+> `@oxdeai/langgraph@1.0.1` npm artifact.
+
+---
+
+## [2.0.0] - Unreleased
+
+**Baseline for this entry:** the published `@oxdeai/langgraph@1.0.1` npm artifact
+(2026-03-19). The version was set to `1.0.1` at `8797931`; the packed
+`dist/types.d.ts` of that artifact is used as the authoritative comparison surface.
+
+> ⚠️ The published `1.0.1` artifact declares `"@oxdeai/core": "workspace:*"` and
+> `"@oxdeai/guard": "workspace:*"`, so **it cannot be installed standalone from the
+> public registry**. That is a defect of the historical release process, not of the
+> source. See **Packaging** below.
+
+### Breaking
+
+- **Requires `@oxdeai/core` 2.0 and `@oxdeai/guard` 2.0.** Both dependencies move
+  to a major line with breaking API and runtime-semantic changes; see those packages'
+  changelogs.
+- **`getState` now returns versioned state** — `{ state, version }` rather than
+  `State`. A store returning no version fails closed.
+- **`setState` is now compare-and-set** — `(state, expectedVersion) => boolean`
+  rather than `(state) => void`. Returning `false` blocks execution.
+- **`strict?: boolean` removed from `LangGraphGuardConfig`.** The field was declared but never
+  read, and never reached the guard. It was inherited from the `@oxdeai/guard@1.0.1`
+  config shape, where it was also inert. Nothing replaces it — it was not a security
+  control, and presenting it as one was the problem.
+- **`expectedAudience` is enforced by the guard.** The adapter derives it from
+  `config.agentId`, so no caller change is required, but an authorization whose
+  audience does not match that agent identity now fails closed.
+
+### Added
+
+Configuration forwarded through to `OxDeAIGuard`. These were supported by the guard
+but unreachable through this adapter:
+
+- **`replayStore`** — durable `auth_id` / `delegation_id` tracking. Without it the
+  guard creates a per-instance in-memory store, so in a horizontally scaled or
+  restart-prone deployment replay protection did not hold across processes and the
+  adapter offered no way to fix that.
+- **`onBoundaryEvent`** — the guard-boundary audit stream. It is disjoint from
+  `onDecision`, so replay rejections, CAS conflicts and hash-binding failures
+  previously produced **no audit record at all** for adapter consumers.
+- **`computeStateHash`** — custom live-state hash strategy, required when
+  authorizations are issued by an external provider whose state canonicalization
+  differs from the core engine's.
+- `trustedKeySets` is exposed on the adapter config for strict authorization
+  verification.
+
+### Trust profile
+
+Unchanged and now documented explicitly in the README: **declared**.
+
+This adapter integrates the lower-level `OxDeAIGuard` boundary. `agent_id` is fixed
+by deployment configuration and is not proposer-controlled. Tool identity and
+recursion depth are **not** established from a `TrustedExecutionContext`:
+`intent.tool` and `intent.depth` are not populated by the default normalization, so
+`ToolAmplificationModule` and `RecursionDepthModule` do not constrain this path.
+
+This release makes **no Tier 1 evaluator-input provenance claim**. Deployments
+requiring it should establish trusted execution context at an authenticating PEP and
+integrate `createSecureGuard` from `@oxdeai/guard` there. A `createSecureGuard`
+adapter entry point is tracked as future work; a framework adapter has no
+authenticated principal of its own and cannot construct that context honestly.
+
+### Packaging
+
+- **Workspace dependencies now use `workspace:^`**, so the packed artifact declares
+  `^2.0.0` ranges instead of the exact pin `workspace:*` resolves to. This fixes
+  standalone installation and lets the adapter tolerate a compatible guard or core
+  patch without a republish.
+- An explicit `files` field is declared. The artifact no longer ships `src/`,
+  `tsconfig.json` or compiled test files.
+- `prepack` now rebuilds before packing, so a stale `dist/` cannot be published.
+- `repository` (with `directory`), `homepage` and `bugs` are declared for npm
+  provenance.
+- This changelog file was added; the package previously shipped none.

--- a/packages/langgraph/README.md
+++ b/packages/langgraph/README.md
@@ -33,8 +33,8 @@ import { createLangGraphGuard } from "@oxdeai/langgraph";
 
 const guard = createLangGraphGuard({
   engine,      // PolicyEngine from @oxdeai/core
-  getState,    // () => State | Promise<State>
-  setState,    // (state: State) => void | Promise<void>
+  getState,    // () => { state, version } | Promise<{ state, version }>
+  setState,    // (state, expectedVersion) => boolean | Promise<boolean>  (CAS)
   agentId: "gpu-agent-1",
 });
 
@@ -128,6 +128,39 @@ semantics as every other OxDeAI protocol demo:
 - **Envelope verification** remains offline and deterministic
 
 All of this is guaranteed by `@oxdeai/guard` - this package adds nothing on top.
+
+---
+
+## Trust profile
+
+**Declared.**
+
+This adapter integrates the lower-level `OxDeAIGuard` boundary. `agent_id` is
+fixed by deployment configuration (`config.agentId`) and is not proposer-controlled;
+the same value is bound as `expectedAudience`, so an authorization issued for a
+different audience fails closed.
+
+Tool identity and recursion depth are **not** established from a
+`TrustedExecutionContext` on this path. The default adapter normalization does not
+populate `intent.tool` or `intent.depth`, so `ToolAmplificationModule` and
+`RecursionDepthModule` do not constrain execution here. The adapter deliberately
+does not derive `intent.tool` from the proposer-supplied tool-call name: doing so
+would activate the module against a value the caller controls, which is weaker than
+leaving it unset.
+
+Deployments that require authenticated Tier 1 evaluator-input provenance should
+establish trusted execution context at an authenticating PEP — where a principal is
+actually authenticated and the route is resolved — and integrate `createSecureGuard`
+from `@oxdeai/guard` there. A framework adapter has no authenticated principal of its
+own, so it cannot construct that context honestly.
+
+Replay protection defaults to a per-guard in-memory store. Multi-process or
+restart-durable deployments must pass an explicit `replayStore`; see
+`createRedisReplayStore` in `@oxdeai/guard`.
+
+Wire `onBoundaryEvent` alongside `onDecision` to observe guard-boundary rejections
+(replay, CAS conflict, hash-binding failure). The two streams are disjoint: a
+boundary rejection produces no decision record.
 
 ---
 

--- a/packages/langgraph/package.json
+++ b/packages/langgraph/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@oxdeai/langgraph",
-  "version": "1.0.1",
-  "license": "Apache-2.0",
+  "version": "2.0.0",
   "description": "Thin LangGraph adapter for the OxDeAI universal execution guard",
+  "license": "Apache-2.0",
   "keywords": [
     "oxdeai",
     "langgraph",
@@ -20,9 +20,25 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/oxdeai/oxdeai.git",
+    "directory": "packages/langgraph"
+  },
+  "homepage": "https://github.com/oxdeai/oxdeai",
+  "bugs": {
+    "url": "https://github.com/oxdeai/oxdeai/issues"
+  },
+  "files": [
+    "dist",
+    "!dist/test",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "dependencies": {
-    "@oxdeai/core": "workspace:*",
-    "@oxdeai/guard": "workspace:*"
+    "@oxdeai/core": "workspace:^",
+    "@oxdeai/guard": "workspace:^"
   },
   "devDependencies": {
     "@oxdeai/sdk": "workspace:*"
@@ -30,6 +46,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "rm -rf dist && tsc -p tsconfig.json",
+    "prepack": "pnpm build",
     "test": "pnpm build && node --test \"dist/test/adapter.test.js\""
   }
 }

--- a/packages/langgraph/src/adapter.ts
+++ b/packages/langgraph/src/adapter.ts
@@ -52,8 +52,11 @@ export function createLangGraphGuard(config: LangGraphGuardConfig): LangGraphGua
     mapActionToIntent: config.mapActionToIntent,
     beforeExecute: config.beforeExecute,
     onDecision: config.onDecision,
+    onBoundaryEvent: config.onBoundaryEvent,
     expectedAudience: config.agentId,
     trustedKeySets: config.trustedKeySets,
+    replayStore: config.replayStore,
+    computeStateHash: config.computeStateHash,
   });
 
   return async function langGraphGuard<T>(

--- a/packages/langgraph/src/types.ts
+++ b/packages/langgraph/src/types.ts
@@ -72,11 +72,34 @@ export type LangGraphGuardConfig = {
    */
   onDecision?: OxDeAIGuardConfig["onDecision"];
 
-  /** When true, missing optional normalizer fields cause hard failures. */
-  strict?: boolean;
+  /**
+   * Audit hook for guard-boundary rejections raised before `execute()` starts —
+   * provenance conflicts, replay rejections, hash-binding failures, CAS conflicts.
+   *
+   * Disjoint from {@link onDecision}: a boundary rejection produces no decision
+   * record, so a deployment wiring only `onDecision` cannot observe one.
+   */
+  onBoundaryEvent?: OxDeAIGuardConfig["onBoundaryEvent"];
 
   /** Trusted keysets required for strict authorization verification. */
   trustedKeySets?: OxDeAIGuardConfig["trustedKeySets"];
+
+  /**
+   * Replay store used for durable `auth_id` / `delegation_id` tracking.
+   *
+   * When omitted the guard creates a per-instance in-memory store, which is
+   * single-process only. Multi-process or restart-durable deployments must
+   * supply a shared backend such as `createRedisReplayStore` from `@oxdeai/guard`.
+   */
+  replayStore?: OxDeAIGuardConfig["replayStore"];
+
+  /**
+   * Custom live-state hash strategy used for `state_hash` binding verification.
+   *
+   * Required when authorizations are issued by an external provider whose state
+   * canonicalization differs from the core PolicyEngine's.
+   */
+  computeStateHash?: OxDeAIGuardConfig["computeStateHash"];
 };
 
 /**

--- a/packages/openai-agents/CHANGELOG.md
+++ b/packages/openai-agents/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog
+
+All notable changes to `@oxdeai/openai-agents` will be documented in this file.
+
+The format is based on Keep a Changelog.
+This project follows Semantic Versioning.
+
+> This file starts at 2.0.0. Versions 1.0.0 and 1.0.1 were published without a
+> changelog; the 2.0.0 entry below reconstructs the delta from the published
+> `@oxdeai/openai-agents@1.0.1` npm artifact.
+
+---
+
+## [2.0.0] - Unreleased
+
+**Baseline for this entry:** the published `@oxdeai/openai-agents@1.0.1` npm artifact
+(2026-03-19). The version was set to `1.0.1` at `8797931`; the packed
+`dist/types.d.ts` of that artifact is used as the authoritative comparison surface.
+
+> ⚠️ The published `1.0.1` artifact declares `"@oxdeai/core": "workspace:*"` and
+> `"@oxdeai/guard": "workspace:*"`, so **it cannot be installed standalone from the
+> public registry**. That is a defect of the historical release process, not of the
+> source. See **Packaging** below.
+
+### Breaking
+
+- **Requires `@oxdeai/core` 2.0 and `@oxdeai/guard` 2.0.** Both dependencies move
+  to a major line with breaking API and runtime-semantic changes; see those packages'
+  changelogs.
+- **`getState` now returns versioned state** — `{ state, version }` rather than
+  `State`. A store returning no version fails closed.
+- **`setState` is now compare-and-set** — `(state, expectedVersion) => boolean`
+  rather than `(state) => void`. Returning `false` blocks execution.
+- **`strict?: boolean` removed from `OpenAIAgentsGuardConfig`.** The field was declared but never
+  read, and never reached the guard. It was inherited from the `@oxdeai/guard@1.0.1`
+  config shape, where it was also inert. Nothing replaces it — it was not a security
+  control, and presenting it as one was the problem.
+- **`expectedAudience` is enforced by the guard.** The adapter derives it from
+  `config.agentId`, so no caller change is required, but an authorization whose
+  audience does not match that agent identity now fails closed.
+
+### Added
+
+Configuration forwarded through to `OxDeAIGuard`. These were supported by the guard
+but unreachable through this adapter:
+
+- **`replayStore`** — durable `auth_id` / `delegation_id` tracking. Without it the
+  guard creates a per-instance in-memory store, so in a horizontally scaled or
+  restart-prone deployment replay protection did not hold across processes and the
+  adapter offered no way to fix that.
+- **`onBoundaryEvent`** — the guard-boundary audit stream. It is disjoint from
+  `onDecision`, so replay rejections, CAS conflicts and hash-binding failures
+  previously produced **no audit record at all** for adapter consumers.
+- **`computeStateHash`** — custom live-state hash strategy, required when
+  authorizations are issued by an external provider whose state canonicalization
+  differs from the core engine's.
+- `trustedKeySets` is exposed on the adapter config for strict authorization
+  verification.
+
+### Trust profile
+
+Unchanged and now documented explicitly in the README: **declared**.
+
+This adapter integrates the lower-level `OxDeAIGuard` boundary. `agent_id` is fixed
+by deployment configuration and is not proposer-controlled. Tool identity and
+recursion depth are **not** established from a `TrustedExecutionContext`:
+`intent.tool` and `intent.depth` are not populated by the default normalization, so
+`ToolAmplificationModule` and `RecursionDepthModule` do not constrain this path.
+
+This release makes **no Tier 1 evaluator-input provenance claim**. Deployments
+requiring it should establish trusted execution context at an authenticating PEP and
+integrate `createSecureGuard` from `@oxdeai/guard` there. A `createSecureGuard`
+adapter entry point is tracked as future work; a framework adapter has no
+authenticated principal of its own and cannot construct that context honestly.
+
+### Packaging
+
+- **Workspace dependencies now use `workspace:^`**, so the packed artifact declares
+  `^2.0.0` ranges instead of the exact pin `workspace:*` resolves to. This fixes
+  standalone installation and lets the adapter tolerate a compatible guard or core
+  patch without a republish.
+- An explicit `files` field is declared. The artifact no longer ships `src/`,
+  `tsconfig.json` or compiled test files.
+- `prepack` now rebuilds before packing, so a stale `dist/` cannot be published.
+- `repository` (with `directory`), `homepage` and `bugs` are declared for npm
+  provenance.
+- This changelog file was added; the package previously shipped none.

--- a/packages/openai-agents/README.md
+++ b/packages/openai-agents/README.md
@@ -34,8 +34,8 @@ import { createOpenAIAgentsGuard } from "@oxdeai/openai-agents";
 
 const guard = createOpenAIAgentsGuard({
   engine,      // PolicyEngine from @oxdeai/core
-  getState,    // () => State | Promise<State>
-  setState,    // (state: State) => void | Promise<void>
+  getState,    // () => { state, version } | Promise<{ state, version }>
+  setState,    // (state, expectedVersion) => boolean | Promise<boolean>  (CAS)
   agentId: "gpu-agent-1",
 });
 
@@ -127,6 +127,39 @@ semantics as every other OxDeAI protocol demo:
 - **Envelope verification** remains offline and deterministic
 
 All of this is guaranteed by `@oxdeai/guard` - this package adds nothing on top.
+
+---
+
+## Trust profile
+
+**Declared.**
+
+This adapter integrates the lower-level `OxDeAIGuard` boundary. `agent_id` is
+fixed by deployment configuration (`config.agentId`) and is not proposer-controlled;
+the same value is bound as `expectedAudience`, so an authorization issued for a
+different audience fails closed.
+
+Tool identity and recursion depth are **not** established from a
+`TrustedExecutionContext` on this path. The default adapter normalization does not
+populate `intent.tool` or `intent.depth`, so `ToolAmplificationModule` and
+`RecursionDepthModule` do not constrain execution here. The adapter deliberately
+does not derive `intent.tool` from the proposer-supplied tool-call name: doing so
+would activate the module against a value the caller controls, which is weaker than
+leaving it unset.
+
+Deployments that require authenticated Tier 1 evaluator-input provenance should
+establish trusted execution context at an authenticating PEP — where a principal is
+actually authenticated and the route is resolved — and integrate `createSecureGuard`
+from `@oxdeai/guard` there. A framework adapter has no authenticated principal of its
+own, so it cannot construct that context honestly.
+
+Replay protection defaults to a per-guard in-memory store. Multi-process or
+restart-durable deployments must pass an explicit `replayStore`; see
+`createRedisReplayStore` in `@oxdeai/guard`.
+
+Wire `onBoundaryEvent` alongside `onDecision` to observe guard-boundary rejections
+(replay, CAS conflict, hash-binding failure). The two streams are disjoint: a
+boundary rejection produces no decision record.
 
 ---
 

--- a/packages/openai-agents/package.json
+++ b/packages/openai-agents/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@oxdeai/openai-agents",
-  "version": "1.0.1",
-  "license": "Apache-2.0",
+  "version": "2.0.0",
   "description": "Thin OpenAI Agents SDK adapter for the OxDeAI universal execution guard",
+  "license": "Apache-2.0",
   "keywords": [
     "oxdeai",
     "openai",
@@ -21,9 +21,25 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/oxdeai/oxdeai.git",
+    "directory": "packages/openai-agents"
+  },
+  "homepage": "https://github.com/oxdeai/oxdeai",
+  "bugs": {
+    "url": "https://github.com/oxdeai/oxdeai/issues"
+  },
+  "files": [
+    "dist",
+    "!dist/test",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "dependencies": {
-    "@oxdeai/core": "workspace:*",
-    "@oxdeai/guard": "workspace:*"
+    "@oxdeai/core": "workspace:^",
+    "@oxdeai/guard": "workspace:^"
   },
   "devDependencies": {
     "@oxdeai/sdk": "workspace:*"
@@ -31,6 +47,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "rm -rf dist && tsc -p tsconfig.json",
+    "prepack": "pnpm build",
     "test": "pnpm build && node --test \"dist/test/adapter.test.js\""
   }
 }

--- a/packages/openai-agents/src/adapter.ts
+++ b/packages/openai-agents/src/adapter.ts
@@ -52,8 +52,11 @@ export function createOpenAIAgentsGuard(config: OpenAIAgentsGuardConfig): OpenAI
     mapActionToIntent: config.mapActionToIntent,
     beforeExecute: config.beforeExecute,
     onDecision: config.onDecision,
+    onBoundaryEvent: config.onBoundaryEvent,
     expectedAudience: config.agentId,
     trustedKeySets: config.trustedKeySets,
+    replayStore: config.replayStore,
+    computeStateHash: config.computeStateHash,
   });
 
   return async function openAIAgentsGuard<T>(

--- a/packages/openai-agents/src/types.ts
+++ b/packages/openai-agents/src/types.ts
@@ -72,11 +72,34 @@ export type OpenAIAgentsGuardConfig = {
    */
   onDecision?: OxDeAIGuardConfig["onDecision"];
 
-  /** When true, missing optional normalizer fields cause hard failures. */
-  strict?: boolean;
+  /**
+   * Audit hook for guard-boundary rejections raised before `execute()` starts —
+   * provenance conflicts, replay rejections, hash-binding failures, CAS conflicts.
+   *
+   * Disjoint from {@link onDecision}: a boundary rejection produces no decision
+   * record, so a deployment wiring only `onDecision` cannot observe one.
+   */
+  onBoundaryEvent?: OxDeAIGuardConfig["onBoundaryEvent"];
 
   /** Trusted keysets required for strict authorization verification. */
   trustedKeySets?: OxDeAIGuardConfig["trustedKeySets"];
+
+  /**
+   * Replay store used for durable `auth_id` / `delegation_id` tracking.
+   *
+   * When omitted the guard creates a per-instance in-memory store, which is
+   * single-process only. Multi-process or restart-durable deployments must
+   * supply a shared backend such as `createRedisReplayStore` from `@oxdeai/guard`.
+   */
+  replayStore?: OxDeAIGuardConfig["replayStore"];
+
+  /**
+   * Custom live-state hash strategy used for `state_hash` binding verification.
+   *
+   * Required when authorizations are issued by an external provider whose state
+   * canonicalization differs from the core PolicyEngine's.
+   */
+  computeStateHash?: OxDeAIGuardConfig["computeStateHash"];
 };
 
 /**

--- a/packages/openclaw/CHANGELOG.md
+++ b/packages/openclaw/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog
+
+All notable changes to `@oxdeai/openclaw` will be documented in this file.
+
+The format is based on Keep a Changelog.
+This project follows Semantic Versioning.
+
+> This file starts at 2.0.0. Versions 1.0.0 and 1.0.1 were published without a
+> changelog; the 2.0.0 entry below reconstructs the delta from the published
+> `@oxdeai/openclaw@1.0.1` npm artifact.
+
+---
+
+## [2.0.0] - Unreleased
+
+**Baseline for this entry:** the published `@oxdeai/openclaw@1.0.1` npm artifact
+(2026-03-19). The version was set to `1.0.1` at `8797931`; the packed
+`dist/types.d.ts` of that artifact is used as the authoritative comparison surface.
+
+> ⚠️ The published `1.0.1` artifact declares `"@oxdeai/core": "workspace:*"` and
+> `"@oxdeai/guard": "workspace:*"`, so **it cannot be installed standalone from the
+> public registry**. That is a defect of the historical release process, not of the
+> source. See **Packaging** below.
+
+### Breaking
+
+- **Requires `@oxdeai/core` 2.0 and `@oxdeai/guard` 2.0.** Both dependencies move
+  to a major line with breaking API and runtime-semantic changes; see those packages'
+  changelogs.
+- **`getState` now returns versioned state** — `{ state, version }` rather than
+  `State`. A store returning no version fails closed.
+- **`setState` is now compare-and-set** — `(state, expectedVersion) => boolean`
+  rather than `(state) => void`. Returning `false` blocks execution.
+- **`strict?: boolean` removed from `OpenClawGuardConfig`.** The field was declared but never
+  read, and never reached the guard. It was inherited from the `@oxdeai/guard@1.0.1`
+  config shape, where it was also inert. Nothing replaces it — it was not a security
+  control, and presenting it as one was the problem.
+- **`expectedAudience` is enforced by the guard.** The adapter derives it from
+  `config.agentId`, so no caller change is required, but an authorization whose
+  audience does not match that agent identity now fails closed.
+
+### Added
+
+Configuration forwarded through to `OxDeAIGuard`. These were supported by the guard
+but unreachable through this adapter:
+
+- **`replayStore`** — durable `auth_id` / `delegation_id` tracking. Without it the
+  guard creates a per-instance in-memory store, so in a horizontally scaled or
+  restart-prone deployment replay protection did not hold across processes and the
+  adapter offered no way to fix that.
+- **`onBoundaryEvent`** — the guard-boundary audit stream. It is disjoint from
+  `onDecision`, so replay rejections, CAS conflicts and hash-binding failures
+  previously produced **no audit record at all** for adapter consumers.
+- **`computeStateHash`** — custom live-state hash strategy, required when
+  authorizations are issued by an external provider whose state canonicalization
+  differs from the core engine's.
+- `trustedKeySets` is exposed on the adapter config for strict authorization
+  verification.
+
+### Trust profile
+
+Unchanged and now documented explicitly in the README: **declared**.
+
+This adapter integrates the lower-level `OxDeAIGuard` boundary. `agent_id` is fixed
+by deployment configuration and is not proposer-controlled. Tool identity and
+recursion depth are **not** established from a `TrustedExecutionContext`:
+`intent.tool` and `intent.depth` are not populated by the default normalization, so
+`ToolAmplificationModule` and `RecursionDepthModule` do not constrain this path.
+
+This release makes **no Tier 1 evaluator-input provenance claim**. Deployments
+requiring it should establish trusted execution context at an authenticating PEP and
+integrate `createSecureGuard` from `@oxdeai/guard` there. A `createSecureGuard`
+adapter entry point is tracked as future work; a framework adapter has no
+authenticated principal of its own and cannot construct that context honestly.
+
+### Packaging
+
+- **Workspace dependencies now use `workspace:^`**, so the packed artifact declares
+  `^2.0.0` ranges instead of the exact pin `workspace:*` resolves to. This fixes
+  standalone installation and lets the adapter tolerate a compatible guard or core
+  patch without a republish.
+- An explicit `files` field is declared. The artifact no longer ships `src/`,
+  `tsconfig.json` or compiled test files.
+- `prepack` now rebuilds before packing, so a stale `dist/` cannot be published.
+- `repository` (with `directory`), `homepage` and `bugs` are declared for npm
+  provenance.
+- This changelog file was added; the package previously shipped none.

--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -34,8 +34,8 @@ import { createOpenClawGuard } from "@oxdeai/openclaw";
 
 const guard = createOpenClawGuard({
   engine,      // PolicyEngine from @oxdeai/core
-  getState,    // () => State | Promise<State>
-  setState,    // (state: State) => void | Promise<void>
+  getState,    // () => { state, version } | Promise<{ state, version }>
+  setState,    // (state, expectedVersion) => boolean | Promise<boolean>  (CAS)
   agentId: "gpu-agent-1",
 });
 
@@ -113,6 +113,39 @@ semantics as every other OxDeAI protocol demo:
 - **Envelope verification** remains offline and deterministic
 
 All of this is guaranteed by `@oxdeai/guard` - this package adds nothing on top.
+
+---
+
+## Trust profile
+
+**Declared.**
+
+This adapter integrates the lower-level `OxDeAIGuard` boundary. `agent_id` is
+fixed by deployment configuration (`config.agentId`) and is not proposer-controlled;
+the same value is bound as `expectedAudience`, so an authorization issued for a
+different audience fails closed.
+
+Tool identity and recursion depth are **not** established from a
+`TrustedExecutionContext` on this path. The default adapter normalization does not
+populate `intent.tool` or `intent.depth`, so `ToolAmplificationModule` and
+`RecursionDepthModule` do not constrain execution here. The adapter deliberately
+does not derive `intent.tool` from the proposer-supplied tool-call name: doing so
+would activate the module against a value the caller controls, which is weaker than
+leaving it unset.
+
+Deployments that require authenticated Tier 1 evaluator-input provenance should
+establish trusted execution context at an authenticating PEP — where a principal is
+actually authenticated and the route is resolved — and integrate `createSecureGuard`
+from `@oxdeai/guard` there. A framework adapter has no authenticated principal of its
+own, so it cannot construct that context honestly.
+
+Replay protection defaults to a per-guard in-memory store. Multi-process or
+restart-durable deployments must pass an explicit `replayStore`; see
+`createRedisReplayStore` in `@oxdeai/guard`.
+
+Wire `onBoundaryEvent` alongside `onDecision` to observe guard-boundary rejections
+(replay, CAS conflict, hash-binding failure). The two streams are disjoint: a
+boundary rejection produces no decision record.
 
 ---
 

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@oxdeai/openclaw",
-  "version": "1.0.1",
-  "license": "Apache-2.0",
+  "version": "2.0.0",
   "description": "Thin OpenClaw adapter for the OxDeAI universal execution guard",
+  "license": "Apache-2.0",
   "keywords": [
     "oxdeai",
     "openclaw",
@@ -19,9 +19,25 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/oxdeai/oxdeai.git",
+    "directory": "packages/openclaw"
+  },
+  "homepage": "https://github.com/oxdeai/oxdeai",
+  "bugs": {
+    "url": "https://github.com/oxdeai/oxdeai/issues"
+  },
+  "files": [
+    "dist",
+    "!dist/test",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "dependencies": {
-    "@oxdeai/core": "workspace:*",
-    "@oxdeai/guard": "workspace:*"
+    "@oxdeai/core": "workspace:^",
+    "@oxdeai/guard": "workspace:^"
   },
   "devDependencies": {
     "@oxdeai/sdk": "workspace:*"
@@ -29,6 +45,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "rm -rf dist && tsc -p tsconfig.json",
+    "prepack": "pnpm build",
     "test": "pnpm build && node --test \"dist/test/adapter.test.js\""
   }
 }

--- a/packages/openclaw/src/adapter.ts
+++ b/packages/openclaw/src/adapter.ts
@@ -54,8 +54,11 @@ export function createOpenClawGuard(config: OpenClawGuardConfig): OpenClawGuardF
     mapActionToIntent: config.mapActionToIntent,
     beforeExecute: config.beforeExecute,
     onDecision: config.onDecision,
+    onBoundaryEvent: config.onBoundaryEvent,
     expectedAudience: config.agentId,
     trustedKeySets: config.trustedKeySets,
+    replayStore: config.replayStore,
+    computeStateHash: config.computeStateHash,
   });
 
   return async function openClawGuard<T>(

--- a/packages/openclaw/src/types.ts
+++ b/packages/openclaw/src/types.ts
@@ -76,11 +76,34 @@ export type OpenClawGuardConfig = {
    */
   onDecision?: OxDeAIGuardConfig["onDecision"];
 
-  /** When true, missing optional normalizer fields cause hard failures. */
-  strict?: boolean;
+  /**
+   * Audit hook for guard-boundary rejections raised before `execute()` starts —
+   * provenance conflicts, replay rejections, hash-binding failures, CAS conflicts.
+   *
+   * Disjoint from {@link onDecision}: a boundary rejection produces no decision
+   * record, so a deployment wiring only `onDecision` cannot observe one.
+   */
+  onBoundaryEvent?: OxDeAIGuardConfig["onBoundaryEvent"];
 
   /** Trusted keysets required for strict authorization verification. */
   trustedKeySets?: OxDeAIGuardConfig["trustedKeySets"];
+
+  /**
+   * Replay store used for durable `auth_id` / `delegation_id` tracking.
+   *
+   * When omitted the guard creates a per-instance in-memory store, which is
+   * single-process only. Multi-process or restart-durable deployments must
+   * supply a shared backend such as `createRedisReplayStore` from `@oxdeai/guard`.
+   */
+  replayStore?: OxDeAIGuardConfig["replayStore"];
+
+  /**
+   * Custom live-state hash strategy used for `state_hash` binding verification.
+   *
+   * Required when authorizations are issued by an external provider whose state
+   * canonicalization differs from the core PolicyEngine's.
+   */
+  computeStateHash?: OxDeAIGuardConfig["computeStateHash"];
 };
 
 /**

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -7,6 +7,70 @@ This project follows Semantic Versioning.
 
 ---
 
+## [2.0.0] - Unreleased
+
+**Baseline for this entry:** the published `@oxdeai/sdk@1.3.3` npm artifact
+(2026-04-23), compared file-by-file against the current candidate.
+
+> ⚠️ `1.3.3` was published and then further modified on `main` without a version
+> bump: the published `dist/guard.js` and `dist/client.js` differ from the current
+> source at the same version number. `2.0.0` restores the guarantee that a version
+> identifies an artifact.
+
+The SDK's own module list is unchanged. The major is not cosmetic dependency
+tracking — it reflects two real consumer-visible changes plus the re-exported core
+surface.
+
+### Breaking
+
+- **`export * from "@oxdeai/core"` re-exports core's 2.0 surface.** Every core
+  breaking change is therefore an SDK breaking change for consumers importing
+  `PolicyEngine` and friends from `@oxdeai/sdk`. See the `@oxdeai/core` 2.0.0 entry
+  — in particular the required `evaluationTime` argument and the now-required
+  `maxClockSkewSeconds` / `maxIntentAgeSeconds` engine options.
+- **`Authorization` is replaced by `AuthorizationV1`** in the public type surface of
+  `client.d.ts`, `guard.d.ts` and `types.d.ts`. Code that annotated these values with
+  the internal `Authorization` type no longer compiles.
+
+### Security hardening
+
+- **Verifier time is taken from the trusted clock, never from `intent.timestamp`.**
+  Previously `OxDeAIClient.verifyAuthorization` and the SDK guard passed
+  `intent.timestamp` as "now". Because that value is proposer-supplied and
+  hash-bound into the authorization at issuance, the expiry comparison was pinned to
+  issuance time and **the authorization never expired**. Both paths now sample the
+  clock boundary once per evaluation and reuse that single sample for the timestamp
+  fallback, for `evaluationTime`, and for verification.
+
+  This changes runtime behaviour for existing callers: artifacts that previously
+  verified indefinitely will now correctly be rejected once expired.
+
+  Note that the SDK clock defaults to `Date.now() / 1000` unless the caller supplies
+  an independent `ClockAdapter`. A supplied value is not automatically independently
+  trusted time.
+
+### Added
+
+- `OxDeAIClient.verifyAuthorization` accepts an optional third argument
+  `{ verificationTime?: number }` for callers that already hold a verification time
+  from their trusted execution boundary. Additive; existing two-argument calls
+  continue to work.
+
+### Changed
+
+- `OxDeAIClient.verifyAuthorization` documents that it inherits the **limited scope**
+  of `PolicyEngine.verifyAuthorization`: it authenticates only the engine-HMAC field
+  subset. Relying parties enforcing an authorization issued by an external party must
+  use the strict standalone verifier with explicit `trustedKeySets`.
+
+### Packaging
+
+- `license`, `repository` (with `directory`), `homepage` and `bugs` are now declared;
+  the published `1.3.3` artifact carried none of them, which blocks npm provenance.
+- `prepack` now rebuilds before packing.
+
+---
+
 ## 1.3.3
 
 - Fix package publish contents: exclude src and test artifacts from the published tarball.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,17 +1,18 @@
 {
   "name": "@oxdeai/sdk",
-  "version": "1.3.3",
+  "version": "2.0.0",
+  "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "dependencies": {
-    "@oxdeai/core": "workspace:*"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/oxdeai/oxdeai.git",
+    "directory": "packages/sdk"
   },
-  "scripts": {
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "build": "rm -rf dist && tsc -p tsconfig.json",
-    "build:test": "rm -rf dist && tsc -p tsconfig.test.json",
-    "test": "pnpm build:test && node --test \"dist/**/*.test.js\""
+  "homepage": "https://github.com/oxdeai/oxdeai",
+  "bugs": {
+    "url": "https://github.com/oxdeai/oxdeai/issues"
   },
   "files": [
     "dist",
@@ -19,5 +20,15 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE"
- ]
+  ],
+  "dependencies": {
+    "@oxdeai/core": "workspace:*"
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "build": "rm -rf dist && tsc -p tsconfig.json",
+    "prepack": "pnpm build",
+    "build:test": "rm -rf dist && tsc -p tsconfig.test.json",
+    "test": "pnpm build:test && node --test \"dist/**/*.test.js\""
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,10 +299,10 @@ importers:
   packages/autogen:
     dependencies:
       '@oxdeai/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@oxdeai/guard':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../guard
     devDependencies:
       '@oxdeai/sdk':
@@ -364,10 +364,10 @@ importers:
   packages/crewai:
     dependencies:
       '@oxdeai/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@oxdeai/guard':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../guard
     devDependencies:
       '@oxdeai/sdk':
@@ -387,10 +387,10 @@ importers:
   packages/langgraph:
     dependencies:
       '@oxdeai/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@oxdeai/guard':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../guard
     devDependencies:
       '@oxdeai/sdk':
@@ -400,10 +400,10 @@ importers:
   packages/openai-agents:
     dependencies:
       '@oxdeai/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@oxdeai/guard':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../guard
     devDependencies:
       '@oxdeai/sdk':
@@ -413,10 +413,10 @@ importers:
   packages/openclaw:
     dependencies:
       '@oxdeai/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@oxdeai/guard':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../guard
     devDependencies:
       '@oxdeai/sdk':

--- a/scripts/audit-tags.mjs
+++ b/scripts/audit-tags.mjs
@@ -4,7 +4,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 
 const GIT_DIR = process.env.GIT_DIR || ".git";
 
-const KEEP_PATTERN = /^(core|cli|conformance|guard|sdk)-v\d+\.\d+\.\d+$/;
+const KEEP_PATTERN = /^(core|cli|conformance|guard|sdk|langgraph|crewai|autogen|openai-agents|openclaw)-v\d+\.\d+\.\d+$/;
 const LEGACY_GLOBAL_PATTERN = /^v\d+\.\d+\.\d+$/;
 const PACKAGE_LIKE_PATTERN = /^([a-z0-9_-]+)-v\d+\.\d+\.\d+(?:[-\w.]*)?$/i;
 

--- a/scripts/cleanup-legacy-tags.mjs
+++ b/scripts/cleanup-legacy-tags.mjs
@@ -5,7 +5,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 
 const GIT_DIR = process.env.GIT_DIR || ".git";
 
-const KEEP_PATTERN = /^(core|cli|conformance|guard|sdk)-v\d+\.\d+\.\d+$/;
+const KEEP_PATTERN = /^(core|cli|conformance|guard|sdk|langgraph|crewai|autogen|openai-agents|openclaw)-v\d+\.\d+\.\d+$/;
 const LEGACY_GLOBAL_PATTERN = /^v\d+\.\d+\.\d+$/;
 const CONFIRM_TOKEN = "DELETE_LEGACY_TAGS";
 

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -34,6 +34,36 @@ const RELEASE_PACKAGES = {
     tagPrefix: "cli",
     changelog: "packages/cli/CHANGELOG.md",
   },
+  langgraph: {
+    name: "@oxdeai/langgraph",
+    path: "packages/langgraph",
+    tagPrefix: "langgraph",
+    changelog: "packages/langgraph/CHANGELOG.md",
+  },
+  crewai: {
+    name: "@oxdeai/crewai",
+    path: "packages/crewai",
+    tagPrefix: "crewai",
+    changelog: "packages/crewai/CHANGELOG.md",
+  },
+  autogen: {
+    name: "@oxdeai/autogen",
+    path: "packages/autogen",
+    tagPrefix: "autogen",
+    changelog: "packages/autogen/CHANGELOG.md",
+  },
+  "openai-agents": {
+    name: "@oxdeai/openai-agents",
+    path: "packages/openai-agents",
+    tagPrefix: "openai-agents",
+    changelog: "packages/openai-agents/CHANGELOG.md",
+  },
+  openclaw: {
+    name: "@oxdeai/openclaw",
+    path: "packages/openclaw",
+    tagPrefix: "openclaw",
+    changelog: "packages/openclaw/CHANGELOG.md",
+  },
 };
 
 const VERSION_RE = /^\d+\.\d+\.\d+$/;
@@ -41,7 +71,7 @@ const VERSION_RE = /^\d+\.\d+\.\d+$/;
 function usage(exitCode = 0) {
   const out = exitCode === 0 ? console.log : console.error;
   out(`Usage:
-  node scripts/release-preflight.mjs --package <core|sdk|conformance|guard|cli> [options]
+  node scripts/release-preflight.mjs --package <core|sdk|conformance|guard|cli|langgraph|crewai|autogen|openai-agents|openclaw> [options]
 
 Options:
   --package <name>              Package short name to validate.


### PR DESCRIPTION
## Summary

Prepare the OxDeAI monorepo for the 2.0 audit/release line without publishing anything or changing protocol semantics.

## Related issue

Progresses #254.

This PR implements the A4/A5 pre-freeze package-readiness portion of the OxDeAI 2.0 release gates.

It does not close 254. Registry publication, provenance, audit freeze/remediation provenance, `next` validation, `latest` promotion, and legacy-package disposition remain tracked there.

This PR covers Phase A4 + A5 of the 2.0 release-readiness plan:

- version correction
- changelog reconstruction
- npm publication metadata
- release-preflight coverage
- adapter package cleanup
- adapter guard-config forwarding
- adapter trust-profile documentation

## Package versions

- `@oxdeai/core` -> `2.0.0`
- `@oxdeai/guard` -> `2.0.0`
- `@oxdeai/sdk` -> `2.0.0`
- `@oxdeai/conformance` -> `2.0.0`
- `@oxdeai/cli` -> `0.3.0`
- all five adapters -> `2.0.0`

Private packages remain unchanged.

## Release readiness

- reconstruct changelogs from the actual published baselines
- add missing `repository`, `homepage`, `bugs`, `files`, and `prepack` metadata
- exclude test/dev artifacts from published tarballs
- add all adapters to release preflight and package-scoped tag policy
- retire the shared `adapters-v*` convention for future releases
- change adapter workspace dependencies to `workspace:^`
- verify packed adapter dependencies resolve to `^2.0.0`
- keep exact core pins for guard/sdk/cli/conformance for the initial 2.0 line

## Adapter changes

All five adapters now forward:

- `replayStore`
- `onBoundaryEvent`
- `computeStateHash`

Also:

- remove the unused `strict?: boolean` config
- document the declared trust profile
- keep `OxDeAIGuard` as the lower-level adapter boundary
- do not fabricate `TrustedExecutionContext`
- do not migrate adapters to `createSecureGuard` in this release

## Verification

- `pnpm install --frozen-lockfile` PASS
- `pnpm -r build` PASS
- `pnpm -r test` PASS: 993 / 993
- policy-boundary security checks PASS
- core API checks PASS
- all 10 tarballs inspected
- zero `workspace:` leakage
- no unwanted test/dev files
- npm external consumer PASS
- pnpm external consumer PASS for core + guard
- strict TypeScript compile PASS
- website `createSecureGuard` example compiles against packed artifacts
- adapter consumer compile PASS

## Out of scope

This PR does not:

- implement #247
- change protocol semantics
- change conformance vectors
- create or move Git tags
- publish npm packages
- migrate adapters to `createSecureGuard`
- modify the website
- add publish workflows

#247 is being handled separately and must land before the audit freeze.