### PR TITLE
ci(rust-verifier): run cargo test in CI so the fixture cannot rot silently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,27 @@ jobs:
         env:
           OXDEAI_ENGINE_SECRET: ci-adapter-validation-secret-testing!!
 
+  rust-verifier:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: examples/rust-verifier
+
+      - name: Rust verifier tests
+        # Pins the bundled fixture's ALLOW/DENY cases at deterministic protocol
+        # time (issue #262). Fails if the fixture or the expiry contract rots.
+        run: cargo test --locked
+        working-directory: examples/rust-verifier
+
   pep-redis-replay:
     runs-on: ubuntu-latest
     services:

--- a/examples/rust-verifier/README.md
+++ b/examples/rust-verifier/README.md
@@ -62,6 +62,11 @@ Expected outcomes in general:
 cargo test
 ```
 
+From the repo root, `pnpm test:rust` runs the same suite with `--locked`. CI runs
+it on every push and pull request (`rust-verifier` job in
+`.github/workflows/ci.yml`), so the bundled fixture cannot silently expire
+or drift out of contract without a red build.
+
 `tests/verify_authorization.rs` verifies the bundled fixture directly:
 
 - ALLOW at its last valid second (`expiry - 1`)

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:vectors:ts": "tsx scripts/verify-canonicalization-vectors.ts",
     "test:vectors:go": "cd go-harness && go run .",
     "test:vectors:py": "python3 python-harness/verify_canonicalization_vectors.py && python3 python-harness/verify_profile_c_vectors.py && python3 python-harness/verify_signed_krl_vectors.py",
+    "test:rust": "cd examples/rust-verifier && cargo test --locked",
     "test:vectors:auth": "node scripts/verify-authorization-vectors.mjs",
     "test:vectors:pep": "node scripts/verify-pep-vectors.mjs",
     "test:vectors:delegation": "node scripts/verify-delegation-vectors.mjs",


### PR DESCRIPTION
Closes the last open acceptance criterion on #262: *"fixture cannot silently expire again without CI detecting it."*

#264 landed the deterministic `VERIFY_NOW` path and the four fixture tests, but nothing runs `cargo test` in CI, so that criterion was still unenforced. This wires it up.

## Changes

- **`.github/workflows/ci.yml`** — new `rust-verifier` job, modeled on the existing Go 1.25 setup: stable toolchain via `dtolnay/rust-toolchain`, cargo cache via `Swatinem/rust-cache` scoped to the example, `cargo test --locked` with `working-directory: examples/rust-verifier`.
- **`package.json`** — root `test:rust` script, listed next to the other harness suites.
- **`examples/rust-verifier/README.md`** — points at the root entry point and the CI job.

`--locked` is deliberate: the example ships a `Cargo.lock`, and CI should fail on drift rather than silently resolve new versions.

## Proof the signal is real

A CI job is only worth adding if it actually goes red when the expiry contract rots. Verified by temporarily breaking the contract in `src/verify_authorization.rs` and observing the failures. Both mutations were reverted; no verifier source is changed by this PR.

**Mutation 1 — verifier ignores the trusted verification time and reads the wall clock.** This is the original defect from the issue: the bundled fixture's fixed expiry is in the past, so the canonical ALLOW case rots.

```
test allow_at_last_valid_second ... FAILED
  assertion `left == right` failed: expected ok, got
  [Violation { code: "AUTH_EXPIRED", message: "authorization has expired" }]
test deny_on_tampered_field ... FAILED
  left: "AUTH_EXPIRED"  right: "AUTH_SIGNATURE_INVALID"
test result: FAILED. 2 passed; 2 failed
```

**Mutation 2 — expiry boundary relaxed from exclusive to inclusive (`<=` to `<`).**

```
test deny_at_expiry_boundary ... FAILED
  left: "ok"  right: "invalid"
test result: FAILED. 3 passed; 1 failed
```

Both exit `101`, so the job fails the build.

## Local run

`cargo 1.98.0`, `rustc 1.98.0`:

```
Running unittests src/main.rs
test tests::absent_uses_real_now ... ok
test tests::valid_i64_overrides_real_now ... ok
test tests::malformed_is_explicit_error ... ok
test result: ok. 3 passed; 0 failed

Running tests/verify_authorization.rs
test allow_at_last_valid_second ... ok
test deny_at_expiry_boundary ... ok
test deny_when_expired ... ok
test deny_on_tampered_field ... ok
test result: ok. 4 passed; 0 failed
```

## Constraints

- No production package source changed. Scope is the example's README, the workflow, and the root `package.json`.
- Fixture expiry not moved into the future, as the issue requires.
- No verification check weakened or bypassed.
