### PR TITLE
docs: add pull request template and contributor guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+## Summary
+
+Describe what this PR changes and why.
+
+## Changes
+
+-
+-
+
+## Security impact
+
+Does this change affect authorization, verification, replay protection, trusted state, provenance, execution boundaries, or CI security gates?
+
+- [ ] No security-relevant behavior changed
+- [ ] Security-relevant behavior changed and is described below
+
+Details:
+
+## Validation
+
+List the commands and tests run, with their results.
+
+```text
+command
+result
+```
+
+## Regression proof
+
+For bug fixes or security-sensitive changes, describe how the failure was reproduced and how the fix is proven.
+
+Where practical, include a negative or mutation test showing that the relevant protection fails when deliberately broken.
+
+## Scope
+
+- [ ] No unrelated changes
+- [ ] No required CI check weakened, bypassed, or made advisory
+- [ ] No production behavior changed unless explicitly described
+- [ ] Documentation updated where required
+
+## Related issue
+
+Closes #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 # Contributing to OxDeAI
 
 **Status:** Working contribution guide for OxDeAI v1
-**Last updated:** 2026-06-04
+
+**Last updated:** 2026-09-04
 
 Thank you for considering contributing to OxDeAI.
 
@@ -273,29 +274,45 @@ A good pull request:
 
 ### 6.2 PR body should include
 
-For non-trivial PRs, include:
+Pull requests should use the repository pull request template at:
+
+```text
+.github/pull_request_template.md
+```
+
+Do not remove required sections from the template when they apply.
+
+For non-trivial PRs, the PR body should clearly describe:
 
 ```text
 Summary:
+
 What changed:
 
 Why:
-Why the change is needed:
 
 Boundary:
-What this does not change:
 
 Validation:
-Commands run and results:
 ```
 
-For protocol or security-sensitive PRs, also include:
+For protocol, bug-fix, or security-sensitive PRs, also include:
 
 ```text
+Security impact:
+
 Invariants preserved:
+
+Regression proof:
+
 Residual risks:
+
 Audit/spec updates:
 ```
+
+Regression proof should reproduce the failure mode where practical and show that the relevant test or CI signal fails when the protection is deliberately broken.
+
+Required CI checks must not be weakened, bypassed, or made advisory in order to merge a contribution.
 
 ### 6.3 Validation before PR
 


### PR DESCRIPTION
## Summary

Add a repository pull request template and align `CONTRIBUTING.md` with the PR structure expected for OxDeAI contributions.

The goal is to make PR scope, validation, security impact, and regression evidence explicit before review.

## Changes

- add `.github/pull_request_template.md`
- require PRs to describe summary, changes, security impact, validation, regression proof, scope, and related issue
- update `CONTRIBUTING.md` to reference the repository PR template
- clarify additional expectations for protocol, bug-fix, and security-sensitive PRs
- state that required CI checks must not be weakened, bypassed, or made advisory for merge
- update the contribution guide date

## Security impact

- [x] No security-relevant runtime behavior changed
- [ ] Security-relevant behavior changed and is described below

Details:

Documentation and contribution-process changes only. No authorization, verification, replay, provenance, trusted-state, execution-boundary, or production behavior is modified.

## Validation

```text
git diff --check
PASS

git diff --no-index --check /dev/null .github/pull_request_template.md
PASS

git diff --cached --check
PASS
````

## Regression proof

Not applicable. This PR does not change runtime behavior.

## Scope

* [x] No unrelated changes
* [x] No required CI check weakened, bypassed, or made advisory
* [x] No production behavior changed
* [x] Documentation updated where required

## Related issue

N/A