### PR TITLE
security: separate policy-boundary and advisory gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Core API report fingerprint
         run: pnpm -C packages/core api:fingerprint:check
 
+      - name: Security-gate wiring regression tests
+        run: pnpm run security:gate:test
+
       - name: Website lint (best-effort)
         run: pnpm -C website lint || echo "website lint skipped (format locally)"
 

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -7,7 +7,11 @@ on:
     branches: [main]
 
 jobs:
-  security:
+  # Reproducible: depends only on repo state and inputs. Fails on a
+  # deterministic policy-boundary regression, independent of external
+  # advisory data.
+  security-policy-boundary:
+    name: Security Policy Boundary
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,8 +35,36 @@ jobs:
       - name: Build protocol packages
         run: pnpm build:protocol
 
+      - name: Policy-boundary repro harness
+        run: pnpm run security:policy-boundary
+
+  # Freshness-dependent: the external advisory database can change while the
+  # commit and lockfile stay the same, so this can fail or pass differently
+  # on reruns of the same commit. Never invokes the policy-boundary harness.
+  security-advisory-gate:
+    name: Security Advisory Gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+      - run: corepack enable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install security-gate dependencies
+        run: >-
+          pnpm install --frozen-lockfile
+          --filter .
+          --filter @oxdeai/core...
+          --filter @oxdeai/sdk...
+          --filter @oxdeai/guard...
+
       - name: Audit
         run: pnpm audit --json > audit.json || true
 
-      - name: Security Gate
+      - name: Security advisory gate
         run: node scripts/security-gate.mjs audit.json security/vuln-policy.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,7 @@ pnpm test
 pnpm -C packages/conformance validate
 pnpm test:vectors:all
 pnpm security:gate
+pnpm run security:policy-boundary
 ```
 
 Adapter validation, when relevant:
@@ -306,6 +307,7 @@ pnpm test
 pnpm -C packages/conformance validate
 pnpm test:vectors:all
 pnpm security:gate
+pnpm run security:policy-boundary
 ```
 
 When adapters are affected:

--- a/docs/security/SECURITY-GATE.md
+++ b/docs/security/SECURITY-GATE.md
@@ -9,9 +9,14 @@ Non-normative (developer documentation)
 
 
 
-Repo-level pre-merge security gate (non-normative). Protocol definitions live in `SPEC.md` and `docs/spec/`; this gate enforces repository policy, not OxDeAI protocol artifacts.
+Repo-level pre-merge security checks (non-normative). Protocol definitions live in `SPEC.md` and `docs/spec/`; these checks enforce repository policy, not OxDeAI protocol artifacts.
 
-Deterministic pre-merge authorization: audit intent + state + policy -> ALLOW / DENY.
+Two independent CI checks, both required for release:
+
+- **Security Policy Boundary**: reproducible release check. Runs the repo-local policy-boundary repro harness (`pnpm run security:policy-boundary`). Depends only on repo state and inputs; a given commit produces the same result on every rerun.
+- **Security Advisory Gate**: freshness-dependent security evidence. Evaluates the generated `pnpm audit` output against `security/vuln-policy.json` and the current exception list. The external advisory database can change while the commit and lockfile stay the same, so this check can pass or fail differently across reruns of an unchanged commit.
+
+The advisory gate never invokes the policy-boundary harness, and the harness never depends on advisory data. Neither check's failure is treated as a warning; both block merge on failure.
 
 ## Core invariant
 
@@ -63,7 +68,7 @@ Rules:
 2) Commit the change and re-run the gate.
 3) Remove exceptions once fixed.
 
-## How it runs
+## How the advisory gate runs
 - CI runs `pnpm audit --json > audit.json || true`
 - Then `node scripts/security-gate.mjs audit.json security/vuln-policy.json`
-- Gate prints blocking findings, matched/expired exceptions, warnings, and the final decision (ALLOW / DENY).
+- The gate prints blocking findings, matched/expired exceptions, warnings, and the final decision (ALLOW / DENY). It does not run the policy-boundary harness; that runs as the separate `Security Policy Boundary` CI check (`pnpm run security:policy-boundary`).

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "security:audit": "pnpm audit --json > audit.json || true",
     "security:gate": "node scripts/security-gate.mjs audit.json security/vuln-policy.json",
     "security:policy-boundary": "tsx scripts/security/repro-policy-boundary-attacks.ts",
+    "security:gate:test": "node scripts/test-security-gate.mjs",
     "tags:audit": "node scripts/audit-tags.mjs",
     "tags:cleanup:dry": "node scripts/cleanup-legacy-tags.mjs",
     "tags:cleanup:local": "node scripts/cleanup-legacy-tags.mjs --apply-local --confirm=DELETE_LEGACY_TAGS",

--- a/scripts/security-gate.mjs
+++ b/scripts/security-gate.mjs
@@ -1,13 +1,20 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 /**
- * Security gate: fails when audit findings lack a valid, non-expired exception.
+ * Security advisory gate: fails when audit findings lack a valid, non-expired
+ * exception.
+ *
+ * This is freshness-dependent evidence: the external advisory database can
+ * change while the commit and lockfile stay the same, so the same input can
+ * produce a different decision on a later run. It is deliberately separate
+ * from the reproducible policy-boundary check (`pnpm run security:policy-boundary`),
+ * which depends only on repo state and inputs. Do not reintroduce that
+ * harness here; run it as its own CI check instead.
  *
  * Usage: node scripts/security-gate.mjs audit.json security/vuln-policy.json
  */
 import fs from "node:fs";
 import crypto from "node:crypto";
-import { spawnSync } from "node:child_process";
 
 const args = process.argv.slice(2);
 const [auditPath, policyPath] = args.filter((a) => !a.startsWith("--"));
@@ -150,7 +157,7 @@ for (const f of findings) {
 const fmt = (f) =>
   `${f.severity || "unknown"} | ${f.package || "?"} | id=${f.id || "?"} | path=${f.path || "-"}`;
 
-console.log("== Security Gate ==");
+console.log("== Security Advisory Gate ==");
 console.log(`Findings: ${findings.length}`);
 console.log(`Blocking: ${blocking.length}`);
 console.log(`Matched exceptions: ${matched.length}`);
@@ -207,11 +214,4 @@ if (artifactOut) {
   console.log(`Artifact written to ${artifactOut}`);
 }
 
-console.log("\n== Policy-Boundary Repro Harness ==");
-const harness = spawnSync("pnpm", ["run", "security:policy-boundary"], { stdio: "inherit" });
-const harnessOk = harness.status === 0;
-if (!harnessOk) {
-  console.log(`\nPolicy-boundary repro harness failed (exit code ${harness.status ?? "unknown"}).`);
-}
-
-process.exit(ok && harnessOk ? 0 : 1);
+process.exit(ok ? 0 : 1);

--- a/scripts/test-security-gate.mjs
+++ b/scripts/test-security-gate.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Regression for the security-gate / policy-boundary split (P1).
+ *
+ * Verifies:
+ *  1. advisory ALLOW -> gate exits 0, independent of the harness.
+ *  2. advisory DENY  -> gate exits 1, independent of the harness.
+ *  3. the gate's exit code never varies with the real harness's current
+ *     result (proves scenarios 1-3 of the required matrix: whichever way
+ *     the harness currently runs, the two outcomes never combine).
+ *  4. scripts/security-gate.mjs contains no reference to the harness
+ *     command or its exit code (advisory path never invokes it).
+ *  5. the harness source contains no reference to audit/advisory/exception
+ *     data (policy-boundary path never depends on live advisory data).
+ *  6. the CI workflow defines both checks as independent jobs, each
+ *     invoking only its own command.
+ *
+ * Plain assert + spawnSync, matching scripts/test-api-guard.mjs.
+ */
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDir, "..");
+const gatePath = join(repoRoot, "scripts/security-gate.mjs");
+const harnessPath = join(repoRoot, "scripts/security/repro-policy-boundary-attacks.ts");
+const workflowPath = join(repoRoot, ".github/workflows/security-gate.yml");
+
+const fixtureDir = mkdtempSync(join(tmpdir(), "oxdeai-security-gate-"));
+
+function writeFixturePolicy() {
+  const policyPath = join(fixtureDir, "policy.json");
+  writeFileSync(
+    policyPath,
+    JSON.stringify({
+      rules: { critical: "deny", high: "deny", moderate: "require_exception", low: "warn" },
+      exceptions: [],
+    }),
+  );
+  return policyPath;
+}
+
+function writeAuditFixture(name, advisories) {
+  const auditPath = join(fixtureDir, `${name}.json`);
+  writeFileSync(auditPath, JSON.stringify({ advisories }));
+  return auditPath;
+}
+
+function runGate(auditPath, policyPath) {
+  return spawnSync("node", [gatePath, auditPath, policyPath], { encoding: "utf8" });
+}
+
+try {
+  const policyPath = writeFixturePolicy();
+  const cleanAudit = writeAuditFixture("clean", {});
+  const blockingAudit = writeAuditFixture("blocking", {
+    "adv-1": {
+      id: 999999,
+      module_name: "example-pkg",
+      severity: "high",
+      findings: [{ paths: ["root > example-pkg@1.0.0"] }],
+    },
+  });
+
+  // 1. advisory ALLOW -> exit 0.
+  const allow = runGate(cleanAudit, policyPath);
+  assert.equal(allow.status, 0, `expected gate exit 0 on clean audit, got ${allow.status}\n${allow.stdout}`);
+  assert.match(allow.stdout, /Decision: ALLOW/);
+  process.stdout.write("PASS advisory-allow-exit-0\n");
+
+  // 2. advisory DENY -> exit 1.
+  const deny = runGate(blockingAudit, policyPath);
+  assert.equal(deny.status, 1, `expected gate exit 1 on blocking audit, got ${deny.status}\n${deny.stdout}`);
+  assert.match(deny.stdout, /Decision: DENY/);
+  process.stdout.write("PASS advisory-deny-exit-1\n");
+
+  // 3. independence: run the real harness once, record its current result,
+  // then confirm the gate's exit codes above did not change with it either
+  // way. Before the fix this would have been impossible to state, because
+  // the gate's own exit code was ANDed with the harness's.
+  const harness = spawnSync("pnpm", ["run", "security:policy-boundary"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  const harnessPassed = harness.status === 0;
+  process.stdout.write(`harness current result: ${harnessPassed ? "PASS" : "FAIL"} (status=${harness.status})\n`);
+  // Regardless of harnessPassed, the two gate runs above already produced
+  // exit 0 and exit 1 respectively, driven only by the audit fixture. That
+  // is the independence property: assert it holds for both matrix legs.
+  assert.equal(allow.status, 0, "advisory ALLOW must stay exit 0 regardless of harness result");
+  assert.equal(deny.status, 1, "advisory DENY must stay exit 1 regardless of harness result");
+  process.stdout.write("PASS gate-independent-of-harness-result\n");
+
+  // 4. advisory code path never invokes the harness. A comment naming the
+  // harness (to explain the separation) is fine; a subprocess call is not.
+  const gateSource = readFileSync(gatePath, "utf8");
+  assert.ok(
+    !/spawnSync|spawn\(|execSync|execFileSync/.test(gateSource),
+    "security-gate.mjs must not shell out to any subprocess",
+  );
+  process.stdout.write("PASS advisory-never-invokes-harness\n");
+
+  // 5. policy-boundary code path never depends on live advisory data.
+  const harnessSource = readFileSync(harnessPath, "utf8");
+  for (const token of ["audit.json", "vuln-policy", "advisories", "security-gate"]) {
+    assert.ok(!harnessSource.includes(token), `harness must not reference ${token}`);
+  }
+  process.stdout.write("PASS harness-never-depends-on-advisory-data\n");
+
+  // 6. CI workflow: two independent jobs, each invoking only its own command.
+  const workflow = readFileSync(workflowPath, "utf8");
+  const jobs = workflow.split(/\n  (?=[a-z][a-z0-9-]*:\n)/);
+  const boundaryJob = jobs.find((j) => j.startsWith("security-policy-boundary:"));
+  const advisoryJob = jobs.find((j) => j.startsWith("security-advisory-gate:"));
+  assert.ok(boundaryJob, "workflow must define a security-policy-boundary job");
+  assert.ok(advisoryJob, "workflow must define a security-advisory-gate job");
+  assert.match(boundaryJob, /name: Security Policy Boundary/);
+  assert.match(advisoryJob, /name: Security Advisory Gate/);
+  assert.match(boundaryJob, /security:policy-boundary/);
+  assert.ok(!boundaryJob.includes("security-gate.mjs"), "policy-boundary job must not run the advisory gate script");
+  assert.match(advisoryJob, /security-gate\.mjs/);
+  assert.ok(!advisoryJob.includes("security:policy-boundary"), "advisory job must not run the policy-boundary harness");
+  process.stdout.write("PASS workflow-jobs-independent\n");
+
+  process.stdout.write("\nsecurity-gate split: all checks passed\n");
+} finally {
+  rmSync(fixtureDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

- `scripts/security-gate.mjs` now evaluates only advisory findings against `security/vuln-policy.json`; it no longer invokes or combines its exit status with the policy-boundary harness.
- `.github/workflows/security-gate.yml` now exposes two independent jobs:
  - `Security Policy Boundary`
  - `Security Advisory Gate`
- Added `scripts/test-security-gate.mjs` as a deterministic regression for the wiring split and wired it into CI.
- Updated `docs/security/SECURITY-GATE.md` and `CONTRIBUTING.md` to distinguish reproducible release checks from freshness-dependent security evidence.

No vulnerability policy, exception, or policy-boundary semantics changed.

Both checks remain required by the OxDeAI 2.0 release process.

## Test plan

- [x] `pnpm run security:gate:test`
- [x] advisory gate with fresh audit input: ALLOW
- [x] `pnpm run security:policy-boundary`
- [x] `pnpm validate:adapters`
- [x] `git diff --check`

## Operational follow-up

Branch protection must be updated to replace the previous combined required check with both new status checks after their exact GitHub check names are observed on this PR.

Related to #254
Closes #267