### PR TITLE
docs: clarify OxDeAI applicability and deployment topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ points are solved by placing a decision point next to the executor.
 When neither condition applies, do not make the decision detachable.
 
 This boundary came out of a public exchange with a Cerbos maintainer:
-[r/AskNetsec thread](https://www.reddit.com/r/AskNetsec/comments/1vkh8za/) · [applicability discussion](#TBD)
+[r/AskNetsec thread](https://www.reddit.com/r/AskNetsec/comments/1vkh8za/) · [applicability discussion](docs/architecture/why-oxdeai.md#applicability)
 
 ---
 

--- a/docs/architecture/eta-positioning-note.md
+++ b/docs/architecture/eta-positioning-note.md
@@ -15,7 +15,7 @@ Assert OxDeAI as the production enforcement layer for autonomous learning system
 
 **1) Framing Correction**
 - Before: OxDeAI is complementary.  
-- After: OxDeAI is a condition of deployability. Without an execution boundary, System M is control without enforcement; learning systems are not deployable.
+- After: An execution authorization boundary is a condition of deployability. Without one, System M is control without enforcement; learning systems are not deployable.
 
 **2) Territory**
 - Paper domain: learning, adaptation, autonomy.  
@@ -25,7 +25,7 @@ Assert OxDeAI as the production enforcement layer for autonomous learning system
 **3) Architecture Upgrade**
 - Paper path: `System M → Agent → Action → World`  
 - Production path: `System M → Agent → OxDeAI → Execution → World`  
-OxDeAI is on the critical path-non-optional, not a sidecar.
+OxDeAI is on the critical execution path. Authorization enforcement is mandatory, regardless of whether the PEP is deployed inline, as a sidecar, or through another non-bypassable topology.
 
 **4) Mapping to OxDeAI**
 - Auth(A,P,S): present (intent+policy+state → decision)  

--- a/docs/architecture/why-oxdeai.md
+++ b/docs/architecture/why-oxdeai.md
@@ -175,6 +175,26 @@ The demos differ by runtime surface, not by OxDeAI semantics. Each produces the 
 
 Status signals: Canonicalization vectors are locked; AuthorizationV1 / PEP / DelegationV1 are Stable; VerificationEnvelopeV1 pending; ExecutionReceiptV1 planned. Proof points: locked vectors - `docs/spec/test-vectors/canonicalization-v1.json`, `authorization-v1.json`, `pep-vectors-v1.json`, `delegation-vectors-v1.json`.
 
+## Applicability
+
+OxDeAI's detachable authorization model is not the default architecture for every authorization problem.
+
+Prefer inline or sidecar policy evaluation when:
+
+- the evaluator and executor operate within the same trust domain; and
+- the executor can access or reconstruct the authoritative premises required to evaluate the action.
+
+Detachable authorization is justified when at least one of the following applies:
+
+1. An independent relying party must verify what was authorized without relying on the executor or operator's internal logs.
+2. The execution boundary cannot independently access or reconstruct the authoritative premises used to make the authorization decision.
+
+Topology, service separation, or latency alone are not sufficient reasons to introduce detachable authorization.
+
+Outside these cases, a simpler inline or local authorization architecture should generally be preferred.
+
+Here, "sidecar" refers to deployment topology. OxDeAI's enforcement boundary may itself be deployed as a sidecar. This is distinct from whether authorization decisions are detachable and independently verifiable across trust boundaries.
+
 ## Positioning
 
 | Layer | What it does | OxDeAI? |

--- a/packages/core/src/policy/modules/VelocityModule.ts
+++ b/packages/core/src/policy/modules/VelocityModule.ts
@@ -4,7 +4,12 @@ import type { State } from "../../types/state.js";
 import type { PolicyEvaluationContext, PolicyResult } from "../../types/policy.js";
 import { statelessModuleCodec } from "./_codec.js";
 
-/** @public */
+/**
+ * Enforces a fixed-window action limit using trusted evaluation time.
+ * This is not a rolling or sliding-window limiter.
+ *
+ * @public
+ */
 export function VelocityModule(
   intent: Intent,
   state: State,


### PR DESCRIPTION
## Summary

Clarify when OxDeAI's detachable authorization model is appropriate, remove an outdated applicability placeholder, and disambiguate deployment topology from authorization semantics.

This is a documentation/comment-only change. No runtime behavior, protocol semantics, public API, tests, or CI behavior are modified.

## Changes

- add `## Applicability` to `docs/architecture/why-oxdeai.md`
- define when detachable authorization is justified
- clarify that inline and sidecar are deployment topologies, not weaker authorization models
- replace the dead `#TBD` README link with the local applicability section
- clarify that an execution authorization boundary is the deployability requirement, not OxDeAI specifically
- clarify that OxDeAI enforcement remains mandatory when selected as the execution boundary, regardless of inline, sidecar, or other non-bypassable topology
- document `VelocityModule` as a trusted-time fixed-window limiter, not a rolling/sliding-window limiter

## Applicability invariant

Prefer inline or local authorization when the evaluator and executor share the same trust domain and authoritative premises are locally available.

Detachable authorization is justified when:

1. an independent relying party must verify what was authorized without relying on the executor/operator's internal logs; or
2. the execution boundary cannot independently access or reconstruct the authoritative premises used for the decision.

Topology, service separation, or latency alone are not sufficient justification.

## Validation

- `git grep -n '#TBD'` -> no occurrences
- core typecheck -> PASS
- `git diff --check` -> PASS
- no runtime logic changed
- no protocol semantics changed
- no public API changed
- no tests or CI changed

## Scope

Documentation/comment-only cleanup for the OxDeAI 2.0 release surface.