### PR TITLE
docs: refresh 2.0 pre-freeze package guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![CI](https://github.com/oxdeai/oxdeai/actions/workflows/ci.yml/badge.svg)](https://github.com/oxdeai/oxdeai/actions/workflows/ci.yml)
 
-Non-bypassable execution authorization for AI agents.
+Execution authorization for AI agents.
+No valid authorization, no execution through the reviewed enforcement boundary.
 
 Deterministic boundary:
 (intent, state, policy) → ALLOW | DENY
@@ -45,18 +46,36 @@ If `DENY` → execution is unreachable
 
 ## Execution Boundary
 
-OxDeAI enforces a strict invariant:
+OxDeAI enforces a strict invariant at the reviewed enforcement boundary:
 
-> **No authorization → no execution**
+> **No valid authorization, no execution through the reviewed enforcement boundary.**
 
-All tool calls **MUST** pass through the PEP Gateway:
+A tool call routed through the PEP Gateway:
 
-* authorization verified before execution
-* intent hash must match canonical input
-* replay protection enforced
-* fail-closed by default
+* has its authorization verified before execution
+* has its intent hash checked against canonical input
+* is subject to replay protection
+* fails closed by default
 
-There is **no execution path outside the boundary**.
+This holds for calls that go through the boundary. It does not by itself make
+every possible call path in a deployment non-bypassable: see
+[Scope and limits](#scope-and-limits).
+
+---
+
+## Scope and limits
+
+The guarantees above apply to the reviewed enforcement boundary
+(`@oxdeai/guard`), not to a deployment as a whole. A deployment is only as
+strong as its weakest unreviewed call path.
+
+Current, authoritative scope and residual-limit documents for the 2.0 line:
+
+- [`docs/audits/2.0-residual-scope.md`](./docs/audits/2.0-residual-scope.md): what 2.0 targets and what remains out of scope (evaluator/state authority, external-resource TOCTOU, post-execution-start audit semantics).
+- [`docs/audits/external-review-scope-v2.md`](./docs/audits/external-review-scope-v2.md): the current external review scope.
+
+`docs/audits/protocol-audit-post-interoperability.md` is a historical snapshot
+dated 2026-06-04 and is not a current-state reference.
 
 ---
 
@@ -115,7 +134,7 @@ Most agent systems control behavior.
 
 OxDeAI controls execution.
 
-Without an execution boundary, agents are not production-safe.
+Without an execution boundary, unauthorized or unintended execution is not prevented.
 
 ## Applicability
 
@@ -126,11 +145,11 @@ baseline and should generally be preferred.
 
 A detachable authorization artifact is justified in two cases:
 
-* **Independent verification** — the party that must verify the authorization
+* **Independent verification**: the party that must verify the authorization
   is not the party that ran the decision point or controls the enforcement log
   (counterparty, auditor, regulator). Decision logs are evidence the operator
   produced about the operator's own enforcement.
-* **Unreachable premises** — the executor cannot reach the authoritative
+* **Unreachable premises**: the executor cannot reach the authoritative
   inputs required to re-evaluate locally, across a separate trust/network zone
   or third-party boundary.
 
@@ -274,10 +293,11 @@ pnpm build
 
 export OXDEAI_ENGINE_SECRET='test-secret-must-be-at-least-32-chars!!'
 pnpm -C examples/openclaw start
-
----
+```
 
 Runs an OpenClaw agent with enforced execution authorization.
+
+---
 
 ## Delegated Authorization
 

--- a/docs/audits/protocol-audit-post-interoperability.md
+++ b/docs/audits/protocol-audit-post-interoperability.md
@@ -1,5 +1,22 @@
 # Protocol Audit - Post-Interoperability Hardening
 
+> ⚠️ **HISTORICAL SNAPSHOT. SUPERSEDED.** This document records the protocol
+> audit state as it stood on **2026-06-04**. It is preserved as-is for
+> historical record and is **not** the authoritative current-state audit.
+> Some entries below carry later strikethrough/"✓ resolved" annotations from
+> incremental edits made after that date; where those annotations conflict
+> with the surrounding prose (e.g. status labels, assertion counts) this
+> document is not reconciled and should not be read as internally consistent
+> current-state reporting. Do not treat any status, count, or "resolved" note
+> here as reflecting the OxDeAI 2.0 release.
+>
+> For the current OxDeAI 2.0 pre-freeze scope, use:
+>
+> - [`docs/audits/external-review-scope-v2.md`](./external-review-scope-v2.md): current external review scope
+> - [`docs/audits/2.0-residual-scope.md`](./2.0-residual-scope.md): current residual security scope and what 2.0 does/does not target
+>
+> The date below is the original audit date and has not been changed.
+
 **Date:** 2026-06-04
 **Scope:** OxDeAI execution authorization boundary protocol, after completion of the external-provider interoperability hardening sequence
 **Auditor:** Internal protocol audit (Ange)
@@ -342,7 +359,7 @@ New deployments start with an empty replay store. Authorization artifacts issued
 
 ### 7.1 External Implementer Readiness
 
-**Status: PARTIAL** — Status remains PARTIAL because external implementer readiness still depends on independent security review and establishing an external feedback / co-author channel. Profile C cross-language coverage is no longer the blocker; it was resolved by #119 and #120.
+**Status: PARTIAL.** Status remains PARTIAL because external implementer readiness still depends on independent security review and establishing an external feedback / co-author channel. Profile C cross-language coverage is no longer the blocker; it was resolved by #119 and #120.
 
 - `AuthorizationV1` is well-specified and has cross-language conformance vectors (Go harness).
 - Canonicalization-v1 is fully specified with cross-language vectors.

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,7 @@
 Reference integrations and usage examples for OxDeAI.
 
 ## Included
+
 - `gpu-guard` - deterministic GPU provisioning guard with audit chain
 - `langgraph` - LangGraph integration demo with OxDeAI PDP/PEP guard boundary
 - `openai-tools` - OpenAI tools/runtime integration demo with matching policy scenario
@@ -11,3 +12,28 @@ Reference integrations and usage examples for OxDeAI.
 - `autogen` - AutoGen-shaped integration demo with shared boundary contract
 - `openclaw` - OpenClaw-shaped integration demo with the canonical authorization boundary flow
 - `rust-verifier` - reference-only Rust verifier skeleton (`AuthorizationV1` fail-closed path)
+- `agentgram-demo` - deterministic execution boundary for Agentgram actions using the OxDeAI SDK
+- `delegation` - `DelegationV1` demo: a parent agent delegates strictly narrowed authority to a child agent
+- `execution-boundary-demo` - two-panel UI contrasting an unprotected path against the OxDeAI-guarded path
+- `lgf-frappe-pep` - minimal OxDeAI PEP for the LGF-managed Frappe Helpdesk proof of concept
+- `non-bypassable-demo` - canonical `Agent -> PEP Gateway -> Protected Upstream` demo: the agent process has no direct call path to the protected upstream
+- `sift` - end-to-end demo tracing the integration path from a Sift governance receipt to OxDeAI execution authorization
+- `sift-boundary-demo` - terminal demo of Sift-to-OxDeAI execution-boundary enforcement across 4 scenarios
+- `reference-sift-oxdeai` - reference implementation of Sift-to-OxDeAI integration with execution-boundary enforcement
+
+## Known-broken at HEAD
+
+The runtime fixes for these are tracked and handled separately from documentation
+changes. Do not treat them as verified until fixed.
+
+- `delegation-demo`: `OxDeAIGuard` construction in `src/scenario.ts` omits the
+  now-required `trustedKeySets`. Both `pnpm start` and `pnpm terminal` currently
+  throw `OxDeAIGuardConfigurationError` on invocation.
+- `non-bypassable-openclaw`: `agent.mjs` builds an unsigned, structurally
+  incomplete `AuthorizationV1` fixture instead of reusing
+  `non-bypassable-demo/auth-fixture.mjs`'s signed fixture. The documented
+  ALLOW / DENY_HASH_MISMATCH / REPLAY scenarios do not currently produce the
+  documented outcomes.
+
+`non-bypassable-demo` is the canonical, currently-working non-bypassability
+example and is unaffected by the above.

--- a/examples/langgraph/README.md
+++ b/examples/langgraph/README.md
@@ -42,7 +42,7 @@ LangGraph workflow node
   -> proposed provision_gpu(asset, region)
   -> createLangGraphGuard (pep.ts)
       -> maps LangGraphToolCall -> ProposedAction
-      -> OxDeAIGuard -> evaluatePure(intent, state)
+      -> OxDeAIGuard -> evaluatePure(intent, state, evaluationTime)
           -> DENY  => OxDeAIDenyError, no execution
           -> ALLOW => Authorization required + verified
   -> execute() called only after authorization check

--- a/examples/lgf-frappe-pep/README.md
+++ b/examples/lgf-frappe-pep/README.md
@@ -168,7 +168,7 @@ docker compose -f examples/lgf-frappe-pep/docker-compose.redis.yml down
 
 The replay backend is one implementation detail behind the PEP boundary. Redis here is used only to validate replay persistence behavior.
 
-CI now runs this same test in the `pep-redis-replay` job in [.github/workflows/ci.yml](/home/ange/OxDeAI-core/.github/workflows/ci.yml:93) against a real `redis:7-alpine` service.
+CI now runs this same test in the `pep-redis-replay` job in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) against a real `redis:7-alpine` service.
 
 That CI job:
 

--- a/examples/openai-tools/README.md
+++ b/examples/openai-tools/README.md
@@ -39,7 +39,7 @@ Agent
   ▼
 PEP  (pep.ts)          ← enforcement point - thin by design, no policy logic
   │
-  ├─ evaluatePure(intent, state)
+  ├─ evaluatePure(intent, state, evaluationTime)
   │     ├─ DENY  → return denial, execution structurally blocked
   │     └─ ALLOW → Authorization artifact issued
   │
@@ -62,7 +62,7 @@ PDP  (policy.ts)       ← decision point - deterministic, pure, no side effects
 ## Execution flow
 
 1. Agent proposes `provision_gpu(asset, region)`
-2. PEP builds an Intent and calls `evaluatePure(intent, state)`
+2. PEP builds an Intent and calls `evaluatePure(intent, state, evaluationTime)`
 3. **DENY** → PEP returns denial; tool is never invoked
 4. **ALLOW** → PEP asserts the Authorization artifact is present (throws if missing)
 5. PEP calls the tool; commits `nextState` from the PDP result

--- a/packages/autogen/README.md
+++ b/packages/autogen/README.md
@@ -1,6 +1,6 @@
 # @oxdeai/autogen
 AutoGen adapter to the OxDeAI execution-time authorization protocol.
-Sends AutoGen tool calls through @oxdeai/guard; enforcement is local, fail-closed, non-bypassable.
+Sends AutoGen tool calls through @oxdeai/guard; enforcement is local and fail-closed.
 
 ---
 
@@ -36,6 +36,7 @@ const guard = createAutoGenGuard({
   getState,    // () => { state, version } | Promise<{ state, version }>
   setState,    // (state, expectedVersion) => boolean | Promise<boolean>  (CAS)
   agentId: "gpu-agent-1",
+  trustedKeySets: [myKeySet], // required, passed through to OxDeAIGuard
 });
 
 // In your AutoGen function executor:
@@ -62,6 +63,7 @@ const guard = createAutoGenGuard({
   getState,
   setState,
   agentId: "gpu-agent-1",
+  trustedKeySets: [myKeySet],
   mapActionToIntent(action) {
     // action.name, action.args, action.context.agent_id and intent_id are available
     return buildProvisionIntent(action.args.asset as string, action.args.region as string);
@@ -102,10 +104,14 @@ semantics as every other OxDeAI protocol demo:
 
 - **No Authorization = no execution**, even on ALLOW
 - **DENY** blocks the execute callback before it is called
-- **State transitions** happen only after successful execution
+- **State (CAS) commit happens before `execute()` runs**, not after; a failure
+  inside `execute()` does not roll the state commit back
 - **Envelope verification** remains offline and deterministic
 
 All of this is guaranteed by `@oxdeai/guard` - this package adds nothing on top.
+See [`@oxdeai/guard` Known limits](../guard/README.md#known-limits) for what
+this boundary does not cover (evaluator/state authority, external-resource
+TOCTOU, post-execution-start audit semantics).
 
 ---
 
@@ -127,8 +133,8 @@ would activate the module against a value the caller controls, which is weaker t
 leaving it unset.
 
 Deployments that require authenticated Tier 1 evaluator-input provenance should
-establish trusted execution context at an authenticating PEP — where a principal is
-actually authenticated and the route is resolved — and integrate `createSecureGuard`
+establish trusted execution context at an authenticating PEP (where a principal is
+actually authenticated and the route is resolved) and integrate `createSecureGuard`
 from `@oxdeai/guard` there. A framework adapter has no authenticated principal of its
 own, so it cannot construct that context honestly.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,8 +1,19 @@
 # @oxdeai/cli
-CLI for the OxDeAI execution-time authorization protocol (non-bypassable execution boundary).
-Runs local verification and artifact inspection; no valid authorization → execution should not proceed.
+CLI for the OxDeAI execution-time authorization protocol.
+Runs local verification and artifact inspection; no valid authorization means execution should not proceed.
 
 `@oxdeai/cli` is a thin Node.js wrapper around `@oxdeai/core` verification and local state workflows. It is framework-agnostic and intended for local policy operations, artifact inspection, and deterministic verification.
+
+## Version and registry status
+
+The published npm package (`npm view @oxdeai/cli version`) is `0.2.4`. This
+repository's current `packages/cli/package.json` version is `0.3.0`
+(unreleased). The two differ in behavior, not just number: per
+[`CHANGELOG.md`](./CHANGELOG.md), `0.3.0` enforces a valid `engine_secret` on
+the validation path and requires an explicit `--trusted-keyset` (or
+`--mode best-effort`) on strict `verify` entry points; the published `0.2.4`
+does neither. Commands below and their env-var requirements describe this
+repository's `0.3.0` behavior, not the currently published `0.2.4` artifact.
 
 ## Quickstart
 
@@ -12,6 +23,16 @@ Install the CLI:
 
 ```bash
 npm install -g @oxdeai/cli
+```
+
+This installs the published `0.2.4` line, not the `0.3.0` behavior described
+below. To run the behavior in this repository, use the local monorepo
+workflow instead (see "Local monorepo contributors").
+
+`build`, `verify auth`, and `launch dry-run` require a trusted engine secret:
+
+```bash
+export OXDEAI_ENGINE_SECRET='test-secret-must-be-at-least-32-chars!!'
 ```
 
 Basic commands:
@@ -76,7 +97,8 @@ Legacy helper commands are still available (`init`, `launch`, `state`, `audit`, 
 
 ### build
 
-Builds a canonical snapshot verification payload from state.
+Builds a canonical snapshot verification payload from state. Requires
+`OXDEAI_ENGINE_SECRET` (see Quickstart).
 
 ```bash
 oxdeai build snapshot
@@ -129,6 +151,7 @@ oxdeai verify all
 ### auth
 
 Creates and inspects authorization artifacts for local relying-party tests.
+`auth create` requires `OXDEAI_ENGINE_SECRET`; `auth inspect` does not.
 
 ```bash
 oxdeai auth create PROVISION 100 us-east-1 --agent agent-1 --nonce 1 --out authorization.json --json
@@ -154,7 +177,8 @@ oxdeai examples init
 
 ### launch dry-run
 
-Evaluates an action without mutating local state or audit files.
+Evaluates an action without mutating local state or audit files. Requires
+`OXDEAI_ENGINE_SECRET`.
 
 ```bash
 oxdeai launch dry-run PROVISION 100 us-east-1 --agent agent-1 --nonce 1 --json
@@ -162,7 +186,11 @@ oxdeai launch dry-run PROVISION 100 us-east-1 --agent agent-1 --nonce 1 --json
 
 ### replay
 
-Protocol-aware stub in `0.1.x`. It returns a clear unsupported response and points users to deterministic audit verification (`verify --kind audit`).
+Protocol-aware stub. The current implementation (`packages/cli/src/main.ts`)
+reports itself as `@oxdeai/cli v0.2.x` in this message; that string has not
+been updated to match this package's own `package.json` version (`0.3.0`,
+unreleased). It returns a clear unsupported response and points users to
+deterministic audit verification (`verify --kind audit`).
 
 ## Output and Exit Codes
 

--- a/packages/conformance/README.md
+++ b/packages/conformance/README.md
@@ -113,7 +113,13 @@ Signing domain: `OXDEAI_KRL_V1`. KRL signing fixture key (`krl-2026-01`, issuer 
 
 **Coverage scope:** TypeScript / `@oxdeai/core` conformance runner. No cross-language harness integration in Patch A. `SiftHttpKeyStore` integration deferred to Patch B.
 
-Current validator assertion count: `209`.
+### Trusted-Time Semantics (v2.0+)
+
+- `trusted-time.json` - exercises the trusted-time freshness gate (`docs/spec/core/trusted-time-v1.md`) end to end: issuance, velocity, tool-window, and replay evaluation under trusted `evaluationTime`, plus protocol-domain and malformed-input rejection.
+
+44 vectors, 1 assertion each, run via a dedicated `runTrustedTimeConformance` harness (`src/trustedTimeConformance.ts`) rather than the generic vector-comparison path used by the sets above.
+
+Current validator assertion count: `259` (re-run `pnpm -C packages/conformance validate` for the live figure before relying on this number).
 
 ### Adapter ops required for DelegationV1
 
@@ -143,6 +149,7 @@ compatibility but not used by the harness runners.
 | `delegation-signature-verification.json` | Ed25519 verification path | Yes - independently verified |
 | `key-lifecycle-verification.json` | Key status (active/revoked/retired), `not_before`/`not_after` windows, wrong-kid rejection | Yes - portable across any `verifyAuthorization` implementation |
 | `clock-semantics-verification.json` | Strict zero-tolerance expiry, `issued_at` informational, Encoding A + B boundary pins | Yes - portable; no crypto required |
+| `trusted-time.json` | Trusted-time freshness gate: issuance, velocity, tool-window, replay under `evaluationTime`; protocol-domain and malformed-input rejection | TypeScript only (dedicated `runTrustedTimeConformance` harness) |
 | `profile-c-state-verification.json` | Semantic state verification: hash comparison, strategy mismatch, compute-throws, TOCTOU, Encoding B | TypeScript only (TS runner); **Go + Python cover all 8 modes** via `docs/spec/test-vectors/profile-c-state-verification.json` (#120) |
 | `delegation.property.test.ts` (D-P1–D-P5) | PBT over scope / hash / mutation | TypeScript only |
 | `guard.delegation.property.test.ts` (G-D1–G-D3) | Guard PEP delegation path | TypeScript only |
@@ -159,8 +166,11 @@ pnpm -C packages/conformance validate
 Expected success output includes:
 
 ```text
-Conformance passed: 209 assertions
+Conformance passed: 259 assertions
 ```
+
+(This figure moves as vectors are added. Treat the live `pnpm validate` output
+as authoritative, not this number.)
 
 ## Adapter Contract
 The validator is built around a pluggable adapter (`ConformanceAdapter`) so non-TypeScript runtimes can be checked against the same vectors.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,5 +1,5 @@
 # @oxdeai/core
-Execution-time authorization protocol (ETA) - non-bypassable execution boundary.
+Execution-time authorization protocol (ETA): deterministic pre-execution decision layer.
 Deterministic decision: (intent, state, policy) → ALLOW | DENY, emits AuthorizationV1 artifacts.
 Fail-closed verification at the PEP; no valid authorization → no execution path.
 
@@ -22,7 +22,7 @@ Prevents retries, loops, and unintended side effects from ever reaching executio
 ## Quickstart (minimal)
 
 ```ts
-import { PolicyEngine, verifyAuthorization } from "@oxdeai/core";
+import { PolicyEngine, verifyAuthorization, RECOMMENDED_TRUSTED_TIME_PROFILE } from "@oxdeai/core";
 
 const engine = new PolicyEngine({
   policy_version: "v1.7",
@@ -30,8 +30,11 @@ const engine = new PolicyEngine({
   authorization_signing_alg: "Ed25519",
   authorization_private_key_pem: process.env.OXDEAI_SIGNING_KEY_PEM!,
   engine_secret: process.env.OXDEAI_ENGINE_SECRET!,
-  strictDeterminism: true
+  strictDeterminism: true,
+  ...RECOMMENDED_TRUSTED_TIME_PROFILE // maxClockSkewSeconds / maxIntentAgeSeconds: required, no default
 });
+
+const evaluationTime = 1_730_000_000; // trusted PEP clock, sampled once per evaluation, never derived from intent.timestamp
 
 const intent = {
   intent_id: "intent-1",
@@ -60,7 +63,7 @@ const state = {
   tool_limits: { window_seconds: 60, max_calls: { "agent-123": 10 }, calls: {} }
 };
 
-const decision = engine.evaluatePure(intent, state);
+const decision = engine.evaluatePure(intent, state, evaluationTime);
 
 if (decision.decision === "DENY") {
   throw new Error(decision.reasons.join(", "));
@@ -68,7 +71,10 @@ if (decision.decision === "DENY") {
 
 // Allowed: authorization artifact is attached
 const auth = decision.authorization;
-const verified = verifyAuthorization(auth, { policyId: engine.computePolicyId() });
+const verified = verifyAuthorization(auth, {
+  now: evaluationTime, // trusted verifier time: never the ambient wall clock, never intent.timestamp
+  expectedPolicyId: engine.computePolicyId()
+});
 if (verified.status !== "ok") throw new Error("authorization failed verification");
 
 if (decision.decision === "ALLOW") {
@@ -86,7 +92,21 @@ if (decision.decision === "ALLOW") {
 
 Release policy note: OxDeAI uses package-scoped versions and package-scoped tags. `@oxdeai/core` has its own package version line; coordinated release commits do not imply shared package versions across `core`, `sdk`, or `conformance`. See [`docs/release/RELEASE.md`](../../docs/release/RELEASE.md).
 
-Current `@oxdeai/core` package line: **1.7.x**.
+Current `@oxdeai/core` package line: **2.0.0**.
+
+v2.0.0 is a breaking release. See [`CHANGELOG.md`](./CHANGELOG.md) for the full
+list; the changes that affect every call site are:
+
+- `evaluationTime` is now a **required** argument on `evaluate`, `evaluatePure`,
+  and `simulateSequence`. There is no implicit wall-clock fallback and no
+  derivation from `intent.timestamp`.
+- `EngineOptions.maxClockSkewSeconds` and `maxIntentAgeSeconds` are now
+  **required**. A `PolicyEngine` constructed without an explicit trusted-time
+  policy does not start. `RECOMMENDED_TRUSTED_TIME_PROFILE` supplies conformant
+  values for deployments that want to opt into the recommended profile
+  explicitly rather than choosing their own.
+- Verifier options use `expectedPolicyId` (not `policyId`) on
+  `verifyAuthorization`, `verifyAuditEvents`, and `verifyEnvelope`.
 
 v1.7.x adds on top of the preserved v1.6.x verification surface:
 
@@ -302,7 +322,7 @@ Strict mode removes implicit entropy sources.
 ## Show me the invariant
 
 ```ts
-const out = engine.evaluatePure(intent, state);
+const out = engine.evaluatePure(intent, state, evaluationTime);
 if (out.decision !== "ALLOW") throw new Error(out.reasons.join(", "));
 const policyId = engine.computePolicyId();
 const stateHash = engine.computeStateHash(out.nextState);
@@ -324,9 +344,9 @@ No non-deterministic ordering.
 ## Minimal Example
 
 ```ts
-import { PolicyEngine, verifyEnvelope } from "@oxdeai/core";
-const engine = new PolicyEngine({...});
-const decision = engine.evaluatePure(intent, state);
+import { PolicyEngine, verifyEnvelope, RECOMMENDED_TRUSTED_TIME_PROFILE } from "@oxdeai/core";
+const engine = new PolicyEngine({ ...RECOMMENDED_TRUSTED_TIME_PROFILE, /* ... */ });
+const decision = engine.evaluatePure(intent, state, evaluationTime);
 if (decision.decision !== "ALLOW") throw new Error(decision.reasons.join(", "));
 
 const result = verifyEnvelope(envelopeBytes);
@@ -431,21 +451,27 @@ Verification envelopes remain post-execution evidence artifacts verified with `v
 ## Example: Pure Evaluation
 
 ```ts
-import { PolicyEngine } from "@oxdeai/core";
+import { PolicyEngine, RECOMMENDED_TRUSTED_TIME_PROFILE } from "@oxdeai/core";
 import type { State, Intent } from "@oxdeai/core";
 
 // Policy configuration is bound in the engine instance.
-// evaluatePure(intent, state) evaluates against that bound policy.
+// evaluatePure(intent, state, evaluationTime) evaluates against that bound
+// policy at the given trusted evaluation time.
 const engine = new PolicyEngine({
   policy_version: "v1.7",
   authorization_ttl_seconds: 60,
   authorization_signing_alg: "Ed25519",
   authorization_private_key_pem: process.env.OXDEAI_SIGNING_KEY_PEM!,
   engine_secret: process.env.OXDEAI_ENGINE_SECRET!,
-  strictDeterminism: true
+  strictDeterminism: true,
+  ...RECOMMENDED_TRUSTED_TIME_PROFILE // maxClockSkewSeconds / maxIntentAgeSeconds: required, no default
 });
 
-const now = 1730000000; // injected timestamp (seconds)
+// `now` seeds the intent's own (untrusted) timestamp field below.
+// `evaluationTime` is the separate, trusted PEP clock sample passed to
+// evaluatePure. Never derived from intent.timestamp.
+const now = 1730000000;
+const evaluationTime = now;
 
 const state: State = {
   policy_version: "v1.7",
@@ -478,7 +504,7 @@ const intent: Intent = {
   depth: 0
 };
 
-const out = engine.evaluatePure(intent, state, { mode: "fail-fast" });
+const out = engine.evaluatePure(intent, state, evaluationTime, { mode: "fail-fast" });
 
 if (out.decision === "DENY") {
   console.error(out.reasons);
@@ -513,7 +539,7 @@ const releaseIntent: Intent = {
   timestamp: now
 };
 
-const rel = engine.evaluatePure(releaseIntent, out.nextState);
+const rel = engine.evaluatePure(releaseIntent, out.nextState, evaluationTime);
 ```
 
 ---
@@ -583,7 +609,7 @@ Snapshots are portable, deterministic, and verifiable across runtimes.
 ## Adapters (v0.8)
 
 ```ts
-import { PolicyEngine } from "@oxdeai/core";
+import { PolicyEngine, RECOMMENDED_TRUSTED_TIME_PROFILE } from "@oxdeai/core";
 import { FileStateStore, FileAuditSink } from "@oxdeai/core/adapters";
 
 const stateStore = new FileStateStore("./policy-state.bin");
@@ -595,11 +621,12 @@ const engine = new PolicyEngine({
   authorization_signing_alg: "Ed25519",
   authorization_private_key_pem: process.env.OXDEAI_SIGNING_KEY_PEM!,
   engine_secret: process.env.OXDEAI_ENGINE_SECRET!,
+  ...RECOMMENDED_TRUSTED_TIME_PROFILE, // maxClockSkewSeconds / maxIntentAgeSeconds: required, no default
   stateStore,
   auditSink
 });
 
-const out = engine.evaluate(intent, state);
+const out = engine.evaluate(intent, state, evaluationTime);
 engine.commitState(state);
 await engine.flushAudit();
 await engine.flushState();
@@ -617,19 +644,20 @@ In strict mode, verification returns `ok` once the audit trace includes at least
 `verifyAuditEvents(...)` recomputes `auditHeadHash` offline from the provided audit events, and validates policy binding (`policyId`) plus non-decreasing timestamps.
 
 ```ts
-import { PolicyEngine, verifyAuditEvents } from "@oxdeai/core";
+import { PolicyEngine, verifyAuditEvents, RECOMMENDED_TRUSTED_TIME_PROFILE } from "@oxdeai/core";
 const engine = new PolicyEngine({
   policy_version: "v1.7",
   authorization_ttl_seconds: 60,
   authorization_signing_alg: "Ed25519",
   authorization_private_key_pem: process.env.OXDEAI_SIGNING_KEY_PEM!,
-  checkpoint_every_n_events: 2
+  checkpoint_every_n_events: 2,
+  ...RECOMMENDED_TRUSTED_TIME_PROFILE // maxClockSkewSeconds / maxIntentAgeSeconds: required, no default
 });
-const first = engine.evaluatePure(intent1, state);
+const first = engine.evaluatePure(intent1, state, evaluationTime);
 if (first.decision !== "ALLOW") throw new Error(first.reasons.join(", "));
-const out = engine.evaluatePure(intent2, first.nextState);
+const out = engine.evaluatePure(intent2, first.nextState, evaluationTime);
 const events = engine.audit.snapshot();
-const verified = verifyAuditEvents(events, { policyId: engine.computePolicyId() }); // strict by default
+const verified = verifyAuditEvents(events, { expectedPolicyId: engine.computePolicyId() }); // strict by default
 console.log(verified.status === "ok"); // true when checkpoints exist
 ```
 
@@ -728,7 +756,17 @@ Stateless verification layer for protocol artifacts.
 * `@oxdeai/sdk@1.3.2`: JSDoc clarifications pointing to `createVerifier` and explicit trust
 * Conformance: deterministic secret fixture, env var override removed from validator
 
-### v2.x - Verifiable Execution Infrastructure (planned)
+### v2.0 - Trusted-Time & Verification Hardening (this release)
+
+- `evaluationTime` required on every evaluation entry point (`evaluate`, `evaluatePure`, `simulateSequence`); no implicit wall-clock fallback, no derivation from `intent.timestamp`
+- `EngineOptions.maxClockSkewSeconds` / `maxIntentAgeSeconds` required, with `RECOMMENDED_TRUSTED_TIME_PROFILE` as an explicit opt-in default
+- Verifier options renamed to `expectedPolicyId` across `verifyAuthorization`, `verifyAuditEvents`, `verifyEnvelope`
+- Public `AuthorizationV1` artifact boundary separated from the engine's internal representation (`toPublicAuthorizationV1`)
+- `@oxdeai/guard` Tier 1 secure path (`createSecureGuard`, `createTrustedExecutionContext`): see [`@oxdeai/guard`](../guard/README.md)
+
+See [`CHANGELOG.md`](./CHANGELOG.md) for the complete breaking-change list.
+
+### v2.x - Verifiable Execution Infrastructure (planned, post-2.0)
 
 - deterministic execution receipts
 - binary Merkle batching of receipt hashes

--- a/packages/crewai/README.md
+++ b/packages/crewai/README.md
@@ -1,5 +1,5 @@
 # @oxdeai/crewai
-CrewAI adapter to the OxDeAI execution-time authorization protocol (non-bypassable boundary).
+CrewAI adapter to the OxDeAI execution-time authorization protocol.
 Routes CrewAI tool calls through @oxdeai/guard; no valid authorization → no execution.
 
 ---
@@ -13,8 +13,8 @@ different shape from OxDeAI's `ProposedAction`. This adapter:
 2. Maps `toolCall.id` → `context.intent_id` (when present)
 3. Passes the resulting `ProposedAction` to `OxDeAIGuard`
 
-Everything else — policy evaluation, authorization verification, state
-persistence, fail-closed behavior — happens inside `@oxdeai/guard`.
+Everything else (policy evaluation, authorization verification, state
+persistence, fail-closed behavior) happens inside `@oxdeai/guard`.
 
 ---
 
@@ -36,6 +36,7 @@ const guard = createCrewAIGuard({
   getState,    // () => { state, version } | Promise<{ state, version }>
   setState,    // (state, expectedVersion) => boolean | Promise<boolean>  (CAS)
   agentId: "gpu-agent-1",
+  trustedKeySets: [myKeySet], // required, passed through to OxDeAIGuard
 });
 
 // In your CrewAI tool executor:
@@ -62,6 +63,7 @@ const guard = createCrewAIGuard({
   getState,
   setState,
   agentId: "gpu-agent-1",
+  trustedKeySets: [myKeySet],
   mapActionToIntent(action) {
     // action.name, action.args, action.context.agent_id and intent_id are available
     return buildProvisionIntent(action.args.asset as string, action.args.region as string);
@@ -84,10 +86,10 @@ try {
   await guard(toolCall, execute);
 } catch (err) {
   if (err instanceof OxDeAIDenyError) {
-    // Policy denied — err.reasons contains the violation codes
+    // Policy denied. err.reasons contains the violation codes
     console.error("denied:", err.reasons);
   } else if (err instanceof OxDeAIAuthorizationError) {
-    // Authorization artifact missing or invalid — hard security failure
+    // Authorization artifact missing or invalid. Hard security failure
     throw err;
   }
 }
@@ -102,10 +104,14 @@ semantics as every other OxDeAI protocol demo:
 
 - **No Authorization = no execution**, even on ALLOW
 - **DENY** blocks the execute callback before it is called
-- **State transitions** happen only after successful execution
+- **State (CAS) commit happens before `execute()` runs**, not after; a failure
+  inside `execute()` does not roll the state commit back
 - **Envelope verification** remains offline and deterministic
 
-All of this is guaranteed by `@oxdeai/guard` — this package adds nothing on top.
+All of this is guaranteed by `@oxdeai/guard`, this package adds nothing on top.
+See [`@oxdeai/guard` Known limits](../guard/README.md#known-limits) for what
+this boundary does not cover (evaluator/state authority, external-resource
+TOCTOU, post-execution-start audit semantics).
 
 ---
 
@@ -127,8 +133,8 @@ would activate the module against a value the caller controls, which is weaker t
 leaving it unset.
 
 Deployments that require authenticated Tier 1 evaluator-input provenance should
-establish trusted execution context at an authenticating PEP — where a principal is
-actually authenticated and the route is resolved — and integrate `createSecureGuard`
+establish trusted execution context at an authenticating PEP (where a principal is
+actually authenticated and the route is resolved) and integrate `createSecureGuard`
 from `@oxdeai/guard` there. A framework adapter has no authenticated principal of its
 own, so it cannot construct that context honestly.
 

--- a/packages/guard/README.md
+++ b/packages/guard/README.md
@@ -1,7 +1,20 @@
 # @oxdeai/guard
 Policy Enforcement Point for the OxDeAI execution-time authorization protocol.
-Enforces the non-bypassable execution boundary: verifies AuthorizationV1 locally, fail-closed.
-No valid authorization → no execution callback is invoked.
+Verifies AuthorizationV1 locally, fail-closed.
+No valid authorization, no execution through the reviewed enforcement boundary.
+
+Current `@oxdeai/guard` package line: **2.0.0**. See [`CHANGELOG.md`](./CHANGELOG.md)
+for the full breaking-change list. `expectedAudience` and `trustedKeySets` are
+now required, `getState`/`setState` are versioned/CAS, and `createSecureGuard`
+is new in this release.
+
+This package exposes two entry points:
+
+- **`OxDeAIGuard`**: the lower-level guard API (documented first, below).
+- **`createSecureGuard`**: the Tier 1 secure path, built on top of `OxDeAIGuard`,
+  which additionally reconciles proposer-declared identity against a
+  server-established `TrustedExecutionContext`. See
+  [Tier 1 secure path](#tier-1-secure-path).
 
 ---
 
@@ -14,10 +27,10 @@ gaps.
 
 `@oxdeai/guard` provides that shared layer:
 
-- **One place** for all PEP logic — adapters stay thin.
-- **Fail-closed** — ambiguous state, missing artifacts, or evaluation errors
+- **One place** for all PEP logic: adapters stay thin.
+- **Fail-closed**: ambiguous state, missing artifacts, or evaluation errors
   block execution.
-- **No runtime-specific code** — pure TypeScript, no LangGraph/CrewAI/OpenAI
+- **No runtime-specific code**: pure TypeScript, no LangGraph/CrewAI/OpenAI
   imports.
 
 ---
@@ -40,6 +53,8 @@ const guard = OxDeAIGuard({
   engine,      // PolicyEngine from @oxdeai/core
   getState,    // () => { state, version } | Promise<{ state, version }>
   setState,    // (state, expectedVersion) => boolean | Promise<boolean>  (CAS)
+  expectedAudience: "agent-xyz", // required: must match engine's authorization_audience
+  trustedKeySets: [myKeySet],    // required: KeySets used to verify Ed25519 signatures
 });
 
 // Call it before every tool execution.
@@ -62,6 +77,13 @@ The `execute` callback is **only invoked when the policy engine returns ALLOW
 and the authorization artifact passes cryptographic verification**. On DENY,
 `OxDeAIDenyError` is thrown and execution never reaches the callback.
 
+**Ordering:** the CAS `setState(nextState, expectedVersion)` commit happens
+before `execute()` is invoked, not after. This blocks execution on a
+concurrent-modification conflict before any side effect runs. It does not
+mean the guard confirms `execute()` succeeded before committing state: a
+failure inside `execute()` after the commit does not roll the state commit
+back. See [Known limits](#known-limits).
+
 ---
 
 ## Custom action-to-intent mapping
@@ -79,6 +101,8 @@ const guard = OxDeAIGuard({
   engine,
   getState,
   setState,
+  expectedAudience: "agent-xyz",
+  trustedKeySets: [myKeySet],
   mapActionToIntent(action) {
     return buildIntent({
       agent_id: action.context?.agent_id as string,
@@ -103,18 +127,106 @@ OxDeAIGuard({
   engine,
   getState,
   setState,
+  expectedAudience: "agent-xyz",
+  trustedKeySets: [myKeySet],
 
   // Called after authorization but before execution.
   async beforeExecute(action, authorization) {
     logger.info("executing", { action: action.name, auth_id: authorization.auth_id });
   },
 
-  // Called after every decision (ALLOW and DENY). Errors here are swallowed.
+  // Called after a completed policy decision: a valid ALLOW (once the
+  // protected callback has returned) or a valid DENY. Errors here are
+  // swallowed.
   async onDecision({ action, decision, authorization, reasons }) {
     auditLog.write({ action: action.name, decision, reasons });
   },
+
+  // Called for a rejection raised at the guard boundary BEFORE execute()
+  // starts and that never produced a policy decision: an unbranded trusted
+  // context, a provenance conflict, a delegation replay, a state-hash
+  // mismatch, a CAS conflict. Disjoint from onDecision: a rejection is
+  // reported on exactly one of the two hooks, never both. Errors here are
+  // swallowed.
+  async onBoundaryEvent({ stage, boundaryFailure, policyEvaluated }) {
+    auditLog.write({ stage, boundaryFailure, policyEvaluated });
+  },
 });
 ```
+
+Neither hook reports the outcome of the protected `execute()` callback itself.
+Once `execute()` has started, the guard has already permitted the action; a
+failure inside the callback is the caller's own outcome, not a guard decision,
+and is not represented on either stream (see
+[Known limits](#known-limits)).
+
+---
+
+## Tier 1 secure path
+
+`OxDeAIGuard` (above) trusts whatever `agent_id`, `tool`, and `depth` the
+caller's `ProposedAction`/`Intent` declares. `createSecureGuard` closes that
+gap for deployments that can authenticate the caller and resolve the route
+before evaluation: it reconciles the proposer's declared identity against a
+server-established `TrustedExecutionContext`, and fails closed on conflict,
+before the policy engine ever runs.
+
+```typescript
+import { createSecureGuard, createTrustedExecutionContext } from "@oxdeai/guard";
+
+const guard = createSecureGuard(
+  {
+    engine,
+    getState,
+    setState,
+    expectedAudience: "agent-xyz",
+    trustedKeySets: [myKeySet],
+  },
+  { tenancy: "single-tenant" } // or "multi-tenant": required, never defaulted
+);
+
+// Constructed by the PEP AFTER authenticating the caller and resolving the
+// protected route. Never deserialize this from proposer-controlled request
+// JSON. It is a separate positional argument precisely so there is no place
+// in the request payload to put a forged one.
+const trustedContext = createTrustedExecutionContext({
+  principalId: authenticatedPrincipal.id,
+  agentId: authenticatedPrincipal.agentId,
+  adapterId: "http-adapter",
+  depth: currentCallDepth, // required, never defaulted: no implicit "root call" fallback
+});
+
+const result = await guard(
+  trustedContext,
+  {
+    name: "provision_gpu",
+    args: { asset: "a100", region: "us-east-1" },
+    estimatedCost: 500,
+    resourceType: "gpu",
+    context: { target: "gpu-pool-us-east-1" },
+  },
+  async () => provisionGpu("a100", "us-east-1")
+);
+```
+
+`TrustedExecutionContext` carries trusted/derived execution premises
+(`principalId`, `agentId`, `adapterId`, `depth`, and optionally `tenantId`,
+`tool`, `routeClassification`): values the PEP itself established, not values
+the proposer supplied. For each reconciled field:
+
+- proposer claim **absent** → the trusted premise is used;
+- proposer claim **matches** the trusted premise → used, recorded as matched;
+- proposer claim **conflicts** with the trusted premise → reconciliation fails
+  closed, throwing `OxDeAIProvenanceConflictError` before the engine runs;
+  `execute` is never called.
+
+`OxDeAIGuard` remains available, unchanged, as the lower-level API. Use it
+directly when the deployment cannot yet establish a `TrustedExecutionContext`
+(no authenticated caller identity, no resolved route). `createSecureGuard` is
+built on top of it: the shared enforcement body (state read, evaluation,
+authorization verification, replay consumption, hash binding, CAS,
+execution ordering) is identical; the two entry points differ only in how the
+evaluated intent's provenance is established.
 
 ---
 
@@ -122,21 +234,25 @@ OxDeAIGuard({
 
 | Condition | Outcome |
 |---|---|
-| Engine returns DENY | `OxDeAIDenyError` thrown — execute not called |
+| Engine returns DENY | `OxDeAIDenyError` thrown, execute not called |
 | ALLOW without authorization artifact | `OxDeAIAuthorizationError` thrown |
 | ALLOW without nextState | `OxDeAIAuthorizationError` thrown |
 | `verifyAuthorization` fails | `OxDeAIAuthorizationError` thrown |
 | Normalization fails | `OxDeAINormalizationError` thrown |
 | `evaluatePure` throws | `OxDeAIAuthorizationError` thrown (fail-closed) |
-| Delegation chain verification fails | `OxDeAIDelegationError` thrown — execute not called |
+| Delegation chain verification fails | `OxDeAIDelegationError` thrown, execute not called |
 | Delegation scope widens or expiry exceeds parent | `OxDeAIDelegationError` thrown |
 | In-scope delegation action | `execute` called; `setState` not called on delegation path |
+| (Tier 1 only) proposer claim conflicts with `TrustedExecutionContext` | `OxDeAIProvenanceConflictError` thrown, execute not called |
 
 **There is no code path that executes without a valid, verified authorization.**
+This is a claim about the guard boundary itself. See
+[Known limits](#known-limits) for what it does not cover (state-source
+authority, external-resource TOCTOU, post-execution-start failures).
 
 ---
 
-## Replay store — production requirements
+## Replay store: production requirements
 
 The guard prevents replay via a pluggable `ReplayStore`. Every `auth_id` and
 `delegation_id` is atomically check-and-consumed before execution.
@@ -164,6 +280,7 @@ const guard = OxDeAIGuard({
   engine,
   getState,
   setState,
+  expectedAudience: "agent-xyz",
   trustedKeySets: [myKeySet],
   replayStore: createRedisReplayStore({ client: redis }),
 });
@@ -180,7 +297,7 @@ wins across any number of instances; all others see `null` and receive
 | `AuthorizationV1` | `replay:auth:<auth_id>` |
 | `DelegationV1` | `replay:delegation:<delegation_id>` |
 
-**TTL:** derived from artifact `expiry` — `max(1, expiry - now)`. Keys
+**TTL:** derived from artifact `expiry`: `max(1, expiry - now)`. Keys
 auto-evict after the artifact expires. No manual cleanup required.
 
 **Fail-closed:** if Redis is unavailable (network failure, timeout, restart),
@@ -231,7 +348,7 @@ const myStore: ReplayStore = {
 
 | Class | When thrown |
 |---|---|
-| `OxDeAIDenyError` | Policy DENY — inspect `.reasons` for violation codes |
+| `OxDeAIDenyError` | Policy DENY, inspect `.reasons` for violation codes |
 | `OxDeAIAuthorizationError` | Missing/invalid authorization artifact |
 | `OxDeAIGuardConfigurationError` | Misconfigured guard (programming error) |
 | `OxDeAINormalizationError` | ProposedAction cannot be converted to an Intent |
@@ -256,7 +373,7 @@ The guard verifies the full delegation chain before policy evaluation:
 - Signatures are valid at every link
 
 On any violation, `OxDeAIDelegationError` is thrown and `execute` is never
-called. `setState` is also not called on the delegation path — the scope is
+called. `setState` is also not called on the delegation path: the scope is
 committed by the parent authorization.
 
 Property-based coverage: G-D1 (allow path), G-D2 (all invalid classes fail
@@ -264,19 +381,19 @@ closed), G-D3 (wrong parent hash mismatch).
 
 ---
 
-## Default normalizer — field mapping
+## Default normalizer: field mapping
 
 | `ProposedAction` field | Maps to `Intent` field | Default when absent |
 |---|---|---|
 | `context.agent_id` (**required**) | `agent_id` | throws |
 | `name` | `action_type` (heuristic) | `"PROVISION"` |
-| `resourceType` | `action_type` (overrides name) | — |
+| `resourceType` | `action_type` (overrides name) | - |
 | `estimatedCost` | `amount` (× 1 000 000, bigint) | `0n` |
 | `timestampSeconds` | `timestamp` | `Date.now() / 1000` |
 | `context.target` | `target` | `action.name` |
 | `context.intent_id` | `intent_id` | random hex |
 | `context.nonce` | `nonce` | random bigint |
-| `args` (sorted JSON) | `metadata_hash` (sha256 hex) | — |
+| `args` (sorted JSON) | `metadata_hash` (sha256 hex) | - |
 
 ---
 
@@ -287,6 +404,41 @@ closed), G-D3 (wrong parent hash mismatch).
 - Do **not** add LangGraph / CrewAI / OpenAI / runtime-specific imports here.
 - Runtime adapter packages must remain **thin bindings** that call `OxDeAIGuard`.
 - Do **not** duplicate authorization checks inside adapters.
+
+---
+
+## Known limits
+
+The invariants above describe the guard boundary itself: what happens between
+a proposed action arriving and `execute()` being invoked. They do not extend
+past that boundary. Full detail, including exactly what 2.0 does and does not
+target:
+
+- [`docs/audits/2.0-residual-scope.md`](../../docs/audits/2.0-residual-scope.md)
+- [`docs/audits/external-review-scope-v2.md`](../../docs/audits/external-review-scope-v2.md)
+
+- **Evaluator/state authority.** `createSecureGuard` reconciles trusted
+  *evaluator-input* identity (`agent_id`, `tool`, `depth`), not state or policy
+  authority. `getState()` remains a deployment-supplied function; the guard's
+  only check against it is hash consistency (`state_hash` binding) plus CAS
+  version-conflict detection. Neither proves the state source is honest,
+  current, or non-compromised.
+- **External-resource TOCTOU.** The guard's CAS/state-version check protects
+  OxDeAI's own policy-state transition. It does not serialize mutation of an
+  external resource that the protected `execute()` callback goes on to touch.
+  an authorization can be issued against one resource version and the resource
+  can change before `execute()` runs, with OxDeAI's own state CAS succeeding
+  regardless.
+- **Post-execution-start audit semantics.** `onDecision` and `onBoundaryEvent`
+  together account for everything up through a successful `ALLOW` or a valid
+  `DENY`. Once `execute()` has started, a failure inside the callback is not
+  represented as an `onDecision` record or an `onBoundaryEvent`. It is the
+  caller's own outcome, and the current lifecycle produces no final decision
+  record for it on either stream.
+
+None of these are claimed as solved by 2.0. Do not describe this package as
+guaranteeing state-source authority, generic external-resource TOCTOU safety,
+or complete post-execution-start audit coverage.
 
 ---
 

--- a/packages/langgraph/README.md
+++ b/packages/langgraph/README.md
@@ -1,5 +1,5 @@
 # @oxdeai/langgraph
-LangGraph adapter for the OxDeAI execution-time authorization protocol (non-bypassable boundary).
+LangGraph adapter for the OxDeAI execution-time authorization protocol.
 Maps LangGraph tool calls to @oxdeai/guard; verification stays local and fail-closed.
 
 ---
@@ -36,6 +36,7 @@ const guard = createLangGraphGuard({
   getState,    // () => { state, version } | Promise<{ state, version }>
   setState,    // (state, expectedVersion) => boolean | Promise<boolean>  (CAS)
   agentId: "gpu-agent-1",
+  trustedKeySets: [myKeySet], // required, passed through to OxDeAIGuard
 });
 
 // In your LangGraph tool node:
@@ -84,6 +85,7 @@ const guard = createLangGraphGuard({
   getState,
   setState,
   agentId: "gpu-agent-1",
+  trustedKeySets: [myKeySet],
   mapActionToIntent(action) {
     // action.name, action.args, action.context.agent_id and intent_id are available
     return buildProvisionIntent(action.args.asset as string, action.args.region as string);
@@ -124,10 +126,14 @@ semantics as every other OxDeAI protocol demo:
 
 - **No Authorization = no execution**, even on ALLOW
 - **DENY** blocks the execute callback before it is called
-- **State transitions** happen only after successful execution
+- **State (CAS) commit happens before `execute()` runs**, not after; a failure
+  inside `execute()` does not roll the state commit back
 - **Envelope verification** remains offline and deterministic
 
-All of this is guaranteed by `@oxdeai/guard` - this package adds nothing on top.
+All of this is guaranteed by `@oxdeai/guard`, this package adds nothing on top.
+See [`@oxdeai/guard` Known limits](../guard/README.md#known-limits) for what
+this boundary does not cover (evaluator/state authority, external-resource
+TOCTOU, post-execution-start audit semantics).
 
 ---
 
@@ -149,8 +155,8 @@ would activate the module against a value the caller controls, which is weaker t
 leaving it unset.
 
 Deployments that require authenticated Tier 1 evaluator-input provenance should
-establish trusted execution context at an authenticating PEP — where a principal is
-actually authenticated and the route is resolved — and integrate `createSecureGuard`
+establish trusted execution context at an authenticating PEP (where a principal is
+actually authenticated and the route is resolved) and integrate `createSecureGuard`
 from `@oxdeai/guard` there. A framework adapter has no authenticated principal of its
 own, so it cannot construct that context honestly.
 

--- a/packages/openai-agents/README.md
+++ b/packages/openai-agents/README.md
@@ -1,6 +1,6 @@
 # @oxdeai/openai-agents
 OpenAI Agents SDK adapter for the OxDeAI execution-time authorization protocol.
-All tool calls pass through @oxdeai/guard (non-bypassable boundary, fail-closed verification).
+All tool calls pass through @oxdeai/guard (fail-closed verification).
 
 ---
 
@@ -37,6 +37,7 @@ const guard = createOpenAIAgentsGuard({
   getState,    // () => { state, version } | Promise<{ state, version }>
   setState,    // (state, expectedVersion) => boolean | Promise<boolean>  (CAS)
   agentId: "gpu-agent-1",
+  trustedKeySets: [myKeySet], // required, passed through to OxDeAIGuard
 });
 
 // In your tool execution handler:
@@ -83,6 +84,7 @@ const guard = createOpenAIAgentsGuard({
   getState,
   setState,
   agentId: "gpu-agent-1",
+  trustedKeySets: [myKeySet],
   mapActionToIntent(action) {
     // action.name, action.args (from toolCall.input), action.context.agent_id available
     return buildProvisionIntent(action.args.asset as string, action.args.region as string);
@@ -123,10 +125,14 @@ semantics as every other OxDeAI protocol demo:
 
 - **No Authorization = no execution**, even on ALLOW
 - **DENY** blocks the execute callback before it is called
-- **State transitions** happen only after successful execution
+- **State (CAS) commit happens before `execute()` runs**, not after; a failure
+  inside `execute()` does not roll the state commit back
 - **Envelope verification** remains offline and deterministic
 
-All of this is guaranteed by `@oxdeai/guard` - this package adds nothing on top.
+All of this is guaranteed by `@oxdeai/guard`, this package adds nothing on top.
+See [`@oxdeai/guard` Known limits](../guard/README.md#known-limits) for what
+this boundary does not cover (evaluator/state authority, external-resource
+TOCTOU, post-execution-start audit semantics).
 
 ---
 
@@ -148,8 +154,8 @@ would activate the module against a value the caller controls, which is weaker t
 leaving it unset.
 
 Deployments that require authenticated Tier 1 evaluator-input provenance should
-establish trusted execution context at an authenticating PEP — where a principal is
-actually authenticated and the route is resolved — and integrate `createSecureGuard`
+establish trusted execution context at an authenticating PEP (where a principal is
+actually authenticated and the route is resolved) and integrate `createSecureGuard`
 from `@oxdeai/guard` there. A framework adapter has no authenticated principal of its
 own, so it cannot construct that context honestly.
 

--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -1,6 +1,6 @@
 # @oxdeai/openclaw
 OpenClaw adapter for the OxDeAI execution-time authorization protocol.
-Enforces the non-bypassable execution boundary via @oxdeai/guard; no authorization → no execution.
+Enforces the execution boundary via @oxdeai/guard; no authorization, no execution.
 
 ---
 
@@ -37,6 +37,7 @@ const guard = createOpenClawGuard({
   getState,    // () => { state, version } | Promise<{ state, version }>
   setState,    // (state, expectedVersion) => boolean | Promise<boolean>  (CAS)
   agentId: "gpu-agent-1",
+  trustedKeySets: [myKeySet], // required, passed through to OxDeAIGuard
 });
 
 // In your OpenClaw action dispatcher:
@@ -68,6 +69,7 @@ const guard = createOpenClawGuard({
   getState,
   setState,
   agentId: "gpu-agent-1",
+  trustedKeySets: [myKeySet],
   mapActionToIntent(action) {
     // action.name, action.args, action.context.agent_id,
     // action.context.intent_id (from step_id) and workflow_id are available
@@ -109,10 +111,14 @@ semantics as every other OxDeAI protocol demo:
 
 - **No Authorization = no execution**, even on ALLOW
 - **DENY** blocks the execute callback before it is called
-- **State transitions** happen only after successful execution
+- **State (CAS) commit happens before `execute()` runs**, not after; a failure
+  inside `execute()` does not roll the state commit back
 - **Envelope verification** remains offline and deterministic
 
-All of this is guaranteed by `@oxdeai/guard` - this package adds nothing on top.
+All of this is guaranteed by `@oxdeai/guard`, this package adds nothing on top.
+See [`@oxdeai/guard` Known limits](../guard/README.md#known-limits) for what
+this boundary does not cover (evaluator/state authority, external-resource
+TOCTOU, post-execution-start audit semantics).
 
 ---
 
@@ -134,8 +140,8 @@ would activate the module against a value the caller controls, which is weaker t
 leaving it unset.
 
 Deployments that require authenticated Tier 1 evaluator-input provenance should
-establish trusted execution context at an authenticating PEP — where a principal is
-actually authenticated and the route is resolved — and integrate `createSecureGuard`
+establish trusted execution context at an authenticating PEP (where a principal is
+actually authenticated and the route is resolved) and integrate `createSecureGuard`
 from `@oxdeai/guard` there. A framework adapter has no authenticated principal of its
 own, so it cannot construct that context honestly.
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,12 +1,16 @@
 # @oxdeai/sdk
 Developer toolkit for the OxDeAI execution-time authorization protocol (ETA).
-Builds intents/states and guard boundaries that remain non-bypassable and fail-closed at execution.
+Builds intents/states and guard boundaries that fail closed at execution.
 
 ## Status
 
 Release policy note: OxDeAI uses package-scoped versions and package-scoped tags. `@oxdeai/sdk` has its own package version line; coordinated release commits do not imply shared package versions across `core`, `sdk`, or `conformance`. See [`docs/release/RELEASE.md`](../../docs/release/RELEASE.md).
 
-Current `@oxdeai/sdk` package line: `1.3.x`.
+Current `@oxdeai/sdk` package line: **2.0.0**. `export * from "@oxdeai/core"`
+re-exports core's 2.0 surface, so every core 2.0 breaking change (in particular
+the required `evaluationTime` argument and the now-required
+`maxClockSkewSeconds` / `maxIntentAgeSeconds` engine options) is a consumer-visible
+change here too. See [`CHANGELOG.md`](./CHANGELOG.md) for the full list.
 
 The SDK is an integration surface and does not redefine protocol semantics.
 
@@ -30,9 +34,10 @@ OxDeAI SDK sits at the runtime integration boundary:
 Diagram source/editing policy:
 - [`docs/diagrams/README.md`](../../docs/diagrams/README.md)
 
-## Guard API (v1.3 adoption layer)
+## Guard API
 
-The SDK exposes a framework-agnostic guard boundary:
+The SDK exposes its own framework-agnostic guard boundary, built directly on
+`OxDeAIClient`'s in-process `stateAdapter`/`auditAdapter`/`clock`:
 
 ```ts
 const guard = createGuard({ engine, stateAdapter, auditAdapter, clock });
@@ -49,12 +54,27 @@ This keeps PDP/PEP separation explicit:
 - PDP: `PolicyEngine.evaluatePure(...)` decides
 - PEP: guard callback boundary enforces execute-or-refuse
 
+**`createGuard` is not the canonical universal PEP.** It is a convenience
+boundary scoped to the SDK's own in-process adapters, useful for prototypes,
+scripts, and simple single-process integrations. It does not implement
+versioned/CAS state commits, a pluggable replay store, delegation, or trusted
+execution-context provenance reconciliation.
+
+**[`@oxdeai/guard`](../guard/README.md) is the dedicated enforcement-boundary
+package for the 2.0 architecture.** `OxDeAIGuard` and the Tier 1
+`createSecureGuard` path are what production deployments should use. It is a
+separate package specifically so that every runtime adapter (LangGraph,
+CrewAI, OpenAI Agents SDK, OpenClaw, custom agents) shares one PEP
+implementation instead of each re-implementing this boundary. Prefer
+`@oxdeai/guard` for anything beyond a single-process prototype; treat the
+SDK's `createGuard` as the lower-level/legacy-compatible path it is.
+
 OxDeAI sits below agent frameworks (OpenAI tools, LangGraph, others) as the deterministic authorization boundary.
 
 ## Quick Example
 
 ```ts
-import { PolicyEngine } from "@oxdeai/core";
+import { PolicyEngine, RECOMMENDED_TRUSTED_TIME_PROFILE } from "@oxdeai/core";
 import {
   OxDeAIClient,
   createGuard,
@@ -67,7 +87,8 @@ import {
 const engine = new PolicyEngine({
   policy_version: "v1",
   engine_secret: "example-secret-must-be-32-chars!",
-  authorization_ttl_seconds: 120
+  authorization_ttl_seconds: 120,
+  ...RECOMMENDED_TRUSTED_TIME_PROFILE // maxClockSkewSeconds / maxIntentAgeSeconds: required, no default
 });
 
 const stateAdapter = new InMemoryStateAdapter(

--- a/packages/sift/README.md
+++ b/packages/sift/README.md
@@ -407,7 +407,7 @@ const store = new SiftHttpKeyStore({
 
 **Single-node / single-writer.** `createFileBackedKrlWatermarkStore` uses read-modify-write and is NOT safe for concurrent writes from multiple processes. Multi-node deployments should implement `KrlWatermarkStore` backed by a database with atomic compare-and-set.
 
-**Last-known-good (LKG) signed-KRL cache.** Opt-in cache that improves cold-start and fetch-failure resilience. When configured, `SiftHttpKeyStore` writes the signed KRL payload to the cache after every successful signed verification + durable watermark persistence. On subsequent fetch failures, the cache provides a fallback — but **only after full re-verification through `verifyKrl`**. A cached payload is never trusted without re-verification.
+**Last-known-good (LKG) signed-KRL cache.** Opt-in cache that improves cold-start and fetch-failure resilience. When configured, `SiftHttpKeyStore` writes the signed KRL payload to the cache after every successful signed verification + durable watermark persistence. On subsequent fetch failures, the cache provides a fallback, but **only after full re-verification through `verifyKrl`**. A cached payload is never trusted without re-verification.
 
 ```ts
 import {
@@ -439,9 +439,9 @@ const store = new SiftHttpKeyStore({
 | `createFileBackedSignedKrlCache(path)` | Persistent single-node cache; atomic write |
 
 **Mode behavior:**
-- `signed_required` — valid LKG may be used after re-verification on fetch failure; invalid/expired/malformed LKG fails closed.
-- `signed_preferred` — LKG fallback attempted; if LKG is invalid or absent, preserves existing compatibility behavior.
-- `unsigned_legacy` — LKG is never read or written.
+- `signed_required`: valid LKG may be used after re-verification on fetch failure; invalid/expired/malformed LKG fails closed.
+- `signed_preferred`: LKG fallback attempted; if LKG is invalid or absent, preserves existing compatibility behavior.
+- `unsigned_legacy`: LKG is never read or written.
 
 **No constructor I/O.** LKG is never accessed at construction time. Cache access happens exclusively inside `refresh()`.
 
@@ -453,7 +453,7 @@ const store = new SiftHttpKeyStore({
 
 **Status fields:** `lkgCacheActive: boolean` (true when active `revokedKids` came from LKG), `lkgVerifiedAt?: number` (unix seconds of the LKG entry's `verifiedAt`). No payload, signature bytes, or key material is ever exposed in status.
 
-**Closing RT-TRUST-2.** The KRL transport-integrity gap is closeable for a given deployment when all three are configured: `signed_required` + `KrlWatermarkStore` + `SignedKrlCache`. Without all three, residual risks remain (see `docs/audits/protocol-audit-post-interoperability.md`).
+**Closing RT-TRUST-2.** The KRL transport-integrity gap is closeable for a given deployment when all three are configured: `signed_required` + `KrlWatermarkStore` + `SignedKrlCache`. Without all three, residual risks remain (see [`docs/audits/2.0-residual-scope.md`](../../docs/audits/2.0-residual-scope.md) and [`docs/audits/external-review-scope-v2.md`](../../docs/audits/external-review-scope-v2.md); `docs/audits/protocol-audit-post-interoperability.md` is a historical snapshot dated 2026-06-04, not a current-state reference).
 
 **Deprecation trajectory:**
 
@@ -461,7 +461,7 @@ const store = new SiftHttpKeyStore({
 |---------|--------|
 | Current (`signed_preferred` default) | `unsigned_legacy` warns at construction via `process.emitWarning(DEP_OXDEAI_KRL_UNSIGNED_LEGACY)`; `signed_preferred` unsigned fallback warns once per instance via `console.warn` |
 | `v-next` | See above (already landed) |
-| `v-after` | `unsigned_legacy` removed; default becomes `signed_required` — **breaking change for callers not wiring `verifyKrl`** |
+| `v-after` | `unsigned_legacy` removed; default becomes `signed_required`. **Breaking change for callers not wiring `verifyKrl`** |
 
 ---
 
@@ -480,7 +480,7 @@ import {
 import { verifySignedKrl } from "@oxdeai/core";
 import type { KeySet } from "@oxdeai/core";
 
-// Your KRL signing key sets — distinct from AuthorizationV1 signing keys.
+// Your KRL signing key sets, distinct from AuthorizationV1 signing keys.
 const krlSigningKeySets: KeySet[] = [
   {
     issuer: "your-krl-authority",
@@ -550,7 +550,7 @@ OxDeAI provides:
 - deterministic state binding
 - audience binding
 - replay protection
-- non-bypassable execution enforcement at the PEP
+- fail-closed execution enforcement at the reviewed PEP boundary
 
 These guarantees are intentionally separated.
 
@@ -836,10 +836,10 @@ authoritative at the Sift contract boundary.
 ## Related docs
 
 * `../../docs/adapters/sift.md`
-* `../../docs/spec/authorization-v1.md`
-* `../../docs/spec/pep-gateway-v1.md`
-* `../../docs/spec/verification-v1.md`
-* `../../docs/spec/canonicalization-v1.md`
+* `../../docs/spec/artifacts/authorization-v1.md`
+* `../../docs/spec/enforcement/pep-gateway-v1.md`
+* `../../docs/spec/verification/verification-v1.md`
+* `../../docs/spec/core/canonicalization-v1.md`
 
 ## Invariant
 


### PR DESCRIPTION
## Summary

Refresh OxDeAI 2.0 release-facing documentation before `S_freeze`.

This aligns package READMEs, root guidance, adapter examples, conformance counts, and the historical protocol audit pointer with the current 2.0 APIs and trust boundary.

## Changes

- update stale 1.x / pre-2.0 package guidance
- align `PolicyEngine` examples with trusted-time requirements
- document `createSecureGuard` / `createTrustedExecutionContext`
- distinguish Tier 1 trusted-context enforcement from lower-level guard paths
- add required `trustedKeySets` to adapter README examples
- correct CAS-before-`execute()` ordering claims
- tighten non-bypassability and production-safety wording to the reviewed enforcement boundary
- document `onDecision` vs `onBoundaryEvent`
- reconcile conformance documentation with the current 259-assertion validator result
- distinguish current repo behavior from published CLI registry behavior
- refresh broken/stale spec and example documentation links
- mark the post-interoperability audit as a historical snapshot and point to the current 2.0 residual/review scope
- remove Unicode em dash characters from all changed documentation

## Validation

- `@oxdeai/core`: 373/373 tests pass
- `@oxdeai/guard`: 213/213 tests pass
- `@oxdeai/sdk`: 10/10 tests pass
- conformance: 259/259 assertions pass
- adapter validation: 6/6 PASS, `verifyEnvelope=ok`
- policy-boundary attack repro: all required invariants held
- `git diff --check`: clean
- no production source files changed
- no runtime example code changed

## Remaining pre-freeze blockers

Handled separately:

- broken `examples/delegation-demo`
- broken `examples/non-bypassable-openclaw`
- expired `examples/rust-verifier` fixture
- CLI internal version-string inconsistency

Closes the documentation portion of the OxDeAI 2.0 pre-freeze hardening work.