### PR TITLE
docs(spec): close normative conformance and verification gaps

### DIFF
--- a/docs/spec/artifacts/signed-krl-v1.md
+++ b/docs/spec/artifacts/signed-krl-v1.md
@@ -1,6 +1,7 @@
 # SignedKRLV1 Specification
 
-**Version:** v1.0 (Patch A — artifact definition and pure verifier only)  
+**Version:** v1.0
+**Patch:** Patch A - artifact definition and pure verifier only
 **Status:** Draft  
 **Depends on:** `canonicalization-v1.md`, `authorization-v1.md §17` (clock model)
 
@@ -10,36 +11,50 @@
 
 `SignedKRLV1` is a provider-neutral OxDeAI Key Revocation List artifact.
 
-It allows a KRL publisher to cryptographically commit to a set of revoked key IDs
-and expiry semantics, such that any verifier with the correct trusted KRL signing
-public key can verify the list independently — without network trust, without
-transport-layer assumptions, and without shared secrets.
+It allows a KRL publisher to cryptographically commit to a set of revoked key IDs and expiry semantics, such that any verifier with the appropriate trusted KRL signing public key can verify the list independently, without network trust, transport-layer integrity assumptions, or shared secrets.
 
-> **Protocol invariant being enforced:**
->
-> ```
-> revoked provider key
-> → must not be accepted
-> → no AuthorizationV1 bridge
-> → no execution path
-> ```
+### Protocol objective
 
-`SignedKRLV1` closes the gap where an unsigned KRL depends on transport security
-(HTTPS) for its integrity. A compromised transport path can suppress revocations;
-a signed KRL cannot.
+The complete SignedKRL integration is intended to enforce the following end-to-end invariant:
+
+```text
+revoked provider key
+-> must not be accepted
+-> no AuthorizationV1 bridge
+-> no execution path
+```
+
+Patch A does **not** by itself establish this end-to-end execution invariant.
+
+Patch A defines:
+
+- the `SignedKRLV1` artifact
+- its signing construction
+- its trusted-time semantics
+- its pure verification rules
+- portable conformance evidence
+
+Enforcement of a successful KRL verification result inside a provider keystore or execution path is deferred to Patch B.
+
+`SignedKRLV1` closes the integrity gap of an unsigned KRL whose authenticity depends entirely on transport security. A signed KRL can be authenticated independently after delivery.
 
 ---
 
 ## 2. Provider-neutral scope
 
-`SignedKRLV1` is a standalone OxDeAI protocol artifact. It is independent of:
+`SignedKRLV1` is a standalone OxDeAI protocol artifact.
 
-- Any specific provider (Sift, OpenAI, etc.)
-- The `AuthorizationV1` signing key
-- The `DelegationV1` signing key
+It is independent of:
 
-The KRL signing key is a **distinct trust domain**. Verifiers are configured with
-a static trusted KRL signing key set that is separate from authorization key sets.
+- any specific provider, including Sift or OpenAI
+- the `AuthorizationV1` signing key
+- the `DelegationV1` signing key
+
+The KRL signing key is a **distinct trust domain**.
+
+Verifiers MUST be configured with a trusted KRL signing key set that is separate from authorization and delegation signing key sets.
+
+The trust anchor used to verify a KRL MUST NOT depend on a live network fetch during verification.
 
 ---
 
@@ -62,26 +77,30 @@ a static trusted KRL signing key set that is separate from authorization key set
 }
 ```
 
-### Field reference
+### 3.1 Field reference
 
 | Field | Type | Required | Description |
-|-------|------|----------|-------------|
+|---|---|---:|---|
 | `version` | `"SignedKRLV1"` | Yes | Artifact type discriminator. |
 | `issuer` | non-empty string | Yes | Identity of the KRL publisher. |
-| `krl_version` | non-negative integer | Yes | Monotonically increasing version counter. See §6. |
-| `issued_at` | integer (unix seconds) | Yes | Informational only in v1. Not enforced as a lower bound. See §7. |
-| `not_after` | integer (unix seconds) | Yes | Strict zero-tolerance expiry. See §5. |
-| `revoked_kids` | array of strings | Yes | Revoked key IDs. Must be deduplicated. See §8. |
-| `nonce` | string | No | Optional replay-prevention nonce. Included in signing payload when present. |
+| `krl_version` | non-negative safe integer | Yes | Per-issuer publication version. See §8. |
+| `issued_at` | integer Unix seconds | Yes | Informational only in v1. See §7. |
+| `not_after` | integer Unix seconds | Yes | Strict zero-tolerance expiry. See §6. |
+| `revoked_kids` | array of strings | Yes | Revoked key IDs. MUST be deduplicated. See §9. |
+| `nonce` | string | No | Optional signed nonce. Patch A defines no consumed-nonce replay state. See §8.2. |
 | `signature.alg` | `"Ed25519"` | Yes | Only Ed25519 is accepted in v1. |
-| `signature.kid` | non-empty string | Yes | Identifies the KRL signing key in the trusted key set. |
-| `signature.sig` | non-empty string | Yes | Base64-encoded Ed25519 signature over the signing payload. |
+| `signature.kid` | non-empty string | Yes | Identifies the KRL signing key in the trusted KRL signing key set. |
+| `signature.sig` | non-empty string | Yes | Base64-encoded Ed25519 signature over the signing input. |
+
+Unknown or structurally invalid fields MUST cause verification failure as `KRL_MALFORMED`.
 
 ---
 
 ## 4. Canonical signing payload
 
-The signing payload **includes all normative fields except `signature.sig`**:
+The signing payload MUST include all normative artifact fields except `signature.sig`.
+
+Example:
 
 ```json
 {
@@ -98,195 +117,537 @@ The signing payload **includes all normative fields except `signature.sig`**:
 }
 ```
 
-The `nonce` field is included when present; it is absent from the payload when the
-artifact does not carry a nonce.
+The optional `nonce` field MUST be included in the signing payload when present.
 
-### Field inclusion / exclusion summary
+When the artifact does not contain `nonce`, the key MUST be omitted entirely from the signing payload.
+
+### 4.1 Field inclusion summary
 
 | Field | In signing payload? |
-|-------|-------------------|
+|---|---:|
 | `version` | Yes |
 | `issuer` | Yes |
 | `krl_version` | Yes |
 | `issued_at` | Yes |
 | `not_after` | Yes |
 | `revoked_kids` | Yes |
-| `nonce` | Yes (when present) |
+| `nonce` | Yes, when present |
 | `signature.alg` | Yes |
 | `signature.kid` | Yes |
-| `signature.sig` | **No** — excluded |
+| `signature.sig` | No |
+
+This construction is specific to `SignedKRLV1`.
+
+Implementations MUST NOT infer the signing-payload rules of `SignedKRLV1` from `AuthorizationV1` or `DelegationV1`.
 
 ---
 
-## 5. KRL domain prefix
+## 5. Signing domain and signature construction
 
-The Ed25519 signature is computed over:
+The Ed25519 signing input is:
 
-```
+```text
 OXDEAI_KRL_V1\n + canonicalJson(signedKrlSigningPayload(envelope))
 ```
 
-Using `signatureInput(SIGNING_DOMAINS.KRL_V1, signedKrlSigningPayload(envelope))`
-from the OxDeAI core cryptographic library.
+Equivalent reference-library construction:
 
-This domain prefix is the **provider contract for SignedKRLV1**. Any implementation
-signing or verifying a `SignedKRLV1` artifact must use:
+```text
+signatureInput(
+  SIGNING_DOMAINS.KRL_V1,
+  signedKrlSigningPayload(envelope)
+)
+```
 
-1. OxDeAI canonicalization-v1 (not Sift canonicalization or any other encoding)
-2. The `OXDEAI_KRL_V1\n` domain prefix
-3. Ed25519 raw signing (no hash wrapper — Ed25519 operates directly on the preimage)
+A conforming implementation MUST use:
+
+1. OxDeAI `canonicalization-v1`
+2. the exact domain prefix `OXDEAI_KRL_V1\n`
+3. Ed25519
+4. direct Ed25519 signing over the resulting preimage
+
+Implementations MUST NOT:
+
+- use another canonicalization scheme
+- omit or alter the domain prefix
+- pre-hash the signing input with SHA-256 or another hash before Ed25519 signing
+- encode the signature as base64url instead of the required base64 representation
+
+`signature.sig` MUST contain the base64 encoding of the resulting Ed25519 signature bytes.
 
 ---
 
 ## 6. Strict zero-tolerance expiry semantics
 
-Validity window: `now < not_after`
+`SignedKRLV1` uses the same zero-tolerance upper validity boundary as `AuthorizationV1`.
 
+The validity condition is:
+
+```text
+now < not_after
 ```
-now < not_after   → valid
-now >= not_after  → KRL_EXPIRED (no grace period)
+
+Therefore:
+
+```text
+now < not_after   -> temporally valid
+now >= not_after  -> KRL_EXPIRED
 ```
 
-Exactly parallel to `AuthorizationV1` expiry semantics (see `authorization-v1.md §17`).
-NTP synchronization is required at the verifier.
+At the exact boundary:
 
-Issuers should build delivery latency into the `not_after` window.
+```text
+now == not_after
+```
+
+the artifact MUST be rejected as:
+
+```text
+KRL_EXPIRED
+```
+
+No grace period or clock-skew extension is applied by the SignedKRL verifier.
+
+This is exactly parallel to the `AuthorizationV1` expiry model defined in `authorization-v1.md §17`.
+
+Verifier deployments SHOULD maintain sufficiently synchronized trusted clocks.
+
+Issuers SHOULD account for expected publication and delivery latency when choosing `not_after`.
 
 ---
 
-## 7. `issued_at` — informational only in v1
+## 7. `issued_at` is informational in v1
 
-`issued_at` is required to be an integer unix timestamp, but the verifier does
-**not** enforce a lower bound (`now >= issued_at` is not checked). An artifact
-with `issued_at` in the future is accepted if it passes all other checks.
+`issued_at` MUST be a valid integer Unix timestamp.
 
-This matches the `issued_at` semantics of `AuthorizationV1` (see §17.2 of that spec).
+The verifier MUST NOT enforce `issued_at` as a lower validity boundary in SignedKRLV1 v1.
+
+In particular, this check is not performed:
+
+```text
+now >= issued_at
+```
+
+An artifact with an `issued_at` value in the future MUST NOT be rejected solely for that reason.
+
+It MAY be accepted if every other verification requirement succeeds.
+
+This matches the `issued_at` semantics of `AuthorizationV1 §17.2`.
 
 ---
 
-## 8. Per-issuer `krl_version` regression
+## 8. Per-issuer `krl_version`
 
-`krl_version` must be a non-negative safe integer. Producers must monotonically
-increase `krl_version` across successive KRL publications for the same issuer.
+### 8.1 Version requirements
 
-Verifiers enforce this via an injected `previousKrlVersionByIssuer` map:
+`krl_version` MUST be a non-negative safe integer.
 
+For successive KRL publications belonging to the same issuer, producers MUST assign strictly increasing `krl_version` values.
+
+For example:
+
+```text
+issuer A: 40 -> 41 -> 42
 ```
+
+is conformant producer behavior.
+
+This is a per-issuer sequence. Versions from different issuers are independent:
+
+```text
+issuer A -> version 3
+issuer B -> version 1
+```
+
+is valid.
+
+### 8.2 Verifier regression rule
+
+The verifier receives an optional per-issuer high-watermark through:
+
+```text
+previousKrlVersionByIssuer
+```
+
+When a previous version exists, the verifier MUST apply:
+
+```text
 if krl_version < previousKrlVersionByIssuer[issuer]:
-  → KRL_VERSION_REGRESSION
+    -> KRL_VERSION_REGRESSION
 ```
 
-This check is **per-issuer, not global**. A version-3 KRL from issuer A and a
-version-1 KRL from issuer B are independent.
+Equality does **not** constitute a version regression in v1:
 
-**Patch A limitation:** `previousKrlVersionByIssuer` is injected state only. There
-is no persistent high-watermark storage in v1. The caller (e.g., `SiftHttpKeyStore`
-in Patch B) is responsible for maintaining the per-issuer high-watermark and
-injecting it into verification calls.
+```text
+krl_version == previousKrlVersionByIssuer[issuer]
+```
+
+MUST NOT produce `KRL_VERSION_REGRESSION`.
+
+This permits idempotent re-verification or re-delivery of a KRL carrying the same version.
+
+A producer MUST nevertheless use a strictly higher version when publishing a new KRL for the same issuer.
+
+Patch A does not attempt to determine whether two same-version artifacts contain identical content. Deployment logic MUST NOT treat same-version acceptance as authorization to replace an already trusted high-watermark artifact with conflicting content without an explicit state-management policy.
+
+### 8.3 Optional nonce
+
+`nonce` is an optional signed field.
+
+When present, it is cryptographically bound to the artifact because it is included in the signing payload.
+
+Patch A does **not** define:
+
+- consumed-nonce storage
+- nonce uniqueness requirements
+- nonce replay rejection
+- a replay-window lifecycle for KRL artifacts
+
+Therefore, implementations MUST NOT claim Patch A nonce replay enforcement solely because the artifact contains a `nonce`.
+
+Replay-state semantics, if required by a deployment, belong to the stateful integration layer.
+
+### 8.4 Patch A high-watermark limitation
+
+`previousKrlVersionByIssuer` is injected verifier state.
+
+Patch A defines no persistent high-watermark storage.
+
+The caller is responsible for:
+
+- maintaining the per-issuer high-watermark
+- supplying it to verification
+- updating persistent state only according to the deployment's state-management rules
+
+Persistent high-watermark enforcement is deferred to Patch B.
 
 ---
 
 ## 9. `revoked_kids` deduplication
 
-Producers MUST emit a deduplicated `revoked_kids` list. Verifiers MUST reject
-duplicate entries as `KRL_MALFORMED`. Silent deduplication is not permitted — the
-artifact must be corrected at the producer.
+Producers MUST emit a deduplicated `revoked_kids` array.
+
+Verifiers MUST reject any artifact containing duplicate entries.
+
+Example invalid input:
+
+```json
+{
+  "revoked_kids": ["key-1", "key-1"]
+}
+```
+
+The verifier MUST return:
+
+```text
+KRL_MALFORMED
+```
+
+Silent deduplication is NOT permitted.
+
+The producer must correct the artifact instead.
 
 ---
 
-## 10. Reason codes
+## 10. Verification procedure
+
+To provide deterministic fail-closed behavior and stable reason-code semantics, a SignedKRLV1 verifier MUST apply the following logical verification sequence.
+
+A verifier MAY organize its internal implementation differently only if it produces exactly the same externally observable verdict and reason code for every conforming test vector and every overlapping failure covered by this specification.
+
+### Step 1 - Structural validation
+
+Validate:
+
+- artifact shape
+- required fields
+- field types
+- `version == "SignedKRLV1"`
+- non-empty `issuer`
+- non-negative safe-integer `krl_version`
+- integer `issued_at`
+- integer `not_after`
+- `revoked_kids` is an array of strings
+- no duplicate `revoked_kids`
+- signature object shape
+
+Failure:
+
+```text
+KRL_MALFORMED
+```
+
+### Step 2 - Signature algorithm
+
+Require:
+
+```text
+signature.alg == "Ed25519"
+```
+
+Otherwise:
+
+```text
+KRL_UNSUPPORTED_ALG
+```
+
+This check occurs before cryptographic signature verification.
+
+### Step 3 - Trusted signing key resolution
+
+Resolve `signature.kid` only from the configured trusted KRL signing key set.
+
+If the key is absent:
+
+```text
+KRL_UNKNOWN_SIGNING_KID
+```
+
+If no trusted KRL signing key set was supplied:
+
+```text
+KRL_UNKNOWN_SIGNING_KID
+```
+
+The verifier MUST NOT fetch an unknown KRL signing key from the network.
+
+### Step 4 - Signing key lifecycle
+
+Evaluate the resolved key using the standard key lifecycle rules at trusted time `now`.
+
+If the key exists but is inactive:
+
+```text
+KRL_SIGNING_KEY_INACTIVE
+```
+
+### Step 5 - Signature verification
+
+Construct the signing input exactly as defined in §§4-5 and verify the Ed25519 signature.
+
+If verification fails:
+
+```text
+KRL_SIG_INVALID
+```
+
+### Step 6 - Artifact expiry
+
+Apply:
+
+```text
+now < not_after
+```
+
+If:
+
+```text
+now >= not_after
+```
+
+return:
+
+```text
+KRL_EXPIRED
+```
+
+No `issued_at` lower-bound check is performed.
+
+### Step 7 - Per-issuer version regression
+
+When a prior per-issuer high-watermark exists:
+
+```text
+if krl_version < previousKrlVersionByIssuer[issuer]:
+    -> KRL_VERSION_REGRESSION
+```
+
+Equality is not a regression.
+
+### Step 8 - Success
+
+If all required checks pass:
+
+```text
+status = ok
+```
+
+The pure verifier returns a successful verification result.
+
+Patch A does not itself apply the resulting revocation set to a provider keystore or execution path.
+
+---
+
+## 11. Reason codes
+
+The following reason codes are normative for SignedKRLV1 verification.
 
 | Code | Trigger |
-|------|---------|
-| `KRL_MALFORMED` | Missing required field, wrong type, `revoked_kids` not an array of strings, or duplicate entries in `revoked_kids`. |
-| `KRL_UNSUPPORTED_ALG` | `signature.alg` is present but is not `"Ed25519"`. |
-| `KRL_UNKNOWN_SIGNING_KID` | `signature.kid` not found in the trusted KRL signing key set (or no trusted key set was provided). |
-| `KRL_SIGNING_KEY_INACTIVE` | The KRL signing key was found in the trusted key set, but `keyIsActiveAt()` returned false (revoked, retired past window, or `not_before`/`not_after` constraint). |
-| `KRL_SIG_INVALID` | Ed25519 signature verification failed. |
+|---|---|
+| `KRL_MALFORMED` | Missing required field, wrong type, invalid structural value, malformed `revoked_kids`, or duplicate revoked key IDs. |
+| `KRL_UNSUPPORTED_ALG` | `signature.alg` is present but is not exactly `"Ed25519"`. |
+| `KRL_UNKNOWN_SIGNING_KID` | `signature.kid` is absent from the trusted KRL signing key set, or no trusted KRL signing key set was supplied. |
+| `KRL_SIGNING_KEY_INACTIVE` | The signing key exists but is inactive according to key lifecycle rules at `now`. |
+| `KRL_SIG_INVALID` | Ed25519 signature verification fails. |
 | `KRL_EXPIRED` | `now >= not_after`. |
 | `KRL_VERSION_REGRESSION` | `krl_version < previousKrlVersionByIssuer[issuer]`. |
 
-### `KRL_UNKNOWN_SIGNING_KID` vs `KRL_SIGNING_KEY_INACTIVE`
+### 11.1 Unknown signing key vs inactive signing key
 
-Mirrors the existing `AUTH_KID_UNKNOWN` vs `AUTH_KEY_INACTIVE` distinction:
+These conditions MUST remain distinct.
 
 | Code | Condition |
-|------|-----------|
-| `KRL_UNKNOWN_SIGNING_KID` | `kid` is not present in the trusted key set at all. |
-| `KRL_SIGNING_KEY_INACTIVE` | `kid` is present but `keyIsActiveAt(key, now)` returns `false`. |
+|---|---|
+| `KRL_UNKNOWN_SIGNING_KID` | `kid` is not present in the trusted KRL signing key set. |
+| `KRL_SIGNING_KEY_INACTIVE` | `kid` exists, but `keyIsActiveAt(key, now)` returns false. |
+
+This distinction mirrors `AUTH_KID_UNKNOWN` and `AUTH_KEY_INACTIVE` in AuthorizationV1 verification.
 
 ---
 
-## 11. Static trusted KRL signing key model
+## 12. Static trusted KRL signing key model
 
-KRL signing keys are configured **statically** at the verifier — they are not
-fetched over the network. This is an explicit design choice: the trust anchor for
-KRL integrity must not itself depend on a network fetch that could be suppressed.
+KRL signing keys MUST be configured statically at the verifier.
 
-The trusted KRL signing key set is a standard `KeySet` (as defined in `keyset.ts`),
-using `KeySetKey` entries with `alg: "Ed25519"`. Key lifecycle rules (`status`,
-`not_before`, `not_after`) apply to KRL signing keys exactly as they do to
-authorization signing keys.
+They MUST NOT be discovered through a live network fetch during KRL verification.
+
+This is a deliberate trust-boundary rule: the authenticity anchor for a revocation artifact must not depend on a transport path that could itself suppress or replace the trust material used to verify that artifact.
+
+The trusted KRL signing key set uses the standard OxDeAI `KeySet` / `KeySetKey` model.
+
+KRL signing keys use:
+
+```text
+alg = "Ed25519"
+```
+
+Standard key lifecycle fields apply, including:
+
+- `status`
+- `not_before`
+- `not_after`
+
+`keyIsActiveAt(key, now)` MUST be applied consistently with authorization signing keys.
 
 ---
 
-## 12. Patch A limitations
+## 13. Patch A limitations
 
-The following are explicitly out of scope for Patch A and will be addressed in subsequent patches:
+Patch A includes:
+
+| Capability | Patch A status |
+|---|---|
+| SignedKRLV1 artifact definition | Included |
+| Canonical signing payload | Included |
+| Ed25519 verification | Included |
+| Strict expiry semantics | Included |
+| Per-issuer version regression check | Included |
+| Pure verifier | Included |
+| Portable conformance vectors | Included |
+
+The following are explicitly outside Patch A:
 
 | Limitation | Deferred to |
-|-----------|------------|
+|---|---|
 | Integration into `SiftHttpKeyStore` | Patch B |
 | `krl_mode` configuration (`signed_required`, `signed_preferred`, `unsigned_legacy`) | Patch B |
-| `now` injection into `SiftHttpKeyStore.refresh()` | Patch B |
+| Trusted `now` injection into `SiftHttpKeyStore.refresh()` | Patch B |
 | Persistent per-issuer `krl_version` high-watermark storage | Patch B |
 | Last-known-good KRL cache | Patch B |
-| Cross-language conformance vectors — Go | #119 Go PR (merged) |
-| Cross-language conformance vectors — Python | #119 Python PR (merged) |
-| Cross-language conformance vectors — Rust | Future |
-| KRL signing key rotation automation | Future |
 | `krlStatus` / `getKrlStatus()` surface | Patch B |
+| Rust cross-language vectors | Future |
+| KRL signing-key rotation automation | Future |
+
+Repository merge or issue status is implementation metadata and is not part of the protocol semantics defined by this specification.
 
 ---
 
-## 13. Conformance coverage
+## 14. Conformance coverage
 
-Conformance vectors: `packages/conformance/vectors/signed-krl-verification.json`
+The normative portable SignedKRLV1 vector source is:
 
-Runner: `pnpm -C packages/conformance validate`
+```text
+docs/spec/test-vectors/signed-krl-v1.json
+```
+
+The TypeScript conformance mirror is:
+
+```text
+packages/conformance/vectors/signed-krl-verification.json
+```
+
+The TypeScript runner is:
+
+```text
+pnpm -C packages/conformance validate
+```
+
+### 14.1 Named vectors
 
 | Vector | Mode | Expected outcome |
-|--------|------|-----------------|
-| `krl-001` | `valid` | `ok` — signature verifies, not expired |
-| `krl-002` | `invalid-signature` | `KRL_SIG_INVALID` — tampered signature |
-| `krl-003` | `expired` | `KRL_EXPIRED` — `now >= not_after` |
-| `krl-004` | `malformed-revoked-kids` | `KRL_MALFORMED` — `revoked_kids` is a string |
-| `krl-005` | `duplicate-revoked-kids` | `KRL_MALFORMED` — duplicate entries |
-| `krl-006` | `unknown-signing-kid` | `KRL_UNKNOWN_SIGNING_KID` — kid not in trusted set |
-| `krl-007` | `signing-key-inactive` | `KRL_SIGNING_KEY_INACTIVE` — key revoked |
-| `krl-008` | `unsupported-alg` | `KRL_UNSUPPORTED_ALG` — `alg != "Ed25519"` |
-| `krl-009` | `version-regression` | `KRL_VERSION_REGRESSION` — version went backwards |
+|---|---|---|
+| `krl-001` | `valid` | `ok` |
+| `krl-002` | `invalid-signature` | `KRL_SIG_INVALID` |
+| `krl-003` | `expired` | `KRL_EXPIRED` |
+| `krl-004` | `malformed-revoked-kids` | `KRL_MALFORMED` |
+| `krl-005` | `duplicate-revoked-kids` | `KRL_MALFORMED` |
+| `krl-006` | `unknown-signing-kid` | `KRL_UNKNOWN_SIGNING_KID` |
+| `krl-007` | `signing-key-inactive` | `KRL_SIGNING_KEY_INACTIVE` |
+| `krl-008` | `unsupported-alg` | `KRL_UNSUPPORTED_ALG` |
+| `krl-009` | `version-regression` | `KRL_VERSION_REGRESSION` |
 
-**Coverage scope:** Two runners:
+The observable results of these normative vectors MUST remain stable unless this specification and the vector corpus are versioned together.
 
-| Runner | Command | Coverage |
-|--------|---------|---------|
-| TypeScript (`@oxdeai/core`) | `pnpm -C packages/conformance validate` | 9 mode-based vectors (dynamic artifact construction) |
-| **Go harness** | `pnpm test:vectors:go` | **9 portable vectors with committed artifacts — independent Ed25519 verification** |
-| **Python harness** | `pnpm test:vectors:py` | **9 portable vectors with committed artifacts — independent Ed25519 verification via ctypes + libcrypto** |
+### 14.2 Vector relationship
 
-**Vector relationship.** `docs/spec/test-vectors/signed-krl-v1.json` is the normative
-portable cross-language vector source for SignedKRLV1. It contains committed
-`SignedKRLV1` artifacts with pre-computed Ed25519 signatures that Go and Python
-reproduce independently using only canonicalization-v1 and standard Ed25519 libraries.
-`packages/conformance/vectors/signed-krl-verification.json` is the TypeScript
-conformance mirror (mode-driven, no committed artifacts). Future changes must keep
-both files aligned or document divergence explicitly.
+`docs/spec/test-vectors/signed-krl-v1.json` is the normative portable cross-language vector source.
 
-**Independent verification model.** The Go and Python harnesses do not consume
-TypeScript-generated intermediate artifacts (canonical bytes, signing preimages). Each
-independently reconstructs the signing preimage from committed vector inputs using its
-own canonicalization-v1 implementation and verifies the Ed25519 signature using its
-own crypto library (`crypto/ed25519` for Go; `ctypes + libcrypto` for Python). The
-duplicate-kids signature (`+mwEd2QP5+...`) serves as the cross-language byte-equivalence
-proof point.
+It contains committed `SignedKRLV1` artifacts and precomputed Ed25519 signatures suitable for independent verification.
+
+`packages/conformance/vectors/signed-krl-verification.json` is the TypeScript conformance mirror.
+
+Changes MUST keep the two representations semantically aligned or explicitly document an intentional divergence.
+
+### 14.3 Independent verification model
+
+Cross-language harnesses SHOULD reconstruct the SignedKRL signing preimage independently from committed vector inputs.
+
+They SHOULD NOT depend on TypeScript-generated intermediate values such as:
+
+- canonical bytes
+- signing preimages
+- generated signatures
+
+Independent implementations SHOULD use their own:
+
+- canonicalization-v1 implementation
+- Ed25519 implementation
+- language-native or independently linked cryptographic library
+
+This independence provides evidence of cross-language byte equivalence rather than merely testing multiple wrappers around the same implementation.
+
+Current repository implementation status for individual language harnesses is evidence metadata, not a normative protocol requirement.
+
+---
+
+## 15. Security properties and non-claims
+
+A conforming Patch A implementation provides evidence that:
+
+- the KRL artifact was signed by a configured trusted KRL signing key
+- the signing key was active at trusted verification time
+- the artifact has not expired
+- its version has not regressed below the supplied per-issuer watermark
+- its revoked key list is structurally valid and deduplicated
+- its signed fields have not been modified without invalidating the signature
+
+Patch A does **not** by itself prove that:
+
+- a provider keystore actually applied the KRL
+- a revoked provider key was removed from all execution paths
+- persistent high-watermark state survived restart
+- stale but still unexpired KRLs were replaced by fresher ones
+- a nonce was consumed or replay-protected
+- the verifier received the newest KRL available from the publisher
+
+Those properties require additional stateful enforcement and deployment behavior outside the Patch A pure-verifier boundary.

--- a/docs/spec/conformance/conformance-v1.md
+++ b/docs/spec/conformance/conformance-v1.md
@@ -4,356 +4,697 @@
 
 This specification defines the conformance requirements for Execution-Time Authorization (ETA) implementations.
 
-Conformance ensures that independent implementations:
-- behave deterministically
-- enforce fail-closed authorization
-- produce verifiable and reproducible outcomes
-- cannot be bypassed at execution time
+ETA conformance is intended to establish that independent implementations:
+
+- behave deterministically within the conformance surfaces they implement
+- apply OxDeAI canonicalization rules consistently
+- fail closed on invalid, unverifiable, or ambiguous authorization inputs
+- produce verifiable and reproducible authorization artifacts and outcomes
+- enforce the authorization boundary so that execution cannot proceed without valid authorization
+- produce compatible results across independent implementations that claim the same conformance surface
+
+Conformance is evaluated against the normative specifications and official conformance vectors identified by this document.
 
 ---
 
 ## 2. Conformance Definition
 
-An implementation is ETA-conformant if and only if it satisfies ALL of the following:
+An implementation is ETA-conformant for a declared conformance surface if and only if it satisfies every mandatory requirement applicable to that surface.
 
-1. Deterministic evaluation
-2. Canonicalization compliance
-3. Fail-closed behavior
-4. Non-bypassable enforcement
-5. Artifact correctness and verification
-6. Cross-implementation consistency
+The core conformance categories are:
 
-Failure in any category results in non-conformance.
+1. deterministic evaluation
+2. canonicalization compliance
+3. fail-closed behavior
+4. non-bypassable enforcement
+5. artifact correctness and verification
+6. cross-implementation consistency
+
+Failure of any mandatory requirement applicable to the declared surface results in non-conformance for that surface.
+
+An implementation MUST NOT claim support for a category, profile, artifact, or runtime surface that it does not actually implement.
+
+Unsupported categories MUST be reported as unsupported, not emulated solely to claim parity.
 
 ---
 
-## 3. Test Categories
+## 3. Conformance Test Categories
 
 ### 3.1 Determinism Tests
 
-Goal: identical inputs → identical outputs
+**Goal:** identical trusted inputs produce identical observable authorization results.
 
 Test:
-- Run authorization N times with identical `(intent, state, policy)`
 
-Requirement:
-- decision MUST be identical
-- produced artifacts MUST be byte-identical
+Run authorization repeatedly with identical:
 
-Failure conditions:
+```text
+(intent, authoritative state, policy, trusted evaluation inputs)
+```
+
+as applicable to the tested surface.
+
+Requirements:
+
+- the decision MUST be identical
+- deterministic reason-code output MUST be identical
+- when an artifact is deterministically produced from identical inputs, its canonical representation MUST be byte-identical
+- hashes over identical canonical representations MUST be identical
+
+Failure conditions include:
+
 - decision drift
+- reason-code drift where ordering is normative
+- canonical-byte mismatch
 - hash mismatch
-- artifact mismatch
+- deterministic artifact mismatch
+
+Determinism requirements do not authorize an implementation to re-read mutable ambient state or clocks when the underlying specification requires those values to be explicit evaluation inputs.
 
 ---
 
 ### 3.2 Canonicalization Tests
 
-Goal: ensure stable canonical representation
+**Goal:** ensure stable canonical representation across conforming implementations.
 
-Test cases:
+Required test classes include:
+
 - object key reordering
 - nested structures
-- unicode normalization (NFC)
+- Unicode NFC normalization
 - integer boundary handling
-- float rejection
-- duplicate key rejection
+- floating-number rejection
+- duplicate-key rejection
 
-Requirement:
-- canonical bytes MUST be identical across equivalent inputs
-- invalid inputs MUST fail
+Requirements:
 
-Conformance vector source of truth:
-- `docs/spec/test-vectors/canonicalization-v1.json`
-  - canonical JSON and SHA-256 hex MUST match exactly
-  - expected error codes MUST match exactly
+- equivalent valid inputs MUST produce identical canonical bytes
+- canonical JSON MUST match the normative expected value
+- SHA-256 output MUST match where defined by the vector
+- invalid canonicalization inputs MUST fail closed
+- expected canonicalization error codes MUST match where the vector makes the code normative
+
+The normative portable canonicalization vector source is:
+
+```text
+docs/spec/test-vectors/canonicalization-v1.json
+```
 
 ---
 
 ### 3.3 Fail-Closed Tests
 
-Goal: ensure system never allows ambiguous execution
+**Goal:** ensure that invalid, unverifiable, ambiguous, or unsupported conditions cannot result in authorized execution.
 
-Inject failures:
-- missing policy
-- malformed input
+Representative injected failures include:
+
+- missing required policy or trusted configuration
+- malformed protocol input
 - canonicalization failure
-- verification failure
-- unknown key / issuer
+- artifact verification failure
+- unknown signing key
+- inactive signing key
+- unresolved issuer or trust configuration
+- ambiguous key resolution
+- invalid trusted state
+- invalid required configuration
 
 Requirement:
-- decision MUST be DENY
+
+```text
+failure or ambiguity
+-> no valid authorization outcome
+-> no execution
+```
+
+Where the governing specification defines a protocol `DENY`, the implementation MUST return `DENY`.
+
+Where the governing specification requires refusal before policy evaluation, such as invalid mandatory configuration, the implementation MUST refuse evaluation rather than coercing the condition into an `ALLOW` or fabricating a policy `DENY`.
+
+No fail-closed condition may result in execution.
+
+---
 
 ### 3.4 PEP Gateway Boundary Tests
 
-Goal: no execution path without authorization.
+**Goal:** prove that execution cannot bypass the authorization boundary.
 
-Tests:
-- Direct call to upstream without internal token MUST be 403.
-- Gateway must return structured ALLOW/DENY per `pep-gateway-v1` §6.
-- Replay of `auth_id` MUST be denied.
+Required tests include:
 
-### 3.5 Authorization Verification
+- direct access to a protected upstream execution path without the required internal authorization context MUST be rejected
+- the gateway MUST expose the structured authorization behavior defined by `pep-gateway-v1`
+- an authorization artifact that fails required verification MUST NOT reach the protected upstream
+- replay of a consumed `auth_id` MUST be denied where the profile requires authorization replay protection
 
-Requirement: signature, audience, expiry, intent_hash match, and trust config MUST be verified; any failure → DENY.
+For the reference PEP gateway surface, direct unauthorized upstream access MUST return the gateway-defined rejection response, including HTTP `403` where specified by `pep-gateway-v1`.
 
-### 3.6 Delegation (if implemented)
+Passing artifact-verification tests alone is insufficient to establish PEP non-bypassability.
 
-Requirement: DelegationV1 chain MUST be strictly narrowing, single-hop, signed, and parent AuthorizationV1 valid; otherwise DENY.
-
----
-
-## 4. Conformance Artifacts and Execution
-
-Normative vector files:
-- `docs/spec/test-vectors/canonicalization-v1.json`
-- `docs/spec/test-vectors/authorization-v1.json`
-- `docs/spec/test-vectors/pep-vectors-v1.json`
-
-Implementations SHOULD provide runnable harnesses that consume the same vectors and exit non-zero on any mismatch (e.g., TS/Go/Python verifiers).
-
-### 4.1 Minimal runnable checks (current repository)
-
-From repo root:
-- TypeScript reference: `pnpm test:vectors:ts`
-- Go verifier: `pnpm test:vectors:go`
-- Python verifier: `pnpm test:vectors:py`
-- Authorization vectors: `pnpm test:vectors:auth`
-- PEP vectors: `pnpm test:vectors:pep`
-- Trusted-time vectors: `pnpm test:vectors:trusted-time`
-- Aggregate: `pnpm test:vectors:all`
-
-Pass/Fail rule: any mismatch in canonical JSON, SHA-256, or expected error code MUST exit non-zero and is non-conformant.
-
-### 4.2 Trusted-time vector schema
-
-`packages/conformance/vectors/trusted-time.json` uses strict schema version
-`1.0.0` and one category-discriminated `vectors` collection. Every vector has
-an ID unique across the file, an explicit `active` or `pending` status, a
-description, category-specific `input`, and category-specific `expected`
-behavior. Pending vectors additionally require a non-empty `blocked_by` and are
-reported separately; they never count as passing.
-
-The schema names clock domains explicitly (`intent_timestamp`,
-`evaluation_time`, `authorization_issued_at`, `authorization_expiry`,
-`nonce_first_seen_time`, `velocity_window_start`, `tool_window_start`, and
-`verifier_time`). Generic or overloaded timestamp fields are forbidden.
-
-The TypeScript reference runner rejects duplicate IDs, unknown categories or
-fields, malformed status, unsupported public reason codes, and malformed or
-unsafe protocol-second values before executing any vector. Active vectors run
-through Core reference surfaces and are release-blocking through both
-`pnpm -C packages/conformance validate` and `pnpm test:vectors:all`.
-
-The active `tool_window` category executes stateful tool-call sequences through
-`PolicyEngine.evaluatePure`. It verifies trusted window creation,
-caller-timestamp noninterference, denial without quota consumption,
-exact-boundary expiry, backward-time and malformed-state failure, exact state
-propagation, and deterministic repeated execution.
-
-TypeScript executes every active trusted-time category. The current Go and
-Python harnesses claim canonicalization, Profile C verification, and SignedKRL
-verification only; they do not expose PolicyEngine freshness, issuance,
-stateful replay, velocity, or the standalone trusted-time authorization
-verification surface. Those categories are explicitly unsupported in those
-runtimes and MUST NOT be emulated in a harness merely to claim parity. All
-languages enforce the JavaScript safe-integer bound for protocol numeric data
-in the categories they implement.
-
-### 4.3 Pending vectors
-
-Locked vectors exist for canonicalization, authorization, and PEP gateway behavior as listed above. Delegation conformance is presently validated via code-level harnesses; additional locked vectors MAY be added in future versions.
-
-Failure condition:
-- any ALLOW under invalid conditions
+The execution boundary itself MUST be exercised.
 
 ---
 
-### 3.4 Authorization Binding Tests
+### 3.5 Authorization Verification Tests
 
-Goal: ensure authorization is bound to intent/state/policy
+**Goal:** ensure that `AuthorizationV1` artifacts are accepted only after all applicable verification requirements succeed.
 
-Test:
-- reuse authorization with modified intent
-- reuse with modified state
-- reuse under different policy
+Applicable checks include:
 
-Requirement:
-- MUST be rejected
+- artifact structure
+- signature
+- signing-key resolution and lifecycle
+- audience binding
+- expiry
+- `intent_hash`
+- policy binding
+- required trust configuration
+- other profile-specific verification requirements
 
----
+Any verification failure MUST invalidate the authorization.
 
-### 3.5 Replay Protection Tests
-
-Goal: prevent reuse of authorization
-
-Test:
-- reuse same authorization artifact twice
-
-Requirement:
-- second execution MUST be rejected
+An invalid authorization MUST NOT authorize execution.
 
 ---
 
-### 3.6 Artifact Verification Tests
+### 3.6 Authorization Binding Tests
 
-Goal: ensure artifacts are independently verifiable
+**Goal:** prove that an authorization cannot be reused outside the exact authority it represents.
 
-Test:
-- verify signature correctness
-- verify hash binding
-- verify issuer / key resolution
-- tamper with payload
+Required tests include attempts to reuse an authorization with:
 
-Requirement:
-- tampered artifact MUST fail verification
-- valid artifact MUST verify successfully
+- modified intent
+- incompatible execution context
+- a different policy where policy binding applies
+- a different audience where audience binding applies
+- other values that are cryptographically or normatively bound by the artifact
+
+Requirements:
+
+- a changed bound value MUST invalidate verification
+- a valid authorization MUST NOT be transferable to an incompatible execution request
+
+A state-binding claim MUST only be made where the relevant specification actually commits the authorization to that state or to a normative state-derived value.
+
+Conformance MUST NOT infer bindings that the artifact does not encode.
 
 ---
 
-### 3.7 Cross-Implementation Tests
+### 3.7 Replay Protection Tests
 
-Goal: ensure cross-language consistency
+**Goal:** verify replay resistance where replay protection is normative for the tested artifact or execution profile.
 
-Implementations:
-- TypeScript (reference)
+For authorization execution:
+
+```text
+first valid consumption
+-> may execute
+
+subsequent prohibited reuse
+-> MUST NOT execute
+```
+
+Replay tests MUST use the replay identifier and replay scope defined by the relevant artifact or profile.
+
+Replay semantics MUST NOT be generalized across artifacts.
+
+For example, the presence of an optional nonce in an artifact does not establish replay protection unless its specification defines the required replay-state behavior.
+
+---
+
+### 3.8 Artifact Verification Tests
+
+**Goal:** ensure that artifacts can be independently authenticated and validated.
+
+Applicable tests include:
+
+- signature verification
+- canonical signing-input reconstruction
+- cryptographic hash binding
+- issuer and signing-key resolution
+- key lifecycle validation
+- mutation of signed payload fields
+- malformed artifact input
+
+Requirements:
+
+- tampered artifacts MUST fail verification
+- correctly formed and validly signed artifacts MUST verify successfully when all other applicable conditions hold
+- implementations MUST reproduce artifact-specific signing and encoding rules exactly
+
+Signing rules from one artifact family MUST NOT be assumed to apply to another artifact family.
+
+---
+
+### 3.9 Delegation Tests
+
+This category applies only to implementations that claim `DelegationV1` support.
+
+**Goal:** ensure delegated authority never exceeds its valid parent authority.
+
+Applicable requirements include:
+
+- the delegation MUST be signed and verifiable
+- the parent `AuthorizationV1` MUST be valid
+- delegated scope MUST be strictly narrowing according to `delegation-v1`
+- parent binding MUST succeed
+- policy binding MUST succeed
+- the single-hop invariant MUST be enforced
+- applicable expiry rules MUST be enforced
+- any verification or narrowing failure MUST prevent execution
+
+An implementation that does not implement DelegationV1 MUST report the category as unsupported rather than passing it through a stub or emulation.
+
+---
+
+### 3.10 Cross-Implementation Tests
+
+**Goal:** establish portable behavior across independent implementations.
+
+Current implementation families may include:
+
+- TypeScript
 - Go
 - Python
+- other independent implementations added later
 
-Test:
-- same inputs → same canonical bytes
-- same hash
-- same decision
+For every conformance surface jointly claimed by two or more implementations, applicable portable vectors MUST produce the same normative outputs.
 
-Requirement:
-- byte-for-byte equality
+Depending on the vector category, this can include:
+
+- identical canonical bytes
+- identical expected hash
+- identical verification result
+- identical normative reason code
+- identical deterministic artifact representation
+
+Cross-language equality is required only for semantics defined as portable by the corresponding specification.
+
+Implementations MUST NOT fabricate support for unavailable runtime surfaces merely to report cross-language parity.
 
 ---
 
-### 3.8 Non-Bypassability Tests (Critical)
+### 3.11 Non-Bypassability Tests
 
-Goal: ensure execution cannot bypass authorization
+**Goal:** establish that no protected execution path exists without valid authorization.
 
-Test scenarios:
-- direct tool execution without authorization
+This is a critical conformance category.
+
+Required adversarial scenarios include:
+
+- direct execution without authorization
 - skipped authorization step
-- partial verification
+- partial artifact verification
+- invalid authorization presented to the executor
+- replay where replay rejection is required
+- failure between authorization verification and execution-boundary admission
 
 Requirement:
-- execution MUST NOT occur
 
-Failure condition:
-- any execution without valid authorization
+```text
+no valid authorization
+-> no protected execution
+```
+
+Any protected execution that occurs without satisfying the required authorization boundary is a conformance failure.
 
 ---
 
-## 4. Conformance Vectors
+## 4. Official Conformance Vector Sources
 
-A conformant implementation MUST pass all official test vectors.
+A conformant implementation MUST pass all active official vectors applicable to the conformance surfaces it claims.
 
-Vectors MUST include:
+Normative or profile-defined vector sources currently include:
+
+```text
+docs/spec/test-vectors/canonicalization-v1.json
+docs/spec/test-vectors/authorization-v1.json
+docs/spec/test-vectors/pep-vectors-v1.json
+docs/spec/test-vectors/signed-krl-v1.json
+packages/conformance/vectors/trusted-time.json
+```
+
+Artifact-specific specifications MAY designate an additional normative portable source and implementation-specific mirrors.
+
+Where another normative specification designates a vector file as the source of truth for that artifact, that designation is incorporated into ETA conformance for implementations claiming that artifact.
+
+### 4.1 Vector requirements
+
+Official vector suites MUST include the cases required by their governing specification, including applicable:
+
 - valid cases
 - invalid cases
-- edge cases
+- boundary cases
+- malformed cases
+- adversarial cases
 
-Vectors MUST define:
+A vector MUST define enough information to determine its normative expected behavior.
+
+Depending on category, this may include:
+
 - input
 - canonical output
 - expected hash
 - expected decision
+- expected reason code
 - expected verification result
+- expected state transition
+
+Fields that do not apply to a particular vector category are not required merely for schema uniformity.
 
 ---
 
-## 5. Verification Ordering
+## 5. Runnable Conformance Harnesses
 
-Verification steps MUST be deterministic.
+Implementations SHOULD provide runnable harnesses that consume the applicable official vectors and exit non-zero on any active-vector mismatch.
 
-Violation ordering MUST be consistent.
+Current repository entry points include:
+
+```text
+pnpm test:vectors:ts
+pnpm test:vectors:go
+pnpm test:vectors:py
+pnpm test:vectors:auth
+pnpm test:vectors:pep
+pnpm test:vectors:trusted-time
+pnpm test:vectors:all
+```
+
+Repository commands are implementation metadata rather than portable protocol semantics.
+
+For a harness that claims conformance over a vector category:
+
+- every applicable active vector MUST execute
+- every mismatch against a normative expected result MUST cause a non-zero result
+- malformed vector data MUST NOT silently count as passing
+- skipped required vectors MUST NOT count as passing
+
+---
+
+## 6. Trusted-Time Vector Schema
+
+The trusted-time corpus:
+
+```text
+packages/conformance/vectors/trusted-time.json
+```
+
+uses strict schema version:
+
+```text
+1.0.0
+```
+
+and a category-discriminated `vectors` collection.
+
+Each vector MUST contain:
+
+- an ID unique within the corpus
+- an explicit `active` or `pending` status
+- a description
+- category-specific input
+- category-specific expected behavior
+
+A pending vector MUST contain a non-empty:
+
+```text
+blocked_by
+```
+
+Pending vectors MUST be reported separately.
+
+Pending vectors MUST NOT count as passing.
+
+### 6.1 Explicit clock domains
+
+Trusted-time vectors MUST use explicit clock-domain names where applicable, including:
+
+- `intent_timestamp`
+- `evaluation_time`
+- `authorization_issued_at`
+- `authorization_expiry`
+- `nonce_first_seen_time`
+- `velocity_window_start`
+- `tool_window_start`
+- `verifier_time`
+
+Generic or overloaded timestamp fields are forbidden by the trusted-time vector schema.
+
+This prevents vector schemas from erasing distinctions between untrusted intent time and trusted evaluation or verification time.
+
+### 6.2 Trusted-time corpus validation
+
+Before executing trusted-time vectors, the TypeScript reference runner rejects:
+
+- duplicate vector IDs
+- unknown categories
+- unknown fields
+- malformed status values
+- unsupported public reason codes
+- malformed protocol-second values
+- unsafe protocol-second integers
+
+Active vectors execute against the applicable Core reference surfaces.
+
+Active trusted-time vectors are release-blocking through the repository validation paths that include them.
+
+### 6.3 Stateful tool-window coverage
+
+The active `tool_window` category exercises stateful tool-call sequences through the Core policy evaluation surface.
+
+Coverage includes:
+
+- trusted window creation
+- caller timestamp non-interference
+- denial without quota consumption
+- exact-boundary expiry
+- backward trusted-time handling
+- malformed persisted state
+- exact state propagation
+- deterministic repeated execution
+
+---
+
+## 7. Language and Runtime Coverage
+
+Conformance coverage MUST be reported by actual implementation surface.
+
+The current TypeScript reference implementation executes all active trusted-time categories defined by its conformance runner.
+
+Current Go and Python harnesses claim only the surfaces they actually implement, including applicable:
+
+- canonicalization
+- supported authorization verification profiles
+- SignedKRL verification
+
+They do not expose the TypeScript `PolicyEngine` runtime surfaces required for:
+
+- policy freshness evaluation
+- authorization issuance
+- stateful replay evaluation
+- velocity evaluation
+- tool-window evaluation
+- standalone trusted-time authorization surfaces not implemented in those runtimes
+
+Unsupported runtime categories MUST NOT be emulated solely to claim parity.
+
+All implementations MUST enforce the protocol numeric domain, including the JavaScript safe-integer bound, in every category they claim.
+
+---
+
+## 8. Pending and Incomplete Conformance Coverage
+
+Locked portable vectors currently exist for the surfaces designated by their governing specifications.
+
+DelegationV1 is currently validated through code-level harnesses rather than a complete locked portable vector corpus.
+
+Additional locked delegation vectors MAY be introduced in a future conformance version.
+
+The absence of a portable vector suite MUST be reported as an evidence limitation.
+
+It MUST NOT be converted into a claim that cross-language conformance has been established.
+
+Pending vectors and unsupported categories never count as successful conformance evidence.
+
+---
+
+## 9. Verification Ordering
+
+Verification behavior MUST be deterministic.
+
+Where a governing specification defines a normative verification order, implementations MUST preserve its observable semantics.
+
+Where official vectors define the expected reason code for an overlapping-failure case, a conforming implementation MUST produce that expected result.
 
 Implementations MUST NOT:
-- short-circuit inconsistently
-- produce non-deterministic error sets
+
+- short-circuit inconsistently across identical inputs
+- produce non-deterministic reason sets
+- reorder checks in a way that changes a normative externally observable result
+
+This specification does not invent a verification order for artifacts whose governing specification leaves the order unspecified.
 
 ---
 
-## 6. Failure Semantics
+## 10. Failure Semantics
 
-Any ambiguity MUST result in:
+Any unresolved protocol ambiguity at a security boundary MUST fail closed.
 
-DENY
+Examples include:
 
-Ambiguity includes:
 - parsing uncertainty
+- canonicalization failure
 - key resolution failure
-- multiple matching keys
-- undefined behavior
+- multiple conflicting key matches
+- undefined required behavior
+- invalid trusted state
+- invalid mandatory trust configuration
+
+Fail-closed means:
+
+```text
+the condition cannot authorize execution
+```
+
+The exact failure representation is determined by the governing specification.
+
+It may be:
+
+- a protocol `DENY`
+- an artifact-verification failure
+- a gateway rejection
+- refusal to evaluate because required configuration is invalid
+
+An implementation MUST NOT fabricate an `ALLOW`, silently normalize an invalid security-critical condition, or execute through an unresolved ambiguity.
 
 ---
 
-## 7. Reference Implementation
+## 11. Reference and Independent Implementations
 
-A conformant ecosystem MUST provide:
+A conformant ETA ecosystem MUST provide:
 
-- one reference implementation (source of truth)
-- independent verifiers in at least two languages
-- reproducible test harness
+- at least one maintained reference implementation
+- independently implemented verification coverage in at least two implementation languages for portable surfaces claimed as cross-language
+- reproducible conformance harnesses
+- official portable vectors for the claims represented as cross-language conformance
 
----
+The reference implementation is not permitted to override the normative specifications or normative vectors.
 
-## 8. Conformance Output
+Where reference code, prose specification, and normative vector evidence disagree, the disagreement MUST be reported and resolved rather than silently treating implementation behavior as the protocol definition.
 
-A conformance run MUST produce:
-
-- pass/fail per test category
-- deterministic logs
-- reproducible outputs
-
-Optional:
-- hash of conformance run
-- CI integration output
+Independent harnesses SHOULD reconstruct portable cryptographic inputs independently rather than consuming intermediate values generated by the reference implementation.
 
 ---
 
-## 9. Minimal Conformance Criteria
+## 12. Conformance Output
 
-An implementation is ETA-conformant if:
+A conformance run MUST report:
 
-- 100% of required test vectors pass
-- no non-determinism is observed
-- no bypass is possible
-- all failure modes result in DENY
+- pass/fail by applicable test category
+- failed vector identifiers
+- unsupported categories
+- pending vectors
+- reproducible result data sufficient to investigate mismatches
 
----
+Where logs are produced for deterministic conformance results, their normative result content MUST be reproducible.
 
-## 10. Security Guarantees
+Non-semantic runtime metadata such as wall-clock duration, process IDs, or filesystem paths need not be byte-identical.
 
-Conformance ensures:
+Optional output MAY include:
 
-- deterministic authorization behavior
-- non-forgeable decision verification
-- replay resistance
-- enforcement integrity
-
-Conformance does NOT guarantee:
-
-- correctness of policy logic
-- absence of in-scope misuse
-- runtime security outside the authorization boundary
+- hash of a normalized conformance result
+- CI integration metadata
+- implementation version
+- source revision
+- conformance profile identifier
 
 ---
 
-## 11. Invariant Summary
+## 13. Minimal Conformance Criteria
 
-Conformance enforces:
+An implementation MAY claim ETA conformance only when:
 
-canonicalization → stable bytes 
-→ stable hash 
-→ deterministic decision 
-→ verifiable artifact 
-→ enforced execution 
+- 100% of required active vectors applicable to its declared surface pass
+- no required active vector is silently skipped
+- no unresolved deterministic mismatch exists
+- no protected execution bypass exists for the claimed enforcement surface
+- every applicable invalid or ambiguous condition fails closed
+- unsupported categories are declared honestly
+- pending vectors are not represented as passing evidence
 
-Any violation:
+A successful conformance run for one surface MUST NOT be generalized into conformance for unsupported surfaces.
 
-→ DENY 
-→ NO EXECUTION
+Examples:
+
+```text
+canonicalization conformance
+!= PEP enforcement conformance
+```
+
+and:
+
+```text
+artifact verification conformance
+!= non-bypassability proof
+```
+
+---
+
+## 14. Security Guarantees and Non-Guarantees
+
+Successful conformance provides evidence, within the tested and declared surface, of:
+
+- deterministic protocol behavior
+- canonical byte stability where applicable
+- artifact integrity verification
+- required cryptographic binding
+- fail-closed handling
+- replay resistance where replay protection is normative and tested
+- enforcement integrity where the execution boundary is actually exercised
+- cross-implementation compatibility for jointly supported portable surfaces
+
+Conformance does NOT by itself guarantee:
+
+- correctness of application policy logic
+- correctness or truth of external authoritative state
+- absence of misuse that remains valid under the configured policy
+- operating-system or runtime security outside the authorization boundary
+- security properties belonging to an unsupported profile
+- availability or freshness properties not defined by the relevant artifact
+- non-bypassability when only a pure verifier has been tested
+
+Conformance evidence MUST NOT be used to claim properties outside the tested normative surface.
+
+---
+
+## 15. Invariant Summary
+
+ETA conformance links the following properties:
+
+```text
+normative input
+-> canonical representation
+-> stable bytes
+-> stable cryptographic binding
+-> deterministic authorization / verification result
+-> valid artifact where applicable
+-> enforcement at the execution boundary
+```
+
+For every protected execution path:
+
+```text
+valid required authorization
+-> execution MAY proceed
+
+missing, invalid, unverifiable, or ambiguous required authorization
+-> NO EXECUTION
+```
+
+The top-level enforcement invariant is:
+
+```text
+No valid authorization
+-> no protected execution path
+```
+
+Conformance evidence for an earlier stage of the chain MUST NOT be interpreted as proof that later stages are enforced unless those stages are themselves exercised by the applicable conformance surface.

--- a/docs/spec/core/canonicalization-v1.md
+++ b/docs/spec/core/canonicalization-v1.md
@@ -19,12 +19,14 @@ The canonicalization procedure MUST guarantee:
 
 The canonicalization function is defined as:
 
+```text
 C(input) -> canonical_bytes
+```
 
 Where:
 
-- input is a structured value conforming to this specification
-- canonical_bytes is the canonical UTF-8 encoded JSON representation
+- `input` is a structured value conforming to this specification
+- `canonical_bytes` is the canonical UTF-8 encoded JSON representation
 
 ---
 
@@ -32,7 +34,9 @@ Where:
 
 Two inputs are considered equivalent if:
 
+```text
 C(x) == C(y)
+```
 
 No semantic equivalence beyond byte equality is assumed.
 
@@ -65,20 +69,20 @@ Invalid UTF-8 sequences MUST cause canonicalization failure.
 
 Implementations MUST apply the following rules, in order, to produce the canonical JSON bytes:
 
-- Strings: normalize to Unicode NFC; encode as JSON strings.
+- Strings: normalize to Unicode NFC and encode as JSON strings.
 - Object keys: NFC-normalize, reject duplicates after normalization, then sort keys by byte-wise UTF-8 order.
 - Arrays: preserve element order.
-- Numbers: only integers in the safe IEEE-754 range **[-9007199254740991, 9007199254740991]** are allowed; floats and `NaN`/`±Inf` MUST be rejected.
-- BigInt (when present in runtime): serialize as JSON strings.
-- Timestamps: if key == `"ts"`, the value MUST be an integer within the safe range; otherwise reject.
-- Unsupported runtime types (function, symbol, undefined, etc.) MUST be rejected.
-- Output MUST be minified (no insignificant whitespace) and UTF-8 encoded without BOM.
+- Numbers: only integers in the safe IEEE-754 range **[-9007199254740991, 9007199254740991]** are allowed as JSON numbers. Floating-point values and `NaN`/`±Inf` MUST be rejected.
+- BigInt values, when present in a runtime representation, MUST be serialized as JSON strings.
+- Timestamps: if the object key is exactly `"ts"`, the value MUST be an integer within the safe range; otherwise canonicalization MUST fail.
+- Unsupported runtime types, including functions, symbols, and `undefined`, MUST be rejected.
+- Output MUST be minified and UTF-8 encoded without BOM.
 
 ---
 
 ## 7. Error Codes (normative)
 
-When rejecting inputs, implementations MUST fail closed and SHOULD use these canonical error codes to enable cross-language parity:
+When rejecting inputs, implementations MUST fail closed and SHOULD use the following canonical error codes to enable cross-language parity:
 
 - `FLOAT_NOT_ALLOWED`
 - `UNSAFE_INTEGER_NUMBER`
@@ -87,64 +91,97 @@ When rejecting inputs, implementations MUST fail closed and SHOULD use these can
 - `UNSUPPORTED_TYPE`
 - `KEY_RESOLUTION_FAILED` (if post-normalization lookup cannot resolve)
 
-Additional runtime-specific errors MUST NOT leak implementation details and MUST result in failure.
+Additional runtime-specific errors MUST NOT leak implementation details and MUST result in canonicalization failure.
 
-### 7.1 Common invalid cases → required error codes
+### 7.1 Common invalid cases and canonical error codes
 
-| Invalid input                                   | Error code              |
-|-------------------------------------------------|-------------------------|
-| Any float / NaN / ±Inf                          | `FLOAT_NOT_ALLOWED`     |
-| Integer outside safe range                      | `UNSAFE_INTEGER_NUMBER` |
-| Duplicate key after NFC normalization           | `DUPLICATE_KEY`         |
-| Key `ts` with non-integer / unsafe value        | `INVALID_TIMESTAMP`     |
-| Unsupported runtime type (function/symbol/etc.) | `UNSUPPORTED_TYPE`      |
+| Invalid input | Canonical error code |
+|---|---|
+| Any floating-point value / NaN / ±Inf | `FLOAT_NOT_ALLOWED` |
+| Integer outside the safe range when represented as a JSON number | `UNSAFE_INTEGER_NUMBER` |
+| Duplicate key after NFC normalization | `DUPLICATE_KEY` |
+| Key `ts` with a non-integer or unsafe value | `INVALID_TIMESTAMP` |
+| Unsupported runtime type (function, symbol, etc.) | `UNSUPPORTED_TYPE` |
+
+The error codes above are SHOULD-level interoperability recommendations. The requirement to reject the corresponding invalid inputs is MUST-level.
 
 ---
 
-## 6. Allowed Types
+## 8. Allowed Types
 
-The following types are allowed:
+The canonical data model permits the following JSON-compatible types:
 
 - object
 - array
 - string
-- integer
+- integer within the safe range when represented as a JSON number
 - boolean
 - null
 
+Runtime BigInt values are not a canonical JSON type. When accepted by an implementation, they MUST be converted to their JSON string representation according to §6.
+
 ---
 
-## 7. Forbidden Types
+## 9. Forbidden Types
 
-The following MUST cause canonicalization failure:
+The following MUST cause canonicalization failure when presented directly as runtime values:
 
 - floating-point numbers
 - NaN
 - Infinity
 - undefined
 - functions
+- symbols
 - binary values
 - Map / Set
 - Date objects
 - custom class instances
-- language-specific objects
+- language-specific objects not otherwise defined by this specification
 
 ---
 
-## 8. Integer Rules
+## 10. Integer Rules
 
-Integers MAY be represented as JSON numbers only if within:
+Integers MAY be represented as JSON numbers only if they are within:
 
+```text
 [-(2^53 - 1), +(2^53 - 1)]
+```
 
 i.e.:
 
+```text
 [-9007199254740991, 9007199254740991]
+```
 
-Otherwise they MUST be encoded as strings.
+Integers outside that range MUST be represented as decimal JSON strings rather than JSON numbers.
 
 ### Allowed
 
+Safe integer represented as a JSON number:
+
 ```json
-{"count": 42}
-{"count": "9007199254740993"}
+{"count":42}
+```
+
+Integer outside the safe numeric range represented as a string:
+
+```json
+{"count":"9007199254740993"}
+```
+
+### Not Allowed
+
+Unsafe integer represented as a JSON number:
+
+```json
+{"count":9007199254740993}
+```
+
+Floating-point value:
+
+```json
+{"count":42.5}
+```
+
+Both inputs above MUST cause canonicalization failure according to the rules defined in this specification.


### PR DESCRIPTION
## Summary

Closes #309.

This PR closes a set of normative gaps across the OxDeAI specification surface that could otherwise allow conformance evidence to be interpreted more broadly than the protocol actually defines or tests.

The changes are limited to specification and conformance documentation.

Affected files:

* `docs/spec/conformance/conformance-v1.md`
* `docs/spec/core/canonicalization-v1.md`
* `docs/spec/artifacts/signed-krl-v1.md`

The top-level OxDeAI enforcement invariant is unchanged:

```text
No valid authorization
-> no protected execution path
```

The main correction is that evidence for one stage of the authorization chain must not be treated as proof of later stages unless those stages are themselves part of the claimed conformance surface.

## Changes

### Conformance scope and fail-closed semantics

Clarify that conformance is scoped to the exact normative surface being exercised.

The updated specification now distinguishes, for example:

```text
canonicalization conformance
!= PEP enforcement conformance

artifact verification conformance
!= execution non-bypassability proof
```

Fail-closed behavior is also no longer reduced to a universal `DENY`.

Depending on the governing specification, a fail-closed outcome may be represented as:

* protocol `DENY`
* artifact verification failure
* gateway rejection
* refusal to evaluate because required trusted configuration is invalid

The normative requirement is that an invalid, unresolved, or ambiguous security condition cannot authorize protected execution.

The specification explicitly prohibits fabricating `ALLOW`, silently normalizing security-critical invalid input, or continuing execution through unresolved ambiguity.

### Conformance evidence boundaries

Clarify that earlier-stage evidence does not establish later-stage enforcement.

The conformance chain is now expressed explicitly:

```text
normative input
-> canonical representation
-> stable bytes
-> stable cryptographic binding
-> deterministic authorization / verification result
-> valid artifact where applicable
-> enforcement at the execution boundary
```

Conformance evidence for an earlier stage MUST NOT be interpreted as proof that later stages are enforced unless those later stages are themselves exercised by the applicable conformance surface.

This prevents pure verifier evidence from being represented as proof of execution non-bypassability.

### Authorization binding and replay claims

Tighten authorization-binding language so that conformance only claims bindings actually encoded by the governing artifact or normative derived value.

Changing a bound value must invalidate verification, but conformance MUST NOT infer bindings the artifact does not encode.

Replay semantics are also made artifact/profile-specific.

In particular:

```text
nonce present
!= replay protection
```

Replay protection requires the corresponding replay-state semantics to be defined and exercised.

### Deterministic evaluation inputs

Clarify that deterministic authorization evaluation may depend on:

```text
(intent, authoritative state, policy, trusted evaluation inputs)
```

where applicable.

Implementations must not silently re-read mutable ambient state or clocks when the governing specification requires explicit trusted inputs.

## Canonicalization

Clarify several normative rules in `canonicalization-v1.md`.

### Numeric domain

JSON numbers are restricted to safe IEEE-754 integers:

```text
[-9007199254740991, 9007199254740991]
```

Floating-point values, `NaN`, and `±Inf` must fail canonicalization.

Integers outside the safe numeric range must not be represented as JSON numbers.

Runtime BigInt values, where supported, are represented through the protocol-defined JSON string form.

### Runtime types

Unsupported runtime values must fail canonicalization rather than being silently coerced.

This includes:

* functions
* symbols
* `undefined`
* binary values
* Map / Set
* Date instances
* unsupported custom or language-specific objects

### Error-code strength

Separate two previously conflated requirements:

* rejection of invalid inputs is MUST-level
* canonical error-code names are SHOULD-level interoperability guidance

This avoids accidentally turning recommended diagnostic labels into stronger protocol requirements than intended.

### Canonical output

The canonical form remains:

```text
minified UTF-8 JSON
without BOM
```

with NFC-normalized strings and keys, duplicate-key rejection after normalization, byte-wise UTF-8 key ordering, and preserved array order.

## SignedKRLV1

Strengthen the boundary between SignedKRL Patch A pure verification and stateful enforcement.

### Patch A scope

Patch A explicitly covers:

* SignedKRLV1 artifact definition
* canonical signing payload
* Ed25519 verification
* strict expiry semantics
* per-issuer version regression checking
* pure verification
* portable conformance vectors

Patch A explicitly does not establish:

* provider-keystore enforcement
* execution-path revocation enforcement
* persistent version high-watermark storage
* consumed-nonce replay protection
* last-known-good KRL caching
* newest-KRL freshness guarantees

Those properties require stateful integration behavior outside the Patch A pure-verifier boundary.

### Trust domain

The KRL signing key is explicitly defined as a separate trust domain from AuthorizationV1 and DelegationV1 signing keys.

The verifier must resolve the signing key only from the configured trusted KRL signing-key set.

The KRL trust anchor must not depend on a live network fetch during verification.

### Signing construction

The signing construction is now explicit:

```text
OXDEAI_KRL_V1\n
+
canonicalJson(signedKrlSigningPayload(envelope))
```

A conforming implementation must use:

* OxDeAI canonicalization-v1
* the exact `OXDEAI_KRL_V1\n` domain prefix
* Ed25519
* direct Ed25519 signing over the resulting preimage

Implementations must not substitute another canonicalization scheme, omit the domain separator, pre-hash the input before Ed25519, or use base64url where base64 is required.

### Expiry and issued_at

SignedKRLV1 uses strict zero-tolerance expiry:

```text
now < not_after
```

At:

```text
now >= not_after
```

verification fails with:

```text
KRL_EXPIRED
```

`issued_at` remains informational in v1 and is not enforced as a lower validity boundary.

A future `issued_at` is therefore not rejected solely for being in the future.

### Version semantics

`krl_version` is a non-negative safe integer and is monotonic per issuer.

Verifier regression semantics are:

```text
krl_version < previousKrlVersionByIssuer[issuer]
-> KRL_VERSION_REGRESSION
```

Equality is not a regression, allowing idempotent verification or redelivery of the same version.

The specification also makes clear that same-version acceptance is not authorization to replace trusted state with conflicting content without an explicit state-management policy.

### Nonce semantics

The optional nonce is cryptographically bound when present, but Patch A does not define:

* nonce uniqueness
* consumed-nonce state
* replay-window semantics
* nonce replay rejection

Therefore Patch A MUST NOT be represented as providing nonce replay protection solely because the artifact contains a nonce.

### Verification order

Define a deterministic externally observable verification sequence:

1. structural validation
2. signature algorithm validation
3. trusted signing-key resolution
4. signing-key lifecycle validation
5. cryptographic signature verification
6. artifact expiry
7. per-issuer version regression
8. success

Equivalent internal implementations remain valid only if they produce the same observable verdict and reason code for applicable normative vectors and overlapping failure cases.

## Cross-language and evidence scope

Clarify the distinction between protocol requirements and repository implementation metadata.

Portable vector sources remain normative evidence inputs.

Current implementation status for TypeScript, Go, Python, or future Rust harnesses is evidence metadata and must not become protocol semantics.

Cross-language claims must only cover the surfaces actually implemented and exercised by each harness.

Unsupported runtime or enforcement surfaces must not be emulated merely to claim parity.

## Security impact

This PR changes normative specification boundaries and security claims, but does not intentionally change runtime behavior.

The main security effect is reduction of overclaim risk.

Before this change, readers could infer that:

* fail-closed always meant `DENY`
* pure artifact verification implied execution enforcement
* a nonce implied replay protection
* conformance on one surface established adjacent surfaces
* SignedKRL Patch A established stateful revocation enforcement

After this change, those boundaries are explicit.

* No runtime authorization path is intentionally changed
* No security check is weakened
* No required CI check is made advisory
* No verifier failure is converted into success
* No non-bypassability claim is made without execution-boundary evidence
* No cross-language claim is extended beyond executed coverage

## Validation

```text
git diff --check
PASS
```

The patch is documentation/specification-only.

Applicable conformance and vector suites should remain behaviorally unchanged because the PR does not intentionally modify runtime code or test-vector data.

The normative edits are intended to align the prose specification with the actual artifact, verifier, execution-boundary, and evidence semantics already expected by the protocol.

## Scope

* No runtime implementation changes
* No new authorization capability
* No new trust anchor
* No Patch B implementation
* No whole-protocol conformance claim
* No weakening of fail-closed behavior
* No change to the top-level enforcement invariant
* No unrelated files changed

## Related issue

Closes #309
