### PR TITLE
feat(spec): add schema-v2 spec claim verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      - name: Spec-to-code claim traceability
-        run: pnpm verify:spec-claims && pnpm test:spec-claims
-
       - name: Typecheck
         run: pnpm typecheck
 
@@ -82,6 +79,34 @@ jobs:
 
       - name: Vectors (Python canonicalization)
         run: pnpm test:vectors:py
+
+  spec-claims:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify spec claims
+        run: pnpm verify:spec-claims
+
+      - name: Test spec-claims checker
+        run: pnpm test:spec-claims
 
   adapter-validation:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
+      - name: Spec-to-code claim traceability
+        run: pnpm verify:spec-claims && pnpm test:spec-claims
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/docs/verification/spec-claims/INVENTORY.md
+++ b/docs/verification/spec-claims/INVENTORY.md
@@ -1,0 +1,820 @@
+# Claim mapping audit (schema v2)
+
+Review snapshot. Run `pnpm verify:spec-claims` for live counts. Locks are contextual records, not additional normative requirements.
+
+```text
+OxDeAI Spec-to-Code Claim Verification
+
+Registered records: 29
+Normative claim records (curated, not exhaustive): 26
+Contextual corpus locks (not executable requirements): 3
+Traceability (requirements only; references validated; evidence NOT executed by this command):
+ implementation mapped: 20/26
+ executable evidence mapped: 20/26
+ integration evidence: 12/12 required
+ negative evidence: 18/18 required
+ security-critical with negative evidence: 18/25
+ portable conformance evidence: 5/19 applicable
+
+Independent dimensions and evidence capabilities (curated scope, not proof or current execution results):
+ CANON-001 [requirement; normative=specified; evidence=mapped; scope=in-scope; portable] TRACEABLE, TESTED, CONFORMANCE_TESTED
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ CANON-002 [requirement; normative=specified; evidence=mapped; scope=in-scope; portable] TRACEABLE, TESTED, ADVERSARIAL_TESTED, CONFORMANCE_TESTED
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ CANON-003 [requirement; normative=specified; evidence=gap; scope=in-scope; portable] NO EXECUTABLE MAPPING
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ AUTH-ARTIFACT-001 [requirement; normative=specified; evidence=mapped; scope=in-scope; portable] TRACEABLE, TESTED, ADVERSARIAL_TESTED
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ AUTH-VERIFY-001 [requirement; normative=specified; evidence=mapped; scope=in-scope; portable] TRACEABLE, TESTED, INTEGRATION_TESTED, ADVERSARIAL_TESTED
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ AUTH-VERIFY-002 [requirement; normative=specified; evidence=mapped; scope=in-scope; portable] TRACEABLE, TESTED, INTEGRATION_TESTED, ADVERSARIAL_TESTED
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ AUTH-VERIFY-003 [requirement; normative=specified; evidence=mapped; scope=in-scope; portable] TRACEABLE, TESTED, INTEGRATION_TESTED, ADVERSARIAL_TESTED
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ AUTH-BIND-001 [requirement; normative=specified; evidence=mapped; scope=in-scope; implementation-specific] TRACEABLE, TESTED, INTEGRATION_TESTED, ADVERSARIAL_TESTED
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ AUTH-TIME-001 [requirement; normative=specified; evidence=mapped; scope=in-scope; portable] TRACEABLE, TESTED, INTEGRATION_TESTED, ADVERSARIAL_TESTED
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ AUTH-TRUST-001 [requirement; normative=specified; evidence=mapped; scope=in-scope; implementation-specific] TRACEABLE, TESTED, INTEGRATION_TESTED, ADVERSARIAL_TESTED
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ AUTH-REPLAY-001 [requirement; normative=specified; evidence=mapped; scope=in-scope; implementation-specific] TRACEABLE, TESTED, INTEGRATION_TESTED, ADVERSARIAL_TESTED
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ TRUSTED-TIME-001 [requirement; normative=specified; evidence=mapped; scope=in-scope; portable] TRACEABLE, TESTED, INTEGRATION_TESTED, ADVERSARIAL_TESTED
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ TRUSTED-TIME-002 [requirement; normative=specified; evidence=mapped; scope=in-scope; portable] TRACEABLE, TESTED, INTEGRATION_TESTED, ADVERSARIAL_TESTED
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ DELEGATION-001 [requirement; normative=specified; evidence=mapped; scope=in-scope; portable] TRACEABLE, TESTED, ADVERSARIAL_TESTED
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ DELEGATION-002 [requirement; normative=specified; evidence=mapped; scope=in-scope; portable] TRACEABLE, TESTED, ADVERSARIAL_TESTED
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ DELEGATION-003 [requirement; normative=specified; evidence=mapped; scope=in-scope; portable] TRACEABLE, TESTED, ADVERSARIAL_TESTED
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ SIGNED-KRL-001 [requirement; normative=specified; evidence=mapped; scope=in-scope; portable] TRACEABLE, TESTED, ADVERSARIAL_TESTED, CONFORMANCE_TESTED
+  Depends on RT-TRUST-2 (conditional-mitigation; context only): Artifact verification alone does not close the deployment KRL residual.
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+  DO NOT INFER KRL_SIGNATURE_VALID -> KRL_DEPLOYMENT_RESIDUAL_CLOSED: Required deployment configuration and persistent stores are not established by artifact vectors.
+ SIGNED-KRL-002 [requirement; normative=specified; evidence=mapped; scope=in-scope; portable] TRACEABLE, TESTED, ADVERSARIAL_TESTED, CONFORMANCE_TESTED
+  Depends on RT-TRUST-2 (conditional-mitigation; context only): Artifact verification alone does not close the deployment KRL residual.
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+  DO NOT INFER KRL_SIGNATURE_VALID -> KRL_DEPLOYMENT_RESIDUAL_CLOSED: Required deployment configuration and persistent stores are not established by artifact vectors.
+ PROFILE-C-001 [requirement; normative=specified; evidence=mapped; scope=in-scope; portable] TRACEABLE, TESTED, INTEGRATION_TESTED, ADVERSARIAL_TESTED, CONFORMANCE_TESTED
+  Depends on RT-TRUST-1 (trust-premise; context only): State-hash consistency does not establish state-provider integrity.
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+  DO NOT INFER STATE_HASH_MATCH -> STATE_SOURCE_TRUSTED: Honest, current, authoritative state is a deployment premise.
+ PEP-ENFORCE-001 [requirement; normative=specified; evidence=mapped; scope=in-scope; implementation-specific] TRACEABLE, TESTED, INTEGRATION_TESTED, ADVERSARIAL_TESTED
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ PEP-DEPLOY-001 [requirement; normative=specified; evidence=gap; scope=deployment; deployment-assumption] NO EXECUTABLE MAPPING
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ STATE-TRUST-001 [requirement; normative=specified; evidence=gap; scope=deployment; deployment-assumption] NO EXECUTABLE MAPPING
+  Depends on RT-TRUST-1 (trust-premise; context only): State-hash consistency does not establish state-provider integrity.
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+  DO NOT INFER STATE_HASH_MATCH -> STATE_SOURCE_TRUSTED: Honest, current, authoritative state is a deployment premise.
+ VERIFY-ORDER-001 [requirement; normative=ambiguous; evidence=gap; scope=in-scope; portable] NO EXECUTABLE MAPPING
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ DELEGATION-AUDIT-001 [requirement; normative=specified; evidence=gap; scope=in-scope; implementation-specific] NO EXECUTABLE MAPPING
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ ETA-SIGNING-001 [requirement; normative=ambiguous; evidence=gap; scope=in-scope; portable] NO EXECUTABLE MAPPING
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ ETA-DETERMINISM-001 [requirement; normative=specified; evidence=mapped; scope=in-scope; portable] TRACEABLE, TESTED, INTEGRATION_TESTED
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+ CANON-ESC-001 [corpus-lock; normative=unresolved; evidence=unassessed; scope=deferred; documentation-only] NO EXECUTABLE MAPPING
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+  DO NOT INFER SELECTED_CANONICALIZATION_VECTORS_PASS -> CANON_ESC_LOCK_RESOLVED: Existing vectors do not resolve an undefined corpus lock.
+ RT-TRUST-1 [corpus-lock; normative=non-normative; evidence=unassessed; scope=deployment; documentation-only] NO EXECUTABLE MAPPING
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+  DO NOT INFER STATE_HASH_MATCH -> STATE_SOURCE_TRUSTED: Matching state can be manufactured by a compromised provider.
+ RT-TRUST-2 [corpus-lock; normative=non-normative; evidence=unassessed; scope=conditional; documentation-only] NO EXECUTABLE MAPPING
+  Applies when (all conditions; NOT evaluated): krlMode=signed_required, verifyKrl=configured, KrlWatermarkStore=configured, SignedKrlCache=configured
+  DO NOT INFER STRUCTURAL_PASS -> SEMANTIC_PROOF: Reference consistency does not prove the claimed semantics.
+  DO NOT INFER TESTED -> WHOLE_PROTOCOL_CONFORMANCE: Selected executable cases do not establish whole-protocol conformance.
+  DO NOT INFER KRL_SIGNATURE_VALID -> KRL_DEPLOYMENT_RESIDUAL_CLOSED: Signature verification does not establish integrity mode, callback, durable watermark or signed cache configuration.
+
+Issues:
+ unmapped claims: 6
+ ambiguous claims: 2
+ maintainer decisions pending (advisory): 9
+ stale implementation refs: 0
+ stale evidence refs: 0
+ missing required evidence: 0
+ REVIEW CANON-001: Only object ordering is claimed; NFC normalization and collision rejection need separate claims. Negative cases are not required for this ordering-only claim.
+ REVIEW CANON-003: Core canonicalJson receives objects, after raw duplicate keys may be lost. NFC collision detection is not evidence of duplicate-key-aware raw JSON parsing.
+ REVIEW PEP-DEPLOY-001: Deployment topology and upstream access control must be independently evidenced. Gateway tests cannot prove arbitrary deployment non-bypassability.
+ REVIEW STATE-TRUST-001: Provider honesty/coherence is an external deployment obligation. Hash equality and CAS tests do not demonstrate it for a deployed provider.
+ REVIEW VERIFY-ORDER-001: Verification §5 puts signature before expiry; AuthorizationV1 §10 puts expiry before signature. Core collects/sorts violations. No claim of satisfying both incompatible sequences.
+ REVIEW DELEGATION-AUDIT-001: No direct mapping found for required DELEGATION_EXECUTION/DELEGATION_DENIED hash-chained events. Guard boundary event callbacks alone are not evidence of this contract.
+ REVIEW ETA-SIGNING-001: ETA excludes entire signature field; AuthorizationV1 §5 retains nested alg/kid and defines encoding-specific prefix. Normative docs vectors use another verifier/preimage; do not equate corpora.
+ REVIEW ETA-DETERMINISM-001: Inputs include trusted evaluationTime and fixed configuration per trusted-time profile. This selected test does not prove all decision modules deterministic.
+ REVIEW CANON-ESC-001: CANON-ESC-001 was requested for registration by the maintainer; no existing repository definition of this identifier was found. This source is context only. Exact escaping/corpus-lock meaning and disposition require a maintainer decision; no new serialization rule is asserted.
+ REVIEW RT-TRUST-1: The residual is not closed. Minimum state-provider requirements exist, but provider compliance and integrity remain deployment responsibilities. This lock is an audit observation, not another executable protocol requirement.
+ REVIEW RT-TRUST-2: Conditional closure is documented for configured deployments, not established here. Compatibility modes retain residual risk. Applicability conditions describe the documented closure context; the checker never evaluates a deployment or declares this lock closed.
+
+Mapped ≠ demonstrated. Tested ≠ portable conformance tested. Signature validity ≠ trusted premises.
+Structural PASS is not semantic proof or whole-protocol conformance. Dependencies and pending decisions do not close locks.
+See docs/verification/spec-claims/README.md for corpus boundaries and maintainer findings.
+RESULT: PASS (structural verification only)
+```
+
+## CANON-001 — Canonical object key ordering
+
+Source (normative): [docs/spec/core/canonicalization-v1.md](../../../docs/spec/core/canonicalization-v1.md), 6. Serialization Rules (normative) (normative-statement).
+
+Type: requirement. Category: ARTIFACT. Classification: portable.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: Only object ordering is claimed; NFC normalization and collision rejection need separate claims. Negative cases are not required for this ordering-only claim.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- [packages/core/src/crypto/hashes.ts](../../../packages/core/src/crypto/hashes.ts) — `canonicalizeToJson`
+
+Evidence:
+
+- [packages/core/src/test/canonicalization.property.test.ts](../../../packages/core/src/test/canonicalization.property.test.ts) — `C-P2: canonical output is invariant to object key insertion order at every nesting level` (unit; negative=false; portable=false). Core canonicalization property test for the selected serialization rule. Runner: `pnpm -C packages/core test` (TypeScript).
+- [docs/spec/test-vectors/canonicalization-v1.json](../../../docs/spec/test-vectors/canonicalization-v1.json) — `v1-object-key-ordering` (cross-runtime; negative=false; portable=true). Exact sorted canonical JSON and SHA-256; Python independent implementation. Runner: `pnpm test:vectors:py` (Python).
+
+## CANON-002 — Reject floating point numbers
+
+Source (normative): [docs/spec/core/canonicalization-v1.md](../../../docs/spec/core/canonicalization-v1.md), 6. Serialization Rules (normative) (MUST).
+
+Type: requirement. Category: ARTIFACT. Classification: portable.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- [packages/core/src/crypto/hashes.ts](../../../packages/core/src/crypto/hashes.ts) — `canonicalizeToJson`
+
+Evidence:
+
+- [packages/core/src/test/canonicalization.property.test.ts](../../../packages/core/src/test/canonicalization.property.test.ts) — `C-P6: floats, NaN, and ±Infinity are always rejected with FLOAT_NOT_ALLOWED` (unit; negative=true; portable=false). Core canonicalization property test for the selected serialization rule. Runner: `pnpm -C packages/core test` (TypeScript).
+- [docs/spec/test-vectors/canonicalization-v1.json](../../../docs/spec/test-vectors/canonicalization-v1.json) — `i1-float-rejected` (cross-runtime; negative=true; portable=true). Float rejection and expected error code. Runner: `pnpm test:vectors:py` (Python).
+
+## CANON-003 — Reject duplicate keys at raw input parsing
+
+Source (normative): [docs/spec/core/canonicalization-v1.md](../../../docs/spec/core/canonicalization-v1.md), 5. Input Parsing Requirements (MUST).
+
+Type: requirement. Category: ARTIFACT. Classification: portable.
+
+Normative: specified. Evidence: gap. Scope: in-scope. Maintainer decision required: true.
+
+Scope notes: Core canonicalJson receives objects, after raw duplicate keys may be lost. NFC collision detection is not evidence of duplicate-key-aware raw JSON parsing.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- No direct executable mapping claimed.
+
+Evidence:
+
+- No executable evidence claimed.
+
+## AUTH-ARTIFACT-001 — Reject decisions other than ALLOW
+
+Source (normative): [docs/spec/artifacts/authorization-v1.md](../../../docs/spec/artifacts/authorization-v1.md), 4. Canonical Semantic Model (MUST).
+
+Type: requirement. Category: ARTIFACT. Classification: portable.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- [packages/core/src/verification/verifyAuthorization.ts](../../../packages/core/src/verification/verifyAuthorization.ts) — `verifyAuthorization`
+
+Evidence:
+
+- [packages/conformance/vectors/authorization-verification.json](../../../packages/conformance/vectors/authorization-verification.json) — `authorization-verify-004` (vector; negative=true; portable=false). Non-ALLOW decision rejected with AUTH_DECISION_INVALID. Runner: `pnpm -C packages/conformance validate` (TypeScript).
+
+## AUTH-VERIFY-001 — Reject invalid Ed25519 signatures
+
+Source (normative): [docs/spec/artifacts/authorization-v1.md](../../../docs/spec/artifacts/authorization-v1.md), 8. Signature Requirements (MUST).
+
+Type: requirement. Category: VERIFY. Classification: portable.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- [packages/core/src/verification/verifyAuthorization.ts](../../../packages/core/src/verification/verifyAuthorization.ts) — `verifyAuthorization`
+
+Evidence:
+
+- [packages/conformance/vectors/authorization-signature-verification.json](../../../packages/conformance/vectors/authorization-signature-verification.json) — `authorization-sig-002` (vector; negative=true; portable=false). Corrupted signature fails verification. Runner: `pnpm -C packages/conformance validate` (TypeScript).
+- [packages/guard/src/test/guard.authorization.test.ts](../../../packages/guard/src/test/guard.authorization.test.ts) — `A-1 tampered signature: execute is blocked and OxDeAIAuthorizationError is thrown` (integration; negative=true; portable=false). Guard blocks execute on corrupted signature. Runner: `pnpm -C packages/guard test` (TypeScript).
+
+## AUTH-VERIFY-002 — Issuer-scoped trusted key resolution
+
+Source (normative): [docs/spec/artifacts/authorization-v1.md](../../../docs/spec/artifacts/authorization-v1.md), 8. Signature Requirements (MUST).
+
+Type: requirement. Category: TRUST. Classification: portable.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: expectedIssuer is meaningful when independently established. Scalar expectations are not inherently defective; this claim does not prove provenance of configuration.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- [packages/core/src/verification/verifyAuthorization.ts](../../../packages/core/src/verification/verifyAuthorization.ts) — `verifyAuthorization`
+
+Evidence:
+
+- [packages/conformance/vectors/authorization-signature-verification.json](../../../packages/conformance/vectors/authorization-signature-verification.json) — `authorization-sig-004` (vector; negative=true; portable=false). Wrong issuer yields issuer mismatch and unknown key. Runner: `pnpm -C packages/conformance validate` (TypeScript).
+- [packages/guard/src/test/guard.authorization.test.ts](../../../packages/guard/src/test/guard.authorization.test.ts) — `A-2 unknown issuer: execute is blocked and OxDeAIAuthorizationError is thrown` (integration; negative=true; portable=false). Unknown issuer signed with separate key cannot execute. Runner: `pnpm -C packages/guard test` (TypeScript).
+
+## AUTH-VERIFY-003 — Audience matches execution boundary
+
+Source (normative): [docs/spec/artifacts/authorization-v1.md](../../../docs/spec/artifacts/authorization-v1.md), audience (MUST).
+
+Type: requirement. Category: VERIFY. Classification: portable.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- [packages/core/src/verification/verifyAuthorization.ts](../../../packages/core/src/verification/verifyAuthorization.ts) — `verifyAuthorization`
+- [packages/guard/src/guard.ts](../../../packages/guard/src/guard.ts) — `OxDeAIGuard`
+
+Evidence:
+
+- [packages/conformance/vectors/authorization-signature-verification.json](../../../packages/conformance/vectors/authorization-signature-verification.json) — `authorization-sig-005` (vector; negative=true; portable=false). Wrong expected audience rejects. Runner: `pnpm -C packages/conformance validate` (TypeScript).
+- [packages/guard/src/test/guard.authorization.test.ts](../../../packages/guard/src/test/guard.authorization.test.ts) — `A-3 wrong audience: execute is blocked and OxDeAIAuthorizationError is thrown` (integration; negative=true; portable=false). Wrong audience blocks callback execution. Runner: `pnpm -C packages/guard test` (TypeScript).
+
+## AUTH-BIND-001 — Intent hash exactly matches requested action
+
+Source (normative): [docs/spec/artifacts/authorization-v1.md](../../../docs/spec/artifacts/authorization-v1.md), intent_hash (MUST).
+
+Type: requirement. Category: ENFORCEMENT. Classification: implementation-specific.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: Guard integration checks normalized action binding. Pure verifyAuthorization does not recompute the requested action; no portable vector is asserted here.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- [packages/guard/src/guard.ts](../../../packages/guard/src/guard.ts) — `OxDeAIGuard`
+- [packages/core/src/crypto/hashes.ts](../../../packages/core/src/crypto/hashes.ts) — `intentHash`
+
+Evidence:
+
+- [packages/guard/src/test/guard.intent-binding.test.ts](../../../packages/guard/src/test/guard.intent-binding.test.ts) — `IB-2 wrong intent_hash in auth: OxDeAIAuthorizationError thrown, execute blocked` (integration; negative=true; portable=false). Authorization for action A cannot execute action B. Runner: `pnpm -C packages/guard test` (TypeScript).
+
+## AUTH-TIME-001 — Strict expiry at now greater than or equal to expiry
+
+Source (normative): [docs/spec/artifacts/authorization-v1.md](../../../docs/spec/artifacts/authorization-v1.md), expiry / expires_at (MUST).
+
+Type: requirement. Category: TIME. Classification: portable.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- [packages/core/src/verification/verifyAuthorization.ts](../../../packages/core/src/verification/verifyAuthorization.ts) — `verifyAuthorization`
+
+Evidence:
+
+- [packages/conformance/vectors/authorization-verification.json](../../../packages/conformance/vectors/authorization-verification.json) — `authorization-verify-002` (vector; negative=true; portable=false). now equals expiry returns AUTH_EXPIRED. Runner: `pnpm -C packages/conformance validate` (TypeScript).
+- [packages/guard/src/test/guard.authorization.test.ts](../../../packages/guard/src/test/guard.authorization.test.ts) — `A-4 expired auth: execute is blocked and OxDeAIAuthorizationError is thrown` (integration; negative=true; portable=false). Expired signed authorization cannot execute. Runner: `pnpm -C packages/guard test` (TypeScript).
+
+## AUTH-TRUST-001 — Missing strict trust configuration fails closed
+
+Source (normative): [docs/spec/artifacts/authorization-v1.md](../../../docs/spec/artifacts/authorization-v1.md), Strict mode (MUST).
+
+Type: requirement. Category: TRUST. Classification: implementation-specific.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: Evidence is guard configuration enforcement. It does not establish honesty of supplied keys or policy premises.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- [packages/core/src/verification/verifyAuthorization.ts](../../../packages/core/src/verification/verifyAuthorization.ts) — `verifyAuthorization`
+- [packages/guard/src/guard.ts](../../../packages/guard/src/guard.ts) — `OxDeAIGuard`
+
+Evidence:
+
+- [packages/guard/src/test/guard.authorization.test.ts](../../../packages/guard/src/test/guard.authorization.test.ts) — `A-5 missing trustedKeySets: OxDeAIGuardConfigurationError thrown at construction` (integration; negative=true; portable=false). Guard construction rejects missing trustedKeySets. Runner: `pnpm -C packages/guard test` (TypeScript).
+
+## AUTH-REPLAY-001 — Reused auth_id cannot execute
+
+Source (normative): [docs/spec/artifacts/authorization-v1.md](../../../docs/spec/artifacts/authorization-v1.md), 11. Replay Protection (MUST).
+
+Type: requirement. Category: REPLAY. Classification: implementation-specific.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: In-memory/shared-store integration scope only; not proof of distributed durable replay storage.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- [packages/guard/src/guard.ts](../../../packages/guard/src/guard.ts) — `OxDeAIGuard`
+- [packages/guard/src/replayStore.ts](../../../packages/guard/src/replayStore.ts) — `createInMemoryReplayStore`
+
+Evidence:
+
+- [packages/guard/src/test/guard.replay-store.test.ts](../../../packages/guard/src/test/guard.replay-store.test.ts) — `RS-1 default store: auth_id replay blocked on second call to same guard instance` (integration; negative=true; portable=false). Second use blocked; exactly one execution. Runner: `pnpm -C packages/guard test` (TypeScript).
+- [packages/guard/src/test/guard.replay-store.test.ts](../../../packages/guard/src/test/guard.replay-store.test.ts) — `RS-3 shared store: auth_id replay blocked across two distinct guard instances` (integration; negative=true; portable=false). Shared store blocks replay across guard instances. Runner: `pnpm -C packages/guard test` (TypeScript).
+
+## TRUSTED-TIME-001 — Issuance uses trusted evaluation time
+
+Source (normative): [docs/spec/core/trusted-time-v1.md](../../../docs/spec/core/trusted-time-v1.md), 4. Consistency Invariants (MUST).
+
+Type: requirement. Category: TIME. Classification: portable.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- [packages/core/src/policy/PolicyEngine.ts](../../../packages/core/src/policy/PolicyEngine.ts) — `PolicyEngine`
+
+Evidence:
+
+- [packages/core/src/test/trusted-time-integration.test.ts](../../../packages/core/src/test/trusted-time-integration.test.ts) — `issuance tripwire: issued_at and expiry derive from evaluationTime, not intent.timestamp` (integration; negative=true; portable=false). Future-side freshness-valid intent does not drive issuance or expiry. Runner: `pnpm -C packages/core test` (TypeScript).
+
+## TRUSTED-TIME-002 — Reject future freshness violations
+
+Source (normative): [docs/spec/core/trusted-time-v1.md](../../../docs/spec/core/trusted-time-v1.md), 6. Freshness Semantics (Future and Stale) (normative-statement).
+
+Type: requirement. Category: TIME. Classification: portable.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- [packages/core/src/policy/verifyTrustedTime.ts](../../../packages/core/src/policy/verifyTrustedTime.ts) — `verifyTrustedTime`
+- [packages/core/src/policy/PolicyEngine.ts](../../../packages/core/src/policy/PolicyEngine.ts) — `PolicyEngine`
+
+Evidence:
+
+- [packages/core/src/test/trusted-time-integration.test.ts](../../../packages/core/src/test/trusted-time-integration.test.ts) — `future-dated intent → exactly DENY/INTENT_FRESHNESS_FUTURE` (integration; negative=true; portable=false). Future timestamp yields exactly DENY/INTENT_FRESHNESS_FUTURE. Runner: `pnpm -C packages/core test` (TypeScript).
+
+## DELEGATION-001 — Child tools cannot widen supplied parentScope
+
+Source (normative): [docs/spec/artifacts/delegation-v1.md](../../../docs/spec/artifacts/delegation-v1.md), 4.1 Scope Narrowing (MUST).
+
+Type: requirement. Category: DELEGATION. Classification: portable.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: Narrowing is relative to caller-supplied parentScope; no evidence that the scope originated from an authoritative external grant.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- [packages/core/src/verification/verifyDelegation.ts](../../../packages/core/src/verification/verifyDelegation.ts) — `verifyDelegation`
+
+Evidence:
+
+- [packages/conformance/vectors/delegation-verification.json](../../../packages/conformance/vectors/delegation-verification.json) — `delegation-verify-005` (vector; negative=true; portable=false). Tool outside caller-supplied parent scope rejected. Runner: `pnpm -C packages/conformance validate` (TypeScript).
+
+## DELEGATION-002 — Reject delegation as parent (single hop)
+
+Source (normative): [docs/spec/artifacts/delegation-v1.md](../../../docs/spec/artifacts/delegation-v1.md), 4.4 Single-Hop Enforcement (MUST NOT).
+
+Type: requirement. Category: DELEGATION. Classification: portable.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- [packages/core/src/verification/verifyDelegation.ts](../../../packages/core/src/verification/verifyDelegation.ts) — `verifyDelegationChain`
+
+Evidence:
+
+- [packages/conformance/vectors/delegation-chain-verification.json](../../../packages/conformance/vectors/delegation-chain-verification.json) — `delegation-chain-006` (vector; negative=true; portable=false). Delegation parent rejected as multihop. Runner: `pnpm -C packages/conformance validate` (TypeScript).
+
+## DELEGATION-003 — Delegation policy equals parent policy
+
+Source (normative): [docs/spec/artifacts/delegation-v1.md](../../../docs/spec/artifacts/delegation-v1.md), 4.1 Scope Narrowing (MUST).
+
+Type: requirement. Category: DELEGATION. Classification: portable.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: This binds two artifacts. It does not prove that an issuer is independently authorized for that policy. Generic expectedPolicyId remains valid when independently configured.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- [packages/core/src/verification/verifyDelegation.ts](../../../packages/core/src/verification/verifyDelegation.ts) — `verifyDelegationChain`
+
+Evidence:
+
+- [packages/conformance/vectors/delegation-chain-verification.json](../../../packages/conformance/vectors/delegation-chain-verification.json) — `delegation-chain-007` (vector; negative=true; portable=false). Child-parent policy mismatch rejected. Runner: `pnpm -C packages/conformance validate` (TypeScript).
+
+## SIGNED-KRL-001 — Duplicate revoked kids rejected
+
+Source (normative): [docs/spec/artifacts/signed-krl-v1.md](../../../docs/spec/artifacts/signed-krl-v1.md), 9. `revoked_kids` deduplication (MUST).
+
+Type: requirement. Category: TRUST. Classification: portable.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.
+
+Dependency: RT-TRUST-2 (conditional-mitigation). Artifact verification alone does not close the deployment KRL residual.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Forbidden inference: KRL_SIGNATURE_VALID → KRL_DEPLOYMENT_RESIDUAL_CLOSED. Required deployment configuration and persistent stores are not established by artifact vectors.
+
+Implementation:
+
+- [packages/core/src/verification/verifySignedKrl.ts](../../../packages/core/src/verification/verifySignedKrl.ts) — `verifySignedKrl`
+
+Evidence:
+
+- [packages/conformance/vectors/signed-krl-verification.json](../../../packages/conformance/vectors/signed-krl-verification.json) — `krl-005` (vector; negative=true; portable=false). Duplicate revoked kid entries rejected. Runner: `pnpm -C packages/conformance validate` (TypeScript).
+- [docs/spec/test-vectors/signed-krl-v1.json](../../../docs/spec/test-vectors/signed-krl-v1.json) — `KRL_DUPLICATE_REVOKED_KIDS` (cross-runtime; negative=true; portable=true). Independent Python duplicate-entry rejection. Runner: `pnpm test:vectors:py` (Python).
+
+## SIGNED-KRL-002 — Invalid KRL signature rejected
+
+Source (normative): [docs/spec/artifacts/signed-krl-v1.md](../../../docs/spec/artifacts/signed-krl-v1.md), 10. Reason codes (normative-statement).
+
+Type: requirement. Category: VERIFY. Classification: portable.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.
+
+Dependency: RT-TRUST-2 (conditional-mitigation). Artifact verification alone does not close the deployment KRL residual.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Forbidden inference: KRL_SIGNATURE_VALID → KRL_DEPLOYMENT_RESIDUAL_CLOSED. Required deployment configuration and persistent stores are not established by artifact vectors.
+
+Implementation:
+
+- [packages/core/src/verification/verifySignedKrl.ts](../../../packages/core/src/verification/verifySignedKrl.ts) — `verifySignedKrl`
+
+Evidence:
+
+- [packages/conformance/vectors/signed-krl-verification.json](../../../packages/conformance/vectors/signed-krl-verification.json) — `krl-002` (vector; negative=true; portable=false). Tampered signature rejected. Runner: `pnpm -C packages/conformance validate` (TypeScript).
+- [docs/spec/test-vectors/signed-krl-v1.json](../../../docs/spec/test-vectors/signed-krl-v1.json) — `KRL_SIGNED_INVALID_SIG` (cross-runtime; negative=true; portable=true). Independent Python Ed25519 verification rejects tampering. Runner: `pnpm test:vectors:py` (Python).
+
+## PROFILE-C-001 — Live-state hash must match committed state hash
+
+Source (normative): [docs/spec/interoperability/external-provider-profile.md](../../../docs/spec/interoperability/external-provider-profile.md), 2.3.2 Additional Verifier Requirements (beyond Profile B) (normative-statement).
+
+Type: requirement. Category: STATE. Classification: portable.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: Portable evidence covers hash comparison only. Guard integration covers callback blocking separately. Neither establishes current or honest state.
+
+Dependency: RT-TRUST-1 (trust-premise). State-hash consistency does not establish state-provider integrity.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Forbidden inference: STATE_HASH_MATCH → STATE_SOURCE_TRUSTED. Honest, current, authoritative state is a deployment premise.
+
+Implementation:
+
+- [packages/guard/src/guard.ts](../../../packages/guard/src/guard.ts) — `OxDeAIGuard`
+
+Evidence:
+
+- [packages/guard/src/test/guard.state-binding.test.ts](../../../packages/guard/src/test/guard.state-binding.test.ts) — `SB-2 mismatched state_hash: execute is blocked and OxDeAIAuthorizationError is thrown` (integration; negative=true; portable=false). Mismatched state hash blocks execute. Runner: `pnpm -C packages/guard test` (TypeScript).
+- [docs/spec/test-vectors/profile-c-state-verification.json](../../../docs/spec/test-vectors/profile-c-state-verification.json) — `profile-c-002` (cross-runtime; negative=true; portable=true). Portable hash comparison mismatch, not execution or provider honesty. Runner: `pnpm test:vectors:py` (Python).
+
+## PEP-ENFORCE-001 — Invalid authorization prevents execution
+
+Source (normative): [docs/spec/artifacts/authorization-v1.md](../../../docs/spec/artifacts/authorization-v1.md), 1. Purpose (MUST NOT).
+
+Type: requirement. Category: ENFORCEMENT. Classification: implementation-specific.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: Selected guard rejection case only. Does not prove every possible execution path is non-bypassable.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- [packages/guard/src/guard.ts](../../../packages/guard/src/guard.ts) — `OxDeAIGuard`
+
+Evidence:
+
+- [packages/guard/src/test/guard.authorization.test.ts](../../../packages/guard/src/test/guard.authorization.test.ts) — `A-1 tampered signature: execute is blocked and OxDeAIAuthorizationError is thrown` (integration; negative=true; portable=false). Invalid signature prevents execute callback. Runner: `pnpm -C packages/guard test` (TypeScript).
+
+## PEP-DEPLOY-001 — Gateway is sole execution boundary
+
+Source (normative): [docs/spec/enforcement/pep-gateway-v1.md](../../../docs/spec/enforcement/pep-gateway-v1.md), 4.1 Execution Boundary (MUST).
+
+Type: requirement. Category: TRUST. Classification: deployment-assumption.
+
+Normative: specified. Evidence: gap. Scope: deployment. Maintainer decision required: true.
+
+Scope notes: Deployment topology and upstream access control must be independently evidenced. Gateway tests cannot prove arbitrary deployment non-bypassability.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- No direct executable mapping claimed.
+
+Evidence:
+
+- No executable evidence claimed.
+
+## STATE-TRUST-001 — State provider serves coherent view
+
+Source (normative): [docs/spec/state-provider-requirements.md](../../../docs/spec/state-provider-requirements.md), 2.1 Requirement (MUST).
+
+Type: requirement. Category: STATE. Classification: deployment-assumption.
+
+Normative: specified. Evidence: gap. Scope: deployment. Maintainer decision required: true.
+
+Scope notes: Provider honesty/coherence is an external deployment obligation. Hash equality and CAS tests do not demonstrate it for a deployed provider.
+
+Dependency: RT-TRUST-1 (trust-premise). State-hash consistency does not establish state-provider integrity.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Forbidden inference: STATE_HASH_MATCH → STATE_SOURCE_TRUSTED. Honest, current, authoritative state is a deployment premise.
+
+Implementation:
+
+- No direct executable mapping claimed.
+
+Evidence:
+
+- No executable evidence claimed.
+
+## VERIFY-ORDER-001 — Normative verification ordering
+
+Source (normative): [docs/spec/verification/verification-v1.md](../../../docs/spec/verification/verification-v1.md), 9. Determinism and Ordering (MUST).
+
+Type: requirement. Category: VERIFY. Classification: portable.
+
+Normative: ambiguous. Evidence: gap. Scope: in-scope. Maintainer decision required: true.
+
+Scope notes: Verification §5 puts signature before expiry; AuthorizationV1 §10 puts expiry before signature. Core collects/sorts violations. No claim of satisfying both incompatible sequences.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- No direct executable mapping claimed.
+
+Evidence:
+
+- No executable evidence claimed.
+
+## DELEGATION-AUDIT-001 — PEP delegation events included in hash-chained audit log
+
+Source (normative): [docs/spec/artifacts/delegation-v1.md](../../../docs/spec/artifacts/delegation-v1.md), 7. Audit Event (MUST).
+
+Type: requirement. Category: AUDIT. Classification: implementation-specific.
+
+Normative: specified. Evidence: gap. Scope: in-scope. Maintainer decision required: true.
+
+Scope notes: No direct mapping found for required DELEGATION_EXECUTION/DELEGATION_DENIED hash-chained events. Guard boundary event callbacks alone are not evidence of this contract.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- No direct executable mapping claimed.
+
+Evidence:
+
+- No executable evidence claimed.
+
+## ETA-SIGNING-001 — ETA signing payload excludes entire signature field
+
+Source (normative): [docs/spec/core/eta-core-v1.md](../../../docs/spec/core/eta-core-v1.md), 5. Authorization Artifact (AuthorizationV1) (MUST).
+
+Type: requirement. Category: ARTIFACT. Classification: portable.
+
+Normative: ambiguous. Evidence: gap. Scope: in-scope. Maintainer decision required: true.
+
+Scope notes: ETA excludes entire signature field; AuthorizationV1 §5 retains nested alg/kid and defines encoding-specific prefix. Normative docs vectors use another verifier/preimage; do not equate corpora.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- No direct executable mapping claimed.
+
+Evidence:
+
+- No executable evidence claimed.
+
+## ETA-DETERMINISM-001 — Identical trusted inputs produce deterministic signed authorizations
+
+Source (normative): [docs/spec/core/eta-core-v1.md](../../../docs/spec/core/eta-core-v1.md), Requirements (MUST).
+
+Type: requirement. Category: ARTIFACT. Classification: portable.
+
+Normative: specified. Evidence: mapped. Scope: in-scope. Maintainer decision required: false.
+
+Scope notes: Inputs include trusted evaluationTime and fixed configuration per trusted-time profile. This selected test does not prove all decision modules deterministic.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Implementation:
+
+- [packages/core/src/policy/PolicyEngine.ts](../../../packages/core/src/policy/PolicyEngine.ts) — `PolicyEngine`
+
+Evidence:
+
+- [packages/core/src/test/authorization.trusted-time-issuance.test.ts](../../../packages/core/src/test/authorization.trusted-time-issuance.test.ts) — `identical trusted inputs produce deterministic Ed25519 authorizations` (integration; negative=false; portable=false). Repeated trusted inputs produce identical Ed25519 authorization objects. Runner: `pnpm -C packages/core test` (TypeScript).
+
+## CANON-ESC-001 — Unresolved canonicalization corpus lock (maintainer-supplied identifier)
+
+Source (context): [docs/spec/core/canonicalization-v1.md](../../../docs/spec/core/canonicalization-v1.md), 6. Serialization Rules (normative) (not-applicable).
+
+Type: corpus-lock. Category: ARTIFACT. Classification: documentation-only.
+
+Normative: unresolved. Evidence: unassessed. Scope: deferred. Maintainer decision required: true.
+
+Scope notes: CANON-ESC-001 was requested for registration by the maintainer; no existing repository definition of this identifier was found. This source is context only. Exact escaping/corpus-lock meaning and disposition require a maintainer decision; no new serialization rule is asserted.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Forbidden inference: SELECTED_CANONICALIZATION_VECTORS_PASS → CANON_ESC_LOCK_RESOLVED. Existing vectors do not resolve an undefined corpus lock.
+
+Implementation:
+
+- No direct executable mapping claimed.
+
+Evidence:
+
+- No executable evidence claimed.
+
+## RT-TRUST-1 — State provider integrity residual
+
+Source (context): [docs/audits/protocol-audit-post-interoperability.md](../../../docs/audits/protocol-audit-post-interoperability.md), 5.3 Residual Trust Risks (not-applicable).
+
+Type: corpus-lock. Category: TRUST. Classification: documentation-only.
+
+Normative: non-normative. Evidence: unassessed. Scope: deployment. Maintainer decision required: true.
+
+Scope notes: The residual is not closed. Minimum state-provider requirements exist, but provider compliance and integrity remain deployment responsibilities. This lock is an audit observation, not another executable protocol requirement.
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Forbidden inference: STATE_HASH_MATCH → STATE_SOURCE_TRUSTED. Matching state can be manufactured by a compromised provider.
+
+Implementation:
+
+- No direct executable mapping claimed.
+
+Evidence:
+
+- No executable evidence claimed.
+
+## RT-TRUST-2 — Conditional KRL transport-integrity residual
+
+Source (context): [docs/spec/interoperability/external-provider-profile.md](../../../docs/spec/interoperability/external-provider-profile.md), 2.2.5 KRL Integrity at Profile B (not-applicable).
+
+Type: corpus-lock. Category: TRUST. Classification: documentation-only.
+
+Normative: non-normative. Evidence: unassessed. Scope: conditional. Maintainer decision required: true.
+
+Scope notes: Conditional closure is documented for configured deployments, not established here. Compatibility modes retain residual risk. Applicability conditions describe the documented closure context; the checker never evaluates a deployment or declares this lock closed.
+
+Contextual all-of conditions (not evaluated): [{"setting":"krlMode","equals":"signed_required"},{"setting":"verifyKrl","equals":"configured"},{"setting":"KrlWatermarkStore","equals":"configured"},{"setting":"SignedKrlCache","equals":"configured"}]
+
+Forbidden inference: STRUCTURAL_PASS → SEMANTIC_PROOF. Reference consistency does not prove the claimed semantics.
+
+Forbidden inference: TESTED → WHOLE_PROTOCOL_CONFORMANCE. Selected executable cases do not establish whole-protocol conformance.
+
+Forbidden inference: KRL_SIGNATURE_VALID → KRL_DEPLOYMENT_RESIDUAL_CLOSED. Signature verification does not establish integrity mode, callback, durable watermark or signed cache configuration.
+
+Implementation:
+
+- No direct executable mapping claimed.
+
+Evidence:
+
+- No executable evidence claimed.

--- a/docs/verification/spec-claims/MIGRATION.md
+++ b/docs/verification/spec-claims/MIGRATION.md
@@ -1,0 +1,59 @@
+# Registry schema migration: v1 → v2
+
+This is an explicit curated migration, not a runtime repair path. Version 1 and its overloaded `status` are rejected by the version 2 checker. At the migration baseline, all 26 previous IDs, titles, source paths/headings/excerpts, strengths, categories, notes, implementation/evidence records, classifications and explicit evidence obligations were preserved, with `source.role=normative` added to existing sources. After normative spec update #309, selected source headings/excerpts were reconciled to the updated specification text without changing their evidence mappings or executable obligations.
+
+The new schema keeps independently reviewed normative, evidence and scope dimensions. No state or dependency automatically creates, suppresses or satisfies executable obligations.
+
+| v1 status | normativeState | evidenceState | scopeDisposition | maintainerDecisionRequired |
+|---|---|---|---|---|
+| mapped | specified | mapped | in-scope | false |
+| gap | specified | gap | in-scope | true |
+| ambiguous | ambiguous | gap | in-scope | true |
+| assumption | specified | gap | deployment | true |
+
+Other additions: `recordType`, `appliesWhen`, `dependsOn`, `inferenceGuard`. Existing requirements have `recordType=requirement` and `appliesWhen=[]`. All records explicitly prohibit STRUCTURAL_PASS → SEMANTIC_PROOF and TESTED → WHOLE_PROTOCOL_CONFORMANCE. IDs now accept one or more terminal digits, preserving RT-TRUST-1 and RT-TRUST-2 verbatim.
+
+| Existing affected ID | Former status | New normative / evidence / scope | Added dependencies |
+|---|---|---|---|
+| CANON-001 | mapped | specified / mapped / in-scope | None |
+| CANON-002 | mapped | specified / mapped / in-scope | None |
+| CANON-003 | gap | specified / gap / in-scope | None |
+| AUTH-ARTIFACT-001 | mapped | specified / mapped / in-scope | None |
+| AUTH-VERIFY-001 | mapped | specified / mapped / in-scope | None |
+| AUTH-VERIFY-002 | mapped | specified / mapped / in-scope | None |
+| AUTH-VERIFY-003 | mapped | specified / mapped / in-scope | None |
+| AUTH-BIND-001 | mapped | specified / mapped / in-scope | None |
+| AUTH-TIME-001 | mapped | specified / mapped / in-scope | None |
+| AUTH-TRUST-001 | mapped | specified / mapped / in-scope | None |
+| AUTH-REPLAY-001 | mapped | specified / mapped / in-scope | None |
+| TRUSTED-TIME-001 | mapped | specified / mapped / in-scope | None |
+| TRUSTED-TIME-002 | mapped | specified / mapped / in-scope | None |
+| DELEGATION-001 | mapped | specified / mapped / in-scope | None |
+| DELEGATION-002 | mapped | specified / mapped / in-scope | None |
+| DELEGATION-003 | mapped | specified / mapped / in-scope | None |
+| SIGNED-KRL-001 | mapped | specified / mapped / in-scope | RT-TRUST-2 |
+| SIGNED-KRL-002 | mapped | specified / mapped / in-scope | RT-TRUST-2 |
+| PROFILE-C-001 | mapped | specified / mapped / in-scope | RT-TRUST-1 |
+| PEP-ENFORCE-001 | mapped | specified / mapped / in-scope | None |
+| PEP-DEPLOY-001 | assumption | specified / gap / deployment | None |
+| STATE-TRUST-001 | assumption | specified / gap / deployment | RT-TRUST-1 |
+| VERIFY-ORDER-001 | ambiguous | ambiguous / gap / in-scope | None |
+| DELEGATION-AUDIT-001 | gap | specified / gap / in-scope | None |
+| ETA-SIGNING-001 | ambiguous | ambiguous / gap / in-scope | None |
+| ETA-DETERMINISM-001 | mapped | specified / mapped / in-scope | None |
+
+One-time migration-baseline comparison: all retained fields of all 26 records matched the pre-migration registry. After #309, source citations for CANON-002, SIGNED-KRL-001 and SIGNED-KRL-002 were updated to their current normative text, and the contextual citation for CANON-ESC-001 was refreshed. No evidence mapping, normative strength, classification or required level was changed by that reconciliation.
+
+| Added lock | Normative / evidence / scope | Source role | Executable obligations |
+|---|---|---|---|
+| CANON-ESC-001 | unresolved / unassessed / deferred | context | None |
+| RT-TRUST-1 | non-normative / unassessed / deployment | context | None |
+| RT-TRUST-2 | non-normative / unassessed / conditional | context | None |
+
+All three locks require maintainer decisions. CANON-ESC-001 has no discovered repository definition and remains unresolved. RT-TRUST-1 is an audit residual, not a duplicate of STATE-TRUST-001. RT-TRUST-2 records a conditional closure context, not closure or satisfaction of configuration. The contextual source role prevents promotion of these records into normative obligations.
+
+Specific forbidden inferences are also recorded for PROFILE-C-001 and STATE-TRUST-001 (state-hash match → trusted state source) and SIGNED-KRL-001/002 (valid signature → closed deployment residual). Dependencies are informational links, not evidence inheritance.
+
+Modified for this migration: claims.json, verify.mjs, verify.test.mjs, README.md, INVENTORY.md and VALIDATION.md. Added: this MIGRATION.md. Root commands and CI wiring remain as in the original uncommitted implementation.
+
+See [VALIDATION.md](VALIDATION.md) for migration validation results.

--- a/docs/verification/spec-claims/README.md
+++ b/docs/verification/spec-claims/README.md
@@ -1,0 +1,309 @@
+# Spec-to-Code Claim Verification
+
+This is a curated traceability module, not a protocol proof or a replacement for
+conformance execution. Run from the repository root:
+
+```sh
+pnpm verify:spec-claims
+pnpm test:spec-claims
+pnpm verify:spec-claims --json
+pnpm verify:spec-claims --advisory
+```
+
+`PASS` means the registry is structurally consistent and its required references
+resolve. The checker does not execute the referenced evidence. Test execution
+results belong to the existing test/conformance jobs and the review record in
+[VALIDATION.md](VALIDATION.md). Neither a source file nor an existing test proves
+a normative claim. Even passing tests demonstrate only their asserted cases.
+
+## Architecture and CI
+
+- [claims.json](claims.json): explicitly curated, versioned inventory under
+  non-normative documentation. Stable IDs survive title/path changes.
+- [verify.mjs](../../../scripts/spec-claims/verify.mjs): read-only checker,
+  exported verification/report functions, text/JSON CLI, optional advisory scan.
+- [verify.test.mjs](../../../scripts/spec-claims/verify.test.mjs): isolated
+  perturbations and CLI exit-code tests; no tracked source is modified.
+- Root package scripts expose both commands. `.github/workflows/ci.yml` runs
+  them immediately after installation in `build-test`, before typechecking.
+
+The module lives at repository level because deployment assumptions, guard
+execution behavior and portable verifier semantics have different owners.
+It uses Node built-ins and the repository's existing TypeScript dependency to
+parse implementation declarations and static test names. No dependencies,
+protocol behavior, wire formats, normative prose or vectors were changed.
+
+The CI step only checks traceability and the checker itself. Existing CI already
+executes core/guard tests, package conformance, normative vector harnesses, and
+Go/Python validators. Running all of these again in the new step would duplicate
+work. `adapter-validation`, `packed-artifact-consumer-gate`, `rust-verifier`, and
+`pep-redis-replay` remain separate. `security-gate.yml` separately runs the
+policy-boundary reproduction and the externally refreshed dependency advisory
+gate; a green vulnerability gate is not specification evidence.
+
+## Registry schema (version 2)
+
+The checker is the executable schema authority. Objects reject unknown and
+missing fields; arrays, strings, booleans and enums are checked explicitly.
+Every record has all of these fields. The former overloaded `status` is rejected.
+See [MIGRATION.md](MIGRATION.md) for the exact v1 → v2 mapping and affected IDs:
+
+| Field | Contract |
+|---|---|
+| `id` | Stable uppercase identifier ending in one or more digits; globally unique |
+| `title` | Narrow human-readable property, not necessarily every rule in its source section |
+| `source` | `{path, section, quote, role}`: exact Markdown heading/excerpt; `normative` requires `docs/spec`, `context` conveys no normative authority |
+| `strength` | `MUST`, `MUST NOT`, `REQUIRED`, `SHOULD`, `normative-statement` for non-RFC-keyword normative tables/rules, or `not-applicable` for corpus locks |
+| `category` | `ARTIFACT`, `VERIFY`, `ENFORCEMENT`, `TRUST`, `DELEGATION`, `TIME`, `REPLAY`, `STATE`, `AUDIT` |
+| `implementation` | Array of `{path, symbol}`; symbol must resolve to a function, method, class or variable declaration |
+| `evidence` | Array of evidence records, described below |
+| `requiredLevels` | Explicit obligations selected by maintainers; not inferred at runtime from tests or prose |
+| `securityCritical` | Whether the property affects the security boundary |
+| `negativeRequired` | Missing negative evidence fails when true; requires `securityCritical` |
+| `classification` | `portable`, `implementation-specific`, `deployment-assumption`, `documentation-only` |
+| `portableRequired` | Requires a portable classification and explicitly declared portable vector evidence |
+| `recordType` | `requirement` or contextual `corpus-lock`; locks are excluded from normative/evidence coverage denominators |
+| `normativeState` | `specified`, `ambiguous`, `unresolved`, `non-normative`; describes interpretation/authority, not testing |
+| `evidenceState` | `mapped`, `gap`, `unassessed`; curated evidence disposition, separate from derived capabilities |
+| `scopeDisposition` | `in-scope`, `deferred`, `deployment`, `conditional`, `out-of-scope`; does not enable or disable obligations |
+| `appliesWhen` | Array of `{setting, equals}` strings, interpreted as all-of contextual prerequisites; non-empty only for conditional scope, never evaluated |
+| `dependsOn` | Array of `{id, relation, reason}`; relation is `interpretation`, `trust-premise` or `conditional-mitigation` |
+| `inferenceGuard` | Array of `{from, to, reason}` specifying forbidden inferences between named concepts; report metadata, not an inference engine |
+| `maintainerDecisionRequired` | Boolean advisory flag; never fails CI, grants approval or closes a residual |
+| `notes` | Required scope limits, gap/ambiguity rationale or review context |
+
+Evidence records contain:
+
+| Field | Contract |
+|---|---|
+| `path` | Existing test or vector file within repository |
+| `selector` | `{type: "test" | "vector", id}`: exact test name or top-level vector ID, unique in the selected file |
+| `kind` | `unit`, `vector`, `integration`, `adversarial`, `cross-runtime` |
+| `negative` | Human-reviewed adverse-input or noninterference evidence, not inferred from a filename |
+| `portable` | True only for a vector demonstrating the selected portable semantics |
+| `runner` | `{path, contains, command, runtime}`: reviewed execution route, existing runner file and exact binding text |
+| `supports` | Precisely what the assertion demonstrates, including restricted scope |
+
+Runner bindings for tests identify a compiled test filename in the package
+script, or the core `dist/test/*.test.js` glob. Vector bindings identify the
+corpus filename in its consumer. Commands and semantic connection to consumers
+are curated; the checker validates references and bindings, not arbitrary shell
+control flow. It does not infer a successful run from a command string.
+
+Test selectors recognize direct `test("literal name", callback)` declarations
+via the TypeScript AST. Comments/string mentions, `.skip`, `.todo`, dynamic
+names and option-bearing declarations are deliberately excluded. Supporting
+other test forms requires an explicit parser extension with tests. This parser
+does not prove a callback runs in every environment or inspect assertion logic.
+Implementation symbols establish location only; they need not be public exports.
+Paths must be repository-relative, resolve to regular files, and stay inside the
+repository after symlink resolution.
+
+## Evidence strength and failure policy
+
+Capabilities are derived independently from validated mappings:
+
+| Capability | Required mapped evidence |
+|---|---|
+| `TRACEABLE` | Implementation declaration |
+| `TESTED` | Implementation plus executable evidence reference |
+| `INTEGRATION_TESTED` | Implementation plus integration evidence |
+| `ADVERSARIAL_TESTED` | Implementation plus an explicitly negative case |
+| `CONFORMANCE_TESTED` | Implementation plus explicitly portable vector evidence |
+
+The names describe the **declared evidence scope**, not test execution by this
+command. Integration does not imply adversarial evidence. Conformance does not
+imply integration. Negative integration tests carry both dimensions rather than
+being renamed pure adversarial unit tests. Portable does not mean cross-runtime;
+a portable vector can have only a TypeScript consumer. The initial registry
+conservatively declares portable conformance only for its independently exercised
+canonicalization, SignedKRL and Profile-C cases.
+
+Missing files, removed symbols/test names/vector IDs, changed source
+heading/excerpt, duplicate IDs, malformed records, invalid classifications,
+unsatisfied required levels, required negatives and inconsistent portable
+declarations fail with an ID, code and actionable detail. There is no repair or
+regeneration mode. `--registry path` permits explicit temporary inventories for
+self-tests; normal CI always reads the tracked registry.
+
+Existing gaps do not prevent structural PASS when their required levels are
+explicitly empty. They remain visible as REVIEW entries with rationale. This is
+an acknowledged evidence debt, not a waiver of the normative requirement.
+Removing required evidence from a mapped claim fails. Changing the requirements
+or editing any state dimension is an auditable registry edit requiring human review.
+Security-critical claims without any negative evidence are always reported,
+even when no negative is required (e.g. positive determinism evidence).
+
+## Independent states, dependencies and corpus locks
+
+Normative interpretation, evidence disposition and scope are independent axes.
+An ambiguous requirement may have mapped tests; a specified requirement may have
+an evidence gap. A deferred or out-of-scope disposition never suppresses existing
+`requiredLevels`, `negativeRequired` or `portableRequired`. Evidence capability
+calculation is unchanged and never inherits support from dependencies.
+
+`dependsOn` resolves registry IDs after all records have been read, permitting
+forward references. Missing IDs, duplicate edges and self references are
+structural errors. Context cycles are allowed: no traversal propagates proof,
+requirements, resolution or failures. Dependencies on unresolved locks are
+reported but do not make a valid dependent claim fail.
+
+Corpus locks require `source.role=context`, `strength=not-applicable`, empty
+`requiredLevels` and false `negativeRequired`/`portableRequired`. Attempting to
+turn a lock into an executable obligation is a structural schema error. A valid
+unresolved lock has no such obligations and passes. Optional implementation or
+evidence references, if later curated, still undergo normal reference checks;
+they neither resolve the lock nor count as normative conformance coverage.
+
+- `CANON-ESC-001`: maintainer-supplied unresolved ID; no repository definition
+  was found. The canonicalization string rule supplies context only. Exact lock
+  meaning is deferred, with no escaping policy or corpus change inferred.
+- `RT-TRUST-1`: audit residual on state-provider integrity. Existing state
+  requirements remain specified while the residual stays an external trust
+  concern. Profile-C hash equality does not establish provider honesty.
+- `RT-TRUST-2`: conditional residual. `appliesWhen` records all four documented
+  closure prerequisites: `signed_required`, `verifyKrl`, `KrlWatermarkStore`,
+  `SignedKrlCache`. These describe the closure context, not observed deployment
+  configuration. Compatibility modes retain risk. Neither a signature test nor
+  a false decision-required flag closes this lock.
+
+A contextual excerpt inside `docs/spec` does not become a normative source and
+does not suppress advisory discovery. The report shows all three dimensions,
+conditions, dependency reasons and forbidden inferences; it separates locks
+from the original 26 requirement records. Structural PASS is not semantic proof,
+whole-protocol conformance, lock resolution or maintainer approval.
+
+## Normative inventory and corpus boundary
+
+`docs/spec/README.md` and `SPEC.md` identify `docs/spec/**` as normative;
+`SPEC.md` itself is a companion overview. Inspected sources include:
+
+- Core: `eta-core-v1.md`, `canonicalization-v1.md`, `trusted-time-v1.md`.
+- Artifacts: `authorization-v1.md`, `delegation-v1.md`, `signed-krl-v1.md`.
+- Enforcement: `pep-gateway-v1.md`.
+- Verification: `verification-v1.md`, including its pending envelope section.
+- Interoperability: `external-provider-profile.md`.
+- Deployment obligations: `state-provider-requirements.md`.
+- Conformance: `conformance-v1.md` and `test-vectors-v1.md`.
+
+Status must be read per document/section. In particular,
+`test-vectors-v1.md` calls its JSON source normative but calls its Markdown
+non-normative for readability; its publication notes are also stale. The checker
+does not promote all text in a normative directory into a requirement. Envelope
+verification's unfinished dedicated spec is not treated as a completed contract.
+
+| Surface | Current relationship and consumer |
+|---|---|
+| `docs/spec/test-vectors/canonicalization-v1.json` | Explicit normative source of truth; root TS, Go and Python harnesses |
+| `docs/spec/test-vectors/authorization-v1.json` | Locked normative corpus consumed by standalone `scripts/verify-authorization-vectors.mjs`; its preimage excludes the whole signature and is not the package verifier's two-encoding implementation |
+| `docs/spec/test-vectors/pep-vectors-v1.json` | Normative PEP cases consumed by standalone `scripts/verify-pep-vectors.mjs`; not execution of the guard package gateway |
+| `docs/spec/test-vectors/delegation-vectors-v1.json` | Present and referenced by verification spec; standalone delegation harness; older publication notes still say pending |
+| `docs/spec/test-vectors/profile-c-state-verification.json` | Portable hash comparison and selected Encoding B semantics; root Go/Python harnesses; does not exercise TypeScript guard callbacks, CAS or provider honesty |
+| `docs/spec/test-vectors/signed-krl-v1.json` | Portable KRL corpus with `KRL_*` IDs; root Go/Python independent verification |
+| `packages/conformance/vectors/**` | Package runner exercises Core APIs plus fixture logic. Richer verifier/state/delegation/key-lifecycle/clock/trusted-time surfaces; not interchangeable with the docs corpus |
+
+Package SignedKRL uses `krl-001` etc.; docs SignedKRL uses `KRL_SIGNED_VALID`
+etc. Some Profile-C IDs coincide, but that does not make their consumers or
+claims equivalent. The package runner also has its own canonicalization helper;
+its mere use cannot demonstrate all `canonicalization-v1` parsing rules.
+The separate `packages/conformance/go-harness` adapter surface is not what root
+`pnpm test:vectors:go` executes. No corpus was moved, regenerated or unified.
+
+## Initial inventory and manual audit
+
+The 26 migrated requirement records span all nine categories: 20 have implementation and
+executable mappings; six remain unmapped. Twelve require integration, 18 require
+negative evidence, and five have declared portable conformance evidence. There
+are 19 portable classifications, five implementation-specific enforcement
+classifications and two deployment assumptions. None of the 26 requirements uses
+the documentation-only classification; the three additional contextual corpus
+locks use it. See [INVENTORY.md](INVENTORY.md)
+for the per-claim implementation and evidence mapping snapshot.
+
+Manual review examined assertions, not just test names: A-1/A-2/A-3/A-4 check
+that execute was not called; IB-2 compares distinct actions; RS-1 proves exactly
+one execution across replay; RS-3 shares a replay store; SB-2 checks blocked
+execution on mismatched state. Core canonicalization C-P2/C-P6 are unit property
+tests, not integration. Trusted-time cases exercise engine issuance/freshness;
+the determinism test compares complete authorization objects. Vector IDs were
+checked against their actual adverse input/mode and expected result.
+
+Known gaps and ambiguities:
+
+- `CANON-003`: raw duplicate-key parsing lacks a direct Core mapping. Object
+  canonicalization's NFC collision detection is a different property.
+- `DELEGATION-AUDIT-001`: no direct mapping found for the specified
+  `DELEGATION_EXECUTION`/`DELEGATION_DENIED` hash-chained PEP events. General
+  boundary callbacks are not equivalent evidence.
+- `VERIFY-ORDER-001`: verification §5 requires signature before expiry;
+  AuthorizationV1 §10 requires expiry before signature. Core accumulates/sorts
+  violations, so its ordering tests cannot prove both normative sequences.
+- `ETA-SIGNING-001`: ETA excludes the entire signature field; AuthorizationV1
+  specifies nested alg/kid retention and encoding-specific domain separation.
+- `PEP-DEPLOY-001` and `STATE-TRUST-001`: real deployment non-bypassability and
+  coherent/authoritative provider state need external deployment evidence.
+
+Additional inspection findings are advisory, not silently invented claims:
+
+- `verifyAuthorization` and `verifySignedKrl` have ambient-time fallbacks;
+  verification §4 specifies explicit injected `now`. Register the exact strict
+  API requirement and determine intended applicability before changing behavior.
+- `expectedIssuer`/`expectedPolicyId` are valid generic comparison options when
+  established independently. Issuer-policy authorization provenance is not
+  proved by comparing scalar fields, nor by comparing parent and child policy
+  IDs. The inventory makes neither inference.
+- Tests for provenance, Redis/CAS behavior, API surfaces, transport behavior and
+  general property families are not automatically normative claims. The advisory
+  command lists statically named tests without registry mappings; an unmapped
+  test may still implement a real requirement. It is not necessarily orphaned.
+- `gateway.enforcement.test.ts` and `gateway.vectors.test.ts` are absent from the
+  guard package's explicit default test list. Root `test:vectors:pep` runs a
+  standalone harness. Do not claim those gateway tests execute in the existing
+  default suite just because their files exist.
+
+## Public claims for maintainer review
+
+No public documentation was rewritten.
+
+- `SPEC.md:3` says locked canonicalization, authorization, PEP and delegation
+  vectors pass across TypeScript, Go and Python CI harnesses. Root Go/Python
+  actually cover canonicalization, Profile-C and SignedKRL (28 cases per
+  language), not the complete authorization/PEP/delegation surface.
+- `SPEC.md:71` says only canonicalization vectors are published. Authorization,
+  PEP and delegation JSON files now exist. `test-vectors-v1.md` has similarly
+  stale delegation publication wording.
+- `README.md:204` already states the narrower cross-language scope accurately.
+  Broad phrases such as “Verification works across runtimes” should be read
+  with that limitation rather than as whole-protocol independent verification.
+- Core README statements about preventing all side effects require a correctly
+  deployed enforcement boundary; the library cannot prove arbitrary deployment
+  topology. Guard README's “through the reviewed enforcement boundary” wording
+  better expresses the tested scope.
+- Package conformance README's older SignedKRL paragraph says there is no
+  cross-language integration, while its later coverage distinction describes
+  the newer root harness coverage. These refer to different stages/surfaces and
+  need editorial reconciliation.
+
+## Drift, limitations and follow-up
+
+`--advisory` scans uppercase MUST/REQUIRED/SHOULD lines and lists unmapped static
+tests. It is deterministic but heuristic: multiline prose, inherited normative
+strength, quoted examples, overlapping claims and dynamic tests make it
+incomplete and noisy. Its counts never affect CI. It does not assert a total
+count of all protocol requirements.
+
+Stable names and excerpts expose removed evidence and selected prose drift.
+Changes within a test body, assertion weakening, skipped enclosing suites,
+implementation logic changes, runner control flow changes and specification
+changes outside registered excerpts still require review and ordinary tests.
+No logical implication from assertion to requirement is mechanically proven.
+The initial inventory is useful but partial; its coverage ratios apply only to
+registered claims. No test-run attestation, whole-protocol conformance badge or
+signature-to-premise-trust implication is generated.
+
+Recommended separate issues (not implemented here): reconcile normative signing
+and ordering conflicts; investigate duplicate-aware parsing and delegation audit
+evidence; review explicit-time fallback applicability; fix stale public coverage
+statements; make gateway test scheduling explicit; expand the curated inventory
+and adverse cases; collect deployment-specific replay/state/topology evidence;
+review the separate corpus-unification proposal without assuming equivalence.

--- a/docs/verification/spec-claims/VALIDATION.md
+++ b/docs/verification/spec-claims/VALIDATION.md
@@ -1,0 +1,182 @@
+# Schema v2 migration validation
+
+All changes remain uncommitted. The original architecture, AST selectors, evidence
+capabilities, explicit required levels, CI command and vector boundary are
+unchanged. [MIGRATION.md](MIGRATION.md) records the exact field migration and all
+26 affected existing IDs, plus the three contextual locks added.
+
+## Actual migration validation
+
+| Command/check | Result |
+|---|---|
+| `pnpm verify:spec-claims` | Structural PASS: 29 records, comprising 26 requirements and 3 contextual locks; zero errors |
+| `pnpm test:spec-claims` | 43/43 passed, zero skipped |
+| `pnpm verify:spec-claims && pnpm test:spec-claims` | Existing CI command passed; two additional positive/schema tests were then added and the final 43-test suite passed separately |
+| `pnpm typecheck` | Workspace PASS, including protocol builds |
+| `pnpm -C packages/conformance validate` | 259 assertions passed |
+| `pnpm test:vectors:all` | All constituent validators passed again; counts below |
+| `node scripts/spec-claims/verify.mjs --json` | Parseable JSON; zero issues; all new metadata retained |
+| `node scripts/spec-claims/verify.mjs --advisory` | 332 candidate prose lines / 594 unmapped static test names, unchanged; contextual locks do not suppress normative discovery |
+| `node --check scripts/spec-claims/verify.mjs` | PASS |
+| `node --check scripts/spec-claims/verify.test.mjs` | PASS |
+| `git diff --check` | PASS |
+| Migration-baseline registry comparison | All retained fields of all 26 existing records matched the pre-migration registry at migration time; post-#309 source citations were then reconciled separately without changing evidence or obligations |
+| Protected surface diff | This spec-claims work changes no normative specification, protocol behavior or vector tree; source citations were reconciled against the already-merged #309 normative changes |
+
+`pnpm test:vectors:all` executed `test:vectors:ts` (11), `test:vectors:auth`
+(12), `test:vectors:pep` (9), `test:vectors:delegation` (12),
+`test:vectors:trusted-time` (44 active/passed, zero failed/pending),
+`test:vectors:go` and `test:vectors:py` (each 11 canonicalization + 8 Profile-C +
+9 SignedKRL). These were actual validator executions, not inferred from references.
+Subprocess self-tests and the vector aggregate used the previously necessary
+sandbox escalation. No runtime suites were weakened or replaced. Core/guard test
+counts in the historical section below are from the initial implementation, not
+new runs for this schema-only migration.
+
+## Test changes
+
+The previous 25 tests remain, migrated to version 2. Eighteen tests were added:
+
+- Ten CLI failure cases: legacy version, legacy status, dangling dependency,
+  malformed inference guard, invalid decision flag, missing conditional context,
+  three attempted lock promotions (obligation, source role, strength), and removal
+  of required negatives from a deferred claim with a pending decision.
+- Eight further cases: all 60 combinations of the three dimensions preserve
+  evidence capabilities; all three locks pass without executable obligations;
+  forward dependencies do not confer proof or resolution; all four RT-TRUST-2
+  conditions remain represented; contextual excerpts do not suppress advisory
+  discovery; malformed/duplicate dependency metadata fails; a lock may carry
+  mapped evidence without gaining normative authority; contextual source drift
+  and duplicate conditions fail structurally.
+
+The initial six requested temporary failure demonstrations still run and pass.
+No unresolved lock, dependency on one, conditional deployment prerequisite, or
+pending maintainer decision causes CI failure. Invalid references and explicit
+missing evidence obligations still fail; scope metadata cannot waive them.
+
+## Review state
+
+There are nine advisory pending maintainer decisions: the original six unmapped
+requirements plus the three added contextual locks. CANON-ESC-001 has no discovered
+repository definition; no escaping semantics were invented. RT-TRUST-1 remains a
+state-provider residual. RT-TRUST-2 retains all four documented deployment closure
+prerequisites, without asserting they are configured or sufficient for whole-system
+trust. No normative ambiguity or lock was resolved.
+
+Counts for the 26-record requirement inventory remain 20/26 implementation and
+executable mappings, 12/12 required integration, 18/18 required negative, 18/25
+security-critical with negative evidence, and 5/19 portable conformance mappings.
+Post-#309 source-citation reconciliation did not change these evidence counts.
+Locks are excluded from those coverage denominators. Structural PASS is not
+semantic proof, whole-protocol conformance or maintainer approval.
+
+---
+
+# Original v1 implementation validation (historical)
+
+This record describes actual local execution during implementation. It is not
+read as evidence by the structural checker and is not an enduring attestation
+for later commits. All changes were left uncommitted for maintainer review.
+
+## Changes
+
+Added:
+
+- `scripts/spec-claims/verify.mjs`: schema checks, selectors, reports and advisory scan.
+- `scripts/spec-claims/verify.test.mjs`: 25 tests including temporary CLI perturbations.
+- `docs/verification/spec-claims/claims.json`: 26 curated claims.
+- `docs/verification/spec-claims/README.md`: architecture, schema, corpus boundary,
+  public-claim review, limitations and follow-up issues.
+- `docs/verification/spec-claims/INVENTORY.md`: per-claim implementation/evidence audit snapshot.
+- `docs/verification/spec-claims/VALIDATION.md`: this execution record.
+
+Modified:
+
+- `package.json`: `verify:spec-claims` and `test:spec-claims` commands.
+- `.github/workflows/ci.yml`: one step in `build-test`, using the exact locally
+  validated command `pnpm verify:spec-claims && pnpm test:spec-claims`.
+
+No protocol source, normative document, vector, lockfile or existing test changed.
+
+## Executed commands
+
+| Exact command | Result |
+|---|---|
+| `pnpm verify:spec-claims` | PASS; 26 claims; no structural errors |
+| `pnpm test:spec-claims` | 25/25 passed |
+| `pnpm verify:spec-claims && pnpm test:spec-claims` | Exact new CI command passed after final checker edits |
+| `pnpm typecheck` | PASS across workspace; includes `build:protocol` (core, SDK and guard builds) |
+| `pnpm -C packages/core test` | 383/383 passed; core rebuilt |
+| `pnpm -C packages/guard test` | 219/219 passed; guard test build passed |
+| `pnpm -C packages/conformance validate` | 259 assertions passed; core and conformance builds passed |
+| `pnpm test:vectors:all` | PASS; all constituent commands below executed successfully |
+| `node scripts/spec-claims/verify.mjs --json` | PASS; parseable JSON, zero issues |
+| `node scripts/spec-claims/verify.mjs --advisory` | PASS; 332 candidate prose lines and 594 static tests without registry mappings, advisory only |
+| `node --check scripts/spec-claims/verify.mjs` | PASS |
+| `node --check scripts/spec-claims/verify.test.mjs` | PASS |
+| `git diff --check` | PASS |
+
+Constituent commands actually executed by `pnpm test:vectors:all`:
+
+| Command | Result |
+|---|---|
+| `pnpm test:vectors:ts` | 11 canonicalization vectors passed |
+| `pnpm test:vectors:auth` | 12 authorization vectors passed |
+| `pnpm test:vectors:pep` | 9 PEP vectors passed |
+| `pnpm test:vectors:delegation` | 12 delegation vectors passed |
+| `pnpm test:vectors:trusted-time` | 44 active, 44 passed, zero failed/pending |
+| `pnpm test:vectors:go` | 11 canonicalization + 8 Profile-C + 9 SignedKRL passed |
+| `pnpm test:vectors:py` | 11 canonicalization + 8 Profile-C + 9 SignedKRL passed |
+
+Go and Python success is limited to these actual surfaces. No Rust run, complete
+cross-language authorization/delegation/PEP verification, or live distributed
+Redis deployment validation is claimed by this record.
+
+Initial restricted-sandbox attempts could not capture Node subprocess output
+(`spawnSync EPERM`) and could not create tsx's local IPC socket (`listen EPERM`).
+The checker subprocess self-tests and the vector aggregate were rerun successfully
+with approved sandbox escalation. Core/guard suites were also executed with that
+permission so their subprocess/socket behavior was not suppressed. These retries
+did not alter tests or replace evidence. Local Node was v23.3.0; CI uses Node 22.
+
+## Verifier failure demonstrations
+
+Each CLI mutation writes only a new temporary registry under the OS temporary
+directory, invokes the checker, asserts exit status 1 and the diagnostic code,
+then removes the temporary directory in `finally`. Normative sources are never
+edited. All six specifically requested cases passed:
+
+| Perturbation | Verified diagnostic |
+|---|---|
+| Duplicate claim ID | `DUPLICATE_ID` |
+| Missing normative source | `MISSING_SOURCE` |
+| Missing implementation file | `STALE_IMPLEMENTATION` |
+| Missing evidence file | `STALE_EVIDENCE` |
+| Required negative evidence removed | `MISSING_NEGATIVE` |
+| Malformed claim | `MALFORMED` |
+
+Additional passing tests cover stale test/vector IDs, symbols, source excerpts
+and sections; missing integration/portable evidence; invalid classification;
+TypeScript mislabeled cross-runtime; unknown fields; runner binding drift; path
+traversal; absent implementation; malformed nested types; empty inventory;
+comments/skips/dynamic names; isolated evidence removal; and visible
+non-required gaps. The isolated repository fixture copies only referenced files
+and confirms that replacing a test with a comment fails.
+
+## Review outcome
+
+- 20/26 claims have implementation and executable mappings.
+- 12/12 required integration mappings and 18/18 required negative mappings resolve.
+- 18/25 security-critical claims have negative evidence. Remaining cases are
+  reported explicitly, including gaps/assumptions and selected positive properties.
+- Five claims declare portable conformance evidence out of 19 portable semantic
+  classifications; five other claims describe implementation-specific enforcement,
+  and two describe deployment assumptions.
+- Six claims remain unmapped: two evidence gaps, two normative ambiguities, two
+  deployment assumptions. Their empty required levels are deliberate, visible
+  inventory decisions, not claims that the requirements have been fulfilled.
+
+The manual audit and recommended follow-up issues are in [README.md](README.md).
+The per-claim selectors, runners and limits are in [INVENTORY.md](INVENTORY.md).
+Structural PASS does not resolve the acknowledged normative ambiguities or make
+claims of complete protocol conformance.

--- a/docs/verification/spec-claims/claims.json
+++ b/docs/verification/spec-claims/claims.json
@@ -1,0 +1,1957 @@
+{
+  "version": 2,
+  "claims": [
+    {
+      "id": "CANON-001",
+      "title": "Canonical object key ordering",
+      "source": {
+        "path": "docs/spec/core/canonicalization-v1.md",
+        "section": "## 6. Serialization Rules (normative)",
+        "quote": "- Object keys: NFC-normalize, reject duplicates after normalization, then sort keys by byte-wise UTF-8 order.",
+        "role": "normative"
+      },
+      "strength": "normative-statement",
+      "category": "ARTIFACT",
+      "implementation": [
+        {
+          "path": "packages/core/src/crypto/hashes.ts",
+          "symbol": "canonicalizeToJson"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/core/src/test/canonicalization.property.test.ts",
+          "selector": {
+            "type": "test",
+            "id": "C-P2: canonical output is invariant to object key insertion order at every nesting level"
+          },
+          "kind": "unit",
+          "negative": false,
+          "portable": false,
+          "runner": {
+            "path": "packages/core/package.json",
+            "contains": "dist/test/*.test.js",
+            "command": "pnpm -C packages/core test",
+            "runtime": "TypeScript"
+          },
+          "supports": "Core canonicalization property test for the selected serialization rule."
+        },
+        {
+          "path": "docs/spec/test-vectors/canonicalization-v1.json",
+          "selector": {
+            "type": "vector",
+            "id": "v1-object-key-ordering"
+          },
+          "kind": "cross-runtime",
+          "negative": false,
+          "portable": true,
+          "runner": {
+            "path": "python-harness/verify_canonicalization_vectors.py",
+            "contains": "canonicalization-v1.json",
+            "command": "pnpm test:vectors:py",
+            "runtime": "Python"
+          },
+          "supports": "Exact sorted canonical JSON and SHA-256; Python independent implementation."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "CONFORMANCE_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": false,
+      "classification": "portable",
+      "portableRequired": true,
+      "notes": "Only object ordering is claimed; NFC normalization and collision rejection need separate claims. Negative cases are not required for this ordering-only claim.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "CANON-002",
+      "title": "Reject floating point numbers",
+      "source": {
+        "path": "docs/spec/core/canonicalization-v1.md",
+        "section": "## 6. Serialization Rules (normative)",
+        "quote": "- Numbers: only integers in the safe IEEE-754 range **[-9007199254740991, 9007199254740991]** are allowed as JSON numbers. Floating-point values and `NaN`/`\u00b1Inf` MUST be rejected.",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "ARTIFACT",
+      "implementation": [
+        {
+          "path": "packages/core/src/crypto/hashes.ts",
+          "symbol": "canonicalizeToJson"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/core/src/test/canonicalization.property.test.ts",
+          "selector": {
+            "type": "test",
+            "id": "C-P6: floats, NaN, and \u00b1Infinity are always rejected with FLOAT_NOT_ALLOWED"
+          },
+          "kind": "unit",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/core/package.json",
+            "contains": "dist/test/*.test.js",
+            "command": "pnpm -C packages/core test",
+            "runtime": "TypeScript"
+          },
+          "supports": "Core canonicalization property test for the selected serialization rule."
+        },
+        {
+          "path": "docs/spec/test-vectors/canonicalization-v1.json",
+          "selector": {
+            "type": "vector",
+            "id": "i1-float-rejected"
+          },
+          "kind": "cross-runtime",
+          "negative": true,
+          "portable": true,
+          "runner": {
+            "path": "python-harness/verify_canonicalization_vectors.py",
+            "contains": "canonicalization-v1.json",
+            "command": "pnpm test:vectors:py",
+            "runtime": "Python"
+          },
+          "supports": "Float rejection and expected error code."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "ADVERSARIAL_TESTED",
+        "CONFORMANCE_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": true,
+      "classification": "portable",
+      "portableRequired": true,
+      "notes": "Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "CANON-003",
+      "title": "Reject duplicate keys at raw input parsing",
+      "source": {
+        "path": "docs/spec/core/canonicalization-v1.md",
+        "section": "## 5. Input Parsing Requirements",
+        "quote": "- duplicate keys MUST be detected during parsing",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "ARTIFACT",
+      "implementation": [],
+      "evidence": [],
+      "requiredLevels": [],
+      "securityCritical": true,
+      "negativeRequired": false,
+      "classification": "portable",
+      "portableRequired": false,
+      "notes": "Core canonicalJson receives objects, after raw duplicate keys may be lost. NFC collision detection is not evidence of duplicate-key-aware raw JSON parsing.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "gap",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": true
+    },
+    {
+      "id": "AUTH-ARTIFACT-001",
+      "title": "Reject decisions other than ALLOW",
+      "source": {
+        "path": "docs/spec/artifacts/authorization-v1.md",
+        "section": "## 4. Canonical Semantic Model",
+        "quote": "The `decision` field **MUST** be `\"ALLOW\"`. Any other value **MUST** be rejected.",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "ARTIFACT",
+      "implementation": [
+        {
+          "path": "packages/core/src/verification/verifyAuthorization.ts",
+          "symbol": "verifyAuthorization"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/conformance/vectors/authorization-verification.json",
+          "selector": {
+            "type": "vector",
+            "id": "authorization-verify-004"
+          },
+          "kind": "vector",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/conformance/src/validate.ts",
+            "contains": "authorization-verification.json",
+            "command": "pnpm -C packages/conformance validate",
+            "runtime": "TypeScript"
+          },
+          "supports": "Non-ALLOW decision rejected with AUTH_DECISION_INVALID."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "ADVERSARIAL_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": true,
+      "classification": "portable",
+      "portableRequired": false,
+      "notes": "Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "AUTH-VERIFY-001",
+      "title": "Reject invalid Ed25519 signatures",
+      "source": {
+        "path": "docs/spec/artifacts/authorization-v1.md",
+        "section": "## 8. Signature Requirements",
+        "quote": "* Verify the Ed25519 signature over the preimage",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "VERIFY",
+      "implementation": [
+        {
+          "path": "packages/core/src/verification/verifyAuthorization.ts",
+          "symbol": "verifyAuthorization"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/conformance/vectors/authorization-signature-verification.json",
+          "selector": {
+            "type": "vector",
+            "id": "authorization-sig-002"
+          },
+          "kind": "vector",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/conformance/src/validate.ts",
+            "contains": "authorization-signature-verification.json",
+            "command": "pnpm -C packages/conformance validate",
+            "runtime": "TypeScript"
+          },
+          "supports": "Corrupted signature fails verification."
+        },
+        {
+          "path": "packages/guard/src/test/guard.authorization.test.ts",
+          "selector": {
+            "type": "test",
+            "id": "A-1 tampered signature: execute is blocked and OxDeAIAuthorizationError is thrown"
+          },
+          "kind": "integration",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/guard/package.json",
+            "contains": "dist/test/guard.authorization.test.js",
+            "command": "pnpm -C packages/guard test",
+            "runtime": "TypeScript"
+          },
+          "supports": "Guard blocks execute on corrupted signature."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "INTEGRATION_TESTED",
+        "ADVERSARIAL_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": true,
+      "classification": "portable",
+      "portableRequired": false,
+      "notes": "Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "AUTH-VERIFY-002",
+      "title": "Issuer-scoped trusted key resolution",
+      "source": {
+        "path": "docs/spec/artifacts/authorization-v1.md",
+        "section": "## 8. Signature Requirements",
+        "quote": "* Resolve `kid` to a trusted public key for the artifact's issuer",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "TRUST",
+      "implementation": [
+        {
+          "path": "packages/core/src/verification/verifyAuthorization.ts",
+          "symbol": "verifyAuthorization"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/conformance/vectors/authorization-signature-verification.json",
+          "selector": {
+            "type": "vector",
+            "id": "authorization-sig-004"
+          },
+          "kind": "vector",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/conformance/src/validate.ts",
+            "contains": "authorization-signature-verification.json",
+            "command": "pnpm -C packages/conformance validate",
+            "runtime": "TypeScript"
+          },
+          "supports": "Wrong issuer yields issuer mismatch and unknown key."
+        },
+        {
+          "path": "packages/guard/src/test/guard.authorization.test.ts",
+          "selector": {
+            "type": "test",
+            "id": "A-2 unknown issuer: execute is blocked and OxDeAIAuthorizationError is thrown"
+          },
+          "kind": "integration",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/guard/package.json",
+            "contains": "dist/test/guard.authorization.test.js",
+            "command": "pnpm -C packages/guard test",
+            "runtime": "TypeScript"
+          },
+          "supports": "Unknown issuer signed with separate key cannot execute."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "INTEGRATION_TESTED",
+        "ADVERSARIAL_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": true,
+      "classification": "portable",
+      "portableRequired": false,
+      "notes": "expectedIssuer is meaningful when independently established. Scalar expectations are not inherently defective; this claim does not prove provenance of configuration.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "AUTH-VERIFY-003",
+      "title": "Audience matches execution boundary",
+      "source": {
+        "path": "docs/spec/artifacts/authorization-v1.md",
+        "section": "### audience",
+        "quote": "* **MUST** match the execution boundary",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "VERIFY",
+      "implementation": [
+        {
+          "path": "packages/core/src/verification/verifyAuthorization.ts",
+          "symbol": "verifyAuthorization"
+        },
+        {
+          "path": "packages/guard/src/guard.ts",
+          "symbol": "OxDeAIGuard"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/conformance/vectors/authorization-signature-verification.json",
+          "selector": {
+            "type": "vector",
+            "id": "authorization-sig-005"
+          },
+          "kind": "vector",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/conformance/src/validate.ts",
+            "contains": "authorization-signature-verification.json",
+            "command": "pnpm -C packages/conformance validate",
+            "runtime": "TypeScript"
+          },
+          "supports": "Wrong expected audience rejects."
+        },
+        {
+          "path": "packages/guard/src/test/guard.authorization.test.ts",
+          "selector": {
+            "type": "test",
+            "id": "A-3 wrong audience: execute is blocked and OxDeAIAuthorizationError is thrown"
+          },
+          "kind": "integration",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/guard/package.json",
+            "contains": "dist/test/guard.authorization.test.js",
+            "command": "pnpm -C packages/guard test",
+            "runtime": "TypeScript"
+          },
+          "supports": "Wrong audience blocks callback execution."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "INTEGRATION_TESTED",
+        "ADVERSARIAL_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": true,
+      "classification": "portable",
+      "portableRequired": false,
+      "notes": "Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "AUTH-BIND-001",
+      "title": "Intent hash exactly matches requested action",
+      "source": {
+        "path": "docs/spec/artifacts/authorization-v1.md",
+        "section": "### intent_hash",
+        "quote": "* **MUST** exactly match the requested action",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "ENFORCEMENT",
+      "implementation": [
+        {
+          "path": "packages/guard/src/guard.ts",
+          "symbol": "OxDeAIGuard"
+        },
+        {
+          "path": "packages/core/src/crypto/hashes.ts",
+          "symbol": "intentHash"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/guard/src/test/guard.intent-binding.test.ts",
+          "selector": {
+            "type": "test",
+            "id": "IB-2 wrong intent_hash in auth: OxDeAIAuthorizationError thrown, execute blocked"
+          },
+          "kind": "integration",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/guard/package.json",
+            "contains": "dist/test/guard.intent-binding.test.js",
+            "command": "pnpm -C packages/guard test",
+            "runtime": "TypeScript"
+          },
+          "supports": "Authorization for action A cannot execute action B."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "INTEGRATION_TESTED",
+        "ADVERSARIAL_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": true,
+      "classification": "implementation-specific",
+      "portableRequired": false,
+      "notes": "Guard integration checks normalized action binding. Pure verifyAuthorization does not recompute the requested action; no portable vector is asserted here.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "AUTH-TIME-001",
+      "title": "Strict expiry at now greater than or equal to expiry",
+      "source": {
+        "path": "docs/spec/artifacts/authorization-v1.md",
+        "section": "### expiry / expires_at",
+        "quote": "* **MUST** be strictly enforced: valid iff `now < expiry`; `now >= expiry` \u2192 `AUTH_EXPIRED`",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "TIME",
+      "implementation": [
+        {
+          "path": "packages/core/src/verification/verifyAuthorization.ts",
+          "symbol": "verifyAuthorization"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/conformance/vectors/authorization-verification.json",
+          "selector": {
+            "type": "vector",
+            "id": "authorization-verify-002"
+          },
+          "kind": "vector",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/conformance/src/validate.ts",
+            "contains": "authorization-verification.json",
+            "command": "pnpm -C packages/conformance validate",
+            "runtime": "TypeScript"
+          },
+          "supports": "now equals expiry returns AUTH_EXPIRED."
+        },
+        {
+          "path": "packages/guard/src/test/guard.authorization.test.ts",
+          "selector": {
+            "type": "test",
+            "id": "A-4 expired auth: execute is blocked and OxDeAIAuthorizationError is thrown"
+          },
+          "kind": "integration",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/guard/package.json",
+            "contains": "dist/test/guard.authorization.test.js",
+            "command": "pnpm -C packages/guard test",
+            "runtime": "TypeScript"
+          },
+          "supports": "Expired signed authorization cannot execute."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "INTEGRATION_TESTED",
+        "ADVERSARIAL_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": true,
+      "classification": "portable",
+      "portableRequired": false,
+      "notes": "Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "AUTH-TRUST-001",
+      "title": "Missing strict trust configuration fails closed",
+      "source": {
+        "path": "docs/spec/artifacts/authorization-v1.md",
+        "section": "### Strict mode",
+        "quote": "* Missing trust configuration **MUST** fail closed",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "TRUST",
+      "implementation": [
+        {
+          "path": "packages/core/src/verification/verifyAuthorization.ts",
+          "symbol": "verifyAuthorization"
+        },
+        {
+          "path": "packages/guard/src/guard.ts",
+          "symbol": "OxDeAIGuard"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/guard/src/test/guard.authorization.test.ts",
+          "selector": {
+            "type": "test",
+            "id": "A-5 missing trustedKeySets: OxDeAIGuardConfigurationError thrown at construction"
+          },
+          "kind": "integration",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/guard/package.json",
+            "contains": "dist/test/guard.authorization.test.js",
+            "command": "pnpm -C packages/guard test",
+            "runtime": "TypeScript"
+          },
+          "supports": "Guard construction rejects missing trustedKeySets."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "INTEGRATION_TESTED",
+        "ADVERSARIAL_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": true,
+      "classification": "implementation-specific",
+      "portableRequired": false,
+      "notes": "Evidence is guard configuration enforcement. It does not establish honesty of supplied keys or policy premises.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "AUTH-REPLAY-001",
+      "title": "Reused auth_id cannot execute",
+      "source": {
+        "path": "docs/spec/artifacts/authorization-v1.md",
+        "section": "## 11. Replay Protection",
+        "quote": "* `auth_id` **MUST** be single-use",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "REPLAY",
+      "implementation": [
+        {
+          "path": "packages/guard/src/guard.ts",
+          "symbol": "OxDeAIGuard"
+        },
+        {
+          "path": "packages/guard/src/replayStore.ts",
+          "symbol": "createInMemoryReplayStore"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/guard/src/test/guard.replay-store.test.ts",
+          "selector": {
+            "type": "test",
+            "id": "RS-1 default store: auth_id replay blocked on second call to same guard instance"
+          },
+          "kind": "integration",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/guard/package.json",
+            "contains": "dist/test/guard.replay-store.test.js",
+            "command": "pnpm -C packages/guard test",
+            "runtime": "TypeScript"
+          },
+          "supports": "Second use blocked; exactly one execution."
+        },
+        {
+          "path": "packages/guard/src/test/guard.replay-store.test.ts",
+          "selector": {
+            "type": "test",
+            "id": "RS-3 shared store: auth_id replay blocked across two distinct guard instances"
+          },
+          "kind": "integration",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/guard/package.json",
+            "contains": "dist/test/guard.replay-store.test.js",
+            "command": "pnpm -C packages/guard test",
+            "runtime": "TypeScript"
+          },
+          "supports": "Shared store blocks replay across guard instances."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "INTEGRATION_TESTED",
+        "ADVERSARIAL_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": true,
+      "classification": "implementation-specific",
+      "portableRequired": false,
+      "notes": "In-memory/shared-store integration scope only; not proof of distributed durable replay storage.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "TRUSTED-TIME-001",
+      "title": "Issuance uses trusted evaluation time",
+      "source": {
+        "path": "docs/spec/core/trusted-time-v1.md",
+        "section": "## 4. Consistency Invariants",
+        "quote": "   `issued_at = evaluation_time`.",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "TIME",
+      "implementation": [
+        {
+          "path": "packages/core/src/policy/PolicyEngine.ts",
+          "symbol": "PolicyEngine"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/core/src/test/trusted-time-integration.test.ts",
+          "selector": {
+            "type": "test",
+            "id": "issuance tripwire: issued_at and expiry derive from evaluationTime, not intent.timestamp"
+          },
+          "kind": "integration",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/core/package.json",
+            "contains": "dist/test/*.test.js",
+            "command": "pnpm -C packages/core test",
+            "runtime": "TypeScript"
+          },
+          "supports": "Future-side freshness-valid intent does not drive issuance or expiry."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "INTEGRATION_TESTED",
+        "ADVERSARIAL_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": true,
+      "classification": "portable",
+      "portableRequired": false,
+      "notes": "Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "TRUSTED-TIME-002",
+      "title": "Reject future freshness violations",
+      "source": {
+        "path": "docs/spec/core/trusted-time-v1.md",
+        "section": "## 6. Freshness Semantics (Future and Stale)",
+        "quote": "- **Future-dated.** `\u0394 > maxClockSkewSeconds` \u2192 `DENY`, no authorization minted.",
+        "role": "normative"
+      },
+      "strength": "normative-statement",
+      "category": "TIME",
+      "implementation": [
+        {
+          "path": "packages/core/src/policy/verifyTrustedTime.ts",
+          "symbol": "verifyTrustedTime"
+        },
+        {
+          "path": "packages/core/src/policy/PolicyEngine.ts",
+          "symbol": "PolicyEngine"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/core/src/test/trusted-time-integration.test.ts",
+          "selector": {
+            "type": "test",
+            "id": "future-dated intent \u2192 exactly DENY/INTENT_FRESHNESS_FUTURE"
+          },
+          "kind": "integration",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/core/package.json",
+            "contains": "dist/test/*.test.js",
+            "command": "pnpm -C packages/core test",
+            "runtime": "TypeScript"
+          },
+          "supports": "Future timestamp yields exactly DENY/INTENT_FRESHNESS_FUTURE."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "INTEGRATION_TESTED",
+        "ADVERSARIAL_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": true,
+      "classification": "portable",
+      "portableRequired": false,
+      "notes": "Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "DELEGATION-001",
+      "title": "Child tools cannot widen supplied parentScope",
+      "source": {
+        "path": "docs/spec/artifacts/delegation-v1.md",
+        "section": "### 4.1 Scope Narrowing",
+        "quote": "| `scope.tools` | Effective child tools MUST be a subset of `parentScope.tools` when defined. Omitted child tools inherit that constraint unchanged; an explicitly supplied child list is compared against it as given. Equal sets are valid. |",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "DELEGATION",
+      "implementation": [
+        {
+          "path": "packages/core/src/verification/verifyDelegation.ts",
+          "symbol": "verifyDelegation"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/conformance/vectors/delegation-verification.json",
+          "selector": {
+            "type": "vector",
+            "id": "delegation-verify-005"
+          },
+          "kind": "vector",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/conformance/src/validate.ts",
+            "contains": "delegation-verification.json",
+            "command": "pnpm -C packages/conformance validate",
+            "runtime": "TypeScript"
+          },
+          "supports": "Tool outside caller-supplied parent scope rejected."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "ADVERSARIAL_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": true,
+      "classification": "portable",
+      "portableRequired": false,
+      "notes": "Narrowing is relative to caller-supplied parentScope; no evidence that the scope originated from an authoritative external grant.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "DELEGATION-002",
+      "title": "Reject delegation as parent (single hop)",
+      "source": {
+        "path": "docs/spec/artifacts/delegation-v1.md",
+        "section": "### 4.4 Single-Hop Enforcement",
+        "quote": "A `DelegationV1` artifact MUST NOT be used as the parent of another `DelegationV1`. The PEP MUST reject any chain where the parent artifact is itself a delegation.",
+        "role": "normative"
+      },
+      "strength": "MUST NOT",
+      "category": "DELEGATION",
+      "implementation": [
+        {
+          "path": "packages/core/src/verification/verifyDelegation.ts",
+          "symbol": "verifyDelegationChain"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/conformance/vectors/delegation-chain-verification.json",
+          "selector": {
+            "type": "vector",
+            "id": "delegation-chain-006"
+          },
+          "kind": "vector",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/conformance/src/validate.ts",
+            "contains": "delegation-chain-verification.json",
+            "command": "pnpm -C packages/conformance validate",
+            "runtime": "TypeScript"
+          },
+          "supports": "Delegation parent rejected as multihop."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "ADVERSARIAL_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": true,
+      "classification": "portable",
+      "portableRequired": false,
+      "notes": "Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "DELEGATION-003",
+      "title": "Delegation policy equals parent policy",
+      "source": {
+        "path": "docs/spec/artifacts/delegation-v1.md",
+        "section": "### 4.1 Scope Narrowing",
+        "quote": "| `policy_id` | MUST equal parent `policy_id` |",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "DELEGATION",
+      "implementation": [
+        {
+          "path": "packages/core/src/verification/verifyDelegation.ts",
+          "symbol": "verifyDelegationChain"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/conformance/vectors/delegation-chain-verification.json",
+          "selector": {
+            "type": "vector",
+            "id": "delegation-chain-007"
+          },
+          "kind": "vector",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/conformance/src/validate.ts",
+            "contains": "delegation-chain-verification.json",
+            "command": "pnpm -C packages/conformance validate",
+            "runtime": "TypeScript"
+          },
+          "supports": "Child-parent policy mismatch rejected."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "ADVERSARIAL_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": true,
+      "classification": "portable",
+      "portableRequired": false,
+      "notes": "This binds two artifacts. It does not prove that an issuer is independently authorized for that policy. Generic expectedPolicyId remains valid when independently configured.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "SIGNED-KRL-001",
+      "title": "Duplicate revoked kids rejected",
+      "source": {
+        "path": "docs/spec/artifacts/signed-krl-v1.md",
+        "section": "## 9. `revoked_kids` deduplication",
+        "quote": "Verifiers MUST reject any artifact containing duplicate entries.",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "TRUST",
+      "implementation": [
+        {
+          "path": "packages/core/src/verification/verifySignedKrl.ts",
+          "symbol": "verifySignedKrl"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/conformance/vectors/signed-krl-verification.json",
+          "selector": {
+            "type": "vector",
+            "id": "krl-005"
+          },
+          "kind": "vector",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/conformance/src/validate.ts",
+            "contains": "signed-krl-verification.json",
+            "command": "pnpm -C packages/conformance validate",
+            "runtime": "TypeScript"
+          },
+          "supports": "Duplicate revoked kid entries rejected."
+        },
+        {
+          "path": "docs/spec/test-vectors/signed-krl-v1.json",
+          "selector": {
+            "type": "vector",
+            "id": "KRL_DUPLICATE_REVOKED_KIDS"
+          },
+          "kind": "cross-runtime",
+          "negative": true,
+          "portable": true,
+          "runner": {
+            "path": "python-harness/verify_signed_krl_vectors.py",
+            "contains": "signed-krl-v1.json",
+            "command": "pnpm test:vectors:py",
+            "runtime": "Python"
+          },
+          "supports": "Independent Python duplicate-entry rejection."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "ADVERSARIAL_TESTED",
+        "CONFORMANCE_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": true,
+      "classification": "portable",
+      "portableRequired": true,
+      "notes": "Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [
+        {
+          "id": "RT-TRUST-2",
+          "relation": "conditional-mitigation",
+          "reason": "Artifact verification alone does not close the deployment KRL residual."
+        }
+      ],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        },
+        {
+          "from": "KRL_SIGNATURE_VALID",
+          "to": "KRL_DEPLOYMENT_RESIDUAL_CLOSED",
+          "reason": "Required deployment configuration and persistent stores are not established by artifact vectors."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "SIGNED-KRL-002",
+      "title": "Invalid KRL signature rejected",
+      "source": {
+        "path": "docs/spec/artifacts/signed-krl-v1.md",
+        "section": "## 11. Reason codes",
+        "quote": "| `KRL_SIG_INVALID` | Ed25519 signature verification fails. |",
+        "role": "normative"
+      },
+      "strength": "normative-statement",
+      "category": "VERIFY",
+      "implementation": [
+        {
+          "path": "packages/core/src/verification/verifySignedKrl.ts",
+          "symbol": "verifySignedKrl"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/conformance/vectors/signed-krl-verification.json",
+          "selector": {
+            "type": "vector",
+            "id": "krl-002"
+          },
+          "kind": "vector",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/conformance/src/validate.ts",
+            "contains": "signed-krl-verification.json",
+            "command": "pnpm -C packages/conformance validate",
+            "runtime": "TypeScript"
+          },
+          "supports": "Tampered signature rejected."
+        },
+        {
+          "path": "docs/spec/test-vectors/signed-krl-v1.json",
+          "selector": {
+            "type": "vector",
+            "id": "KRL_SIGNED_INVALID_SIG"
+          },
+          "kind": "cross-runtime",
+          "negative": true,
+          "portable": true,
+          "runner": {
+            "path": "python-harness/verify_signed_krl_vectors.py",
+            "contains": "signed-krl-v1.json",
+            "command": "pnpm test:vectors:py",
+            "runtime": "Python"
+          },
+          "supports": "Independent Python Ed25519 verification rejects tampering."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "ADVERSARIAL_TESTED",
+        "CONFORMANCE_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": true,
+      "classification": "portable",
+      "portableRequired": true,
+      "notes": "Evidence demonstrates the selected cases only; review semantic adequacy when changing this claim.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [
+        {
+          "id": "RT-TRUST-2",
+          "relation": "conditional-mitigation",
+          "reason": "Artifact verification alone does not close the deployment KRL residual."
+        }
+      ],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        },
+        {
+          "from": "KRL_SIGNATURE_VALID",
+          "to": "KRL_DEPLOYMENT_RESIDUAL_CLOSED",
+          "reason": "Required deployment configuration and persistent stores are not established by artifact vectors."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "PROFILE-C-001",
+      "title": "Live-state hash must match committed state hash",
+      "source": {
+        "path": "docs/spec/interoperability/external-provider-profile.md",
+        "section": "#### 2.3.2 Additional Verifier Requirements (beyond Profile B)",
+        "quote": "| Live-state hash match | `computeStateHash(state)` == `authorization.state_hash` | `OxDeAIAuthorizationError` |",
+        "role": "normative"
+      },
+      "strength": "normative-statement",
+      "category": "STATE",
+      "implementation": [
+        {
+          "path": "packages/guard/src/guard.ts",
+          "symbol": "OxDeAIGuard"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/guard/src/test/guard.state-binding.test.ts",
+          "selector": {
+            "type": "test",
+            "id": "SB-2 mismatched state_hash: execute is blocked and OxDeAIAuthorizationError is thrown"
+          },
+          "kind": "integration",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/guard/package.json",
+            "contains": "dist/test/guard.state-binding.test.js",
+            "command": "pnpm -C packages/guard test",
+            "runtime": "TypeScript"
+          },
+          "supports": "Mismatched state hash blocks execute."
+        },
+        {
+          "path": "docs/spec/test-vectors/profile-c-state-verification.json",
+          "selector": {
+            "type": "vector",
+            "id": "profile-c-002"
+          },
+          "kind": "cross-runtime",
+          "negative": true,
+          "portable": true,
+          "runner": {
+            "path": "python-harness/verify_profile_c_vectors.py",
+            "contains": "profile-c-state-verification.json",
+            "command": "pnpm test:vectors:py",
+            "runtime": "Python"
+          },
+          "supports": "Portable hash comparison mismatch, not execution or provider honesty."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "INTEGRATION_TESTED",
+        "ADVERSARIAL_TESTED",
+        "CONFORMANCE_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": true,
+      "classification": "portable",
+      "portableRequired": true,
+      "notes": "Portable evidence covers hash comparison only. Guard integration covers callback blocking separately. Neither establishes current or honest state.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [
+        {
+          "id": "RT-TRUST-1",
+          "relation": "trust-premise",
+          "reason": "State-hash consistency does not establish state-provider integrity."
+        }
+      ],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        },
+        {
+          "from": "STATE_HASH_MATCH",
+          "to": "STATE_SOURCE_TRUSTED",
+          "reason": "Honest, current, authoritative state is a deployment premise."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "PEP-ENFORCE-001",
+      "title": "Invalid authorization prevents execution",
+      "source": {
+        "path": "docs/spec/artifacts/authorization-v1.md",
+        "section": "## 1. Purpose",
+        "quote": "> If no valid `AuthorizationV1` is present, execution **MUST NOT** occur.",
+        "role": "normative"
+      },
+      "strength": "MUST NOT",
+      "category": "ENFORCEMENT",
+      "implementation": [
+        {
+          "path": "packages/guard/src/guard.ts",
+          "symbol": "OxDeAIGuard"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/guard/src/test/guard.authorization.test.ts",
+          "selector": {
+            "type": "test",
+            "id": "A-1 tampered signature: execute is blocked and OxDeAIAuthorizationError is thrown"
+          },
+          "kind": "integration",
+          "negative": true,
+          "portable": false,
+          "runner": {
+            "path": "packages/guard/package.json",
+            "contains": "dist/test/guard.authorization.test.js",
+            "command": "pnpm -C packages/guard test",
+            "runtime": "TypeScript"
+          },
+          "supports": "Invalid signature prevents execute callback."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "INTEGRATION_TESTED",
+        "ADVERSARIAL_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": true,
+      "classification": "implementation-specific",
+      "portableRequired": false,
+      "notes": "Selected guard rejection case only. Does not prove every possible execution path is non-bypassable.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "PEP-DEPLOY-001",
+      "title": "Gateway is sole execution boundary",
+      "source": {
+        "path": "docs/spec/enforcement/pep-gateway-v1.md",
+        "section": "### 4.1 Execution Boundary",
+        "quote": "The PEP Gateway **MUST** act as the **sole execution boundary** for protected actions.",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "TRUST",
+      "implementation": [],
+      "evidence": [],
+      "requiredLevels": [],
+      "securityCritical": true,
+      "negativeRequired": false,
+      "classification": "deployment-assumption",
+      "portableRequired": false,
+      "notes": "Deployment topology and upstream access control must be independently evidenced. Gateway tests cannot prove arbitrary deployment non-bypassability.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "gap",
+      "scopeDisposition": "deployment",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": true
+    },
+    {
+      "id": "STATE-TRUST-001",
+      "title": "State provider serves coherent view",
+      "source": {
+        "path": "docs/spec/state-provider-requirements.md",
+        "section": "### 2.1 Requirement",
+        "quote": "A compliant state provider MUST serve a coherent state view to `getState()`.",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "STATE",
+      "implementation": [],
+      "evidence": [],
+      "requiredLevels": [],
+      "securityCritical": true,
+      "negativeRequired": false,
+      "classification": "deployment-assumption",
+      "portableRequired": false,
+      "notes": "Provider honesty/coherence is an external deployment obligation. Hash equality and CAS tests do not demonstrate it for a deployed provider.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "gap",
+      "scopeDisposition": "deployment",
+      "appliesWhen": [],
+      "dependsOn": [
+        {
+          "id": "RT-TRUST-1",
+          "relation": "trust-premise",
+          "reason": "State-hash consistency does not establish state-provider integrity."
+        }
+      ],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        },
+        {
+          "from": "STATE_HASH_MATCH",
+          "to": "STATE_SOURCE_TRUSTED",
+          "reason": "Honest, current, authoritative state is a deployment premise."
+        }
+      ],
+      "maintainerDecisionRequired": true
+    },
+    {
+      "id": "VERIFY-ORDER-001",
+      "title": "Normative verification ordering",
+      "source": {
+        "path": "docs/spec/verification/verification-v1.md",
+        "section": "## 9. Determinism and Ordering",
+        "quote": "- Check ordering **MUST** follow the sequences in \u00a7\u00a75\u20136 to ensure deterministic results across implementations.",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "VERIFY",
+      "implementation": [],
+      "evidence": [],
+      "requiredLevels": [],
+      "securityCritical": true,
+      "negativeRequired": false,
+      "classification": "portable",
+      "portableRequired": false,
+      "notes": "Verification \u00a75 puts signature before expiry; AuthorizationV1 \u00a710 puts expiry before signature. Core collects/sorts violations. No claim of satisfying both incompatible sequences.",
+      "recordType": "requirement",
+      "normativeState": "ambiguous",
+      "evidenceState": "gap",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": true
+    },
+    {
+      "id": "DELEGATION-AUDIT-001",
+      "title": "PEP delegation events included in hash-chained audit log",
+      "source": {
+        "path": "docs/spec/artifacts/delegation-v1.md",
+        "section": "## 7. Audit Event",
+        "quote": "Both events MUST be included in the hash-chained audit log.",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "AUDIT",
+      "implementation": [],
+      "evidence": [],
+      "requiredLevels": [],
+      "securityCritical": false,
+      "negativeRequired": false,
+      "classification": "implementation-specific",
+      "portableRequired": false,
+      "notes": "No direct mapping found for required DELEGATION_EXECUTION/DELEGATION_DENIED hash-chained events. Guard boundary event callbacks alone are not evidence of this contract.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "gap",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": true
+    },
+    {
+      "id": "ETA-SIGNING-001",
+      "title": "ETA signing payload excludes entire signature field",
+      "source": {
+        "path": "docs/spec/core/eta-core-v1.md",
+        "section": "## 5. Authorization Artifact (AuthorizationV1)",
+        "quote": "- The signature preimage MUST be the canonical JSON bytes of the AuthorizationV1 object, **excluding the `signature` field**, using the canonicalization rules in `canonicalization-v1.md`.",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "ARTIFACT",
+      "implementation": [],
+      "evidence": [],
+      "requiredLevels": [],
+      "securityCritical": true,
+      "negativeRequired": false,
+      "classification": "portable",
+      "portableRequired": false,
+      "notes": "ETA excludes entire signature field; AuthorizationV1 \u00a75 retains nested alg/kid and defines encoding-specific prefix. Normative docs vectors use another verifier/preimage; do not equate corpora.",
+      "recordType": "requirement",
+      "normativeState": "ambiguous",
+      "evidenceState": "gap",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": true
+    },
+    {
+      "id": "ETA-DETERMINISM-001",
+      "title": "Identical trusted inputs produce deterministic signed authorizations",
+      "source": {
+        "path": "docs/spec/core/eta-core-v1.md",
+        "section": "### Requirements",
+        "quote": "- Identical inputs MUST produce identical outputs.",
+        "role": "normative"
+      },
+      "strength": "MUST",
+      "category": "ARTIFACT",
+      "implementation": [
+        {
+          "path": "packages/core/src/policy/PolicyEngine.ts",
+          "symbol": "PolicyEngine"
+        }
+      ],
+      "evidence": [
+        {
+          "path": "packages/core/src/test/authorization.trusted-time-issuance.test.ts",
+          "selector": {
+            "type": "test",
+            "id": "identical trusted inputs produce deterministic Ed25519 authorizations"
+          },
+          "kind": "integration",
+          "negative": false,
+          "portable": false,
+          "runner": {
+            "path": "packages/core/package.json",
+            "contains": "dist/test/*.test.js",
+            "command": "pnpm -C packages/core test",
+            "runtime": "TypeScript"
+          },
+          "supports": "Repeated trusted inputs produce identical Ed25519 authorization objects."
+        }
+      ],
+      "requiredLevels": [
+        "TRACEABLE",
+        "TESTED",
+        "INTEGRATION_TESTED"
+      ],
+      "securityCritical": true,
+      "negativeRequired": false,
+      "classification": "portable",
+      "portableRequired": false,
+      "notes": "Inputs include trusted evaluationTime and fixed configuration per trusted-time profile. This selected test does not prove all decision modules deterministic.",
+      "recordType": "requirement",
+      "normativeState": "specified",
+      "evidenceState": "mapped",
+      "scopeDisposition": "in-scope",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        }
+      ],
+      "maintainerDecisionRequired": false
+    },
+    {
+      "id": "CANON-ESC-001",
+      "title": "Unresolved canonicalization corpus lock (maintainer-supplied identifier)",
+      "source": {
+        "path": "docs/spec/core/canonicalization-v1.md",
+        "section": "## 6. Serialization Rules (normative)",
+        "quote": "- Strings: normalize to Unicode NFC and encode as JSON strings.",
+        "role": "context"
+      },
+      "strength": "not-applicable",
+      "category": "ARTIFACT",
+      "implementation": [],
+      "evidence": [],
+      "requiredLevels": [],
+      "securityCritical": true,
+      "negativeRequired": false,
+      "classification": "documentation-only",
+      "portableRequired": false,
+      "notes": "CANON-ESC-001 was requested for registration by the maintainer; no existing repository definition of this identifier was found. This source is context only. Exact escaping/corpus-lock meaning and disposition require a maintainer decision; no new serialization rule is asserted.",
+      "recordType": "corpus-lock",
+      "normativeState": "unresolved",
+      "evidenceState": "unassessed",
+      "scopeDisposition": "deferred",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        },
+        {
+          "from": "SELECTED_CANONICALIZATION_VECTORS_PASS",
+          "to": "CANON_ESC_LOCK_RESOLVED",
+          "reason": "Existing vectors do not resolve an undefined corpus lock."
+        }
+      ],
+      "maintainerDecisionRequired": true
+    },
+    {
+      "id": "RT-TRUST-1",
+      "title": "State provider integrity residual",
+      "source": {
+        "path": "docs/audits/protocol-audit-post-interoperability.md",
+        "section": "### 5.3 Residual Trust Risks",
+        "quote": "**RT-TRUST-1: State provider integrity** *(SPECIFIED WITH RESIDUAL)*",
+        "role": "context"
+      },
+      "strength": "not-applicable",
+      "category": "TRUST",
+      "implementation": [],
+      "evidence": [],
+      "requiredLevels": [],
+      "securityCritical": true,
+      "negativeRequired": false,
+      "classification": "documentation-only",
+      "portableRequired": false,
+      "notes": "The residual is not closed. Minimum state-provider requirements exist, but provider compliance and integrity remain deployment responsibilities. This lock is an audit observation, not another executable protocol requirement.",
+      "recordType": "corpus-lock",
+      "normativeState": "non-normative",
+      "evidenceState": "unassessed",
+      "scopeDisposition": "deployment",
+      "appliesWhen": [],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        },
+        {
+          "from": "STATE_HASH_MATCH",
+          "to": "STATE_SOURCE_TRUSTED",
+          "reason": "Matching state can be manufactured by a compromised provider."
+        }
+      ],
+      "maintainerDecisionRequired": true
+    },
+    {
+      "id": "RT-TRUST-2",
+      "title": "Conditional KRL transport-integrity residual",
+      "source": {
+        "path": "docs/spec/interoperability/external-provider-profile.md",
+        "section": "#### 2.2.5 KRL Integrity at Profile B",
+        "quote": "Full RT-TRUST-2 closure requires `signed_required` + `verifyKrl` + `KrlWatermarkStore` + `SignedKrlCache`; compatibility modes retain residual transport-trust risk.",
+        "role": "context"
+      },
+      "strength": "not-applicable",
+      "category": "TRUST",
+      "implementation": [],
+      "evidence": [],
+      "requiredLevels": [],
+      "securityCritical": true,
+      "negativeRequired": false,
+      "classification": "documentation-only",
+      "portableRequired": false,
+      "notes": "Conditional closure is documented for configured deployments, not established here. Compatibility modes retain residual risk. Applicability conditions describe the documented closure context; the checker never evaluates a deployment or declares this lock closed.",
+      "recordType": "corpus-lock",
+      "normativeState": "non-normative",
+      "evidenceState": "unassessed",
+      "scopeDisposition": "conditional",
+      "appliesWhen": [
+        {
+          "setting": "krlMode",
+          "equals": "signed_required"
+        },
+        {
+          "setting": "verifyKrl",
+          "equals": "configured"
+        },
+        {
+          "setting": "KrlWatermarkStore",
+          "equals": "configured"
+        },
+        {
+          "setting": "SignedKrlCache",
+          "equals": "configured"
+        }
+      ],
+      "dependsOn": [],
+      "inferenceGuard": [
+        {
+          "from": "STRUCTURAL_PASS",
+          "to": "SEMANTIC_PROOF",
+          "reason": "Reference consistency does not prove the claimed semantics."
+        },
+        {
+          "from": "TESTED",
+          "to": "WHOLE_PROTOCOL_CONFORMANCE",
+          "reason": "Selected executable cases do not establish whole-protocol conformance."
+        },
+        {
+          "from": "KRL_SIGNATURE_VALID",
+          "to": "KRL_DEPLOYMENT_RESIDUAL_CLOSED",
+          "reason": "Signature verification does not establish integrity mode, callback, durable watermark or signed cache configuration."
+        }
+      ],
+      "maintainerDecisionRequired": true
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "test:vectors:pep": "node scripts/verify-pep-vectors.mjs",
     "test:vectors:delegation": "node scripts/verify-delegation-vectors.mjs",
     "test:vectors:trusted-time": "pnpm -C packages/conformance validate:trusted-time",
-    "test:vectors:all": "pnpm test:vectors:ts && pnpm test:vectors:auth && pnpm test:vectors:pep && pnpm test:vectors:delegation && pnpm test:vectors:trusted-time && pnpm test:vectors:go && pnpm test:vectors:py"
+    "test:vectors:all": "pnpm test:vectors:ts && pnpm test:vectors:auth && pnpm test:vectors:pep && pnpm test:vectors:delegation && pnpm test:vectors:trusted-time && pnpm test:vectors:go && pnpm test:vectors:py",
+    "verify:spec-claims": "node scripts/spec-claims/verify.mjs",
+    "test:spec-claims": "node --test scripts/spec-claims/verify.test.mjs"
   },
   "devDependencies": {
     "@oxdeai/core": "workspace:*",

--- a/scripts/spec-claims/verify.mjs
+++ b/scripts/spec-claims/verify.mjs
@@ -1,0 +1,254 @@
+import { readFileSync, readdirSync, realpathSync, statSync } from 'node:fs';
+import { resolve, relative, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+export const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+export const REGISTRY = 'docs/verification/spec-claims/claims.json';
+const classifications = ['portable', 'implementation-specific', 'deployment-assumption', 'documentation-only'];
+const levels = ['TRACEABLE', 'TESTED', 'INTEGRATION_TESTED', 'ADVERSARIAL_TESTED', 'CONFORMANCE_TESTED'];
+const kinds = ['unit', 'vector', 'integration', 'adversarial', 'cross-runtime'];
+const categories = ['ARTIFACT', 'VERIFY', 'ENFORCEMENT', 'TRUST', 'DELEGATION', 'TIME', 'REPLAY', 'STATE', 'AUDIT'];
+const isObject = x => x !== null && typeof x === 'object' && !Array.isArray(x);
+const nonempty = x => typeof x === 'string' && x.trim().length > 0;
+
+// Deliberately recognizes direct, statically named node:test declarations only.
+// Comments, string mentions, dynamic names, .skip/.todo and options are not evidence.
+const testCache = new Map();
+const declarationCache = new Map();
+export function testNames(source, path) {
+  const key = `${path}\0${source}`;
+  if (testCache.has(key)) return [...testCache.get(key)];
+  const names = [];
+  const tree = ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true);
+  const visit = node => {
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === 'test' &&
+        node.arguments.length === 2 && ts.isStringLiteralLike(node.arguments[0]) &&
+        (ts.isArrowFunction(node.arguments[1]) || ts.isFunctionExpression(node.arguments[1]))) names.push(node.arguments[0].text);
+    ts.forEachChild(node, visit);
+  };
+  visit(tree);
+  testCache.set(key, names);
+  return [...names];
+}
+
+export function verify(registry, root = ROOT) {
+  const issues = [], rows = [];
+  const error = (id, code, detail) => issues.push({ id, code, detail });
+  function record(x, keys, at) {
+    if (!isObject(x)) { error(at, 'MALFORMED', 'expected object'); return false; }
+    for (const k of keys) if (!(k in x)) error(at, 'MALFORMED', `missing ${k}`);
+    for (const k of Object.keys(x)) if (!keys.includes(k)) error(at, 'MALFORMED', `unknown field ${k}`);
+    return keys.every(k => k in x);
+  }
+  function string(x, at) { if (!nonempty(x)) error(at, 'MALFORMED', 'expected non-empty string'); }
+  function enumeration(x, values, at) { if (!values.includes(x)) error(at, 'MALFORMED', `expected one of ${values.join(', ')}`); }
+  function array(x, at) { if (!Array.isArray(x)) { error(at, 'MALFORMED', 'expected array'); return []; } return x; }
+  function boolean(x, at) { if (typeof x !== 'boolean') error(at, 'MALFORMED', 'expected boolean'); }
+  function file(path, at, code) {
+    if (!nonempty(path) || path.includes('\\') || path.startsWith('/') || path.split('/').some(p => p === '..' || p === '.')) {
+      error(at, code, `invalid repository-relative path: ${String(path)}`); return null;
+    }
+    try {
+      const abs = realpathSync(resolve(root, path));
+      if (relative(realpathSync(root), abs).startsWith('..') || !statSync(abs).isFile()) throw Error('outside root or not a file');
+      return readFileSync(abs, 'utf8');
+    } catch { error(at, code, `missing/unreadable file: ${path}`); return null; }
+  }
+  if (!record(registry, ['version', 'claims'], 'registry')) return { issues, rows };
+  if (registry.version !== 2) error('registry', 'MALFORMED', 'version must be 2 (explicit migration required)');
+  if (Array.isArray(registry.claims) && registry.claims.length === 0) error('registry', 'MALFORMED', 'claim inventory must not be empty');
+  const ids = new Set();
+  for (const [i, c] of array(registry.claims, 'claims').entries()) {
+    const at = nonempty(c?.id) ? c.id : `claims[${i}]`;
+    const before = issues.length;
+    if (!record(c, ['id', 'title', 'source', 'strength', 'category', 'implementation', 'evidence', 'requiredLevels', 'securityCritical', 'negativeRequired', 'classification', 'portableRequired', 'recordType', 'normativeState', 'evidenceState', 'scopeDisposition', 'appliesWhen', 'dependsOn', 'inferenceGuard', 'maintainerDecisionRequired', 'notes'], at)) continue;
+    for (const k of ['id', 'title', 'notes']) string(c[k], `${at}.${k}`);
+    if (!/^[A-Z][A-Z0-9-]*-[0-9]+$/.test(c.id)) error(at, 'MALFORMED', 'invalid stable claim ID');
+    if (ids.has(c.id)) error(at, 'DUPLICATE_ID', c.id);
+    ids.add(c.id);
+    enumeration(c.strength, ['MUST', 'MUST NOT', 'REQUIRED', 'SHOULD', 'normative-statement', 'not-applicable'], `${at}.strength`);
+    enumeration(c.category, categories, `${at}.category`);
+    enumeration(c.classification, classifications, `${at}.classification`);
+    enumeration(c.recordType, ['requirement', 'corpus-lock'], `${at}.recordType`);
+    enumeration(c.normativeState, ['specified', 'ambiguous', 'unresolved', 'non-normative'], `${at}.normativeState`);
+    enumeration(c.evidenceState, ['mapped', 'gap', 'unassessed'], `${at}.evidenceState`);
+    enumeration(c.scopeDisposition, ['in-scope', 'deferred', 'deployment', 'conditional', 'out-of-scope'], `${at}.scopeDisposition`);
+    for (const k of ['securityCritical', 'negativeRequired', 'portableRequired', 'maintainerDecisionRequired']) boolean(c[k], `${at}.${k}`);
+    for (const k of ['implementation', 'evidence', 'requiredLevels', 'dependsOn', 'inferenceGuard', 'appliesWhen']) array(c[k], `${at}.${k}`);
+    if (issues.length > before) continue;
+    // Review metadata is not an execution policy. Only explicit evidence obligations gate CI.
+    if (c.recordType === 'corpus-lock' && (c.strength !== 'not-applicable' || c.source?.role !== 'context' || c.requiredLevels.length || c.negativeRequired || c.portableRequired)) error(at, 'LOCK_PROMOTION', 'corpus locks require contextual sourcing, not-applicable strength and no executable evidence obligations');
+    if (c.recordType === 'requirement' && (c.strength === 'not-applicable' || c.source?.role !== 'normative')) error(at, 'MALFORMED', 'requirements retain normative source and strength');
+    const dependencies = new Set();
+    for (const d of c.dependsOn) {
+      if (!record(d, ['id', 'relation', 'reason'], `${at}.dependsOn`)) continue;
+      string(d.id, `${at}.dependsOn.id`); string(d.reason, `${at}.dependsOn.reason`);
+      enumeration(d.relation, ['interpretation', 'trust-premise', 'conditional-mitigation'], `${at}.dependsOn.relation`);
+      if (d.id === c.id || dependencies.has(d.id)) error(at, 'INVALID_DEPENDENCY', 'self or duplicate dependency');
+      dependencies.add(d.id);
+    }
+    for (const g of c.inferenceGuard) {
+      if (!record(g, ['from', 'to', 'reason'], `${at}.inferenceGuard`)) continue;
+      for (const k of ['from', 'to', 'reason']) string(g[k], `${at}.inferenceGuard.${k}`);
+    }
+    const settings = new Set();
+    for (const condition of c.appliesWhen) {
+      if (!record(condition, ['setting', 'equals'], `${at}.appliesWhen`)) continue;
+      string(condition.setting, `${at}.appliesWhen.setting`); string(condition.equals, `${at}.appliesWhen.equals`);
+      if (settings.has(condition.setting)) error(at, 'MALFORMED', 'duplicate applicability setting');
+      settings.add(condition.setting);
+    }
+    if ((c.scopeDisposition === 'conditional') !== (c.appliesWhen.length > 0)) error(at, 'MALFORMED', 'conditional scope requires non-empty appliesWhen; other scopes require []');
+    if (c.negativeRequired && !c.securityCritical) error(at, 'MALFORMED', 'negativeRequired requires securityCritical');
+    if (record(c.source, ['path', 'section', 'quote', 'role'], `${at}.source`)) {
+      enumeration(c.source.role, ['normative', 'context'], `${at}.source.role`);
+      string(c.source.section, `${at}.source.section`); string(c.source.quote, `${at}.source.quote`);
+      const prose = file(c.source.path, at, 'MISSING_SOURCE');
+      if (typeof c.source.path !== 'string' || !c.source.path.endsWith('.md') || (c.source.role === 'normative' && !c.source.path.startsWith('docs/spec/'))) error(at, 'MISSING_SOURCE', 'source must be Markdown; normative source must be docs/spec/**/*.md');
+      if (prose !== null) {
+        const lines = prose.split(/\r?\n/), start = lines.indexOf(c.source.section);
+        const depth = String(c.source.section).match(/^#+/)?.[0].length;
+        let end = start + 1;
+        while (end < lines.length && !(depth && new RegExp(`^#{1,${depth}} `).test(lines[end]))) end++;
+        if (start < 0 || !depth || !lines.slice(start, end).join('\n').includes(c.source.quote)) error(at, 'STALE_SOURCE', 'section/quote no longer matches; review normative drift');
+      }
+    }
+    let impl = 0;
+    for (const ref of array(c.implementation, `${at}.implementation`)) {
+      if (!record(ref, ['path', 'symbol'], `${at}.implementation`)) continue;
+      string(ref.symbol, `${at}.symbol`);
+      const source = file(ref.path, at, 'STALE_IMPLEMENTATION');
+      if (source !== null) {
+        const key = `${ref.path}\0${source}`;
+        if (!declarationCache.has(key)) {
+          const tree = ts.createSourceFile(ref.path, source, ts.ScriptTarget.Latest, true);
+          const declarations = new Set();
+          const visit = node => {
+            if ((ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node) || ts.isMethodDeclaration(node) || ts.isVariableDeclaration(node)) && node.name) declarations.add(node.name.getText(tree));
+            ts.forEachChild(node, visit);
+          };
+          visit(tree);
+          declarationCache.set(key, declarations);
+        }
+        const found = declarationCache.get(key).has(ref.symbol);
+        if (!found) error(at, 'STALE_IMPLEMENTATION', `${ref.path}: declaration ${ref.symbol} missing`); else impl++;
+      }
+    }
+    const evidence = [];
+    for (const [j, ref] of array(c.evidence, `${at}.evidence`).entries()) {
+      const eBefore = issues.length;
+      if (!record(ref, ['path', 'selector', 'kind', 'negative', 'portable', 'runner', 'supports'], `${at}.evidence[${j}]`)) continue;
+      enumeration(ref.kind, kinds, `${at}.evidence.kind`);
+      boolean(ref.negative, `${at}.evidence.negative`); boolean(ref.portable, `${at}.evidence.portable`);
+      string(ref.supports, `${at}.evidence.supports`);
+      const source = file(ref.path, at, 'STALE_EVIDENCE');
+      if (record(ref.selector, ['type', 'id'], `${at}.selector`)) {
+        enumeration(ref.selector.type, ['test', 'vector'], `${at}.selector.type`); string(ref.selector.id, `${at}.selector.id`);
+        if (source !== null) {
+          try {
+            const data = ref.selector.type === 'vector' ? JSON.parse(source) : null;
+            const names = ref.selector.type === 'test' ? testNames(source, ref.path) : (Array.isArray(data) ? data : data.vectors).map(v => v.id);
+            if (names.filter(n => n === ref.selector.id).length !== 1) error(at, 'STALE_EVIDENCE', `${ref.path}: ${ref.selector.id} must identify exactly one active test/vector`);
+          } catch { error(at, 'STALE_EVIDENCE', `${ref.path}: cannot resolve selector`); }
+        }
+      }
+      if (record(ref.runner, ['path', 'contains', 'command', 'runtime'], `${at}.runner`)) {
+        for (const k of ['contains', 'command', 'runtime']) string(ref.runner[k], `${at}.runner.${k}`);
+        const runner = file(ref.runner.path, at, 'STALE_EVIDENCE');
+        if (ref.selector?.type === 'test' && typeof ref.path === 'string' && !String(ref.runner.contains).includes(ref.path.split('/').at(-1).replace(/\.ts$/, '.js')) && !String(ref.runner.contains).includes('dist/test/*.test.js')) error(at, 'STALE_EVIDENCE', 'test runner binding must name compiled test or core test glob');
+        if (runner !== null && !runner.includes(ref.runner.contains)) error(at, 'STALE_EVIDENCE', `${ref.runner.path}: runner binding missing: ${ref.runner.contains}`);
+      }
+      if (ref.portable && (c.classification !== 'portable' || ref.selector?.type !== 'vector')) error(at, 'PORTABLE_INCONSISTENT', 'portable evidence requires a portable claim and vector selector');
+      if (ref.kind === 'vector' && ref.selector?.type !== 'vector') error(at, 'MALFORMED', 'vector kind requires vector selector');
+      if (ref.kind === 'adversarial' && !ref.negative) error(at, 'MALFORMED', 'adversarial evidence must be negative');
+      if (ref.kind === 'cross-runtime' && (!ref.portable || !['Go', 'Python', 'Rust'].includes(ref.runner?.runtime))) error(at, 'PORTABLE_INCONSISTENT', 'cross-runtime evidence requires portable vector and independent runtime');
+      if (issues.length === eBefore) evidence.push(ref);
+    }
+    const supported = [];
+    if (impl) supported.push('TRACEABLE');
+    if (impl && evidence.length) supported.push('TESTED');
+    if (impl && evidence.some(e => e.kind === 'integration')) supported.push('INTEGRATION_TESTED');
+    if (impl && evidence.some(e => e.negative)) supported.push('ADVERSARIAL_TESTED');
+    if (impl && evidence.some(e => e.portable)) supported.push('CONFORMANCE_TESTED');
+    for (const level of array(c.requiredLevels, `${at}.requiredLevels`)) {
+      enumeration(level, levels, `${at}.requiredLevels`);
+      if (!supported.includes(level)) error(at, 'MISSING_REQUIRED_EVIDENCE', level);
+    }
+    if (c.evidenceState === 'mapped' && (!impl || (c.recordType === 'requirement' && !c.requiredLevels.includes('TRACEABLE')))) error(at, 'MISSING_IMPLEMENTATION', 'mapped claim needs implementation and required TRACEABLE');
+    if (c.negativeRequired && !evidence.some(e => e.negative)) error(at, 'MISSING_NEGATIVE', 'required negative evidence absent');
+    if (c.portableRequired && (c.classification !== 'portable' || !evidence.some(e => e.portable))) error(at, 'PORTABLE_INCONSISTENT', 'required portable evidence absent or classification invalid');
+    rows.push({ id: c.id, recordType: c.recordType, normativeState: c.normativeState, evidenceState: c.evidenceState, scopeDisposition: c.scopeDisposition, appliesWhen: c.appliesWhen, dependsOn: c.dependsOn, inferenceGuard: c.inferenceGuard, maintainerDecisionRequired: c.maintainerDecisionRequired, classification: c.classification, impl, evidence, levels: supported, valid: issues.length === before, securityCritical: c.securityCritical, negativeRequired: c.negativeRequired, portableRequired: c.portableRequired, requiredLevels: Array.isArray(c.requiredLevels) ? c.requiredLevels : [], notes: c.notes });
+  }
+  // Resolve after all records: forward references are permitted. No proof, obligation,
+  // applicability or failure is inherited from a dependency, including cyclic context.
+  for (const row of rows) for (const dependency of row.dependsOn) {
+    if (isObject(dependency) && nonempty(dependency.id) && !ids.has(dependency.id)) {
+      error(row.id, 'INVALID_DEPENDENCY', `unknown target ${dependency.id}`);
+      row.valid = false;
+    }
+  }
+  return { issues, rows };
+}
+
+export function report(result) {
+  const { issues, rows } = result;
+  const claims = rows.filter(r => r.recordType === 'requirement');
+  const count = fn => claims.filter(fn).length;
+  const lines = ['OxDeAI Spec-to-Code Claim Verification', '', `Registered records: ${rows.length}`, `Normative claim records (curated, not exhaustive): ${claims.length}`, `Contextual corpus locks (not executable requirements): ${rows.length - claims.length}`, 'Traceability (requirements only; references validated; evidence NOT executed by this command):',
+    ` implementation mapped: ${count(r => r.impl > 0)}/${claims.length}`,
+    ` executable evidence mapped: ${count(r => r.evidence.length > 0)}/${claims.length}`,
+    ` integration evidence: ${count(r => r.requiredLevels.includes('INTEGRATION_TESTED') && r.levels.includes('INTEGRATION_TESTED'))}/${count(r => r.requiredLevels.includes('INTEGRATION_TESTED'))} required`,
+    ` negative evidence: ${count(r => r.negativeRequired && r.evidence.some(e => e.negative))}/${count(r => r.negativeRequired)} required`,
+    ` security-critical with negative evidence: ${count(r => r.securityCritical && r.evidence.some(e => e.negative))}/${count(r => r.securityCritical)}`,
+    ` portable conformance evidence: ${count(r => r.classification === 'portable' && r.evidence.some(e => e.portable))}/${count(r => r.classification === 'portable')} applicable`,
+    '', 'Independent dimensions and evidence capabilities (curated scope, not proof or current execution results):'];
+  for (const r of rows) {
+    lines.push(` ${r.id} [${r.recordType}; normative=${r.normativeState}; evidence=${r.evidenceState}; scope=${r.scopeDisposition}; ${r.classification}] ${r.levels.join(', ') || 'NO EXECUTABLE MAPPING'}`);
+    if (r.appliesWhen.length) lines.push(`  Applies when (all conditions; NOT evaluated): ${r.appliesWhen.map(c => `${c?.setting}=${c?.equals}`).join(', ')}`);
+    for (const d of r.dependsOn) lines.push(`  Depends on ${d?.id} (${d?.relation}; context only): ${d?.reason}`);
+    for (const g of r.inferenceGuard) lines.push(`  DO NOT INFER ${g?.from} -> ${g?.to}: ${g?.reason}`);
+  }
+  lines.push('', 'Issues:', ` unmapped claims: ${count(r => !r.impl)}`, ` ambiguous claims: ${count(r => r.normativeState === 'ambiguous')}`, ` maintainer decisions pending (advisory): ${rows.filter(r => r.maintainerDecisionRequired).length}`, ` stale implementation refs: ${issues.filter(i => i.code === 'STALE_IMPLEMENTATION').length}`, ` stale evidence refs: ${issues.filter(i => i.code === 'STALE_EVIDENCE').length}`, ` missing required evidence: ${issues.filter(i => ['MISSING_REQUIRED_EVIDENCE', 'MISSING_NEGATIVE', 'PORTABLE_INCONSISTENT'].includes(i.code)).length}`);
+  for (const r of rows.filter(r => r.maintainerDecisionRequired || r.normativeState !== 'specified' || r.evidenceState !== 'mapped' || r.scopeDisposition !== 'in-scope' || (r.securityCritical && !r.evidence.some(e => e.negative)))) lines.push(` REVIEW ${r.id}: ${r.notes}`);
+  for (const i of issues) lines.push(` ERROR ${i.id} ${i.code}: ${i.detail}`);
+  lines.push('', 'Mapped ≠ demonstrated. Tested ≠ portable conformance tested. Signature validity ≠ trusted premises.', 'Structural PASS is not semantic proof or whole-protocol conformance. Dependencies and pending decisions do not close locks.', 'See docs/verification/spec-claims/README.md for corpus boundaries and maintainer findings.', `RESULT: ${issues.length ? 'FAIL' : 'PASS'} (structural verification only)`);
+  return lines.join('\n');
+}
+
+export function advisory(registry, root = ROOT) {
+  const candidates = [], unmappedTests = [];
+  const walk = dir => readdirSync(resolve(root, dir), { withFileTypes: true }).sort((a, b) => a.name < b.name ? -1 : 1).flatMap(e => e.isDirectory() ? walk(`${dir}/${e.name}`) : [`${dir}/${e.name}`]);
+  for (const path of walk('docs/spec').filter(p => p.endsWith('.md'))) {
+    const quotes = (registry.claims ?? []).filter(c => c.recordType === 'requirement' && c.source?.role === 'normative' && c.source.path === path).map(c => c.source.quote);
+    readFileSync(resolve(root, path), 'utf8').split(/\r?\n/).forEach((line, i) => {
+      if (/\b(MUST|REQUIRED|SHOULD)\b/.test(line) && !quotes.some(q => q.includes(line) || line.includes(q))) candidates.push(`${path}:${i + 1}: ${line.trim()}`);
+    });
+  }
+  const mapped = new Set((registry.claims ?? []).flatMap(c => c.evidence ?? []).map(e => `${e.path}#${e.selector?.id}`));
+  for (const dir of ['packages/core/src/test', 'packages/guard/src/test', 'packages/conformance/src']) {
+    for (const path of walk(dir).filter(p => p.endsWith('.test.ts'))) {
+      for (const name of testNames(readFileSync(resolve(root, path), 'utf8'), path)) if (!mapped.has(`${path}#${name}`)) unmappedTests.push(`${path}#${name}`);
+    }
+  }
+  return `ADVISORY ONLY — candidates may overlap registered claims; no CI authority\nPotential unregistered normative lines (${candidates.length}):\n${candidates.join('\n')}\nTests without a registry mapping (${unmappedTests.length}; not necessarily without a requirement):\n${unmappedTests.join('\n')}`;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const args = process.argv.slice(2);
+    let registryPath = resolve(ROOT, REGISTRY);
+    const index = args.indexOf('--registry');
+    if (index !== -1) {
+      if (!args[index + 1] || args[index + 1].startsWith('--')) throw Error('--registry requires a JSON path');
+      registryPath = resolve(args[index + 1]);
+      args.splice(index, 2);
+    }
+    if (args.some(a => !['--advisory', '--json'].includes(a))) throw Error('usage: node scripts/spec-claims/verify.mjs [--json] [--advisory] [--registry path]');
+    const registry = JSON.parse(readFileSync(registryPath, 'utf8'));
+    const result = verify(registry);
+    console.log(args.includes('--json') ? JSON.stringify(result, null, 2) : report(result));
+    if (args.includes('--advisory')) console.log(advisory(registry));
+    process.exitCode = result.issues.length ? 1 : 0;
+  } catch (e) { console.error(`RESULT: FAIL — ${e.message}`); process.exitCode = 1; }
+}

--- a/scripts/spec-claims/verify.test.mjs
+++ b/scripts/spec-claims/verify.test.mjs
@@ -1,0 +1,221 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve, dirname } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { verify, report, advisory, testNames, ROOT, REGISTRY } from './verify.mjs';
+
+const original = JSON.parse(readFileSync(resolve(ROOT, REGISTRY), 'utf8'));
+const fresh = () => structuredClone(original);
+const lock = r => r.claims.find(c => c.id === 'RT-TRUST-2');
+const mutations = [
+  ['legacy schema rejected', r => r.version = 1, 'MALFORMED'],
+  ['legacy status rejected', r => r.claims[0].status = 'mapped', 'MALFORMED'],
+  ['unknown dependency', r => r.claims[0].dependsOn = [{ id: 'ABSENT-1', relation: 'interpretation', reason: 'test' }], 'INVALID_DEPENDENCY'],
+  ['malformed inference guard', r => r.claims[0].inferenceGuard = [{ from: 'PASS' }], 'MALFORMED'],
+  ['invalid decision flag', r => r.claims[0].maintainerDecisionRequired = 'yes', 'MALFORMED'],
+  ['conditional scope without conditions', r => lock(r).appliesWhen = [], 'MALFORMED'],
+  ['lock promoted to executable obligation', r => lock(r).requiredLevels = ['TESTED'], 'LOCK_PROMOTION'],
+  ['lock promoted to normative source', r => lock(r).source.role = 'normative', 'LOCK_PROMOTION'],
+  ['lock promoted to normative strength', r => lock(r).strength = 'MUST', 'LOCK_PROMOTION'],
+  ['deferred pending claim still enforces negatives', r => { const c = r.claims.find(c => c.id === 'AUTH-VERIFY-001'); c.scopeDisposition = 'deferred'; c.maintainerDecisionRequired = true; c.evidence = []; }, 'MISSING_NEGATIVE'],
+  ['duplicate claim ID', r => r.claims.push(structuredClone(r.claims[0])), 'DUPLICATE_ID'],
+  ['missing spec path', r => r.claims[0].source.path = 'docs/spec/missing.md', 'MISSING_SOURCE'],
+  ['missing implementation path', r => r.claims[0].implementation[0].path = 'missing.ts', 'STALE_IMPLEMENTATION'],
+  ['missing evidence path', r => r.claims[0].evidence[0].path = 'missing.test.ts', 'STALE_EVIDENCE'],
+  ['required negative evidence absent', r => r.claims.find(c => c.id === 'AUTH-VERIFY-001').evidence = [], 'MISSING_NEGATIVE'],
+  ['malformed claim', r => delete r.claims[0].title, 'MALFORMED'],
+  ['stale test name', r => r.claims[0].evidence[0].selector.id = 'removed test', 'STALE_EVIDENCE'],
+  ['stale vector ID', r => r.claims[0].evidence[1].selector.id = 'removed vector', 'STALE_EVIDENCE'],
+  ['stale implementation symbol', r => r.claims[0].implementation[0].symbol = 'removedSymbol', 'STALE_IMPLEMENTATION'],
+  ['stale source quote', r => r.claims[0].source.quote = 'removed requirement', 'STALE_SOURCE'],
+  ['stale source section', r => r.claims[0].source.section = '## Removed', 'STALE_SOURCE'],
+  ['required integration absent', r => r.claims[0].requiredLevels.push('INTEGRATION_TESTED'), 'MISSING_REQUIRED_EVIDENCE'],
+  ['invalid classification', r => r.claims[0].classification = 'universal-proof', 'MALFORMED'],
+  ['inconsistent portable declaration', r => r.claims[0].classification = 'implementation-specific', 'PORTABLE_INCONSISTENT'],
+  ['required portable evidence absent', r => r.claims[0].evidence.pop(), 'PORTABLE_INCONSISTENT'],
+  ['TypeScript mislabeled cross-runtime', r => r.claims[0].evidence[1].runner.runtime = 'TypeScript', 'PORTABLE_INCONSISTENT'],
+  ['unknown schema field', r => r.claims[0].proven = true, 'MALFORMED'],
+  ['runner binding removed', r => r.claims[0].evidence[0].runner.contains = 'dist/test/removed.test.js', 'STALE_EVIDENCE'],
+  ['path traversal', r => r.claims[0].implementation[0].path = '../escape.ts', 'STALE_IMPLEMENTATION'],
+  ['mapped without implementation', r => r.claims[0].implementation = [], 'MISSING_IMPLEMENTATION'],
+];
+
+test('current registry passes deterministically without claiming execution', () => {
+  const a = verify(fresh()), b = verify(fresh());
+  assert.deepEqual(a.issues, []);
+  assert.deepEqual(a, b);
+  assert.match(report(a), /evidence NOT executed/);
+  assert.match(report(a), /structural verification only/);
+});
+
+for (const [name, mutate, code] of mutations) {
+  test(`${name} -> FAIL, including CLI exit status`, () => {
+    const r = fresh(); mutate(r);
+    const result = verify(r);
+    assert.ok(result.issues.some(i => i.code === code), JSON.stringify(result.issues));
+    assert.match(report(result), /RESULT: FAIL/);
+    const tmp = mkdtempSync(resolve(tmpdir(), 'oxdeai-claim-selftest-'));
+    try {
+      const path = resolve(tmp, 'claims.json'); writeFileSync(path, JSON.stringify(r));
+      const child = spawnSync(process.execPath, ['scripts/spec-claims/verify.mjs', '--registry', path], { cwd: ROOT, encoding: 'utf8' });
+      assert.ifError(child.error);
+      assert.equal(child.status, 1, child.stderr);
+      assert.match(child.stdout, new RegExp(code));
+    } finally { rmSync(tmp, { recursive: true, force: true }); }
+  });
+}
+
+test('malformed types produce diagnostics, never throw', () => {
+  for (const key of Object.keys(original.claims[0])) {
+    const r = fresh(); r.claims[0][key] = null;
+    assert.ok(verify(r).issues.length, key);
+  }
+  for (const key of ['source', 'implementation', 'evidence']) {
+    const r = fresh(); r.claims[0][key] = 42;
+    assert.ok(verify(r).issues.length, key);
+  }
+  for (const field of ['source', 'evidence']) {
+    const example = field === 'source' ? original.claims[0].source : original.claims[0].evidence[0];
+    for (const key of Object.keys(example)) {
+      const r = fresh();
+      const target = field === 'source' ? r.claims[0].source : r.claims[0].evidence[0];
+      target[key] = null;
+      assert.ok(verify(r).issues.length, `${field}.${key}`);
+    }
+  }
+  for (const value of [null, {}, [], { version: 2, claims: 'bad' }, { version: 2, claims: [] }]) assert.ok(verify(value).issues.length);
+});
+
+test('comments, mentions, skipped, todo and dynamic tests cannot satisfy a selector', () => {
+  assert.deepEqual(testNames(`
+    // test("comment", () => {});
+    const mention = 'test("mention", () => {})';
+    test.skip("skip", () => {});
+    test.todo("todo");
+    test("options", { skip: true }, () => {});
+    test(dynamic, () => {});
+    test("active", () => {});
+  `, 'fixture.ts'), ['active']);
+});
+
+test('removed active test replaced with a comment fails in an isolated repository', () => {
+  const tmp = mkdtempSync(resolve(tmpdir(), 'oxdeai-claim-tree-'));
+  try {
+    const r = { version: 2, claims: [structuredClone(original.claims[0])] };
+    for (const ref of [r.claims[0].source, ...r.claims[0].implementation, ...r.claims[0].evidence, ...r.claims[0].evidence.map(e => e.runner)]) {
+      const target = resolve(tmp, ref.path); mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, readFileSync(resolve(ROOT, ref.path)));
+    }
+    assert.deepEqual(verify(r, tmp).issues, []);
+    const e = r.claims[0].evidence[0];
+    writeFileSync(resolve(tmp, e.path), `// test(${JSON.stringify(e.selector.id)}, () => {});`);
+    assert.ok(verify(r, tmp).issues.some(i => i.code === 'STALE_EVIDENCE'));
+  } finally { rmSync(tmp, { recursive: true, force: true }); }
+});
+
+test('non-required gaps remain visible without changing structural exit semantics', () => {
+  const r = { version: 2, claims: fresh().claims.filter(c => c.evidenceState !== 'mapped') };
+  const result = verify(r);
+  assert.deepEqual(result.issues, []);
+  assert.match(report(result), /NO EXECUTABLE MAPPING/);
+  assert.match(report(result), /REVIEW VERIFY-ORDER-001/);
+});
+
+
+test('state dimensions vary independently without upgrading or suppressing evidence', () => {
+  const base = { version: 2, claims: [structuredClone(original.claims[0])] };
+  const expected = verify(base).rows[0].levels;
+  for (const normativeState of ['specified', 'ambiguous', 'unresolved', 'non-normative']) {
+    for (const evidenceState of ['mapped', 'gap', 'unassessed']) {
+      for (const scopeDisposition of ['in-scope', 'deferred', 'deployment', 'conditional', 'out-of-scope']) {
+        const r = structuredClone(base), c = r.claims[0];
+        Object.assign(c, { normativeState, evidenceState, scopeDisposition, maintainerDecisionRequired: true });
+        c.appliesWhen = scopeDisposition === 'conditional' ? [{ setting: 'review-context', equals: 'configured' }] : [];
+        const result = verify(r);
+        assert.deepEqual(result.issues, []);
+        assert.deepEqual(result.rows[0].levels, expected);
+      }
+    }
+  }
+});
+
+test('all three unresolved locks pass with zero executable requirements and remain visible', () => {
+  const r = { version: 2, claims: fresh().claims.filter(c => c.recordType === 'corpus-lock') };
+  const result = verify(r);
+  assert.deepEqual(result.issues, []);
+  assert.deepEqual(result.rows.map(c => c.id), ['CANON-ESC-001', 'RT-TRUST-1', 'RT-TRUST-2']);
+  for (const c of result.rows) {
+    assert.deepEqual(c.levels, []);
+    assert.deepEqual(c.requiredLevels, []);
+    assert.equal(c.maintainerDecisionRequired, true);
+  }
+  const output = report(result);
+  assert.match(output, /Normative claim records \(curated, not exhaustive\): 0/);
+  assert.match(output, /implementation mapped: 0\/0/);
+  assert.match(output, /RESULT: PASS/);
+  assert.match(output, /NOT evaluated/);
+  assert.match(output, /not semantic proof or whole-protocol conformance/);
+});
+
+test('dependencies resolve forward and do not inherit proof or failures', () => {
+  const r = fresh();
+  const result = verify(r);
+  assert.deepEqual(result.issues, []);
+  const profile = result.rows.find(c => c.id === 'PROFILE-C-001');
+  assert.ok(profile.levels.includes('CONFORMANCE_TESTED'));
+  assert.deepEqual(result.rows.find(c => c.id === 'RT-TRUST-1').levels, []);
+  // Making a maintainer decision does not close the residual or change evidence.
+  lock(r).maintainerDecisionRequired = false;
+  assert.deepEqual(verify(r).rows.find(c => c.id === 'RT-TRUST-2').levels, []);
+});
+
+test('conditional RT-TRUST-2 preserves every documented closure prerequisite', () => {
+  assert.deepEqual(lock(original).appliesWhen, [
+    { setting: 'krlMode', equals: 'signed_required' },
+    { setting: 'verifyKrl', equals: 'configured' },
+    { setting: 'KrlWatermarkStore', equals: 'configured' },
+    { setting: 'SignedKrlCache', equals: 'configured' },
+  ]);
+});
+
+test('contextual lock excerpts never suppress normative advisory discovery', () => {
+  const without = fresh(); without.claims = without.claims.filter(c => c.recordType === 'requirement');
+  assert.equal(advisory(original), advisory(without));
+});
+
+test('dependency and applicability metadata reject malformed entries and duplicate edges', () => {
+  for (const field of ['dependsOn', 'inferenceGuard', 'appliesWhen']) {
+    const r = fresh(); r.claims[0][field] = [null];
+    assert.ok(verify(r).issues.some(i => i.code === 'MALFORMED'));
+  }
+  const r = fresh();
+  r.claims[0].dependsOn = [{ id: r.claims[0].id, relation: 'interpretation', reason: 'self' }];
+  assert.ok(verify(r).issues.some(i => i.code === 'INVALID_DEPENDENCY'));
+  r.claims[0].dependsOn = Array(2).fill({ id: 'RT-TRUST-1', relation: 'trust-premise', reason: 'duplicate' });
+  assert.ok(verify(r).issues.some(i => i.code === 'INVALID_DEPENDENCY'));
+});
+
+test('a corpus lock can gain evidence without gaining normative authority or obligations', () => {
+  const c = structuredClone(lock(original));
+  c.evidenceState = 'mapped';
+  c.implementation = structuredClone(original.claims[0].implementation);
+  c.evidence = [structuredClone(original.claims[0].evidence[0])];
+  const result = verify({ version: 2, claims: [c] });
+  assert.deepEqual(result.issues, []);
+  assert.ok(result.rows[0].levels.includes('TESTED'));
+  assert.deepEqual(result.rows[0].requiredLevels, []);
+  assert.equal(result.rows[0].normativeState, 'non-normative');
+  assert.equal(result.rows[0].maintainerDecisionRequired, true);
+  assert.match(report(result), /executable evidence mapped: 0\/0/);
+});
+
+test('context records still enforce source drift and conditional schema integrity', () => {
+  const c = structuredClone(lock(original));
+  c.source.quote = 'removed contextual excerpt';
+  assert.ok(verify({ version: 2, claims: [c] }).issues.some(i => i.code === 'STALE_SOURCE'));
+  c.source = structuredClone(lock(original).source);
+  c.appliesWhen.push(structuredClone(c.appliesWhen[0]));
+  assert.ok(verify({ version: 2, claims: [c] }).issues.some(i => i.code === 'MALFORMED'));
+});


### PR DESCRIPTION
## Summary

Add a schema-v2 spec-to-code claim registry and structural verification gate for OxDeAI.

This change separates normative state, evidence state, and scope disposition so that specification requirements, implementation/evidence mappings, unresolved corpus locks, and deployment/trust residuals remain independently visible.

The checker detects structural drift without treating registry consistency, mapped evidence, or selected tests as proof of semantic correctness or whole-protocol conformance.

## Changes

* Add `docs/verification/spec-claims/` with:

  * schema-v2 claim registry
  * inventory
  * migration notes
  * validation record
  * registry semantics and boundaries
* Add `scripts/spec-claims/verify.mjs` to validate:

  * source sections and quoted excerpts
  * implementation paths and TypeScript symbols
  * active test selectors
  * vector IDs
  * integration and negative evidence requirements
  * portable/cross-runtime evidence declarations
  * dependency, applicability, and inference-guard metadata
* Add `scripts/spec-claims/verify.test.mjs` with 43 deterministic checker tests.
* Distinguish normative `requirement` records from contextual `corpus-lock` records.
* Preserve required evidence obligations independently of review/scope metadata.
* Reconcile `CANON-002`, `SIGNED-KRL-001`, `SIGNED-KRL-002`, and contextual `CANON-ESC-001` source citations with the normative changes already merged in #309 without changing their evidence obligations.
* Add:

  * `pnpm verify:spec-claims`
  * `pnpm test:spec-claims`
* Run both commands as a required CI step.

## Security impact

Does this change affect authorization, verification, replay protection, trusted state, provenance, execution boundaries, or CI security gates?

* [ ] No security-relevant behavior changed
* [x] Security-relevant behavior changed and is described below

Details:

This PR adds a CI security/traceability gate. It does **not** change runtime authorization, artifact verification, replay handling, trusted-state evaluation, or production execution behavior.

The gate fails on structural registry drift, including stale normative citations, implementation symbols, evidence selectors, vector identifiers, and missing required evidence mappings.

The checker explicitly prevents the following inferences:

* structural PASS → semantic correctness
* mapped evidence → evidence execution
* selected tests → whole-protocol conformance
* TypeScript-only evidence → cross-runtime conformance
* valid signature → trusted deployment premises
* pure verification → non-bypassable enforcement
* dependency/applicability metadata → residual closure

Contextual corpus locks cannot satisfy normative executable evidence obligations.

## Validation

```text
pnpm verify:spec-claims
PASS — 29 registered records; 26 normative requirements; 3 contextual locks.
0 stale implementation refs.
0 stale evidence refs.
0 missing required evidence.
RESULT: PASS (structural verification only).

pnpm test:spec-claims
PASS — 43/43 tests.

git diff --check
PASS.
```

Current curated coverage reported by the checker:

```text
implementation mapped:                 20/26
executable evidence mapped:            20/26
required integration evidence:         12/12
required negative evidence:            18/18
security-critical with negative:       18/25
portable conformance evidence:          5/19 applicable
```

These counts describe registry mappings, not proof that the evidence was executed by the structural checker.

## Regression proof

The checker includes mutation/negative coverage proving that protections fail closed when deliberately broken.

Covered cases include:

* legacy schema version
* legacy overloaded status
* unknown dependencies
* malformed inference guards
* invalid decision metadata
* malformed conditional scope
* contextual lock promotion to executable/normative authority
* duplicate claim IDs
* missing spec, implementation, or evidence paths
* missing required negative/integration/portable evidence
* stale test names
* stale vector IDs
* stale implementation symbols
* stale source sections and quotes
* TypeScript evidence mislabeled as cross-runtime
* path traversal
* mapped claims without implementation
* comments, skipped/todo tests, mentions, and dynamic test names attempting to satisfy selectors

The post-#309 source drift was also exercised during development: the checker detected four stale citations and returned FAIL until the affected source anchors were explicitly reconciled.

## Scope

* [x] No unrelated changes
* [x] No required CI check weakened, bypassed, or made advisory
* [x] No production behavior changed unless explicitly described
* [x] Documentation updated where required

This PR does not modify normative specifications, protocol behavior, or vector corpora. It reconciles registry citations against the already-merged #309 normative changes.

## Related issue

Closes #311
