### PR TITLE
fix(build): upgrade pnpm to patched release

### DIFF
--- a/examples/lgf-frappe-pep/Dockerfile
+++ b/examples/lgf-frappe-pep/Dockerfile
@@ -10,7 +10,7 @@
 # build context is the repo root.
 
 FROM node:20-alpine AS build
-RUN corepack enable && corepack prepare pnpm@9.12.2 --activate
+RUN corepack enable && corepack prepare pnpm@10.34.5 --activate
 WORKDIR /app
 
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
@@ -31,7 +31,7 @@ RUN pnpm --filter @oxdeai/core build && \
     pnpm --filter @oxdeai/example-lgf-frappe-pep build
 
 FROM node:20-alpine
-RUN corepack enable && corepack prepare pnpm@9.12.2 --activate
+RUN corepack enable && corepack prepare pnpm@10.34.5 --activate
 WORKDIR /app
 
 LABEL org.opencontainers.image.title="OxDeAI PEP Sidecar"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "oxdeai",
   "private": true,
-  "packageManager": "pnpm@9.12.2",
+  "packageManager": "pnpm@10.34.5",
   "engines": {
     "node": ">=20",
-    "pnpm": ">=9"
+    "pnpm": ">=10.34.5 <11"
   },
   "scripts": {
     "lint": "pnpm typecheck",


### PR DESCRIPTION
## Summary

Upgrade pnpm from 9.12.2 to 10.34.5 to move the repository onto the patched pnpm 10 line before processing untrusted PR install inputs.

## Changes

- pin root `packageManager` to `pnpm@10.34.5`
- tighten `engines.pnpm` to `>=10.34.5 <11`
- update both LGF Frappe PEP Dockerfile pnpm pins to `10.34.5`

No lockfile changes.

## Validation

Validated with pnpm 10.34.5 via Corepack 0.31.0:

- frozen install
- typecheck
- full build
- core API checks
- security gate tests
- recursive workspace tests
- conformance validation: 259 assertions
- TS, authorization, PEP, delegation vectors
- Go vectors
- Python vectors
- adapter validation

All passed.

Closes #285