### PR TITLE
Fix/benchmark current head evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,8 +329,13 @@ Properties:
 
 ## Benchmarks
 
-* ~80–150µs overhead per action (p50)
-* negligible vs agent execution time
+The synthetic protected-path benchmark measures policy evaluation,
+authorization verification, envelope verification, and deterministic in-memory
+tool work against the same tool work without OxDeAI checks. Current results are
+host- and runtime-specific and contain noise/outlier warnings, so no stable
+per-action overhead is claimed. See the
+[benchmark summary](./bench/BENCHMARK_SUMMARY.md) for exact observations and
+limitations.
 
 ---
 

--- a/bench/BENCHMARK_SUMMARY.md
+++ b/bench/BENCHMARK_SUMMARY.md
@@ -1,166 +1,155 @@
-# OxDeAI Benchmark Summary
+# OxDeAI Current-HEAD Benchmark Summary
 
-## 1. Executive Summary
+**Status:** Non-normative, host-specific observation. The run contains noise
+and outlier warnings and does not support a stable or universal overhead claim.
 
-This benchmark evaluates the latency of the main OxDeAI authorization-path primitives on a single host under Node.js. The most meaningful scenarios are:
+## Provenance
 
-- `evaluate`: policy evaluation only
-- `verifyEnvelope`: verification of the execution envelope
-- `baselinePath`: synthetic execution path with no OxDeAI checks
-- `protectedPath`: execution path with OxDeAI checks enabled
-
-On the measured system, the protected execution path adds absolute overhead in the tens of microseconds at single-worker concurrency. For the single-worker run, `protectedPath` adds approximately:
-
-- `+14.8 us` p50 and `+21.8 us` mean in `best-effort` mode
-- `+16.6 us` p50 and `+25.2 us` mean in `strict` mode
-
-The main conclusion is that OxDeAI authorization introduces tens-of-microseconds latency overhead while providing deterministic fail-closed execution control. These numbers are implementation- and environment-specific and should be compared only across similar hardware and runtime configurations.
-
-## 2. Benchmark Methodology
-
-The benchmark was executed from the OxDeAI benchmark harness with:
-
-- 10,000 warmup iterations
-- 100,000 measured iterations
-- 5 runs per scenario
-- concurrency levels of 1 and 4 workers
-- envelope modes `best-effort` and `strict`
-
-The scenarios are defined as follows:
-
-- `evaluate`: runs policy evaluation against a representative in-memory state
-- `verifyEnvelope`: verifies an encoded execution envelope containing a snapshot and audit events
-- `baselinePath`: runs deterministic synthetic tool-execution work with no OxDeAI checks
-- `protectedPath`: runs the protected execution flow, consisting of evaluation, authorization verification, envelope verification, and the same synthetic tool-execution work as the baseline
-
-Reported values are medians across runs for p50, p95, p99, and mean latency. Absolute overhead is computed as:
-
-`protectedPath - baselinePath`
-
-This report focuses on absolute latency in microseconds because relative percentages can be misleading when the baseline is already very small.
-
-## 3. Environment Description
-
-Benchmark host:
-
+- Git commit: `ef00d4c2a71fc63e74287b626be4cac7f3491647`
+- Worktree at measurement: dirty
+- Dirty paths at measurement: `.gitignore`, `bench/cases/evaluate.ts`,
+  `bench/cases/protectedPath.ts`, `bench/cases/verifyAuthorization.ts`,
+  `bench/cases/verifyEnvelope.ts`, `bench/fixtures.ts`, and
+  `bench/runner-core.ts`; the `.gitignore` change was pre-existing and unrelated
+- Timestamp: `2026-09-04T14:59:46.749Z`
 - CPU: Intel(R) Core(TM) i5-7400 CPU @ 3.00GHz
 - Logical cores: 4
-- OS: Linux 5.15.133.1-microsoft-standard-WSL2 x64
-- Runtime: Node.js v22.9.0
-- Architecture: x64
+- Node.js: `v23.3.0`
+- pnpm: `9.12.2`
+- OS: Linux `6.6.87.2-microsoft-standard-WSL2` x64
 - Environment: WSL2
+- Generated JSON SHA-256:
+  `a03efd0eeef231585e571c41ed56a2e672d87a8a652a64c32378a4c78165e9f5`
 
-Benchmark configuration:
+The benchmark compatibility patch replaces the obsolete 17-character fixture
+secret with a 44-character benchmark-only value, supplies the now-required
+`policy_version` on the fixture's `DECISION` audit event, and supplies a
+benchmark-only trusted key set to envelope verification. Production validation
+and verification semantics are unchanged.
 
-- Scenario set: `all`
-- Seed: `20260310`
-- Warmup iterations: `10000`
-- Measured iterations: `100000`
-- Runs: `5`
-- Concurrency: `1, 4`
-- Envelope modes: `best-effort`, `strict`
+An earlier post-secret-fix run was rejected as evidence after an explicit
+status preflight showed that its envelope fixture returned `invalid` and the
+protected callback exited before synthetic tool work. None of that run's
+latencies are used here. After correcting the benchmark-only envelope fixture,
+the preflight returned `ALLOW` / authorization `ok` / envelope `ok` for both
+modes before the run reported below was started.
 
-Because the benchmark was run under WSL2 and JavaScript runtime scheduling, the results should be treated as host-specific measurements rather than protocol-intrinsic constants.
-
-## 4. Latency Analysis
-
-### Single-worker latency
-
-| Scenario | p50 (us) | p95 (us) | p99 (us) | mean (us) | Status |
-|---|---:|---:|---:|---:|---|
-| `evaluate` | 23.833 | 37.501 | 64.520 | 29.956 | NOISY |
-| `verifyEnvelope` (`best-effort`) | 15.457 | 21.654 | 45.956 | 17.199 | NOISY |
-| `verifyEnvelope` (`strict`) | 15.546 | 22.307 | 46.339 | 17.140 | NOISY |
-| `baselinePath` | 8.495 | 8.891 | 23.077 | 8.993 | OK |
-| `protectedPath` (`best-effort`) | 23.326 | 37.275 | 69.070 | 30.843 | NOISY |
-| `protectedPath` (`strict`) | 25.075 | 40.306 | 77.067 | 34.208 | NOISY |
-
-Observations:
-
-- `baselinePath` is the most stable single-worker measurement in this run.
-- `verifyEnvelope` is consistently in the mid-teens of microseconds.
-- `evaluate` is higher than `verifyEnvelope`, which is expected because it executes policy logic over a representative state.
-- `protectedPath` remains in the low tens of microseconds at p50 under single-worker execution.
-
-### Four-worker latency
-
-| Scenario | p50 (us) | p95 (us) | p99 (us) | mean (us) | Status |
-|---|---:|---:|---:|---:|---|
-| `evaluate` | 85.368 | 129.977 | 438.090 | 119.465 | NOISY |
-| `verifyEnvelope` (`best-effort`) | 16.844 | 22.522 | 44.548 | 19.420 | NOISY |
-| `verifyEnvelope` (`strict`) | 16.896 | 22.385 | 44.937 | 20.351 | NOISY |
-| `baselinePath` | 7.682 | 9.079 | 18.554 | 8.548 | NOISY |
-| `protectedPath` (`best-effort`) | 128.727 | 187.245 | 694.495 | 167.152 | NOISY |
-| `protectedPath` (`strict`) | 129.165 | 189.897 | 767.256 | 168.076 | NOISY |
-
-Observations:
-
-- Multi-worker results are materially noisier.
-- `verifyEnvelope` remains relatively stable under 4 workers.
-- `evaluate` and `protectedPath` widen substantially in p95/p99 under concurrent execution, which suggests runtime scheduling and shared-resource effects dominate more of the tail.
-- For engineering interpretation, the single-worker p50 and mean are the clearest indicators of per-operation cost.
-
-## 5. Baseline vs Protected Execution Overhead
-
-Absolute overhead is the most useful measure for this benchmark.
-
-### Single-worker overhead
-
-| Protected mode | Delta p50 (us) | Delta p95 (us) | Delta p99 (us) | Delta mean (us) |
-|---|---:|---:|---:|---:|
-| `best-effort` | 14.831 | 28.384 | 45.993 | 21.850 |
-| `strict` | 16.580 | 31.415 | 53.990 | 25.215 |
-
-### Four-worker overhead
-
-| Protected mode | Delta p50 (us) | Delta p95 (us) | Delta p99 (us) | Delta mean (us) |
-|---|---:|---:|---:|---:|
-| `best-effort` | 121.045 | 178.166 | 675.941 | 158.605 |
-| `strict` | 121.483 | 180.818 | 748.702 | 159.528 |
-
-Interpretation:
-
-- At single-worker concurrency, the incremental cost of OxDeAI protection is on the order of `15-25 us` for p50/mean, depending on envelope mode.
-- The difference between `best-effort` and `strict` envelope verification is small in absolute terms in this run, approximately `1.7-3.4 us`.
-- Under 4-worker concurrency, the absolute overhead increases into the low hundreds of microseconds, indicating that scheduler effects and contention contribute more strongly than the underlying primitive costs.
-
-## 6. Interpretation of Results
-
-The benchmark supports a practical conclusion:
-
-OxDeAI adds a small absolute latency cost to the protected execution path, measured in tens of microseconds for single-worker execution on this host.
-
-That result is consistent with the structure of the protected path:
-
-- policy evaluation
-- authorization verification
-- envelope verification
-- execution gating before tool work
-
-From a systems perspective, this is a bounded pre-execution cost rather than a dominant runtime component. For external operations such as network calls, provisioning actions, payments, or tool invocations, tens of microseconds are typically much smaller than the latency of the protected side effect itself.
-
-The benchmark also shows that tail latency is more sensitive to concurrency than median latency. This suggests the protocol path is cheap enough that runtime and host scheduling effects become a substantial part of the observed distribution, especially at 4-worker concurrency.
-
-## 7. Limitations and Reproducibility Notes
-
-Several limitations are important when interpreting these numbers:
-
-- Results depend on CPU model, clock behavior, memory hierarchy, kernel scheduling, and Node.js version.
-- The benchmark was run under WSL2, which may differ from bare-metal Linux or containerized production deployment.
-- Tail metrics at low absolute latencies are sensitive to runtime noise, garbage collection, and timer resolution.
-- The benchmark uses deterministic synthetic tool work for `baselinePath` and `protectedPath`; this isolates authorization overhead, but it is not a substitute for end-to-end application latency measurement.
-- The reported values describe this implementation and this environment, not a universal property of the protocol.
-
-For reproducibility:
+## Command and methodology
 
 ```bash
-pnpm -C bench run run -- --scenario=all --runs=5 --iterations=100000 --warmup=10000 --concurrency=1,4 --envelopeMode=both
+pnpm -C bench run run -- --scenario=all --runs=5 --iterations=100000 --warmup=10000 --concurrency=1,4 --envelopeMode=both --output-dir=/tmp/oxdeai-bench-ef00d4c-valid
 ```
 
-When comparing results across machines, prioritize:
+- Seed: `20260310`
+- Repetitions: 5 per scenario, worker count, and envelope mode
+- Warmup: 10,000 invocations per repetition
+- Measured samples: 100,000 per repetition
+- Workers: 1 and 4
+- Envelope modes: `best-effort` and `strict`
+- Clock: `process.hrtime.bigint()` around each invocation
+- Aggregation: the reported statistics are the median of the five per-run
+  statistics; samples are not averaged together to hide noisy runs
+- Four-worker mode divides the warmup and measured invocation totals across
+  four worker threads, then combines their samples for each repetition
+- Noise classification: `OK` for coefficient of variation (CV) at most 1.0,
+  `NOISY` for CV at most 5.0, and `EXTREMELY_NOISY` above 5.0
+- Outlier annotation: emitted when any repetition has `max > 100 × p50`
 
-- absolute overhead in microseconds
-- p50 and mean for steady-state cost
-- p95/p99 only across similar hardware/runtime environments
+## Exact measured paths
 
-`verifyAuthorization` is intentionally not emphasized in this report because its standalone latency is close to the noise floor relative to the higher-signal end-to-end path measurements.
+`baselinePath` performs deterministic synthetic tool work only.
+
+`protectedPath` performs:
+
+```text
+PolicyEngine.evaluatePure
+  -> verifyAuthorization
+  -> verifyEnvelope
+  -> the same deterministic synthetic tool work as baselinePath
+```
+
+Authorization verification is included. The fixture uses the engine's
+shared-secret HMAC authorization profile and calls `verifyAuthorization()` with
+`requireSignatureVerification: true` and the matching benchmark-only HMAC
+secret.
+
+Envelope verification is also included. Both envelope modes receive a valid
+trusted key set, but the fixture envelope is unsigned and the benchmark sets
+`requireSignatureVerification: false`. These results therefore include
+snapshot and audit-envelope verification, but not Ed25519 envelope-signature
+verification.
+
+The benchmark does not execute a model call, network request, database
+operation, queue, or application tool. It is not an end-to-end agent-latency
+benchmark.
+
+## Results
+
+All values below are medians across five runs, in microseconds.
+
+| Scenario | Workers | p50 | p95 | p99 | mean | Harness status |
+|---|---:|---:|---:|---:|---:|---|
+| `baselinePath` | 1 | 7.700 | 8.800 | 26.200 | 10.140 | `EXTREMELY_NOISY + OUTLIER_DETECTED` |
+| `protectedPath` (`best-effort`) | 1 | 608.402 | 1846.107 | 5013.036 | 848.773 | `NOISY + OUTLIER_DETECTED` |
+| `protectedPath` (`strict`) | 1 | 573.502 | 1086.004 | 3953.917 | 731.352 | `OK + OUTLIER_DETECTED` |
+| `baselinePath` | 4 | 18.900 | 27.700 | 104.800 | 27.029 | `EXTREMELY_NOISY + OUTLIER_DETECTED` |
+| `protectedPath` (`best-effort`) | 4 | 583.703 | 1933.808 | 5337.927 | 836.890 | `NOISY + OUTLIER_DETECTED` |
+| `protectedPath` (`strict`) | 4 | 588.502 | 1916.217 | 4996.839 | 821.344 | `NOISY + OUTLIER_DETECTED` |
+
+Absolute overhead is computed as the independently aggregated
+`protectedPath - baselinePath` percentiles:
+
+| Mode | Workers | Δp50 | Δp95 | Δp99 | Δmean |
+|---|---:|---:|---:|---:|---:|
+| `best-effort` | 1 | 600.702 | 1837.307 | 4986.836 | 838.633 |
+| `strict` | 1 | 565.802 | 1077.204 | 3927.717 | 721.211 |
+| `best-effort` | 4 | 564.803 | 1906.108 | 5233.127 | 809.860 |
+| `strict` | 4 | 569.602 | 1888.517 | 4892.039 | 794.315 |
+
+Per-run protected-path p50 values were:
+
+| Mode | Workers | Five p50 observations (µs) |
+|---|---:|---|
+| `best-effort` | 1 | 616.202, 608.402, 614.803, 607.602, 587.102 |
+| `strict` | 1 | 573.002, 574.102, 566.002, 573.502, 574.902 |
+| `best-effort` | 4 | 583.703, 582.902, 587.903, 592.703, 583.002 |
+| `strict` | 4 | 592.302, 594.203, 587.903, 588.502, 581.602 |
+
+## Stability assessment
+
+The protected-path p50 observations cluster within each configuration, but
+three of four protected configurations are classified `NOISY`, every protected
+configuration contains an outlier warning, and both baselines are classified
+`EXTREMELY_NOISY`. Tail deltas vary substantially. The one `OK` aggregate
+(`strict`, one worker) still contains an outlier warning and does not make the
+overall evidence stable.
+
+Consequently, this run is suitable for exposing the current order of magnitude
+and for finding benchmark regressions. It is not suitable for publishing a
+stable numeric overhead range. In particular, it does not support the former
+public numeric range or a narrower replacement range.
+
+## Reproduction and limitations
+
+Run the exact command above on an otherwise idle host and retain all five
+repetitions, including noisy or unfavorable results. Compare raw scenario
+latencies and absolute deltas; percentage deltas are misleading when the
+synthetic baseline is very small.
+
+Important limitations:
+
+- Results are specific to this CPU, Node version, WSL2 kernel, code revision,
+  fixture, and scenario order.
+- The recorded run necessarily used an uncommitted benchmark compatibility
+  patch. A clean-worktree run should be recorded after that patch is merged and
+  before any numeric result is promoted externally.
+- The synthetic tool workload cannot establish that authorization overhead is
+  negligible relative to a deployment's model, network, or application work.
+- Envelope signature verification is disabled, so these figures do not include
+  Ed25519 envelope-signature verification.
+- Percentile deltas subtract independently aggregated percentiles; they are not
+  a distribution of paired per-invocation latency differences.
+- The worker implementation does not currently dispatch `verifyDelegation`
+  separately, so multi-worker delegation-labeled rows from `--scenario=all`
+  are not delegation evidence. This does not affect the explicit baseline and
+  protected worker branches used for the overhead table.

--- a/bench/BENCHMARK_SUMMARY.md
+++ b/bench/BENCHMARK_SUMMARY.md
@@ -1,59 +1,55 @@
 # OxDeAI Current-HEAD Benchmark Summary
 
-**Status:** Non-normative, host-specific observation. The run contains noise
-and outlier warnings and does not support a stable or universal overhead claim.
+**Status:** Non-normative, host-specific benchmark evidence. Repeated clean-worktree
+measurements on this host show a consistent protected-path p50 around 0.5-0.55 ms.
+Tail latency and several component scenarios still contain noise and outlier
+warnings, so these results are not a universal runtime guarantee.
 
 ## Provenance
 
-- Git commit: `ef00d4c2a71fc63e74287b626be4cac7f3491647`
-- Worktree at measurement: dirty
-- Dirty paths at measurement: `.gitignore`, `bench/cases/evaluate.ts`,
-  `bench/cases/protectedPath.ts`, `bench/cases/verifyAuthorization.ts`,
-  `bench/cases/verifyEnvelope.ts`, `bench/fixtures.ts`, and
-  `bench/runner-core.ts`; the `.gitignore` change was pre-existing and unrelated
-- Timestamp: `2026-09-04T14:59:46.749Z`
+- Git commit: `b2bcfcf603aefcd60ea0cbcd3b406b59cf77933d`
+- Worktree at measurement: clean
+- Timestamp: `2026-09-05T05:57:46.478Z`
 - CPU: Intel(R) Core(TM) i5-7400 CPU @ 3.00GHz
 - Logical cores: 4
 - Node.js: `v23.3.0`
 - pnpm: `9.12.2`
 - OS: Linux `6.6.87.2-microsoft-standard-WSL2` x64
 - Environment: WSL2
-- Generated JSON SHA-256:
-  `a03efd0eeef231585e571c41ed56a2e672d87a8a652a64c32378a4c78165e9f5`
 
 The benchmark compatibility patch replaces the obsolete 17-character fixture
-secret with a 44-character benchmark-only value, supplies the now-required
-`policy_version` on the fixture's `DECISION` audit event, and supplies a
-benchmark-only trusted key set to envelope verification. Production validation
-and verification semantics are unchanged.
+secret with a benchmark-only value satisfying the current PolicyEngine minimum,
+supplies the now-required `policy_version` on the fixture's `DECISION` audit
+event, and supplies a benchmark-only trusted key set to envelope verification.
+Production validation and verification semantics are unchanged.
 
 An earlier post-secret-fix run was rejected as evidence after an explicit
 status preflight showed that its envelope fixture returned `invalid` and the
 protected callback exited before synthetic tool work. None of that run's
 latencies are used here. After correcting the benchmark-only envelope fixture,
-the preflight returned `ALLOW` / authorization `ok` / envelope `ok` for both
-modes before the run reported below was started.
+the preflight returned `ALLOW`, authorization `ok`, and envelope `ok` for both
+modes before the benchmark evidence was collected.
 
 ## Command and methodology
 
 ```bash
-pnpm -C bench run run -- --scenario=all --runs=5 --iterations=100000 --warmup=10000 --concurrency=1,4 --envelopeMode=both --output-dir=/tmp/oxdeai-bench-ef00d4c-valid
-```
+pnpm -C bench run run -- --scenario=all --runs=5 --iterations=100000 --warmup=10000 --concurrency=1,4 --envelopeMode=both --output-dir=/tmp/oxdeai-bench-b2bcfcf-final-clean
+````
 
-- Seed: `20260310`
-- Repetitions: 5 per scenario, worker count, and envelope mode
-- Warmup: 10,000 invocations per repetition
-- Measured samples: 100,000 per repetition
-- Workers: 1 and 4
-- Envelope modes: `best-effort` and `strict`
-- Clock: `process.hrtime.bigint()` around each invocation
-- Aggregation: the reported statistics are the median of the five per-run
+* Seed: `20260310`
+* Repetitions: 5 per scenario, worker count, and envelope mode
+* Warmup: 10,000 invocations per repetition
+* Measured samples: 100,000 per repetition
+* Workers: 1 and 4
+* Envelope modes: `best-effort` and `strict`
+* Clock: `process.hrtime.bigint()` around each invocation
+* Aggregation: the reported statistics are the median of the five per-run
   statistics; samples are not averaged together to hide noisy runs
-- Four-worker mode divides the warmup and measured invocation totals across
+* Four-worker mode divides the warmup and measured invocation totals across
   four worker threads, then combines their samples for each repetition
-- Noise classification: `OK` for coefficient of variation (CV) at most 1.0,
+* Noise classification: `OK` for coefficient of variation (CV) at most 1.0,
   `NOISY` for CV at most 5.0, and `EXTREMELY_NOISY` above 5.0
-- Outlier annotation: emitted when any repetition has `max > 100 × p50`
+* Outlier annotation: emitted when any repetition has `max > 100 × p50`
 
 ## Exact measured paths
 
@@ -87,47 +83,40 @@ benchmark.
 
 All values below are medians across five runs, in microseconds.
 
-| Scenario | Workers | p50 | p95 | p99 | mean | Harness status |
-|---|---:|---:|---:|---:|---:|---|
-| `baselinePath` | 1 | 7.700 | 8.800 | 26.200 | 10.140 | `EXTREMELY_NOISY + OUTLIER_DETECTED` |
-| `protectedPath` (`best-effort`) | 1 | 608.402 | 1846.107 | 5013.036 | 848.773 | `NOISY + OUTLIER_DETECTED` |
-| `protectedPath` (`strict`) | 1 | 573.502 | 1086.004 | 3953.917 | 731.352 | `OK + OUTLIER_DETECTED` |
-| `baselinePath` | 4 | 18.900 | 27.700 | 104.800 | 27.029 | `EXTREMELY_NOISY + OUTLIER_DETECTED` |
-| `protectedPath` (`best-effort`) | 4 | 583.703 | 1933.808 | 5337.927 | 836.890 | `NOISY + OUTLIER_DETECTED` |
-| `protectedPath` (`strict`) | 4 | 588.502 | 1916.217 | 4996.839 | 821.344 | `NOISY + OUTLIER_DETECTED` |
+| Scenario                        | Workers |    p50 |     p95 |     p99 |   mean | Harness status             |
+| ------------------------------- | ------: | -----: | ------: | ------: | -----: | -------------------------- |
+| `baselinePath`                  |       1 |   7.40 |    7.80 |   22.00 |   7.92 | `OK + OUTLIER_DETECTED`    |
+| `protectedPath` (`best-effort`) |       1 | 548.20 |  737.70 | 2756.21 | 623.86 | `OK + OUTLIER_DETECTED`    |
+| `protectedPath` (`strict`)      |       1 | 554.40 |  747.80 | 3102.31 | 641.59 | `OK + OUTLIER_DETECTED`    |
+| `baselinePath`                  |       4 |  18.90 |   21.00 |   35.50 |  18.73 | `NOISY + OUTLIER_DETECTED` |
+| `protectedPath` (`best-effort`) |       4 | 557.80 | 1075.31 | 3187.85 | 669.81 | `OK`                       |
+| `protectedPath` (`strict`)      |       4 | 560.00 | 1181.43 | 2840.81 | 661.92 | `OK`                       |
 
 Absolute overhead is computed as the independently aggregated
 `protectedPath - baselinePath` percentiles:
 
-| Mode | Workers | Δp50 | Δp95 | Δp99 | Δmean |
-|---|---:|---:|---:|---:|---:|
-| `best-effort` | 1 | 600.702 | 1837.307 | 4986.836 | 838.633 |
-| `strict` | 1 | 565.802 | 1077.204 | 3927.717 | 721.211 |
-| `best-effort` | 4 | 564.803 | 1906.108 | 5233.127 | 809.860 |
-| `strict` | 4 | 569.602 | 1888.517 | 4892.039 | 794.315 |
-
-Per-run protected-path p50 values were:
-
-| Mode | Workers | Five p50 observations (µs) |
-|---|---:|---|
-| `best-effort` | 1 | 616.202, 608.402, 614.803, 607.602, 587.102 |
-| `strict` | 1 | 573.002, 574.102, 566.002, 573.502, 574.902 |
-| `best-effort` | 4 | 583.703, 582.902, 587.903, 592.703, 583.002 |
-| `strict` | 4 | 592.302, 594.203, 587.903, 588.502, 581.602 |
+| Mode          | Workers |   Δp50 |    Δp95 |    Δp99 |  Δmean |
+| ------------- | ------: | -----: | ------: | ------: | -----: |
+| `best-effort` |       1 | 540.80 |  729.90 | 2734.21 | 615.94 |
+| `strict`      |       1 | 547.00 |  740.00 | 3080.31 | 633.67 |
+| `best-effort` |       4 | 538.90 | 1054.31 | 3152.35 | 651.08 |
+| `strict`      |       4 | 541.10 | 1160.43 | 2805.31 | 643.19 |
 
 ## Stability assessment
 
-The protected-path p50 observations cluster within each configuration, but
-three of four protected configurations are classified `NOISY`, every protected
-configuration contains an outlier warning, and both baselines are classified
-`EXTREMELY_NOISY`. Tail deltas vary substantially. The one `OK` aggregate
-(`strict`, one worker) still contains an outlier warning and does not make the
-overall evidence stable.
+Across repeated clean-worktree runs on this host, the protected-path median
+remains comparatively stable. In the latest run, all four protected-path
+configurations are classified `OK`, with p50 overhead between 538.90 µs and
+547.00 µs across one- and four-worker configurations.
 
-Consequently, this run is suitable for exposing the current order of magnitude
-and for finding benchmark regressions. It is not suitable for publishing a
-stable numeric overhead range. In particular, it does not support the former
-public numeric range or a narrower replacement range.
+The benchmark still contains important sources of variability. Several component
+scenarios remain `NOISY`, the four-worker baseline is `NOISY`, and one-worker
+protected-path runs contain outlier warnings. Tail latency is therefore less
+stable than the median.
+
+The current evidence supports a host-specific observation of approximately
+0.5-0.55 ms p50 protected-path overhead on this machine and runtime. It does
+not establish a universal OxDeAI latency guarantee.
 
 ## Reproduction and limitations
 
@@ -138,18 +127,17 @@ synthetic baseline is very small.
 
 Important limitations:
 
-- Results are specific to this CPU, Node version, WSL2 kernel, code revision,
+* Results are specific to this CPU, Node version, WSL2 kernel, code revision,
   fixture, and scenario order.
-- The recorded run necessarily used an uncommitted benchmark compatibility
-  patch. A clean-worktree run should be recorded after that patch is merged and
-  before any numeric result is promoted externally.
-- The synthetic tool workload cannot establish that authorization overhead is
+* The synthetic tool workload cannot establish that authorization overhead is
   negligible relative to a deployment's model, network, or application work.
-- Envelope signature verification is disabled, so these figures do not include
+* Envelope signature verification is disabled, so these figures do not include
   Ed25519 envelope-signature verification.
-- Percentile deltas subtract independently aggregated percentiles; they are not
+* Percentile deltas subtract independently aggregated percentiles; they are not
   a distribution of paired per-invocation latency differences.
-- The worker implementation does not currently dispatch `verifyDelegation`
+* Tail latency remains sensitive to runtime and scheduler noise even though the
+  protected-path median is comparatively stable.
+* The worker implementation does not currently dispatch `verifyDelegation`
   separately, so multi-worker delegation-labeled rows from `--scenario=all`
   are not delegation evidence. This does not affect the explicit baseline and
   protected worker branches used for the overhead table.

--- a/bench/README.md
+++ b/bench/README.md
@@ -2,26 +2,15 @@
 
 ## Executive Summary
 
-Latest full-suite local benchmark run:
+The current-HEAD full-suite run is recorded in
+[`BENCHMARK_SUMMARY.md`](./BENCHMARK_SUMMARY.md), including commit, environment,
+command, repeated-run percentiles, and noise classifications.
 
-- source: `bench/outputs/run-2026-03-11-12-25-55.json`
-- machine: Intel Core i5-7400, 4 logical cores, Node.js v22.9.0, Linux on WSL2
-- config: `--scenario=all --runs=5 --iterations=100000 --warmup=10000 --concurrency=1,4 --envelopeMode=both`
-
-Key results from that run indicate:
-
-- `evaluate` p50 was `23.8 us` on 1 worker.
-- `verifyEnvelope` p50 was `15.5 us` on 1 worker in both `best-effort` and `strict` modes.
-- `baselinePath` and `protectedPath` provide the most useful adoption comparison.
-- the key metric is absolute overhead (`protectedPath - baselinePath`) in microseconds.
-- `protectedPath - baselinePath` was `+14.8 us p50` / `+21.8 us mean` in `best-effort` mode on 1 worker.
-- `protectedPath - baselinePath` was `+16.6 us p50` / `+25.2 us mean` in `strict` mode on 1 worker.
-
-Protected execution therefore adds on the order of tens of microseconds at `p50` in single-worker mode on the tested machine.
-
-Results depend on hardware, runtime, and execution environment; the suite is designed to be reproducible rather than universal.
-
-A fuller run-specific summary is available in [`BENCHMARK_SUMMARY.md`](./BENCHMARK_SUMMARY.md).
+That run does not support a stable numeric overhead claim: relevant scenarios
+contain noise or outlier warnings, and results are specific to the measured
+host, runtime, fixture, and code revision. Use the suite to measure a deployment
+candidate on comparable hardware rather than treating one run as a universal
+runtime guarantee.
 
 ## Overview
 
@@ -49,7 +38,9 @@ Execution path scenarios:
 - `baselinePath`
 - `protectedPath`
 
-The protected path represents a realistic execution flow including OxDeAI authorization checks.
+The protected path is a synthetic execution flow containing OxDeAI
+authorization checks and deterministic in-memory tool work. It is not an
+end-to-end agent, model, network, or application benchmark.
 
 ## Benchmark Goals
 
@@ -58,7 +49,7 @@ The benchmark suite is designed to answer:
 1. How expensive is OxDeAI policy evaluation?
 2. How expensive is authorization verification?
 3. How expensive is envelope verification?
-4. What is the incremental cost of OxDeAI authorization in a realistic execution path?
+4. What is the incremental cost of OxDeAI authorization in this synthetic execution path?
 
 The most important measurement is:
 
@@ -66,7 +57,8 @@ The most important measurement is:
 
 which represents the incremental authorization overhead.
 
-`verifyAuthorization` remains part of the suite for completeness, but it is not emphasized as a primary result because its latency is extremely small and often dominated by runtime noise.
+`verifyAuthorization` remains a separate diagnostic, while public
+interpretation focuses on the complete protected-minus-baseline path.
 
 ## Why This Matters
 
@@ -74,7 +66,8 @@ Agent runtimes already spend time on orchestration, serialization, and tool exec
 
 This suite measures the additional latency introduced by running the protected execution path versus a baseline runtime path.
 
-OxDeAI is designed to add a small, bounded pre-execution authorization cost in exchange for deterministic fail-closed control.
+The suite measures pre-execution authorization cost; whether that cost is
+acceptable depends on the deployment workload and latency budget.
 
 ## Benchmark Methodology
 
@@ -100,7 +93,8 @@ which provides nanosecond resolution.
 
 Samples are stored in nanoseconds and reported in milliseconds.
 
-For documentation and interpretation, the project also reports the main results in microseconds because the protected-path overhead is small enough that microsecond-scale absolute deltas are the most useful engineering view.
+For documentation and interpretation, the project also reports the main
+results in microseconds so absolute deltas remain easy to compare.
 
 ### Multiple runs
 
@@ -144,6 +138,11 @@ only field/binding checks are evaluated.
 ### verifyEnvelope
 
 Measures verification of execution envelopes.
+
+The current fixture envelope is unsigned. The benchmark supplies a valid
+trusted key set for both modes but sets `requireSignatureVerification: false`,
+so this scenario includes snapshot and audit-envelope verification but not
+Ed25519 envelope-signature verification.
 
 Supported modes:
 
@@ -234,12 +233,10 @@ Percentage overhead may be misleading when the baseline path is extremely small.
 
 Therefore absolute microsecond overhead should be considered the primary metric.
 
-For the latest full-suite run on the tested host, the single-worker protected-path overhead was approximately:
-
-- `+14.8 us p50` and `+21.8 us mean` in `best-effort`
-- `+16.6 us p50` and `+25.2 us mean` in `strict`
-
-This is the main performance result to communicate externally.
+The current run contains noise and outlier warnings and therefore does not
+support a stable external numeric claim. See
+[`BENCHMARK_SUMMARY.md`](./BENCHMARK_SUMMARY.md) for the exact observations and
+their classifications.
 
 ## Result Interpretation
 
@@ -251,7 +248,8 @@ Primary interpretation should focus on:
 
 The benchmark is designed to emphasize absolute latency overhead in microseconds, not percentage overhead.
 
-When baseline latency is very small, percentage deltas can become unstable and visually misleading even when absolute overhead remains bounded.
+When baseline latency is very small, percentage deltas can become unstable and
+visually misleading. Absolute deltas remain host- and workload-specific.
 
 ## How To Compare Across Machines
 

--- a/bench/cases/evaluate.ts
+++ b/bench/cases/evaluate.ts
@@ -26,7 +26,7 @@ export function create(seed: number): () => unknown {
   const fx = fixtures.complex;
   const engine = new PolicyEngine({
     policy_version: fx.policy.version,
-    engine_secret: "bench-hmac-secret",
+    engine_secret: "benchmark-only-hmac-secret-at-least-32-chars",
     authorization_ttl_seconds: 120,
     authorization_issuer: "bench-issuer",
     authorization_audience: "bench-rp",

--- a/bench/cases/protectedPath.ts
+++ b/bench/cases/protectedPath.ts
@@ -1,5 +1,5 @@
 import { verifyAuthorization, verifyEnvelope } from "@oxdeai/core";
-import { createProtectedPathFixture } from "../fixtures";
+import { BENCHMARK_ENVELOPE_KEY_SET, createProtectedPathFixture } from "../fixtures";
 
 export const name = "protectedPath";
 
@@ -40,7 +40,7 @@ export function create(seed: number, envelopeMode: "strict" | "best-effort"): ()
     expectedPolicyId: fx.policyId,
     consumedAuthIds: [] as string[],
     requireSignatureVerification: true,
-    legacyHmacSecret: "bench-hmac-secret",
+    legacyHmacSecret: "benchmark-only-hmac-secret-at-least-32-chars",
   };
 
   return () => {
@@ -53,6 +53,7 @@ export function create(seed: number, envelopeMode: "strict" | "best-effort"): ()
     const envResult = verifyEnvelope(fx.envelopeBytes, {
       mode: envelopeMode,
       expectedPolicyId: fx.policyId,
+      trustedKeySets: BENCHMARK_ENVELOPE_KEY_SET,
       requireSignatureVerification: false,
       now: 1_700_000_000,
     });

--- a/bench/cases/verifyAuthorization.ts
+++ b/bench/cases/verifyAuthorization.ts
@@ -13,7 +13,7 @@ export function create(seed: number): () => unknown {
     expectedPolicyId: fixture.policy.id,
     consumedAuthIds: [] as string[],
     requireSignatureVerification: true,
-    legacyHmacSecret: "bench-hmac-secret",
+    legacyHmacSecret: "benchmark-only-hmac-secret-at-least-32-chars",
   };
 
   return () => {

--- a/bench/cases/verifyEnvelope.ts
+++ b/bench/cases/verifyEnvelope.ts
@@ -1,4 +1,4 @@
-import { createFixtureSet } from "../fixtures";
+import { BENCHMARK_ENVELOPE_KEY_SET, createFixtureSet } from "../fixtures";
 import { verifyEnvelope } from "@oxdeai/core";
 
 export const name = "verifyEnvelope";
@@ -10,6 +10,7 @@ export function create(seed: number, mode: "strict" | "best-effort"): () => unkn
     const out = verifyEnvelope(fixture.envelopeBytes, {
       mode,
       expectedPolicyId: fixture.policy.id,
+      trustedKeySets: BENCHMARK_ENVELOPE_KEY_SET,
       requireSignatureVerification: false,
       now: 1_700_000_000,
     });

--- a/bench/fixtures.ts
+++ b/bench/fixtures.ts
@@ -5,7 +5,21 @@ import {
   RECOMMENDED_TRUSTED_TIME_PROFILE,
   verifySnapshot,
 } from "@oxdeai/core";
-import type { Authorization, Intent, State } from "@oxdeai/core";
+import type { AuthorizationV1, Intent, State } from "@oxdeai/core";
+import type { KeySet } from "@oxdeai/core";
+
+export const BENCHMARK_ENVELOPE_KEY_SET: KeySet = {
+  issuer: "bench-envelope-issuer",
+  version: "1",
+  keys: [
+    {
+      kid: "bench-envelope-key",
+      alg: "Ed25519",
+      public_key:
+        "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAWiMMGTYK7zzHwZXLzDpCshxAH6Lgx8gVsJaixePuY7g=\n-----END PUBLIC KEY-----",
+    },
+  ],
+};
 
 export type FixtureProfile = "minimal" | "complex" | "adversarial";
 
@@ -14,7 +28,7 @@ type BenchFixture = {
   policy: { id: string; version: string };
   intent: Intent;
   state: State;
-  auth: Authorization;
+  auth: AuthorizationV1;
   envelopeBytes: Uint8Array;
 };
 
@@ -78,7 +92,7 @@ function deepCloneState(state: State): State {
 function makeEngine(policyId: string, policyVersion: string): PolicyEngine {
   return new PolicyEngine({
     policy_version: policyVersion,
-    engine_secret: "bench-hmac-secret",
+    engine_secret: "benchmark-only-hmac-secret-at-least-32-chars",
     authorization_ttl_seconds: 120,
     authorization_issuer: "bench-issuer",
     authorization_audience: "bench-rp",
@@ -169,7 +183,15 @@ function makeEnvelope(policyId: string, state: State, nowTs: number): Uint8Array
     snapshot,
     events: [
       { type: "INTENT_RECEIVED", timestamp: nowTs, policyId, intent_hash: "h".repeat(64), agent_id: "agent-1" },
-      { type: "DECISION", timestamp: nowTs + 1, policyId, intent_hash: "h".repeat(64), decision: "ALLOW", reasons: [] },
+      {
+        type: "DECISION",
+        timestamp: nowTs + 1,
+        policyId,
+        policy_version: state.policy_version,
+        intent_hash: "h".repeat(64),
+        decision: "ALLOW",
+        reasons: [],
+      },
       { type: "STATE_CHECKPOINT", timestamp: nowTs + 2, policyId, stateHash: snapshotResult.stateHash },
     ],
   } as any);
@@ -252,7 +274,7 @@ export type ProtectedPathFixture = {
   engine: PolicyEngine;
   intent: Intent;
   state: State;
-  auth: Authorization;
+  auth: AuthorizationV1;
   envelopeBytes: Uint8Array;
   toolExecute: (actionType: string, target: string, costMinorUnits: number) => number;
 };

--- a/bench/runner-core.ts
+++ b/bench/runner-core.ts
@@ -1,5 +1,6 @@
 import { Worker } from "node:worker_threads";
 import type { BenchmarkConfig, ScenarioName } from "./config.js";
+import { BENCHMARK_ENVELOPE_KEY_SET } from "./fixtures.js";
 import { computeLatencyStats, median, measureIterations, type LatencyStats } from "./metrics.js";
 
 export type ScenarioHandle = {
@@ -138,11 +139,11 @@ function makeSyntheticToolExecutor() {
 }
 async function main() {
   const core = await import("@oxdeai/core");
-  const { scenario, mode, seed, warmup, iterations } = workerData;
+  const { scenario, mode, seed, warmup, iterations, trustedKeySets } = workerData;
   const policyId = "0123456789abcdef".repeat(4);
   const engine = new core.PolicyEngine({
     policy_version: "bench-complex-v1",
-    engine_secret: "bench-hmac-secret",
+    engine_secret: "benchmark-only-hmac-secret-at-least-32-chars",
     authorization_ttl_seconds: 120,
     authorization_issuer: "bench-issuer",
     authorization_audience: "bench-rp",
@@ -165,7 +166,7 @@ async function main() {
     snapshot,
     events: [
       { type: "INTENT_RECEIVED", timestamp: 1700000000, policyId, intent_hash: "h".repeat(64), agent_id: "agent-1" },
-      { type: "DECISION", timestamp: 1700000001, policyId, intent_hash: "h".repeat(64), decision: "ALLOW", reasons: [] },
+      { type: "DECISION", timestamp: 1700000001, policyId, policy_version: state.policy_version, intent_hash: "h".repeat(64), decision: "ALLOW", reasons: [] },
       { type: "STATE_CHECKPOINT", timestamp: 1700000002, policyId, stateHash: snapVr.stateHash },
     ],
   });
@@ -186,14 +187,14 @@ async function main() {
       expectedPolicyId: policyId,
       consumedAuthIds: [],
       requireSignatureVerification: true,
-      legacyHmacSecret: "bench-hmac-secret",
+      legacyHmacSecret: "benchmark-only-hmac-secret-at-least-32-chars",
     };
     work = () => {
       const decision = engine.evaluatePure(intent, makeState(), 1700000000);
       if (decision.decision !== "ALLOW") return 0;
       const authVr = core.verifyAuthorization(auth, authOpts);
       if (authVr.status !== "ok") return 0;
-      const envVr = core.verifyEnvelope(envelope, { mode, expectedPolicyId: policyId, requireSignatureVerification: false, now: 1700000000 });
+      const envVr = core.verifyEnvelope(envelope, { mode, expectedPolicyId: policyId, trustedKeySets, requireSignatureVerification: false, now: 1700000000 });
       if (envVr.status !== "ok" && envVr.status !== "inconclusive") return 0;
       return runTool(actionType, target, amount);
     };
@@ -207,11 +208,11 @@ async function main() {
       expectedPolicyId: policyId,
       consumedAuthIds: [],
       requireSignatureVerification: true,
-      legacyHmacSecret: "bench-hmac-secret",
+      legacyHmacSecret: "benchmark-only-hmac-secret-at-least-32-chars",
     };
     work = () => core.verifyAuthorization(auth, opts);
   } else {
-    work = () => core.verifyEnvelope(envelope, { mode, expectedPolicyId: policyId, requireSignatureVerification: false, now: 1700000000 });
+    work = () => core.verifyEnvelope(envelope, { mode, expectedPolicyId: policyId, trustedKeySets, requireSignatureVerification: false, now: 1700000000 });
   }
   let sink = 0;
   for (let i = 0; i < warmup; i++) {
@@ -265,6 +266,7 @@ async function runWorkersAttempt(
             seed: config.seed + i,
             warmup: perWorkerWarmup,
             iterations: perWorkerIterations,
+            trustedKeySets: BENCHMARK_ENVELOPE_KEY_SET,
           },
         });
         worker.on("message", (msg) => resolve(msg as WorkerResult));

--- a/docs/release/benchmark-announcement.md
+++ b/docs/release/benchmark-announcement.md
@@ -11,22 +11,11 @@ Announcement draft. This file is not current release policy and must not be used
 
 
 
-OxDeAI now includes a reproducible benchmark suite for measuring the runtime cost of its authorization boundary.
-
-The most important result from the latest full-suite local run is straightforward:
-
-- single-worker protected execution added about `+14.8 us p50` / `+21.8 us mean` in `best-effort` mode
-- single-worker protected execution added about `+16.6 us p50` / `+25.2 us mean` in `strict` mode
-
-These figures are measured as:
-
-`protectedPath - baselinePath`
-
-on the run recorded in:
-
-- `bench/outputs/run-2026-03-11-12-25-55.json`
-
-This is the practical performance result to pay attention to. OxDeAI provides deterministic authorization for agent actions with tens-of-microseconds inline overhead on the tested machine.
+OxDeAI includes a reproducible benchmark suite for measuring the runtime cost
+of its authorization boundary. The current-HEAD run contains noise and outlier
+warnings and does not support a stable numeric headline. Exact observations,
+provenance, and limitations are recorded in
+[`bench/BENCHMARK_SUMMARY.md`](../../bench/BENCHMARK_SUMMARY.md).
 
 ## Why this benchmark exists
 
@@ -68,54 +57,25 @@ These are the most useful scenarios for adoption decisions:
 
 ## Latest measured result
 
-Environment for the latest full-suite run:
-
-- CPU: Intel(R) Core(TM) i5-7400 CPU @ 3.00GHz
-- logical cores: 4
-- runtime: Node.js v22.9.0
-- OS: Linux 5.15.133.1-microsoft-standard-WSL2 x64
-- environment: WSL2
-
-Benchmark configuration:
-
-- `--scenario=all`
-- `--runs=5`
-- `--iterations=100000`
-- `--warmup=10000`
-- `--concurrency=1,4`
-- `--envelopeMode=both`
-
-Selected single-worker results:
-
-| Scenario | p50 (us) | p95 (us) | p99 (us) | mean (us) |
-|---|---:|---:|---:|---:|
-| `evaluate` | 23.833 | 37.501 | 64.520 | 29.956 |
-| `verifyEnvelope` (`best-effort`) | 15.457 | 21.654 | 45.956 | 17.199 |
-| `verifyEnvelope` (`strict`) | 15.546 | 22.307 | 46.339 | 17.140 |
-| `baselinePath` | 8.495 | 8.891 | 23.077 | 8.993 |
-| `protectedPath` (`best-effort`) | 23.326 | 37.275 | 69.070 | 30.843 |
-| `protectedPath` (`strict`) | 25.075 | 40.306 | 77.067 | 34.208 |
-
-Absolute single-worker overhead:
-
-| Protected mode | Delta p50 (us) | Delta p95 (us) | Delta p99 (us) | Delta mean (us) |
-|---|---:|---:|---:|---:|
-| `best-effort` | 14.831 | 28.384 | 45.993 | 21.850 |
-| `strict` | 16.580 | 31.415 | 53.990 | 25.215 |
+The current run is a host-specific observation rather than a publication-ready
+performance range. It uses five repetitions, 100,000 measured samples and
+10,000 warmup invocations per repetition, 1 and 4 workers, and both envelope
+modes. See the benchmark summary for the exact environment, p50/p95/p99 values,
+and harness classifications.
 
 ## Interpretation
 
-The result is not that authorization is “free.” The result is that a deterministic fail-closed authorization boundary can be inserted into an agent execution path with bounded microsecond-scale overhead on the tested host.
+The benchmark does not show that authorization is “free,” nor does it establish
+a universal bound. It measures a synthetic protected path on one host.
 
-For many agent systems, that overhead is small relative to the latency of the protected side effect itself, which is often dominated by:
+In deployments dominated by model calls, network I/O, database operations,
+queueing, or external tool execution, teams can compare the measured local
+authorization cost against those downstream latency budgets. This benchmark
+does not measure that comparison directly.
 
-- network I/O
-- model calls
-- database writes
-- queueing
-- external tool execution
-
-This makes the benchmark useful for systems design decisions. It shows that the authorization boundary is cheap enough to be practical while still being explicit and reproducible.
+This makes the benchmark useful for comparative systems testing, but whether
+the measured cost is acceptable depends on the deployment workload and latency
+budget.
 
 ## Reproducibility
 
@@ -140,9 +100,13 @@ For a full run-specific write-up, see [`bench/BENCHMARK_SUMMARY.md`](../../bench
 
 ### X / Twitter
 
-OxDeAI benchmarks: the protected execution path adds about `16-25 us p50` on a single worker on the tested machine.
+OxDeAI includes a reproducible protected-minus-baseline benchmark. The current
+host-specific run is noisy, so consult the run report rather than quoting a
+stable overhead range.
 
-That path includes deterministic policy evaluation plus authorization/envelope checks before a tool call. The result is a fail-closed authorization boundary for agent actions with bounded inline cost.
+That path includes deterministic policy evaluation plus authorization/envelope
+checks before synthetic tool work. The report records its host-specific cost
+without asserting a universal bound.
 
 Reproducible locally:
 
@@ -158,9 +122,15 @@ OxDeAI is an authorization boundary for agent runtimes.
 
 The model is simple: the runtime proposes an action, OxDeAI evaluates policy deterministically, emits an authorization on `ALLOW`, and the relying party verifies that authorization before any side effect executes. The goal is fail-closed execution control for tool calls, payments, provisioning, and similar agent actions.
 
-We added a reproducible benchmark suite to measure the practical cost of that boundary. On the tested machine, the protected path adds about `16-25 us p50` in single-worker mode versus a baseline path without OxDeAI checks. The benchmark also measures `evaluate`, `verifyEnvelope`, and baseline vs protected execution directly.
+We added a reproducible benchmark suite to measure the practical cost of that
+boundary. It measures `evaluate`, `verifyAuthorization`, `verifyEnvelope`, and
+baseline versus protected synthetic execution directly. The current run is
+host-specific and noisy, so it is reported with exact classifications rather
+than promoted as a stable range.
 
-The result is not zero cost, but it is small enough to be practical for many agent runtimes where the real downstream cost is usually network I/O, model calls, or external tool latency.
+The result is not zero cost. For network- or model-bound runtimes it may be
+small relative to downstream work, but that comparison is workload-dependent
+and is not measured by this synthetic benchmark.
 
 Important details:
 
@@ -170,15 +140,21 @@ Important details:
 - results depend on hardware/runtime
 - benchmark is meant to be rerun, not treated as a universal constant
 
-The repo includes the benchmark harness and generated output so the numbers can be inspected or reproduced.
+The repo includes the benchmark harness and a run-specific summary so the
+methodology and reported observations can be inspected or reproduced.
 
 ### Reddit
 
 OxDeAI is a deterministic authorization layer for agent actions.
 
-We benchmarked the protected execution path, which includes policy evaluation and verification before tool execution. On the tested machine, the added overhead was about `16-25 us p50` in single-worker mode.
+We benchmarked a synthetic protected execution path containing policy
+evaluation, authorization verification, envelope verification, and deterministic
+in-memory tool work. The current host-specific result is noisy and is not a
+stable overhead claim.
 
-What matters is not the isolated microbenchmark, but that a fail-closed authorization boundary can be placed in front of agent actions with bounded runtime cost. That is useful for:
+The microbenchmark measures the local cost of placing a fail-closed
+authorization boundary in front of synthetic agent actions. Whether that cost
+is acceptable is workload-dependent. Relevant applications include:
 
 - tool execution
 - external API calls
@@ -191,7 +167,11 @@ The benchmark is reproducible from the repo and reports `evaluate`, `verifyEnvel
 
 For an agent runtime, the relevant question is usually not whether authorization is fast in the abstract. The relevant question is whether a pre-execution policy boundary can be enforced without materially changing end-to-end runtime behavior.
 
-The current OxDeAI measurements suggest that, on the tested host, the answer is yes for many runtime designs. A protected path adds roughly `16-25 us p50` in single-worker execution. In practice, that is small relative to the latency of most external side effects that agents trigger: HTTP requests, database writes, tool execution, queue operations, or settlement calls.
+The current OxDeAI measurement does not establish end-to-end impact for an
+agent runtime. It measures deterministic in-memory work rather than HTTP
+requests, model calls, database writes, queues, or external tool execution.
+Teams should compare the protected-minus-baseline cost with their own workload
+and latency budget.
 
 That overhead buys a specific property: deterministic fail-closed execution control. The runtime can require a valid authorization artifact before the tool call happens, rather than relying on post-fact logging or heuristic filtering.
 
@@ -202,7 +182,10 @@ The benchmark is structured to make engineering review easier:
 - `baselinePath` gives a no-authorization comparison path
 - `protectedPath` shows the actual inline cost of gating execution
 
-These measurements are bounded inline overhead, not a promise that every environment will see the same number. Teams should rerun the benchmark on their own hardware and compare absolute microsecond overhead in a controlled way.
+These measurements are host-specific inline-overhead observations, not a
+promise that every environment will see the same number. Teams should rerun the
+benchmark on their own hardware and compare absolute microsecond overhead in a
+controlled way.
 
 ### Quickstart example
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -667,11 +667,15 @@ console.log(verified.status === "ok"); // true when checkpoints exist
 
 ## Benchmarks
 
-Adds ~80–150µs per action (p50) for the full protected path (evaluation + authorization verification).
+The synthetic protected-path benchmark includes deterministic policy
+evaluation, shared-secret HMAC authorization verification, unsigned envelope
+verification, and deterministic in-memory tool work. It does not measure model,
+network, or application execution.
 
-Negligible compared to multi-second agent loops.
-
-The protected path includes deterministic policy evaluation and authorization verification before execution becomes reachable.
+Current measurements are host- and runtime-specific and contain noise/outlier
+warnings, so no stable per-action overhead is claimed. See the
+[benchmark summary](../../bench/BENCHMARK_SUMMARY.md) for exact observations,
+provenance, and limitations.
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary

Restores the OxDeAI benchmark harness against current HEAD and replaces stale public performance claims with reproducible, host-specific evidence.

The benchmark had drifted behind current runtime requirements and could no longer produce valid protected-path measurements without fixture repair.

## Root cause

The benchmark harness contained several stale assumptions:

- a 17-character HMAC secret, while `PolicyEngine` now requires at least 32 characters
- envelope `DECISION` events missing the required `policy_version`
- strict envelope verification without the required trusted key set
- legacy benchmark typing that no longer matched the emitted `AuthorizationV1`

An initial post-secret-fix benchmark run was rejected after preflight showed the envelope was still invalid and the protected path exited before synthetic tool execution.

## Changes

- update benchmark-only HMAC fixtures to satisfy current validation
- add required `policy_version` to benchmark envelope events
- provide benchmark-only trusted key material to envelope verification
- align benchmark authorization fixtures with `AuthorizationV1`
- preserve production validation and verification semantics
- document the exact protected path:
  - `PolicyEngine.evaluatePure`
  - `verifyAuthorization`
  - `verifyEnvelope`
  - deterministic synthetic tool work
- remove stale `~80-150µs` and `negligible` public performance claims
- document current benchmark provenance, methodology, limitations, noise, and outliers
- record a clean-worktree benchmark run bound to commit `b2bcfcf603aefcd60ea0cbcd3b406b59cf77933d`

## Current benchmark evidence

On the measured WSL2 host, the latest clean run observed protected-path p50 overhead between approximately `0.54 ms` and `0.55 ms` across one- and four-worker configurations.

All four protected-path configurations were classified `OK`.

Tail latency and several component scenarios still contain noise or outlier warnings, so this is reported as host-specific evidence rather than a universal runtime guarantee.

The benchmark does not measure:

- model calls
- network I/O
- database operations
- queues
- application tool execution
- Ed25519 envelope-signature verification

## Security impact

No production security validation is weakened.

The changes are limited to benchmark fixtures, harness compatibility, benchmark documentation, and public performance wording.

The benchmark continues to exercise fail-closed authorization and envelope verification paths.

## Validation

Passed:

- full benchmark suite with 5 repetitions
- 100,000 measured samples per repetition
- 10,000 warmup invocations
- 1 and 4 workers
- best-effort and strict envelope modes
- explicit preflight confirming:
  - policy decision `ALLOW`
  - authorization verification `ok`
  - envelope verification `ok`
- TypeScript benchmark compilation
- repository typecheck
- `git diff --check`

## Follow-up

The current protected-path p50 is materially higher than the historical benchmark evidence.

This PR does not classify that difference as a performance bug. A separate investigation will determine whether the change is explained by additional security work, benchmark semantics, runtime/environment differences, or a genuine implementation regression.

Closes #281