### PR TITLE
docs: complete targeted OxDeAI 2.0 pre-freeze review

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,22 +259,19 @@ verifyAuthorization(auth, {
 
 ---
 
-## Security Authorization Gate (CI)
+## Release Security Checks (CI)
 
-The repository itself is protected by a deterministic pre-merge authorization boundary.
+The repository uses two separate blocking checks:
 
-```text
-findings + exceptions + policy → ALLOW | DENY
-```
+* **Security Policy Boundary** - a reproducible check of the repo-local
+  policy-boundary attack harness.
+* **Security Advisory Gate** - freshness-dependent security evidence produced
+  from mutable external advisory data and the repository vulnerability policy.
 
-* No valid exception → no merge path
-* High/critical findings → always DENY
-
-The gate can emit a **verifiable decision artifact** (integrity proof).
-
-> Same principle:
-> No valid justification → no merge
-> No valid authorization → no execution
+The advisory gate can emit a hash-bound release-evidence record tied to the
+candidate SHA, lockfile, and retained advisory input. That record is not an
+OxDeAI runtime authorization artifact or an `ExecutionReceiptV1`. See
+[`docs/security/SECURITY-GATE.md`](./docs/security/SECURITY-GATE.md).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-**Last updated:** 2026-06-04
+**Last updated:** 2026-09-03
 
 ---
 
@@ -95,7 +95,8 @@ Current validation posture:
 * Go harness: 28 assertions
 * Python harness: 28 assertions
 * aggregate conformance posture: 265 assertions across TypeScript, Go, and Python
-* security gate: ALLOW
+* security policy-boundary check: pass
+* security advisory evidence: freshness-dependent; rerun and retain it for the exact freeze candidate
 * API fingerprint: unchanged where required
 
 ### Cross-language coverage
@@ -145,7 +146,7 @@ DENY
 * non-bypassable PEP boundary
 * portable offline verification
 * proof-carrying authorization artifacts
-* replay without re-reasoning
+* replay of authorization evaluation and decisions without model re-reasoning
 * explicit trust boundaries
 
 ### Not
@@ -528,7 +529,7 @@ Goal:
 Scope:
 
 * execution receipts
-* `VerificationEnvelopeV1`
+* `VerificationEnvelopeV1` specification/freeze (the Draft codec and verifier are already implemented)
 * Merkle batching
 * proof-of-inclusion
 * optional on-chain anchoring
@@ -588,11 +589,11 @@ authorization remains off-chain-first
 ## Core Specifications
 
 * `docs/spec/core/canonicalization-v1.md`
-* `docs/spec/core/authorization-v1.md`
-* `docs/spec/core/delegation-v1.md`
+* `docs/spec/artifacts/authorization-v1.md`
+* `docs/spec/artifacts/delegation-v1.md`
 * `docs/spec/artifacts/signed-krl-v1.md`
 * `docs/spec/enforcement/pep-gateway-v1.md`
-* `docs/spec/verification-v1.md`
+* `docs/spec/verification/verification-v1.md`
 
 ## Interoperability
 
@@ -606,9 +607,9 @@ authorization remains off-chain-first
 
 ## Operations and Security
 
-* `docs/spec/replay-store-ttl-alignment.md`
-* `docs/spec/threat-model-external-providers.md`
-* `docs/spec/key-custody-and-rotation.md`
+* `docs/architecture/replay-store-ttl-alignment.md`
+* `docs/architecture/threat-model-external-providers.md`
+* `docs/architecture/key-custody-and-rotation.md`
 * `SECURITY.md`
 
 ## Governance and Contribution

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # OxDeAI Specification (v1.3.0)
 
- See: docs/spec/eta-core-v1.md for the minimal Execution-Time Authorization profile. Locked conformance vectors are published for canonicalization, authorization, PEP, and delegation, and pass across TypeScript, Go, and Python verification harnesses executed in CI. AuthorizationV1, PEP Gateway, and DelegationV1 are specified as Stable normative artifacts. SPEC overall remains v1.3.0.
+ See: docs/spec/core/eta-core-v1.md for the minimal Execution-Time Authorization profile. Locked conformance vectors are published for canonicalization, authorization, PEP, and delegation, and pass across TypeScript, Go, and Python verification harnesses executed in CI. AuthorizationV1, PEP Gateway, and DelegationV1 are specified as Stable normative artifacts. SPEC overall remains v1.3.0.
  
 
 > **Status of this document:** This root `SPEC.md` is a versioned index and overview of the

--- a/docs/architecture/eta-positioning-note.md
+++ b/docs/architecture/eta-positioning-note.md
@@ -55,7 +55,7 @@ Learning cannot escape constraints.
 - Unknown action class → DENY  
 - Verification failure → DENY  
 Fully compatible with fail-closed doctrine.
-All hashes and signature preimages MUST use `canonicalization-v1`. Deterministic ordering per `docs/spec/conformance-v1.md`; delegation constraints per `docs/spec/delegation-v1.md`.
+All hashes and signature preimages MUST use `canonicalization-v1`. Deterministic ordering per `docs/spec/conformance/conformance-v1.md`; delegation constraints per `docs/spec/artifacts/delegation-v1.md`.
 
 **8) Positioning**
 - Deterministic execution authorization for autonomous learning systems.  

--- a/docs/architecture/system-m-execution-boundary.md
+++ b/docs/architecture/system-m-execution-boundary.md
@@ -32,7 +32,9 @@ OxDeAI sits on the critical path non-optional, not a sidecar.
 - Capability invariant: actions restricted to approved capability set.  
 - Budget invariant: resource/time/financial ceilings enforced before dispatch.  
 - Failure invariant: repeated or critical faults force deny/lockdown.  
-Learning cannot escape constraints. Constraints are non-bypassable and independent of model behavior.
+For protected actions routed exclusively through the configured PEP, learning
+cannot escape those constraints. Alternate execution paths remain a deployment
+responsibility.
 
 **Learning-Safe Execution Semantics**
 - State inconclusive → DENY  
@@ -40,7 +42,7 @@ Learning cannot escape constraints. Constraints are non-bypassable and independe
 - Unknown action class → DENY  
 - Verification failure → DENY  
 Fail-closed is the default; authorization is deterministic.
-All hashes and signature preimages MUST use `canonicalization-v1`. Deterministic ordering and fail-closed semantics align with `docs/spec/conformance-v1.md`; Delegation single-hop/replay constraints align with `docs/spec/delegation-v1.md`.
+All hashes and signature preimages MUST use `canonicalization-v1`. Deterministic ordering and fail-closed semantics align with `docs/spec/conformance/conformance-v1.md`; Delegation single-hop/replay constraints align with `docs/spec/artifacts/delegation-v1.md`.
 
 **Positioning**
 - Deterministic execution authorization for autonomous learning systems.  

--- a/docs/architecture/why-oxdeai.md
+++ b/docs/architecture/why-oxdeai.md
@@ -43,7 +43,9 @@ The control point is pre-execution:
 - `ALLOW` - the engine emits `AuthorizationV1`
 - the PEP verifies that authorization artifact before the side effect occurs
 
-No execution happens without a verified `ALLOW`. No `AuthorizationV1` exists without a prior deterministic evaluation.
+Through a correctly placed PEP boundary, protected execution does not happen
+without a verified `ALLOW`. No `AuthorizationV1` exists without a prior
+deterministic evaluation.
 
 ## Architecture
 
@@ -115,17 +117,19 @@ parent agent receives AuthorizationV1
   -> child executes within delegated scope
 ```
 
-See [`docs/spec/delegation-v1.md`](../spec/artifacts/delegation-v1.md) for the full artifact specification and chain verification rules.
+See [`docs/spec/artifacts/delegation-v1.md`](../spec/artifacts/delegation-v1.md) for the full artifact specification and chain verification rules.
 
 ## Verification Evidence
 
 OxDeAI preserves a verification path independent of the live runtime:
 
 - **snapshot** - canonical encoding of evaluated policy state
-- **audit events** - hash-chained record of proposed actions, decisions, and execution or refusal
+- **audit events** - hash-chained record of proposed actions, decisions, and any execution or refusal events actually supplied
 - **verification envelope** - packages snapshot plus audit evidence into a portable artifact
 
-`verifyEnvelope()` provides stateless verification of that packaged evidence. It does not require access to the live engine or policy state.
+`verifyEnvelope()` provides stateless verification of that packaged evidence.
+It does not require access to the live engine or policy state, but it is not an
+`ExecutionReceiptV1` and does not establish a complete execution outcome.
 
 This evidence path supports:
 
@@ -187,9 +191,9 @@ OxDeAI does not replace runtimes, orchestration engines, or prompt layers. It en
 
 - [`README.md`](../../README.md)
 - [`SPEC.md`](../../SPEC.md)
-- [`docs/spec/delegation-v1.md`](../spec/artifacts/delegation-v1.md)
-- [`docs/adapter-contract.md`](../adapters/adapter-contract.md)
-- [`docs/pep-production-guide.md`](../architecture/pep-production-guide.md)
+- [`docs/spec/artifacts/delegation-v1.md`](../spec/artifacts/delegation-v1.md)
+- [`docs/adapters/adapter-contract.md`](../adapters/adapter-contract.md)
+- [`docs/architecture/pep-production-guide.md`](../architecture/pep-production-guide.md)
 - [`docs/integrations/README.md`](../integrations/README.md)
 - [`docs/integrations/shared-demo-scenario.md`](../integrations/shared-demo-scenario.md)
 - [`docs/cases/README.md`](../cases/README.md)

--- a/docs/audits/2.0-residual-scope.md
+++ b/docs/audits/2.0-residual-scope.md
@@ -1,13 +1,13 @@
 # OxDeAI 2.0 Residual Security Scope
 
 **Status:** Draft — release-boundary document for the OxDeAI 2.0 line.
-**Companion to:** `docs/audits/openzeppelin-scope-v2.md` (review scope), `docs/audits/protocol-audit-post-interoperability.md` (prior internal audit, 2026-06-04), `docs/architecture/decisions/tier1-evaluator-input-provenance.md` (ADR governing §3), `docs/spec/state-provider-requirements.md` (normative spec governing §3).
+**Companion to:** `docs/audits/external-review-scope-v2.md` (review scope), `docs/audits/protocol-audit-post-interoperability.md` (prior internal audit, 2026-06-04), `docs/architecture/decisions/tier1-evaluator-input-provenance.md` (ADR governing §3), `docs/spec/state-provider-requirements.md` (normative spec governing §3).
 
 ---
 
 ## 1. Purpose
 
-This is a **release-boundary document**, not a backlog dump. Its purpose is to state, precisely and in one place, which security guarantees OxDeAI 2.0 targets and which architectural boundaries remain outside those guarantees **even if the OpenZeppelin review in `openzeppelin-scope-v2.md` passes with no findings**. A residual listed here is not necessarily a defect — several are explicit, documented design boundaries (e.g., "signed does not mean authoritative," §8). What makes this document necessary is that the public claims made for the 2.0 release must not exceed what is listed here as targeted (§2), and must explicitly carry the caveats listed for each residual.
+This is a **release-boundary document**, not a backlog dump. Its purpose is to state, precisely and in one place, which security guarantees OxDeAI 2.0 targets and which architectural boundaries remain outside those guarantees **even if the OpenZeppelin review in `external-review-scope-v2.md` passes with no findings**. A residual listed here is not necessarily a defect — several are explicit, documented design boundaries (e.g., "signed does not mean authoritative," §8). What makes this document necessary is that the public claims made for the 2.0 release must not exceed what is listed here as targeted (§2), and must explicitly carry the caveats listed for each residual.
 
 This document does not track ordinary engineering backlog. Open issues are referenced here only where they bound a security property this release does, or could be perceived to, claim.
 
@@ -92,7 +92,7 @@ Concretely, for every current adapter:
 - `tool` and `depth` fields are **not** populated by any current adapter's default normalization. Because of this, `ToolAmplificationModule` and `RecursionDepthModule` do not constrain execution on adapter-routed paths where those fields are absent — a per-tool cap or a recursion-depth limit configured in policy state simply has no `intent.tool`/`intent.depth` value to match against for these adapters.
 - Adapters remain, deliberately, **lower-level guard integrations**. They do not fabricate a `TrustedExecutionContext` on the caller's behalf, because — per `packages/langgraph/README.md` — "a framework adapter has no authenticated principal of its own, so it cannot construct that context honestly."
 
-Deployments that require authenticated Tier 1 evaluator-input provenance must establish trusted execution context at an authenticating PEP layer of their own and integrate `createSecureGuard` there; the shipped adapters do not provide this today, and migrating them is explicitly deferred (see `openzeppelin-scope-v2.md` §3, "Adapters are not presumed to establish authenticated Tier 1 provenance").
+Deployments that require authenticated Tier 1 evaluator-input provenance must establish trusted execution context at an authenticating PEP layer of their own and integrate `createSecureGuard` there; the shipped adapters do not provide this today, and migrating them is explicitly deferred (see `external-review-scope-v2.md` §3, "Adapters are not presumed to establish authenticated Tier 1 provenance").
 
 ---
 
@@ -155,7 +155,7 @@ The following are open or planned areas, per `ROADMAP.md` and the referenced iss
 
 ## 12. Relationship to external review
 
-This document is expected to change as a result of the OpenZeppelin review described in `docs/audits/openzeppelin-scope-v2.md`:
+This document is expected to change as a result of the OpenZeppelin review described in `docs/audits/external-review-scope-v2.md`:
 
 - Reviewer findings may surface **new** residuals not listed here; this document must be updated to include them.
 - This document must be re-reviewed and updated after the `S_freeze` review completes, and again after `S_fix` is produced.

--- a/docs/protocol/overview.md
+++ b/docs/protocol/overview.md
@@ -26,8 +26,10 @@ OxDeAI evaluates deterministically against the current policy state before execu
 If the decision is `ALLOW`, a signed authorization artifact is emitted.
 If the decision is `DENY`, execution MUST NOT proceed.
 
-No valid authorization artifact → no execution.
-Execution is only reachable through a verified authorization boundary.
+For protected actions routed exclusively through the documented PEP boundary:
+no valid authorization artifact means no execution through that boundary.
+Alternate call paths remain a deployment responsibility; see
+[`docs/audits/2.0-residual-scope.md`](../audits/2.0-residual-scope.md#9-residual-enforcement-placement).
 
 ---
 
@@ -39,7 +41,7 @@ OxDeAI defines the following first-class protocol artifacts:
 |---|---|
 | **AuthorizationV1** | Pre-execution `ALLOW` artifact. Signed, expiring, bound to intent and policy state. |
 | **DelegationV1** | Narrowed sub-authorization issued by a principal to a delegatee. Strictly scoped, locally verifiable. |
-| **VerificationEnvelopeV1** | Portable post-execution evidence bundle. Contains canonical snapshot + audit chain. *(pending specification in docs/spec/)* |
+| **VerificationEnvelopeV1** | Portable canonical snapshot + audit-event bundle for offline verification. It does not attest a complete execution outcome. *(codec/verifier implemented; specification pending in docs/spec/)* |
 | **ExecutionReceiptV1** | *(planned; not specified in this document)* Execution attestation binding receipt to a verified authorization. |
 
 Artifacts are language-independent and MUST be interpreted identically across conformant implementations.
@@ -74,14 +76,14 @@ All hashes and signature preimages MUST use `canonicalization-v1`.
 
 Authorization artifacts are portable and independently verifiable without re-running the policy engine.
 
-The protocol-stable verifier surface is:
+The implemented verifier surface is:
 
 | Verifier | What it checks |
 |---|---|
 | `verifyAuthorization` | Pre-execution gate. Validates an `AuthorizationV1` before allowing execution. |
 | `verifyDelegation` | Validates a `DelegationV1` artifact structurally and against its parent hash. |
 | `verifyDelegationChain` | Validates a delegation + parent authorization pair as a complete chain. |
-| `verifyEnvelope` | Post-execution evidence check. Validates a `VerificationEnvelopeV1` snapshot + audit chain. |
+| `verifyEnvelope` | Validates a `VerificationEnvelopeV1` snapshot + audit chain. The envelope remains Draft and is not an execution receipt. |
 
 Protocol decisions are ALLOW or DENY; error codes are defined in the respective specs (canonicalization, PEP, delegation).
 `ok` / `invalid` / `inconclusive` are interface-level summaries, not protocol-level decisions.
@@ -99,7 +101,8 @@ OxDeAI separates two distinct concerns:
 The OxDeAI boundary sits between them. An agent may have the capability to call an action. It may not execute unless a valid authorization exists for that specific intent and state.
 
 Delegation preserves this invariant: `DelegationV1` can only narrow the delegator's existing authority. Authority cannot be amplified through delegation.
-No valid authorization → no execution path (fail-closed).
+Within the documented PEP boundary, no valid authorization means no execution
+through that boundary (fail-closed).
 
 ---
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oxdeai/cli",
   "version": "0.3.0",
-  "description": "Protocol-focused CLI tooling for OxDeAI artifact build/verify/replay workflows",
+  "description": "Protocol-focused CLI tooling for OxDeAI artifact build, verification, and inspection workflows",
   "license": "Apache-2.0",
   "type": "module",
   "bin": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -444,7 +444,9 @@ If an intent is allowed, the engine emits AuthorizationV1:
 * optional `nonce`, `capability`, `signature`
 * verified pre-execution via `verifyAuthorization()`
 
-Verification envelopes remain post-execution evidence artifacts verified with `verifyEnvelope()`.
+Verification envelopes package a snapshot and audit events for offline
+verification with `verifyEnvelope()`. They are not `ExecutionReceiptV1` and do
+not attest a complete execution outcome.
 
 ---
 


### PR DESCRIPTION
## Summary

- separate reproducible security checks from freshness-dependent advisory evidence
- scope enforcement claims to protected actions routed through the documented PEP boundary
- distinguish `VerificationEnvelopeV1` from a complete execution receipt
- remove the unsupported CLI replay claim from published package metadata
- correct stale audit and specification paths
- preserve explicit residual scope for approval binding, post-execution-start audit semantics, and external-resource TOCTOU

No runtime code, schemas, vectors, or protocol semantics changed.

## Validation

- targeted terminology and high-risk claim sweep
- Markdown link target validation
- `@oxdeai/core` and `@oxdeai/cli` pack inspection
- `pnpm run security:policy-boundary`
- `git diff --check`

Closes #261
Related to #254