### PR TITLE
Fix/cross language coverage 302

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Authorization artifacts prove what was allowed.
 OxDeAI is validated through **verifiable invariants**, not claims:
 
 * frozen canonicalization vectors
-* cross-language verification (TypeScript / Go / Python)
+* cross-language verification on canonicalization, Profile-C state verification and SignedKRLV1 (TypeScript / Go / Python); other surfaces are TypeScript-only
 * conformance suite (CI validated)
 * cross-adapter equivalence
 

--- a/docs/audits/protocol-audit-post-interoperability.md
+++ b/docs/audits/protocol-audit-post-interoperability.md
@@ -198,7 +198,7 @@
 | Area | Status | Notes |
 |------|--------|-------|
 | `DelegationV1` structure | `DONE` | Specified in `delegation-v1.md`. Conformance vectors. |
-| Delegation chain verification | `DONE` | `verifyDelegationChain`. Tested. Cross-language via Go harness. |
+| Delegation chain verification | `DONE` | `verifyDelegationChain`. Tested in TypeScript. A Go adapter references the vectors but `test:vectors:go` does not exercise them; the Python adapter fails at import (#306). Not cross-language verified. |
 | Scope narrowing | `DONE` | Tools + max_amount. Tested. Conformance vectors. |
 | Delegation scope verification in guard | `DONE` | Guard step 3: checks `scope.tools`, `scope.max_amount`. |
 | Delegation replay | `DONE` | `consumeDelegationId` + `consumeAuthId(parentAuth)`. |

--- a/docs/standardization/execution-time-authorization-alignment.md
+++ b/docs/standardization/execution-time-authorization-alignment.md
@@ -130,7 +130,7 @@ Attribution: the invariant names and section references above are drawn from the
 
 **OxDeAI mechanisms:**
 
-**The portable conformance vector suite** ([`docs/spec/test-vectors/`](../spec/test-vectors/)) establishes that verification is independently reproducible. The 12 portable `authorization-v1.json` vectors (Encoding A and Encoding B), the 8 Profile C state-hash vectors (modes 001–008), and the 9 SignedKRLV1 vectors are each exercised by independent Go and Python harnesses that:
+**The portable conformance vector suite** ([`docs/spec/test-vectors/`](../spec/test-vectors/)) establishes that verification is independently reproducible. The 11 canonicalization-v1 vectors, the 8 Profile C state-hash vectors (modes 001–008), and the 9 SignedKRLV1 vectors are each exercised by independent Go and Python harnesses that:
 
 - Independently implement canonicalization-v1
 - Independently compute Ed25519 preimages
@@ -139,7 +139,7 @@ Attribution: the invariant names and section references above are drawn from the
 
 **Byte-equivalence proof.** The `KRL_DUPLICATE_REVOKED_KIDS` vector signature (`+mwEd2QP5+tx6pCKAiF8BKzMAHf1c28mcTQF575pDn/DwgRiJ+PkYnv+sasIdgj1S7E9mSZZK1pOTP43nlnsDA==`) and the Profile C mode 006–008 Encoding B artifact signature (`jMyip7h-GMgl2nV_q8Cz-MuqbD4vgba6vseRejY13e-w8WZeW7UU7ft58JHJFJR0fyZ3NGXvjJBGeKSSJLThCA`) serve as concrete byte-equivalence proof points: three independent implementations (TypeScript, Go, Python) compute identical preimage bytes from identical inputs and verify identical signatures. This is not a claimed property - it is a mechanically verified fact with every run of `pnpm test:vectors:all`.
 
-**Cross-language harness assertion counts** as of #120: 209 TypeScript assertions, 28 Go assertions, 28 Python assertions, covering canonicalization, AuthorizationV1 verification, Profile C state-hash semantics, Profile C Encoding B, and SignedKRLV1.
+**Cross-language harness assertion counts** as of #120: 209 TypeScript assertions, 28 Go assertions, 28 Python assertions. The 28 per language are canonicalization-v1 (11), Profile C state-hash semantics including Encoding B (8), and SignedKRLV1 (9). The 12 portable `authorization-v1.json` vectors are verified in TypeScript only; the Go and Python authorization-verification harness integration is not yet implemented.
 
 **Replayability of individual authorization decisions.** Any verifier holding the issuer's public key, the AuthorizationV1 artifact, and the proposed action can independently verify: signature validity, expiry, audience, issuer, intent hash binding, and (with the live state) state hash binding. The `verify-authorization-vectors.mjs` script demonstrates this for the portable authorization vectors.
 

--- a/packages/conformance/README.md
+++ b/packages/conformance/README.md
@@ -141,14 +141,20 @@ compatibility but not used by the harness runners.
 
 ### Coverage distinction
 
+The `Cross-language?` column reports what `pnpm test:vectors:go` and
+`pnpm test:vectors:py` actually execute, not what is portable in principle.
+Those commands exercise three corpora: canonicalization-v1 (11 vectors),
+Profile-C state verification (8), and SignedKRLV1 (9) - 28 assertions per
+language. Everything else is TypeScript-only today.
+
 | Layer | What it covers | Cross-language? |
 |-------|---------------|-----------------|
-| `delegation-parent-hash.json` | Hash stability, I1 key-order invariance | Yes - SHA256 + canonical JSON only |
-| `delegation-verification.json` | Field checks, expiry, scope, replay, trust-missing | Yes - no crypto required |
-| `delegation-chain-verification.json` | Chain structural checks (hash binding, delegator, expiry ceiling, policy) | Yes - independently recomputed |
-| `delegation-signature-verification.json` | Ed25519 verification path | Yes - independently verified |
-| `key-lifecycle-verification.json` | Key status (active/revoked/retired), `not_before`/`not_after` windows, wrong-kid rejection | Yes - portable across any `verifyAuthorization` implementation |
-| `clock-semantics-verification.json` | Strict zero-tolerance expiry, `issued_at` informational, Encoding A + B boundary pins | Yes - portable; no crypto required |
+| `delegation-parent-hash.json` | Hash stability, I1 key-order invariance | TypeScript only - portable in principle (SHA256 + canonical JSON), but not exercised by `test:vectors:go` |
+| `delegation-verification.json` | Field checks, expiry, scope, replay, trust-missing | TypeScript only - portable in principle (no crypto required), but not exercised by `test:vectors:go` |
+| `delegation-chain-verification.json` | Chain structural checks (hash binding, delegator, expiry ceiling, policy) | TypeScript only - Go and Python adapters exist in `go-harness/` but are not exercised by `test:vectors:go`; the Python adapter fails at import (#306) |
+| `delegation-signature-verification.json` | Ed25519 verification path | TypeScript only - Go and Python adapters exist in `go-harness/` but are not exercised by `test:vectors:go`; the Python adapter fails at import (#306) |
+| `key-lifecycle-verification.json` | Key status (active/revoked/retired), `not_before`/`not_after` windows, wrong-kid rejection | TypeScript only - portable across any `verifyAuthorization` implementation, but `validate.ts` is its only consumer |
+| `clock-semantics-verification.json` | Strict zero-tolerance expiry, `issued_at` informational, Encoding A + B boundary pins | TypeScript only - portable, no crypto required, but `validate.ts` is its only consumer |
 | `trusted-time.json` | Trusted-time freshness gate: issuance, velocity, tool-window, replay under `evaluationTime`; protocol-domain and malformed-input rejection | TypeScript only (dedicated `runTrustedTimeConformance` harness) |
 | `profile-c-state-verification.json` | Semantic state verification: hash comparison, strategy mismatch, compute-throws, TOCTOU, Encoding B | TypeScript only (TS runner); **Go + Python cover all 8 modes** via `docs/spec/test-vectors/profile-c-state-verification.json` (#120) |
 | `delegation.property.test.ts` (D-P1–D-P5) | PBT over scope / hash / mutation | TypeScript only |


### PR DESCRIPTION
## Summary

Four public surfaces claimed cross-language conformance coverage that no harness
delivers. This PR corrects the claims. It does not change what is verified.

`pnpm test:vectors:go` executes three corpora: canonicalization-v1 (11 vectors),
Profile-C state verification (8), SignedKRLV1 (9) — 28 assertions per language.
No delegation, key-lifecycle or clock-semantics vector is exercised outside
TypeScript.

## Changes

- `packages/conformance/README.md` — six rows of the `Cross-language?` table
  answered `Yes` for corpora no harness executes. Each is now `TypeScript only`
  with its actual reason. A header sentence states that the column reports what
  the commands execute, not what is portable in principle.
- `docs/standardization/execution-time-authorization-alignment.md:133` — claimed
  the 12 portable `authorization-v1.json` vectors are each exercised by
  independent Go and Python harnesses. Replaced with the 11 canonicalization-v1
  vectors, which are. Line 142 listed AuthorizationV1 verification among the 28
  assertions while giving a total that excludes it; now enumerates the
  composition.
- `README.md:204` — `cross-language verification (TypeScript / Go / Python)` was
  listed as an unqualified property. Now names the three covered surfaces.
- `docs/audits/protocol-audit-post-interoperability.md:201` — the `DONE` status
  holds for TypeScript; the justification claimed cross-language via Go harness.

## Security impact

- [x] No security-relevant behavior changed
- [ ] Security-relevant behavior changed and is described below

Details: documentation only. No source file, vector, test or CI configuration is
modified. The verification behavior described was already the behavior; only its
description was wrong.

## Validation

```text
pnpm test:vectors:go
PASS i1..i4 — All 11 canonicalization vector(s) passed
PASS profile-c-001..008 — All 8 Profile C vector(s) passed
PASS KRL_* — All 9 SignedKRL vector(s) passed
→ 28 assertions. No delegation, key-lifecycle or clock-semantics vector executed.
```

```text
consumer graph, grep over *.go *.py *.mjs *.ts excluding tests
delegation-parent-hash          validate.ts, extract-vectors.ts, go-harness/main.go
delegation-verification         validate.ts, go-harness/main.go
delegation-chain-verification   validate.ts, extract-vectors.ts, go-harness/main.go, go-harness/adapter_python.py
delegation-signature-verification  same as above
key-lifecycle-verification      validate.ts only
clock-semantics-verification    validate.ts only
→ go-harness/main.go references four delegation corpora; test:vectors:go runs none of them.
```

```text
python3 packages/conformance/go-harness/adapter_python.py
adapter_python.py:29  v["input"]["intent_id"]
KeyError: 'intent_id'
exit=1
→ authorization-payload.json vectors carry intent_timestamp, evaluation_time,
  effective_ttl, intent. No intent_id key exists. Fails at module load.
```

## Regression proof

Not applicable in the usual sense: no code path changes, so there is no failure
to reproduce and no mutation test to write.

The claims were falsified by running the commands the documentation implicitly
cited. The corrected statements are falsifiable the same way — if a later change
makes `test:vectors:go` exercise the delegation corpora, the table rows become
wrong again and must be revised in that PR.

## Scope

- [x] No unrelated changes
- [x] No required CI check weakened, bypassed, or made advisory
- [x] No production behavior changed unless explicitly described
- [x] Documentation updated where required

## Inspected, correct as written, no change

Recorded because #302 requires surfaces found correct to be listed rather than
silently omitted.

- `docs/whitepaper/oxdeai-deterministic-execution-authorization.md` and
  `WhitePaper.md`, §10.5–10.7 — states the coverage precisely and names the
  missing Go/Python authorization-verification harness integration. Used as the
  source for the corrected wording elsewhere.
- `website/index.html:408-412` — qualifies the claim immediately
- `docs/spec/interoperability/external-provider-profile.md:298-300` — confirmed
  by the run above: Go validates all 8 Profile C vectors
- `docs/spec/core/canonicalization-v1.md`
- `docs/spec/artifacts/signed-krl-v1.md:279-291`
- `docs/spec/conformance/conformance-v1.md:216`
- `docs/standardization/aarm-alignment.md:98`
- `docs/architecture/decision-is-not-execution.md`

## Not addressed here

Repairing the Python adapter and extending `test:vectors:go` to the delegation
corpora is #306. That changes what is true; this PR corrects what is claimed.
Doing both in one change is how the incorrect claims arose in the first place.

## Related issue

Closes #302