### PR TITLE
docs: document trusted-time residuals for 2.0

### DIFF
--- a/docs/audits/2.0-residual-scope.md
+++ b/docs/audits/2.0-residual-scope.md
@@ -122,7 +122,35 @@ OxDeAI cannot prevent a deployment from exposing an alternate, unguarded executi
 
 ---
 
-## 10. Deferred capabilities
+## 10. Residual: trusted-clock rollback availability risk
+
+When the relevant policy control applies, time-indexed policy state
+intentionally fails closed if trusted `evaluation_time` moves behind persisted
+state. `VelocityModule` returns `STATE_INVALID` when `evaluation_time` is
+earlier than a velocity `window_start`; for a rate-limited tool call,
+`ToolAmplificationModule` likewise returns `STATE_INVALID` if any persisted
+event timestamp is later than `evaluation_time`. Neither module resets a
+window, discards future-dated state, or substitutes another clock.
+
+An NTP clock step backward, failover to a node with a lagging trusted clock, or
+restoration or replication of policy state produced under a later trusted time
+can therefore temporarily deny otherwise legitimate requests until trusted
+time catches up or state is explicitly reconciled. This preserves
+authorization safety and is not an execution bypass, but creates an
+availability dependency on non-decreasing trusted evaluation time across the
+lifecycle of persisted time-indexed policy state.
+
+Deployments should:
+
+- detect backward movement of trusted evaluation time operationally;
+- preserve trusted-time and state continuity across failover and rolling
+  upgrades;
+- treat state reconciliation or reset as an explicit, audited operation; and
+- not weaken fail-closed behavior to recover availability.
+
+---
+
+## 11. Deferred capabilities
 
 The following are open or planned areas, per `ROADMAP.md` and the referenced issues. None of them are implemented, and none should be described as implemented in any 2.0 release material:
 
@@ -136,7 +164,7 @@ The following are open or planned areas, per `ROADMAP.md` and the referenced iss
 
 ---
 
-## 11. Release claim boundary
+## 12. Release claim boundary
 
 | Area | 2.0 status | Safe claim | Claim to avoid |
 |---|---|---|---|
@@ -153,11 +181,11 @@ The following are open or planned areas, per `ROADMAP.md` and the referenced iss
 
 ---
 
-## 12. Relationship to external review
+## 13. Relationship to external review
 
 This document is expected to change as a result of the OpenZeppelin review described in `docs/audits/external-review-scope-v2.md`:
 
 - Reviewer findings may surface **new** residuals not listed here; this document must be updated to include them.
 - This document must be re-reviewed and updated after the `S_freeze` review completes, and again after `S_fix` is produced.
-- Any finding the project accepts without remediating (rather than fixing) must be reflected here as a residual before any 2.0 artifact is published, with the same treatment given to the residuals already listed in §3–§9.
+- Any finding the project accepts without remediating (rather than fixing) must be reflected here as a residual before any 2.0 artifact is published, with the same treatment given to the residuals already listed in §3–§10.
 - Final published claims for the 2.0 release must match both the exact `S_fix` commit and the residual set as it stands after the review concludes — not the residual set as it stands in this pre-review draft.

--- a/docs/spec/core/trusted-time-v1.md
+++ b/docs/spec/core/trusted-time-v1.md
@@ -274,6 +274,13 @@ Replay, velocity, and tool-call windows MUST key off `evaluation_time` only.
   Missing or malformed required containers and non-finite, fractional,
   negative, or unsafe values MUST fail closed with `STATE_INVALID`.
 
+  > **Operational consequence (non-normative).** Fixed-window semantics may
+  > permit bursts approaching `2 × maxActions` across adjacent window
+  > boundaries. A configured limit of `N` actions per `T` seconds therefore
+  > does not imply a strict bound of `N` actions over every rolling interval of
+  > length `T`. Deployments requiring that property should use a
+  > rolling/sliding-window control instead.
+
 - **Tool-call windows.** Retention and new call timestamps MUST derive only
   from `evaluation_time`. `intent.timestamp` is non-authoritative and MUST NOT
   start, advance, reset, expire, or otherwise influence tool-call quota. A


### PR DESCRIPTION
## Summary

Document two trusted-time residuals that remain relevant to OxDeAI 2.0 release claims.

## Changes

- Document trusted-clock rollback as an availability risk for persisted time-indexed policy state.
- Clarify that rollback or lagging trusted time fails closed with `STATE_INVALID` rather than resetting or discarding future-dated state.
- Add operational guidance for preserving trusted-time/state continuity and auditing reconciliation.
- Document the non-normative fixed-window consequence that bursts can approach `2 × maxActions` across adjacent windows.
- Renumber the affected sections in `docs/audits/2.0-residual-scope.md`.

## Security semantics

No authorization behavior is changed.

The documented rollback condition remains fail-closed:

```text
trusted evaluation_time moves behind persisted policy state
-> STATE_INVALID
-> request denied
-> no execution bypass
````

The fixed-window note is explicitly non-normative and does not change the current policy semantics.

## Scope

Documentation only.

Files changed:

* `docs/audits/2.0-residual-scope.md`
* `docs/spec/core/trusted-time-v1.md`

## Validation

* `git diff --check` clean
* no production source changed