### PR TITLE
docs: correct 2.0 release-facing replayability and post-execution evidence claims

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -74,6 +74,8 @@ Note: locked conformance vectors are currently published only for canonicalizati
 
 OxDeAI defines deterministic pre-execution authorization and post-execution evidence verification for autonomous systems.
 
+The 2.0 reference implementation implements the pre-execution authorization boundary (AuthorizationV1, DelegationV1, PEP Gateway). Post-execution evidence verification is a protocol-defined direction; `ExecutionReceiptV1` remains planned and is not part of the stable 2.0 implementation surface (see Protocol Status in README.md).
+
 A conformant implementation MUST produce deterministic outputs for equivalent inputs and MUST enforce the relying-party verification contract before execution occurs.
 
 The protocol defines portable artifacts that can be issued by one system and verified by another, including across language runtimes or infrastructure boundaries.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -362,7 +362,7 @@ if (result.status === "ok") console.log("artifact verified");
 * Fail closed.
 * Make invariants explicit.
 * Make state portable.
-* Make execution replayable.
+* Make authorization decisions replayable.
 * Separate identity from proof.
 * Prefer deterministic containment over probabilistic detection.
 


### PR DESCRIPTION
## Summary

- Correct `packages/core/README.md` from `Make execution replayable.` to `Make authorization decisions replayable.` so the release-facing claim matches the actual 2.0 capability.
- Clarify `SPEC.md` scope so readers can distinguish the implemented 2.0 pre-execution authorization boundary from planned post-execution evidence support.
- State explicitly that `ExecutionReceiptV1` remains planned and is not part of the stable OxDeAI 2.0 implementation surface.
- Sweep the surrounding release-facing documentation for conflicting replayability or post-execution evidence claims. No additional edits were required.

No runtime code, protocol artifact, AuthorizationV1 semantics, replay protection, policy behavior, conformance behavior, or audit scope changed.

## Validation

- [x] `Make execution replayable.` is absent from `packages/core/README.md`
- [x] `Make authorization decisions replayable.` is present
- [x] Release-facing documentation does not claim `ExecutionReceiptV1` is stable in 2.0
- [x] Existing `ExecutionReceiptV1` references remain consistently scoped as planned / not implemented
- [x] Security release evidence remains explicitly distinct from runtime post-execution evidence
- [x] `git diff --check` passes
- [x] No Unicode em dash introduced in changed files

Closes #269  
Related to #254