### PR TITLE
fix(guard): fail closed on malformed policy deny output

### DIFF
--- a/packages/guard/src/boundaryEvent.ts
+++ b/packages/guard/src/boundaryEvent.ts
@@ -34,10 +34,11 @@
  * A valid `OxDeAIDenyError` is the engine's decision, is reported to
  * `onDecision`, and returns early here; every other guard-boundary rejection
  * emits no decision record, whether or not the engine had already returned an
- * ALLOW. A malformed DENY — one whose `reasons` are invalid, so the engine
- * throws before `OxDeAIDenyError` is constructed — is not a decision and is
- * not covered by this statement; it surfaces as an engine-contract violation
- * and is out of scope here.
+ * ALLOW. A malformed DENY — one whose `reasons` fail the guard's structural
+ * check before `OxDeAIDenyError` is constructed (#247) — is not a decision:
+ * it never reaches `onDecision`, is classified `POLICY_EVALUATION` /
+ * `ENGINE_FAILURE` at the throw site, and is reported here like any other
+ * pre-execution guard-boundary rejection.
  *
  * ## Failure contract
  *

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -20,6 +20,21 @@ import {
 
 // ── validation ────────────────────────────────────────────────────────────────
 
+/**
+ * The engine's public DENY contract is `{ decision: "DENY"; reasons: ReasonCode[] }`
+ * (`ReasonCode` is a string union at runtime). `config.engine` is validated only
+ * structurally (`validateConfig` above requires an `evaluatePure` function), so
+ * it need not be a real `PolicyEngine` instance — a test double, a custom
+ * implementation, or a future engine version can return a `DENY` whose
+ * `reasons` do not match this contract. Reading such a value without checking
+ * it first (`evalResult.reasons.map(String)`) throws an unclassified,
+ * unstructured `TypeError` instead of failing closed as an engine-contract
+ * violation. See #247.
+ */
+function isValidDenyReasons(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((r) => typeof r === "string");
+}
+
 function isValidDelegationScope(scope: unknown): scope is DelegationScope {
   if (scope === null || scope === undefined || typeof scope !== "object" || Array.isArray(scope)) {
     return false;
@@ -96,6 +111,8 @@ async function fireDecision(
  *   7. Return the execute() result.
  *
  * Security invariants:
+ *   - DENY with malformed reasons → OxDeAIAuthorizationError (no execution, no
+ *     decision record, no synthetic DENY — see #247).
  *   - ALLOW without authorization → OxDeAIAuthorizationError (no execution).
  *   - ALLOW without nextState     → OxDeAIAuthorizationError (no execution).
  *   - verifyAuthorization failure → OxDeAIAuthorizationError (no execution).
@@ -412,13 +429,28 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
 
     // ── 5. DENY path ───────────────────────────────────────────────────────
     if (evalResult.decision === "DENY") {
-      const reasons = evalResult.reasons.map(String);
+      // Validate the engine's DENY contract before reading `reasons`. A
+      // malformed result (missing, null, non-array, or containing non-string
+      // elements) is an engine-contract violation, not a policy decision: it
+      // must fail closed without a decision record and without ever
+      // constructing OxDeAIDenyError from unvalidated data. See #247.
+      const rawReasons: unknown = evalResult.reasons;
+      if (!isValidDenyReasons(rawReasons)) {
+        throw reject(
+          "POLICY_EVALUATION",
+          "ENGINE_FAILURE",
+          new OxDeAIAuthorizationError(
+            "PolicyEngine returned DENY with malformed reasons: expected an array of strings. " +
+              "Execution blocked."
+          )
+        );
+      }
       await fireDecision(config.onDecision, {
         action,
         decision: "DENY",
-        reasons,
+        reasons: rawReasons,
       });
-      throw new OxDeAIDenyError(reasons);
+      throw new OxDeAIDenyError(rawReasons);
     }
 
     // ── 6. ALLOW: require authorization artifact and nextState ─────────────

--- a/packages/guard/src/test/guard.boundary-audit.test.ts
+++ b/packages/guard/src/test/guard.boundary-audit.test.ts
@@ -34,6 +34,7 @@
  *   B-23 a throwing audit sink does not change what the caller receives
  *   B-24 the record carries no policyDecision; policyEvaluated carries the fact
  *   B-25 the guard behaves identically with no boundary hook configured
+ *   B-28 a malformed DENY (invalid reasons) emits POLICY_EVALUATION / ENGINE_FAILURE, not a decision (#247)
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -905,4 +906,34 @@ test("B-27 defaultNormalizeAction is unchanged by the audit wiring", () => {
   const intent: Intent = defaultNormalizeAction(baseAction);
   assert.equal(intent.agent_id, AGENT_ID);
   assert.equal(intent.amount, 500_000n);
+});
+
+// ── B-28: malformed DENY is an engine-contract violation, not a decision (#247) ──
+
+test("B-28 a malformed DENY (invalid reasons) emits POLICY_EVALUATION / ENGINE_FAILURE, not a decision", async () => {
+  const audit = collect();
+  let onDecisionCalled = false;
+  let executed = false;
+  const guard = OxDeAIGuard(
+    makeGuardConfig({
+      engine: mockEngine(() => ({ decision: "DENY", reasons: undefined })),
+      onDecision: () => { onDecisionCalled = true; },
+      onBoundaryEvent: audit.hook,
+    })
+  );
+
+  const err = await caught(() => guard(baseAction, async () => { executed = true; return "done"; }));
+  assert.ok(err instanceof OxDeAIAuthorizationError);
+  assert.ok(!(err instanceof OxDeAIDenyError), "a malformed DENY must not surface as a valid OxDeAIDenyError");
+  assert.ok(!onDecisionCalled, "a malformed DENY must never be reported on onDecision as a synthetic decision");
+  assert.ok(!executed, "the protected callback must not execute on a malformed DENY");
+
+  const event = only(audit.events);
+  assert.equal(event.stage, "POLICY_EVALUATION");
+  assert.equal(event.boundaryFailure, "ENGINE_FAILURE");
+  assert.equal(
+    event.policyEvaluated,
+    true,
+    "the engine call returned (unlike B-11, where it threw); only its DENY payload was malformed"
+  );
 });

--- a/packages/guard/src/test/guard.property.test.ts
+++ b/packages/guard/src/test/guard.property.test.ts
@@ -694,3 +694,123 @@ test("G7 onDecision hook errors never surface to the caller for any ProposedActi
     await guard(action, async () => "ok");
   }
 });
+
+// ── generators: malformed / valid DENY reasons (#247) ─────────────────────────
+
+/** Generates an arbitrary value that is never a valid `string[]` reasons array. */
+function genMalformedReasons(rng: () => number): unknown {
+  const kind = pick(rng, ["undefined", "null", "scalar", "object", "mixed-array"] as const);
+  switch (kind) {
+    case "undefined": return undefined;
+    case "null": return null;
+    case "scalar": return genScalar(rng);
+    case "object": return genArgs(rng, 3);
+    default: {
+      // Guaranteed at least one non-string element, mixed in among zero or
+      // more strings at a random position, so the array can never happen to
+      // be all-strings by chance.
+      const strCount = randInt(rng, 0, 3);
+      const arr: unknown[] = Array.from({ length: strCount }, () => genAlphaStr(rng, 1, 8));
+      const badElement = pick(rng, [42, true, null, {}, undefined] as const);
+      arr.splice(randInt(rng, 0, arr.length), 0, badElement);
+      return arr;
+    }
+  }
+}
+
+function genValidReasons(rng: () => number): string[] {
+  const count = randInt(rng, 1, 4);
+  return Array.from({ length: count }, () => genAlphaStr(rng, 3, 20).toUpperCase());
+}
+
+function makeMalformedDenyEngine(reasons: unknown): PolicyEngine {
+  return { evaluatePure: () => ({ decision: "DENY" as const, reasons }) } as unknown as PolicyEngine;
+}
+
+function makeReasonsDenyEngine(reasons: string[]): PolicyEngine {
+  return { evaluatePure: () => ({ decision: "DENY" as const, reasons }) } as unknown as PolicyEngine;
+}
+
+// ── G8: malformed DENY reasons always fail closed as an engine-contract violation (#247) ──
+
+test("G8 malformed DENY reasons always fail closed as OxDeAIAuthorizationError, never execute, never onDecision", async () => {
+  for (const seed of seeds()) {
+    const rng = mulberry32(seed);
+    const action = genAction(rng);
+    const agentId = action.context?.agent_id as string;
+    const state = makePermissiveState(agentId);
+    let currentState = state;
+    let currentVersion = 0;
+    let executeCalled = false;
+    let onDecisionCalled = false;
+
+    const malformed = genMalformedReasons(rng);
+
+    const guard = OxDeAIGuard({
+      engine: makeMalformedDenyEngine(malformed),
+      getState: () => ({ state: currentState, version: currentVersion }),
+      setState: (s, v) => { if (v !== currentVersion) return false; currentState = s; currentVersion++; return true; },
+      onDecision: () => { onDecisionCalled = true; },
+      ...BASE_TRUST,
+    });
+
+    await assert.rejects(
+      () => guard(action, async () => { executeCalled = true; }),
+      (err: unknown) => {
+        assert.ok(
+          err instanceof OxDeAIAuthorizationError,
+          `seed=${seed} reasons=${JSON.stringify(malformed)} expected OxDeAIAuthorizationError, got ${Object.prototype.toString.call(err)}`
+        );
+        assert.ok(
+          !(err instanceof OxDeAIDenyError),
+          `seed=${seed} reasons=${JSON.stringify(malformed)} malformed DENY must never surface as OxDeAIDenyError`
+        );
+        return true;
+      },
+      `seed=${seed}`
+    );
+
+    assert.ok(!executeCalled, `seed=${seed} execute must not be called for malformed DENY reasons`);
+    assert.ok(!onDecisionCalled, `seed=${seed} onDecision must not fire for malformed DENY reasons`);
+  }
+});
+
+// ── G9: valid string[] DENY reasons still follow the normal DENY path (control) ──
+
+test("G9 valid string[] DENY reasons always follow the normal DENY path (control)", async () => {
+  for (const seed of seeds()) {
+    const rng = mulberry32(seed);
+    const action = genAction(rng);
+    const agentId = action.context?.agent_id as string;
+    const state = makePermissiveState(agentId);
+    let currentState = state;
+    let currentVersion = 0;
+    let executeCalled = false;
+    let capturedDecision: string | undefined;
+    let capturedReasons: readonly string[] | undefined;
+
+    const validReasons = genValidReasons(rng);
+
+    const guard = OxDeAIGuard({
+      engine: makeReasonsDenyEngine(validReasons),
+      getState: () => ({ state: currentState, version: currentVersion }),
+      setState: (s, v) => { if (v !== currentVersion) return false; currentState = s; currentVersion++; return true; },
+      onDecision: ({ decision, reasons }) => { capturedDecision = decision; capturedReasons = reasons; },
+      ...BASE_TRUST,
+    });
+
+    await assert.rejects(
+      () => guard(action, async () => { executeCalled = true; }),
+      (err: unknown) => {
+        assert.ok(err instanceof OxDeAIDenyError, `seed=${seed} expected OxDeAIDenyError`);
+        assert.deepEqual(err.reasons, validReasons, `seed=${seed} reasons must pass through unchanged`);
+        return true;
+      },
+      `seed=${seed}`
+    );
+
+    assert.ok(!executeCalled, `seed=${seed} execute must not be called on DENY`);
+    assert.equal(capturedDecision, "DENY", `seed=${seed} onDecision must fire with DENY`);
+    assert.deepEqual(capturedReasons, validReasons, `seed=${seed} onDecision must receive the same reasons`);
+  }
+});

--- a/packages/guard/src/test/guard.test.ts
+++ b/packages/guard/src/test/guard.test.ts
@@ -299,6 +299,60 @@ test("guard: DENY fires onDecision hook with DENY decision", async () => {
   assert.equal(capturedDecision, "DENY");
 });
 
+// ── Part 3b: malformed DENY output fails closed (#247) ───────────────────────
+//
+// A DENY result whose `reasons` do not match the engine's public contract
+// (`ReasonCode[]`) previously reached `evalResult.reasons.map(String)`
+// unchecked, so a mock/custom/future engine that violates the contract raised
+// a raw, unclassified `TypeError` instead of failing closed as an explicit
+// engine-contract violation. These pin the fix: malformed DENY output must
+// block execution, must never reach `onDecision` as a synthetic valid DENY,
+// and must surface as `OxDeAIAuthorizationError`, not a `TypeError`.
+
+function makeMalformedDenyEngine(reasons: unknown): PolicyEngine {
+  return {
+    evaluatePure: () => ({ decision: "DENY" as const, reasons }),
+  } as unknown as PolicyEngine;
+}
+
+for (const [label, reasons] of [
+  ["missing reasons (undefined)", undefined],
+  ["reasons: null", null],
+  ["reasons: not an array (a string)", "BUDGET_EXCEEDED"],
+  ["reasons: not an array (an object)", { code: "BUDGET_EXCEEDED" }],
+  ["reasons: array with a non-string element", ["BUDGET_EXCEEDED", 42]],
+] as const) {
+  test(`guard: malformed DENY (${label}) throws OxDeAIAuthorizationError, not TypeError`, async () => {
+    let executed = false;
+    let onDecisionCalled = false;
+
+    const config = makeGuardConfig({
+      engine: makeMalformedDenyEngine(reasons),
+      onDecision: () => { onDecisionCalled = true; },
+    });
+    const guard = OxDeAIGuard(config);
+
+    await assert.rejects(
+      () => guard(baseAction, async () => { executed = true; }),
+      (err: unknown) => {
+        assert.ok(
+          err instanceof OxDeAIAuthorizationError,
+          `expected OxDeAIAuthorizationError, got ${err instanceof Error ? err.constructor.name : String(err)}`
+        );
+        assert.ok(!(err instanceof OxDeAIDenyError), "malformed DENY must not be a synthetic OxDeAIDenyError");
+        assert.match(err.message, /malformed reasons/);
+        return true;
+      }
+    );
+
+    assert.ok(!executed, "execute must not be called on malformed DENY");
+    assert.ok(!onDecisionCalled, "onDecision must not be called for malformed DENY (no synthetic decision record)");
+  });
+}
+
+// (onBoundaryEvent classification for this failure is pinned in
+// guard.boundary-audit.test.ts B-28, alongside the other stage/failure pins.)
+
 // ── Part 4: ALLOW executes ────────────────────────────────────────────────────
 
 test("guard: ALLOW executes and returns the result", async () => {


### PR DESCRIPTION
## Summary

Closes #247.

Make malformed `PolicyEngine` DENY output fail closed explicitly at the guard boundary instead of relying on incidental runtime exceptions or coercion.

The valid DENY contract remains unchanged:

```text
valid DENY
-> GuardDecisionRecord
-> onDecision
-> OxDeAIDenyError
-> execution blocked
````

Malformed DENY output now follows:

```text
malformed DENY
-> engine contract failure
-> POLICY_EVALUATION / ENGINE_FAILURE
-> no synthetic valid DENY decision
-> no protected execution
```

## Root cause

The guard previously consumed:

```ts
evalResult.reasons.map(String)
```

without runtime structural validation.

That allowed malformed engine output to either:

* surface as a raw `TypeError`, or
* be silently coerced into a valid-looking DENY record, for example non-string reason elements.

## Changes

* validate DENY `reasons` before consuming them
* require `reasons` to be an array of strings
* reuse the existing `ENGINE_FAILURE` boundary rejection path
* do not emit `onDecision` for malformed output
* do not construct `OxDeAIDenyError` from malformed engine data
* keep valid ALLOW and DENY semantics unchanged
* update boundary-event documentation for the corrected behavior

## Tests

Added deterministic coverage for:

* missing `reasons`
* `reasons: null`
* non-array `reasons`
* object-valued `reasons`
* arrays containing non-string elements
* structured `onBoundaryEvent` classification
* protected callback remains blocked
* no synthetic `onDecision`

Added property-based coverage using the guard package's existing seeded property-test convention:

* arbitrary invalid `reasons` always fail closed
* valid `string[]` reasons continue through the normal DENY path

Verification:

* guard focused tests: PASS
* guard boundary audit tests: PASS
* guard property tests: PASS
* full guard suite: 211 / 211 PASS
* core suite: 356 / 356 PASS
* policy-boundary security repro: PASS
* `git diff --check`: PASS

## Scope

This PR does not change:

* valid ALLOW/DENY semantics
* `AuthorizationV1`
* `ReasonCode`
* policy modules
* evaluator provenance
* post-execution-start audit semantics
* release/package metadata
