### PR TITLE
fix(core): use trusted evaluation time for audit timestamps

### DIFF
--- a/packages/core/src/policy/PolicyEngine.ts
+++ b/packages/core/src/policy/PolicyEngine.ts
@@ -466,7 +466,7 @@ export class PolicyEngine {
         type: "INTENT_RECEIVED",
         intent_hash,
         agent_id: intent.agent_id,
-        timestamp: intent.timestamp,
+        timestamp: evaluationTime,
         policyId
       });
 
@@ -492,10 +492,10 @@ export class PolicyEngine {
           decision: "DENY",
           reasons: freshness.reasons,
           policy_version: state.policy_version,
-          timestamp: intent.timestamp,
+          timestamp: evaluationTime,
           policyId
         });
-        this.maybeEmitCheckpoint(policyId, intent.timestamp, state);
+        this.maybeEmitCheckpoint(policyId, evaluationTime, state);
         return { decision: "DENY", reasons: freshness.reasons };
       }
 
@@ -513,10 +513,10 @@ export class PolicyEngine {
           decision: "DENY",
           reasons: decisionResult.reasons,
           policy_version: state.policy_version,
-          timestamp: intent.timestamp,
+          timestamp: evaluationTime,
           policyId
         });
-        this.maybeEmitCheckpoint(policyId, intent.timestamp, state);
+        this.maybeEmitCheckpoint(policyId, evaluationTime, state);
         return { decision: "DENY", reasons: decisionResult.reasons };
       }
 

--- a/packages/core/src/test/trusted-time-integration.test.ts
+++ b/packages/core/src/test/trusted-time-integration.test.ts
@@ -356,3 +356,45 @@ test("issuance tripwire: issued_at and expiry derive from evaluationTime, not in
   assert.equal(out.authorization.expiry, T0 + 60);
   assert.notEqual(out.authorization.issued_at, intent.timestamp);
 });
+
+test("audit timestamps derive from evaluationTime across sequential evaluations", () => {
+  const engine = makeEngine();
+
+  // Regression for #279:
+  // audit event time must come from trusted evaluationTime, not intent.timestamp.
+  // Reusing an older proposer-controlled intent timestamp across later evaluations
+  // must not make the audit stream move backwards in time.
+  const first = engine.evaluatePure(
+    makeIntent({ nonce: 1001n, timestamp: T0 }),
+    freshState(),
+    T0
+  );
+
+  assert.equal(first.decision, "ALLOW");
+
+  const second = engine.evaluatePure(
+    makeIntent({ nonce: 1002n, timestamp: T0 }),
+    first.nextState,
+    T0 + 1
+  );
+
+  assert.equal(second.decision, "ALLOW");
+
+  const timestamps = engine.audit.snapshot().map((e) => e.timestamp);
+
+  for (let i = 1; i < timestamps.length; i++) {
+    assert.ok(
+      timestamps[i] >= timestamps[i - 1],
+      `audit timestamp regressed at index ${i}: ${timestamps[i - 1]} -> ${timestamps[i]}`
+    );
+  }
+
+  const received = engine.audit
+    .snapshot()
+    .filter((e) => e.type === "INTENT_RECEIVED");
+
+  assert.deepEqual(
+    received.map((e) => e.timestamp),
+    [T0, T0 + 1]
+  );
+});


### PR DESCRIPTION
## Summary

Fixes the intermittent `adapter-validation` envelope verification failure tracked in #279.

The failure was reproducible in the LangGraph adapter as:

```text
Envelope verification failed: invalid
violations=NON_MONOTONIC_TIMESTAMP
````

Root cause: `PolicyEngine.evaluatePure()` mixed two time sources in the same audit stream:

* `INTENT_RECEIVED` used proposer-controlled `intent.timestamp`
* `DECISION`, `AUTH_EMITTED`, and ALLOW checkpoints used trusted `evaluationTime`

If one evaluation crossed a one-second boundary, the next `INTENT_RECEIVED` could move the audit timeline backwards and strict envelope verification correctly failed closed with `NON_MONOTONIC_TIMESTAMP`.

## Changes

* Use trusted `evaluationTime` for `INTENT_RECEIVED`
* Use trusted `evaluationTime` for DENY `DECISION` audit events
* Use trusted `evaluationTime` for DENY checkpoints
* Add deterministic regression coverage for sequential evaluations where the proposer timestamp stays fixed while trusted evaluation time advances

`intent.timestamp` remains part of the intent and continues to be used by the trusted-time freshness gate. It no longer acts as the audit clock.

## Security impact

This changes security-relevant audit timestamp provenance.

Before this fix, the audit stream could mix proposer-controlled and trusted timestamps. The verifier remained fail-closed, but valid executions could intermittently produce a non-monotonic audit envelope.

After this fix, audit events emitted by `evaluatePure()` use the trusted evaluation-time boundary consistently.

* [ ] No security-relevant behavior changed
* [x] Security-relevant behavior changed

The fix does not weaken `NON_MONOTONIC_TIMESTAMP`, bypass envelope verification, add retries, or make any required CI check advisory.

## Validation

```text
pnpm --filter @oxdeai/core test -- trusted-time-integration.test.ts
374 passed, 0 failed

pnpm --filter @oxdeai/core test
374 passed, 0 failed

pnpm validate:adapters
openai-tools........ PASS
langgraph........... PASS
crewai.............. PASS
openai-agents-sdk... PASS
autogen............. PASS
openclaw............ PASS

All adapters reported verifyEnvelope=ok.

LangGraph repeated validation after removing diagnostic instrumentation:
20/20 PASS

Earlier patched validation with audit-timeline instrumentation:
50/50 PASS
```

## Regression proof

Before the fix, the failure was reproduced locally with audit events such as:

```text
INTENT_RECEIVED  T
DECISION         T+1
AUTH_EMITTED     T+1
INTENT_RECEIVED  T
```

Strict envelope verification then returned:

```text
NON_MONOTONIC_TIMESTAMP
```

The new regression test forces the same condition deterministically by keeping `intent.timestamp` fixed while advancing `evaluationTime`, and verifies that the emitted audit timestamps remain non-decreasing.

## Scope

* [x] No unrelated changes
* [x] No required CI check weakened, bypassed, retried-until-green, or made advisory
* [x] No production behavior changed outside trusted audit timestamp provenance
* [x] Regression coverage added

## Related issue

Closes #279