### PR TITLE
security: bind freeze evidence to candidate provenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ git.md
 go-harness/go-harness
 examples/rust-verifier/target/
 audit.json
+security-evidence/
 .local/keys/*
 *.pem
 *.der

--- a/docs/security/SECURITY-GATE.md
+++ b/docs/security/SECURITY-GATE.md
@@ -72,3 +72,14 @@ Rules:
 - CI runs `pnpm audit --json > audit.json || true`
 - Then `node scripts/security-gate.mjs audit.json security/vuln-policy.json`
 - The gate prints blocking findings, matched/expired exceptions, warnings, and the final decision (ALLOW / DENY). It does not run the policy-boundary harness; that runs as the separate `Security Policy Boundary` CI check (`pnpm run security:policy-boundary`).
+
+## Release evidence (freeze candidates)
+
+For a freeze candidate such as `S_freeze`, the plain CI decision above is not
+sufficient release evidence on its own: it does not record which commit or
+lockfile were evaluated. `pnpm run security:evidence` binds the decision to
+the exact candidate SHA and lockfile bytes and retains the raw advisory input.
+See [`security/SECURITY-GATE-ARTIFACT.md`](../../security/SECURITY-GATE-ARTIFACT.md)
+for the artifact schema, provenance fields, and generation/verification
+commands. This is release evidence only; it is not `ExecutionReceiptV1`,
+post-execution evidence, or an OxDeAI protocol artifact.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "security:gate": "node scripts/security-gate.mjs audit.json security/vuln-policy.json",
     "security:policy-boundary": "tsx scripts/security/repro-policy-boundary-attacks.ts",
     "security:gate:test": "node scripts/test-security-gate.mjs",
+    "security:evidence": "pnpm run security:audit && node scripts/security-gate.mjs audit.json security/vuln-policy.json --artifact-out=security-evidence/security-gate-decision.json",
     "tags:audit": "node scripts/audit-tags.mjs",
     "tags:cleanup:dry": "node scripts/cleanup-legacy-tags.mjs",
     "tags:cleanup:local": "node scripts/cleanup-legacy-tags.mjs --apply-local --confirm=DELETE_LEGACY_TAGS",

--- a/scripts/security-gate.mjs
+++ b/scripts/security-gate.mjs
@@ -12,13 +12,28 @@
  * harness here; run it as its own CI check instead.
  *
  * Usage: node scripts/security-gate.mjs audit.json security/vuln-policy.json
+ *   [--artifact-out=path]        write a SecurityGateDecision artifact
+ *   [--candidate-sha=sha]        pin the evaluated commit (else `git rev-parse HEAD`)
+ *   [--lockfile=path]            pin the evaluated lockfile (else repo-root pnpm-lock.yaml)
+ *   [--advisory-source=text]     pin the audit tool identity (else auto-detected pnpm version)
+ *
+ * The last three apply only with --artifact-out. See security/SECURITY-GATE-ARTIFACT.md.
  */
 import fs from "node:fs";
+import path from "node:path";
 import crypto from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 const args = process.argv.slice(2);
 const [auditPath, policyPath] = args.filter((a) => !a.startsWith("--"));
-const artifactOut = args.find((a) => a.startsWith("--artifact-out="))?.split("=", 2)[1] ?? null;
+const flag = (name) => args.find((a) => a.startsWith(`--${name}=`))?.split("=", 2)[1] ?? null;
+const artifactOut = flag("artifact-out");
+const candidateShaFlag = flag("candidate-sha");
+const lockfileFlag = flag("lockfile");
+const advisorySourceFlag = flag("advisory-source");
 
 if (!auditPath || !policyPath) {
   console.error(
@@ -189,29 +204,141 @@ const reason = ok
 console.log(`\nDecision: ${decision}`);
 console.log(`Reason: ${reason}`);
 
+// ── Release-evidence provenance (#268) ──────────────────────────────────────
+//
+// Binds the decision artifact to the exact freeze candidate and dependency
+// graph it was evaluated against. Only computed when an artifact is actually
+// requested (--artifact-out): the plain advisory-check path (no artifact)
+// keeps zero git/filesystem dependencies beyond audit.json and the policy
+// file, exactly as before.
+//
+// candidateSha and lockfileHash are binding, not descriptive: a caller must
+// be able to prove which commit and which exact pnpm-lock.yaml bytes were
+// evaluated. Neither is inferred from a branch name or other mutable ref.
+// If neither an explicit override nor ambient git/filesystem state can
+// establish them, evidence generation fails loudly rather than emitting an
+// artifact with absent or guessed provenance.
+const SHA_RE = /^[0-9a-f]{7,40}$/i;
+
+function resolveCandidateSha(explicit) {
+  if (explicit !== null) {
+    if (!SHA_RE.test(explicit)) {
+      throw new Error(
+        `--candidate-sha must be a hex git commit SHA (7-40 hex chars), got: ${JSON.stringify(explicit)}`
+      );
+    }
+    return explicit.toLowerCase();
+  }
+  try {
+    return execFileSync("git", ["rev-parse", "--verify", "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"]
+    }).trim();
+  } catch (err) {
+    throw new Error(
+      "candidateSha could not be determined: not resolvable via `git rev-parse --verify HEAD` " +
+        `in ${repoRoot}. Pass --candidate-sha=<sha> explicitly for release/freeze tooling. (${err.message})`
+    );
+  }
+}
+
+function resolveLockfileHash(explicit) {
+  const lockfilePath = explicit !== null ? explicit : path.join(repoRoot, "pnpm-lock.yaml");
+  let bytes;
+  try {
+    bytes = fs.readFileSync(lockfilePath);
+  } catch (err) {
+    throw new Error(`lockfileHash could not be determined: cannot read ${lockfilePath} (${err.message})`);
+  }
+  return { lockfilePath, lockfileHash: crypto.createHash("sha256").update(bytes).digest("hex") };
+}
+
+function resolveAdvisorySource(explicit) {
+  if (explicit !== null) return explicit;
+  try {
+    const pnpmVersion = execFileSync("pnpm", ["--version"], { encoding: "utf8" }).trim();
+    return `pnpm audit --json (pnpm ${pnpmVersion})`;
+  } catch {
+    // Best-effort only: version detection is descriptive, not a binding
+    // field, so its absence does not fail evidence generation.
+    return "pnpm audit --json";
+  }
+}
+
+let evidenceError = null;
+
 if (artifactOut) {
-  const policyHash = sha256(rules);
-  const exceptionsHash = sha256(exceptions);
-  const findingsHash = sha256(findings);
-  const inputHash = sha256({ policyHash, exceptionsHash, findingsHash, decision, reason });
+  try {
+    const candidateSha = resolveCandidateSha(candidateShaFlag);
+    const { lockfileHash } = resolveLockfileHash(lockfileFlag);
+    const advisorySource = resolveAdvisorySource(advisorySourceFlag);
 
-  const artifact = {
-    formatVersion: 1,
-    type: "SecurityGateDecision",
-    decision,
-    reason,
-    timestamp: new Date().toISOString(),
-    policyHash,
-    exceptionsHash,
-    findingsHash,
-    inputHash
-  };
+    const artifactDir = path.dirname(artifactOut);
+    fs.mkdirSync(artifactDir, { recursive: true });
 
-  const artifactHash = sha256(artifact);
-  artifact.artifactHash = artifactHash;
+    // Retain the raw advisory input alongside the decision artifact. A
+    // findings hash alone is a commitment, not review evidence.
+    const retainedAuditPath = path.join(artifactDir, "audit.json");
+    if (path.resolve(retainedAuditPath) !== path.resolve(auditPath)) {
+      fs.copyFileSync(auditPath, retainedAuditPath);
+    }
 
-  fs.writeFileSync(artifactOut, stableStringify(artifact) + "\n", "utf8");
-  console.log(`Artifact written to ${artifactOut}`);
+    // Avoid silently overwriting unrelated prior evidence: if a decision
+    // artifact for a different candidate already sits at this path, say so.
+    if (fs.existsSync(artifactOut)) {
+      try {
+        const prior = JSON.parse(fs.readFileSync(artifactOut, "utf8"));
+        if (prior.candidateSha && prior.candidateSha !== candidateSha) {
+          console.log(`\nReplacing prior evidence at ${artifactOut}`);
+          console.log(`  previous candidateSha: ${prior.candidateSha}`);
+          console.log(`  new candidateSha:      ${candidateSha}`);
+        }
+      } catch {
+        console.log(`\n${artifactOut} exists but is not a readable prior SecurityGateDecision; overwriting.`);
+      }
+    }
+
+    const policyHash = sha256(rules);
+    const exceptionsHash = sha256(exceptions);
+    const findingsHash = sha256(findings);
+    const inputHash = sha256({ policyHash, exceptionsHash, findingsHash, decision, reason });
+
+    const artifact = {
+      formatVersion: 2,
+      type: "SecurityGateDecision",
+      decision,
+      reason,
+      timestamp: new Date().toISOString(),
+      candidateSha,
+      lockfileHash,
+      advisorySource,
+      policyHash,
+      exceptionsHash,
+      findingsHash,
+      inputHash
+    };
+
+    const artifactHash = sha256(artifact);
+    artifact.artifactHash = artifactHash;
+
+    fs.writeFileSync(artifactOut, stableStringify(artifact) + "\n", "utf8");
+    console.log(`\nArtifact written to ${artifactOut}`);
+    console.log(`Raw advisory input retained at ${retainedAuditPath}`);
+    console.log(`candidateSha: ${candidateSha}`);
+    console.log(`lockfileHash: ${lockfileHash}`);
+    console.log(`advisorySource: ${advisorySource}`);
+  } catch (err) {
+    evidenceError = err;
+    console.error(`\nEvidence generation failed: ${err.message}`);
+  }
+}
+
+// Evidence-capture failure never downgrades a DENY to a pass, and never
+// upgrades an ALLOW into a false "everything is fine": it is reported and
+// fails the process independently of the advisory decision itself.
+if (evidenceError) {
+  process.exit(1);
 }
 
 process.exit(ok ? 0 : 1);

--- a/scripts/test-security-gate.mjs
+++ b/scripts/test-security-gate.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 /**
- * Regression for the security-gate / policy-boundary split (P1).
+ * Regression for the security-gate / policy-boundary split (P1) and the
+ * release-evidence provenance extension (#268).
  *
  * Verifies:
  *  1. advisory ALLOW -> gate exits 0, independent of the harness.
@@ -15,12 +16,28 @@
  *     data (policy-boundary path never depends on live advisory data).
  *  6. the CI workflow defines both checks as independent jobs, each
  *     invoking only its own command.
+ *  7. exact candidateSha is recorded (explicit pin).
+ *  8. exact SHA-256 of pnpm-lock.yaml bytes is recorded as lockfileHash.
+ *  9. advisorySource is recorded (explicit pin and auto-detected default).
+ * 10. raw audit input is retained alongside the decision artifact.
+ * 11. policyHash / exceptionsHash / findingsHash / inputHash are
+ *     independently reproducible, and inputHash's scope is unchanged by
+ *     the new provenance fields.
+ * 12. artifactHash changes when a bound provenance field changes.
+ * 13. malformed (branch-shaped) or missing required candidate/lockfile
+ *     provenance fails evidence generation clearly (non-zero exit).
+ * 14. changing lockfile bytes changes lockfileHash.
+ * 15. evidence generation does not alter the advisory ALLOW/DENY decision.
  *
- * Plain assert + spawnSync, matching scripts/test-api-guard.mjs.
+ * No PBT: every case here is a fixed, small, enumerable fixture (a handful
+ * of known field mutations and byte changes), not a generative invariant
+ * over an open input domain. Plain assert + spawnSync, matching
+ * scripts/test-api-guard.mjs.
  */
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -51,9 +68,30 @@ function writeAuditFixture(name, advisories) {
   return auditPath;
 }
 
-function runGate(auditPath, policyPath) {
-  return spawnSync("node", [gatePath, auditPath, policyPath], { encoding: "utf8" });
+function runGate(auditPath, policyPath, extraArgs = []) {
+  return spawnSync("node", [gatePath, auditPath, policyPath, ...extraArgs], { encoding: "utf8" });
 }
+
+// Independent reimplementation of security-gate.mjs's canonical hashing, so
+// this test recomputes hashes rather than reusing the gate's own function
+// and trivially agreeing with itself.
+function stableStringify(value) {
+  const sorter = (v) => {
+    if (Array.isArray(v)) return v.map(sorter);
+    if (v && typeof v === "object") {
+      return Object.keys(v)
+        .sort()
+        .reduce((acc, k) => {
+          acc[k] = sorter(v[k]);
+          return acc;
+        }, {});
+    }
+    return v;
+  };
+  return JSON.stringify(sorter(value));
+}
+const sha256 = (v) => createHash("sha256").update(stableStringify(v)).digest("hex");
+const sha256Bytes = (buf) => createHash("sha256").update(buf).digest("hex");
 
 try {
   const policyPath = writeFixturePolicy();
@@ -96,13 +134,17 @@ try {
   assert.equal(deny.status, 1, "advisory DENY must stay exit 1 regardless of harness result");
   process.stdout.write("PASS gate-independent-of-harness-result\n");
 
-  // 4. advisory code path never invokes the harness. A comment naming the
-  // harness (to explain the separation) is fine; a subprocess call is not.
+  // 4. advisory code path never invokes the harness. security-gate.mjs may
+  // shell out for its own release-evidence provenance (git rev-parse, pnpm
+  // --version, #268), so the precise check is: no subprocess call site
+  // references the harness, not "no subprocess calls at all". A comment
+  // naming the harness (to explain the separation) is fine.
   const gateSource = readFileSync(gatePath, "utf8");
-  assert.ok(
-    !/spawnSync|spawn\(|execSync|execFileSync/.test(gateSource),
-    "security-gate.mjs must not shell out to any subprocess",
-  );
+  const subprocessLines = gateSource.split("\n").filter((l) => /spawnSync\(|spawn\(|execSync\(|execFileSync\(/.test(l));
+  assert.ok(subprocessLines.length > 0, "expected at least the provenance-detection subprocess calls to exist");
+  for (const line of subprocessLines) {
+    assert.ok(!line.includes("policy-boundary"), `subprocess call site must not reference the harness: ${line.trim()}`);
+  }
   process.stdout.write("PASS advisory-never-invokes-harness\n");
 
   // 5. policy-boundary code path never depends on live advisory data.
@@ -128,6 +170,196 @@ try {
   process.stdout.write("PASS workflow-jobs-independent\n");
 
   process.stdout.write("\nsecurity-gate split: all checks passed\n");
+
+  // ── Release-evidence provenance (#268) ────────────────────────────────────
+
+  const evidenceDir = join(fixtureDir, "evidence");
+  const lockA = join(fixtureDir, "lock-a.yaml");
+  const lockB = join(fixtureDir, "lock-b.yaml");
+  writeFileSync(lockA, "packages:\n  fixture-a: 1.0.0\n");
+  writeFileSync(lockB, "packages:\n  fixture-b: 2.0.0\n");
+
+  const SHA_A = "a".repeat(40);
+  const SHA_B = "b".repeat(40);
+
+  function generate(auditPath, { candidateSha, lockfile, advisorySource, out }) {
+    return runGate(auditPath, policyPath, [
+      `--artifact-out=${out}`,
+      `--candidate-sha=${candidateSha}`,
+      `--lockfile=${lockfile}`,
+      ...(advisorySource ? [`--advisory-source=${advisorySource}`] : []),
+    ]);
+  }
+
+  // 7-11: exact provenance fields recorded, raw input retained, hashes
+  // independently reproducible from the retained inputs.
+  const artifactPathA = join(evidenceDir, "a", "decision.json");
+  const genA = generate(cleanAudit, {
+    candidateSha: SHA_A,
+    lockfile: lockA,
+    advisorySource: "test-source-a",
+    out: artifactPathA,
+  });
+  assert.equal(genA.status, 0, `expected evidence generation to succeed\n${genA.stdout}\n${genA.stderr}`);
+  const artifactA = JSON.parse(readFileSync(artifactPathA, "utf8"));
+
+  assert.equal(artifactA.candidateSha, SHA_A, "candidateSha must record the exact pinned SHA");
+  process.stdout.write("PASS candidate-sha-recorded\n");
+
+  const expectedLockHashA = sha256Bytes(readFileSync(lockA));
+  assert.equal(artifactA.lockfileHash, expectedLockHashA, "lockfileHash must match independently computed SHA-256");
+  process.stdout.write("PASS lockfile-hash-recorded\n");
+
+  assert.equal(artifactA.advisorySource, "test-source-a", "advisorySource must record the pinned value");
+  process.stdout.write("PASS advisory-source-recorded\n");
+
+  const retainedAuditA = join(evidenceDir, "a", "audit.json");
+  assert.ok(existsSync(retainedAuditA), "raw audit input must be retained alongside the decision artifact");
+  assert.deepEqual(
+    JSON.parse(readFileSync(retainedAuditA, "utf8")),
+    JSON.parse(readFileSync(cleanAudit, "utf8")),
+    "retained audit.json must match the audit input actually evaluated",
+  );
+  process.stdout.write("PASS raw-audit-input-retained\n");
+
+  const rules = { critical: "deny", high: "deny", moderate: "require_exception", low: "warn" };
+  const exceptions = [];
+  const findings = []; // cleanAudit has no advisories
+  const expectedPolicyHash = sha256(rules);
+  const expectedExceptionsHash = sha256(exceptions);
+  const expectedFindingsHash = sha256(findings);
+  const expectedInputHash = sha256({
+    policyHash: expectedPolicyHash,
+    exceptionsHash: expectedExceptionsHash,
+    findingsHash: expectedFindingsHash,
+    decision: "ALLOW",
+    reason: "no blocking findings",
+  });
+  assert.equal(artifactA.policyHash, expectedPolicyHash, "policyHash must be reproducible from the policy input");
+  assert.equal(artifactA.exceptionsHash, expectedExceptionsHash, "exceptionsHash must be reproducible from the exception input");
+  assert.equal(artifactA.findingsHash, expectedFindingsHash, "findingsHash must be reproducible per existing semantics");
+  assert.equal(artifactA.inputHash, expectedInputHash, "inputHash must be reproducible per existing semantics");
+  process.stdout.write("PASS policy-exceptions-findings-input-hash-reproducible\n");
+
+  // 12a: inputHash scope is unchanged from formatVersion 1 (commits to the
+  // advisory decision inputs only). Verified across two REAL, separately
+  // generated artifacts that differ only in candidateSha: their policy,
+  // exceptions, and findings are identical, so inputHash must match even
+  // though each run's own timestamp differs.
+  const artifactPathB = join(evidenceDir, "b", "decision.json");
+  const genB = generate(cleanAudit, {
+    candidateSha: SHA_B,
+    lockfile: lockA,
+    advisorySource: "test-source-a",
+    out: artifactPathB,
+  });
+  assert.equal(genB.status, 0, `expected evidence generation to succeed\n${genB.stdout}`);
+  const artifactB = JSON.parse(readFileSync(artifactPathB, "utf8"));
+
+  assert.notEqual(artifactA.candidateSha, artifactB.candidateSha, "fixture setup: candidateSha must actually differ");
+  assert.equal(artifactA.inputHash, artifactB.inputHash, "inputHash must stay identical when only candidateSha changes");
+  process.stdout.write("PASS input-hash-scope-excludes-candidate-sha\n");
+
+  // 12b: artifactHash must be reproducible from exactly the fields the
+  // retained artifact actually carries (the reviewer question this whole
+  // mechanism exists to answer: "can the integrity hashes be recomputed
+  // from the retained inputs?"). Recomputing over everything present in
+  // artifactA and comparing to the stored artifactHash is also the direct,
+  // correct way to prove candidateSha is bound: if the implementation ever
+  // excluded a present field (such as candidateSha) from its own hash
+  // input, this recomputation - which naively includes every field the
+  // retained JSON actually has - would no longer match the stored value.
+  //
+  // A clone that also changes the field's VALUE (not just presence) is not
+  // used here: hashing a present-but-different-value clone always differs
+  // from a hash computed over that field being entirely absent, regardless
+  // of whether the absence is the bug under test, which would make such a
+  // comparison pass for the wrong reason.
+  const { artifactHash: storedHashA, ...restA } = artifactA;
+  const reproducedHashA = sha256(restA);
+  assert.equal(
+    reproducedHashA,
+    storedHashA,
+    "artifactHash must be reproducible from exactly the retained fields (including candidateSha)",
+  );
+  process.stdout.write("PASS artifact-hash-reproducible-from-retained-fields\n");
+
+  // Sanity: the reimplemented hash function is actually sensitive to
+  // candidateSha's value (not just its presence), so the check above is not
+  // vacuously true for an implementation that hashes a constant.
+  const valueMutated = sha256({ ...restA, candidateSha: SHA_B });
+  assert.notEqual(valueMutated, reproducedHashA, "hash must be sensitive to candidateSha's value");
+  process.stdout.write("PASS artifact-hash-sensitive-to-candidate-sha-value\n");
+
+  // 13: malformed / missing required provenance fails clearly.
+  const badSha = runGate(cleanAudit, policyPath, [
+    `--artifact-out=${join(evidenceDir, "bad-sha", "decision.json")}`,
+    "--candidate-sha=main",
+    `--lockfile=${lockA}`,
+  ]);
+  assert.notEqual(badSha.status, 0, "a branch-shaped --candidate-sha must fail evidence generation");
+  assert.match(badSha.stdout + badSha.stderr, /candidate-sha must be a hex git commit SHA/);
+  assert.ok(!existsSync(join(evidenceDir, "bad-sha", "decision.json")), "no artifact must be written on provenance failure");
+  process.stdout.write("PASS malformed-candidate-sha-fails-clearly\n");
+
+  const missingLockfile = join(fixtureDir, "does-not-exist.yaml");
+  const badLock = runGate(cleanAudit, policyPath, [
+    `--artifact-out=${join(evidenceDir, "bad-lock", "decision.json")}`,
+    `--candidate-sha=${SHA_A}`,
+    `--lockfile=${missingLockfile}`,
+  ]);
+  assert.notEqual(badLock.status, 0, "a missing lockfile path must fail evidence generation");
+  assert.match(badLock.stdout + badLock.stderr, /lockfileHash could not be determined/);
+  process.stdout.write("PASS missing-lockfile-fails-clearly\n");
+
+  // 14: changing lockfile bytes changes lockfileHash.
+  const artifactPathC = join(evidenceDir, "c", "decision.json");
+  const genC = generate(cleanAudit, {
+    candidateSha: SHA_A,
+    lockfile: lockB,
+    advisorySource: "test-source-a",
+    out: artifactPathC,
+  });
+  assert.equal(genC.status, 0, `expected evidence generation to succeed\n${genC.stdout}`);
+  const artifactC = JSON.parse(readFileSync(artifactPathC, "utf8"));
+  assert.notEqual(artifactA.lockfileHash, artifactC.lockfileHash, "different lockfile bytes must produce different lockfileHash");
+  process.stdout.write("PASS lockfile-byte-change-changes-hash\n");
+
+  // 15: evidence generation does not alter the advisory decision. Compare
+  // the plain (no --artifact-out) decision against the evidence-mode
+  // decision for both a clean and a blocking audit.
+  const plainAllow = runGate(cleanAudit, policyPath);
+  assert.match(plainAllow.stdout, /Decision: ALLOW/);
+  assert.match(genA.stdout, /Decision: ALLOW/);
+
+  const plainDeny = runGate(blockingAudit, policyPath);
+  assert.match(plainDeny.stdout, /Decision: DENY/);
+  const denyWithEvidence = generate(blockingAudit, {
+    candidateSha: SHA_A,
+    lockfile: lockA,
+    advisorySource: "test-source-a",
+    out: join(evidenceDir, "deny", "decision.json"),
+  });
+  assert.match(denyWithEvidence.stdout, /Decision: DENY/);
+  assert.equal(denyWithEvidence.status, 1, "DENY must still exit 1 with evidence capture enabled");
+  process.stdout.write("PASS evidence-generation-does-not-alter-decision\n");
+
+  // auto-detected advisorySource default is non-empty when not pinned.
+  const autoArtifactPath = join(evidenceDir, "auto", "decision.json");
+  const genAuto = runGate(cleanAudit, policyPath, [
+    `--artifact-out=${autoArtifactPath}`,
+    `--candidate-sha=${SHA_A}`,
+    `--lockfile=${lockA}`,
+  ]);
+  assert.equal(genAuto.status, 0, `expected auto-detected evidence generation to succeed\n${genAuto.stdout}`);
+  const autoArtifact = JSON.parse(readFileSync(autoArtifactPath, "utf8"));
+  assert.ok(
+    typeof autoArtifact.advisorySource === "string" && autoArtifact.advisorySource.length > 0,
+    "advisorySource must default to a non-empty auto-detected value",
+  );
+  process.stdout.write("PASS advisory-source-auto-detected-default\n");
+
+  process.stdout.write("\nrelease-evidence provenance: all checks passed\n");
 } finally {
   rmSync(fixtureDir, { recursive: true, force: true });
 }

--- a/security/SECURITY-GATE-ARTIFACT.md
+++ b/security/SECURITY-GATE-ARTIFACT.md
@@ -1,15 +1,28 @@
 # Security Gate Decision Artifact
 
-Minimal, deterministic proof of the security authorization gate decision. This is not an OxDeAI runtime authorization artifact; it is a lightweight integrity record for the pre-merge vulnerability gate.
+Release evidence for the freshness-dependent security advisory gate. This is
+not an OxDeAI runtime authorization artifact, not `ExecutionReceiptV1`, and
+not post-execution evidence; it is a release-evidence record binding one
+advisory observation to the exact freeze candidate and dependency graph it
+was evaluated against.
 
-## Format
+The advisory result itself is not deterministic: the external advisory
+database and observation time are mutable inputs, so the same commit and
+lockfile can produce a different decision on a later run. What IS
+reproducible is the hashing: identical retained inputs recompute to identical
+hashes, so a reviewer can verify the artifact was not altered after the fact.
+
+## Format (formatVersion 2)
 ```json
 {
-  "formatVersion": 1,
+  "formatVersion": 2,
   "type": "SecurityGateDecision",
   "decision": "ALLOW",
   "reason": "no blocking findings",
   "timestamp": "2026-04-02T10:00:00.000Z",
+  "candidateSha": "a69f5cee8fb99a46ceff8df6f6b29b1002275335",
+  "lockfileHash": "45b6a7d0f6f5dc590490b9db710c1cef4ec6b71f11593751ba3e8b3832a299df",
+  "advisorySource": "pnpm audit --json (pnpm 9.12.0)",
   "policyHash": "...",
   "exceptionsHash": "...",
   "findingsHash": "...",
@@ -18,31 +31,89 @@ Minimal, deterministic proof of the security authorization gate decision. This i
 }
 ```
 
+`formatVersion: 1` artifacts (no `candidateSha`/`lockfileHash`/`advisorySource`)
+remain valid for their own hash verification; `verify-security-gate-artifact.mjs`
+hashes whatever fields the artifact actually has, so it accepts both versions.
+
 Hashes are SHA-256 over a canonical (sorted-key) JSON representation:
 - `policyHash`: hash of `policy.rules`
 - `exceptionsHash`: hash of `exceptions`
 - `findingsHash`: hash of normalized findings
-- `inputHash`: hash of `{ policyHash, exceptionsHash, findingsHash, decision, reason }`
-- `artifactHash`: hash of the artifact object without the `artifactHash` field
+- `inputHash`: hash of `{ policyHash, exceptionsHash, findingsHash, decision, reason }`. Scope unchanged from formatVersion 1: this is the advisory-decision commitment, independent of which candidate/lockfile produced it.
+- `artifactHash`: hash of the full artifact object (including `candidateSha`, `lockfileHash`, `advisorySource`) without the `artifactHash` field itself. Changing any bound provenance field changes `artifactHash`.
+
+## Provenance fields
+
+- `candidateSha`: the exact Git commit SHA evaluated. Never a branch name or
+  other mutable ref. Defaults to `git rev-parse --verify HEAD`; pin explicitly
+  with `--candidate-sha=<sha>` for release/freeze tooling that must not depend
+  on ambient mutable Git state (for example, generating evidence for `S_freeze`
+  against a specific commit regardless of what branch happens to be checked
+  out). Malformed or undeterminable values fail evidence generation; they are
+  never silently omitted or guessed.
+- `lockfileHash`: SHA-256 of the exact `pnpm-lock.yaml` bytes evaluated.
+  Defaults to the repo-root lockfile; pin explicitly with `--lockfile=<path>`.
+  Also fails generation if the file cannot be read.
+- `advisorySource`: identifies the audit tool/command that produced the raw
+  advisory input (for example `pnpm audit --json (pnpm 9.12.0)`). Best-effort
+  when auto-detected; override with `--advisory-source=<text>` when the
+  environment generating the artifact differs from the one that produced the
+  audit input. This does not claim the advisory database is immutable, only
+  which tool produced the observation.
+
+## Raw advisory input
+
+The raw `pnpm audit --json` output used by the gate is retained alongside the
+decision artifact (same directory, `audit.json`), not just committed to via
+`findingsHash`. A hash without the underlying findings is a commitment, not
+review evidence.
 
 ## What it proves
-- The decision (ALLOW/DENY) for a specific set of inputs.
-- Integrity of the inputs used: policy rules, exceptions, findings.
-- Deterministic reproduction: identical logical inputs produce identical hashes.
+- The decision (ALLOW/DENY) for a specific, retained set of inputs.
+- Integrity of those inputs: policy rules, exceptions, raw findings.
+- Which exact commit and lockfile the observation is bound to.
+- Reproducible hash verification: recomputing the hashes from the retained
+  inputs matches the stored values if the artifact has not been altered.
 
 ## What it does NOT prove
 - No cryptographic signature or key-based trust model.
 - No guarantee of who produced the artifact.
-- Not an OxDeAI runtime authorization artifact.
+- No claim that the advisory database is immutable or that the same commit
+  will produce the same decision on a later run.
+- Not an OxDeAI runtime authorization artifact, `ExecutionReceiptV1`, or
+  post-execution evidence.
 
 ## Generate
+
+Ad hoc (auto-derives candidateSha from HEAD, lockfileHash from the repo-root
+lockfile, advisorySource from the local pnpm version):
 ```
 node scripts/security-gate.mjs audit.json security/vuln-policy.json --artifact-out=security-gate-decision.json
 ```
+
+Release evidence for a specific freeze candidate:
+```
+node scripts/security-gate.mjs audit.json security/vuln-policy.json \
+  --artifact-out=security-evidence/security-gate-decision.json \
+  --candidate-sha=<freeze-candidate-sha>
+```
+
+Full evidence-capture path (writes `security-evidence/audit.json` and
+`security-evidence/security-gate-decision.json`, fails if provenance cannot
+be determined):
+```
+pnpm run security:evidence
+```
+
+`security-evidence/` is gitignored: generated evidence is not committed
+automatically. Committing a specific frozen snapshot is a deliberate,
+separate decision, not something these scripts do on their own.
 
 ## Verify
 ```
 node scripts/verify-security-gate-artifact.mjs security-gate-decision.json
 ```
 
-Expected output: PASS/FAIL with computed vs stored hash. If the hash matches, the artifact is intact for the given content.
+Expected output: PASS/FAIL with computed vs stored hash. If the hash matches,
+the artifact is intact for the given content. This confirms integrity of the
+retained artifact; it does not re-run the audit or re-evaluate policy.


### PR DESCRIPTION
## Summary

Capture release security evidence that binds the freshness-dependent advisory
observation to the exact OxDeAI 2.0 freeze candidate.

The security advisory decision artifact now records:

- exact candidate Git SHA
- SHA-256 of the evaluated `pnpm-lock.yaml`
- advisory source identity
- existing policy, exception, findings, input, and artifact integrity hashes

The raw advisory input is retained alongside the decision artifact so the
observed findings remain inspectable and the integrity fields can be
recomputed.

This does not change vulnerability policy, exceptions, policy-boundary
semantics, or advisory ALLOW/DENY behavior.

This is release evidence only. It does not introduce ExecutionReceiptV1,
post-execution evidence, or a new protocol artifact.

## Evidence flow

```text
pnpm audit --json
    ->
raw audit evidence retained
    ->
Security Advisory Gate
    ->
SecurityGateDecision
      candidateSha
      lockfileHash
      advisorySource
      policyHash
      exceptionsHash
      findingsHash
      inputHash
      artifactHash
````

## Verified bindings

For the current candidate:

* `candidateSha` matches `git rev-parse HEAD`
* `lockfileHash` matches an independent SHA-256 of `pnpm-lock.yaml`
* advisory source is recorded as `pnpm audit --json`
* raw audit input used by the gate is retained
* advisory decision remains unchanged by evidence metadata

## Tests

* [x] `pnpm run security:gate:test`
* [x] candidate SHA recorded and validated
* [x] lockfile hash recorded and independently reproducible
* [x] advisory source recorded
* [x] raw audit input retained
* [x] policy / exception / findings / input hashes reproducible
* [x] artifact hash sensitive to candidate provenance
* [x] malformed candidate SHA fails clearly
* [x] missing lockfile fails clearly
* [x] lockfile mutation changes `lockfileHash`
* [x] evidence metadata does not alter advisory decision
* [x] neutralization probe confirmed candidate binding regression is detected
* [x] `pnpm run security:policy-boundary`
* [x] `pnpm validate:adapters`
* [x] fresh advisory gate: ALLOW, 0 findings
* [x] `git diff --check`

One adapter-validation run failed transiently at LangGraph envelope verification.
Two immediate reruns completed 6/6 PASS. No implementation change was made in
response to that failure.

## Release terminology

The policy-boundary checks are reproducible from repository state and inputs.

The vulnerability advisory observation is freshness-dependent because the
external advisory database can change independently of the candidate commit.

The retained evidence binds that observation to the exact reviewed candidate
without describing the advisory result as deterministic.

Closes #268
Related to #254