### PR TITLE
fix(guard): remove same-producer policy expectation

### DIFF
--- a/docs/spec/verification/verification-v1.md
+++ b/docs/spec/verification/verification-v1.md
@@ -38,6 +38,26 @@ Verifiers **MUST** operate on explicit, injected inputs:
 - `replayStore` (for `auth_id` / `delegation_id`) when replay protection is enforced.
 - Optional `expectedDelegatee`/`expectedPolicyId` when required by integration.
 
+### 4.1 Provenance of `expected*` Values
+
+An `expected*` verification value **MUST** originate from trusted configuration
+established independently of the artifact being verified and independently of the
+component that produced that artifact for the current operation. It **MUST NOT**
+be derived from the artifact being verified, from an artifact carried by it, or
+from the producer that created the artifact in the same call.
+
+This rule constrains **provenance only**. It does **NOT** make `expectedPolicyId`,
+`expectedIssuer`, `expectedDelegatee`, or any other optional expectation
+mandatory. Every such value remains optional and configured per integration; the
+rule defines only what qualifies as a valid trust source when one *is* configured.
+
+A value that fails this provenance test **MUST NOT** be configured at all, rather
+than being configured from a non-independent source. Recomputing an expectation
+from the same producer that emitted the artifact restates that producer's own
+derivation and establishes no independent constraint, so it does not satisfy this
+rule even though the two values are compared.
+
+
 ## 5. AuthorizationV1 Verification (Required Ordering)
 
 1. Structural validation (required fields, types).

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -55,16 +55,6 @@ function validateConfig(config: OxDeAIGuardConfig): void {
   if (!config.engine || typeof config.engine.evaluatePure !== "function") {
     throw new OxDeAIGuardConfigurationError("config.engine must be a PolicyEngine instance with an evaluatePure method.");
   }
-  // #301: the direct path derives its expected policy_id from the engine's own
-  // trusted configuration. An engine that cannot state its policy identity
-  // cannot support that check, so it is rejected at construction rather than
-  // producing a TypeError mid-request.
-  if (typeof config.engine.computePolicyId !== "function") {
-    throw new OxDeAIGuardConfigurationError(
-      "config.engine must expose computePolicyId(): the guard derives the expected policy_id from trusted " +
-        "engine configuration rather than from the authorization artifact it is verifying."
-    );
-  }
   if (typeof config.getState !== "function") {
     throw new OxDeAIGuardConfigurationError("config.getState must be a function.");
   }
@@ -597,10 +587,15 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
       mode: "strict",
       trustedKeySets,
       requireSignatureVerification: true,
-      // `expectedPolicyId` is derived from trusted engine construction BEFORE
-      // this artifact exists — never read back out of the artifact it
-      // constrains. The previous `expectedPolicyId: authorization.policy_id`
-      // compared the artifact against itself and could not fail (#301).
+      // No `expectedPolicyId` is passed on this path (#316). Any value the
+      // guard could supply here would come from `config.engine` — the same
+      // producer whose `evaluatePure()` populated `authorization.policy_id` in
+      // this very call, by the same policy derivation. Comparing the two would
+      // restate the producer's own derivation rather than check it against an
+      // independent authority, so the expectation is removed rather than
+      // re-sourced. An earlier form read the value straight off the artifact
+      // (`expectedPolicyId: authorization.policy_id`), which was the same
+      // defect stated more obviously.
       //
       // `expectedIssuer` is deliberately NOT passed. Issuer is already bound
       // cryptographically: findKeyInKeySets() selects the key set by
@@ -618,7 +613,6 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
       // authority claim to check. See `trustedDelegationAuthorities` and
       // `PepGatewayOptions.trustedAuthorizationAuthorities` for the paths where
       // the artifact does arrive from outside.
-      expectedPolicyId: config.engine.computePolicyId(),
       expectedAudience: config.expectedAudience,
     });
 

--- a/packages/guard/src/test/guard.authorization.test.ts
+++ b/packages/guard/src/test/guard.authorization.test.ts
@@ -5,7 +5,7 @@
  * Verifies that OxDeAIGuard enforces strict AuthorizationV1 verification
  * on the standard (non-delegation) path.
  *
- * Test IDs: A-1 through A-6.
+ * Test IDs: A-1 through A-6, plus A-8/A-9 (#316 same-producer provenance).
  *
  *   A-1  Tampered signature → OxDeAIAuthorizationError, execute blocked
  *   A-2  Unknown issuer     → OxDeAIAuthorizationError, execute blocked
@@ -13,6 +13,8 @@
  *   A-4  Expired auth       → OxDeAIAuthorizationError, execute blocked
  *   A-5  Missing trustedKeySets → OxDeAIGuardConfigurationError at construction
  *   A-6  Valid auth         → execute runs, result returned
+ *   A-8  Same-producer construction: artifact policy_id == engine.computePolicyId()
+ *   A-9  validateConfig requires only what the execution path consumes
  */
 
 import test from "node:test";
@@ -23,7 +25,7 @@ import type { Authorization, AuthorizationV1, Intent, State } from "@oxdeai/core
 
 import { OxDeAIGuard } from "../guard.js";
 import { OxDeAIAuthorizationError, OxDeAIGuardConfigurationError } from "../errors.js";
-import { TEST_KEYSET, signAuth } from "./helpers/fixtures.js";
+import { TEST_KEYSET, TEST_KEYPAIR, signAuth } from "./helpers/fixtures.js";
 import { defaultNormalizeAction } from "../normalizeAction.js";
 import type { OxDeAIGuardConfig, ProposedAction } from "../types.js";
 
@@ -49,15 +51,7 @@ function makeBaseState(): State {
   };
 }
 
-/**
- * @param enginePolicyId Policy identity this engine's trusted configuration
- *   establishes. Defaults to the artifact's own `policy_id` so existing cases
- *   keep their meaning, but it is a SEPARATE input on purpose: the guard
- *   verifies `authorization.policy_id` against `engine.computePolicyId()`
- *   (#301), and a helper that always returned the artifact's own value could
- *   never exercise that comparison.
- */
-function makeFakeEngine(auth: AuthorizationV1, enginePolicyId: string = auth.policy_id) {
+function makeFakeEngine(auth: AuthorizationV1) {
   return {
     evaluatePure(_intent: Intent, state: State) {
       return {
@@ -68,19 +62,14 @@ function makeFakeEngine(auth: AuthorizationV1, enginePolicyId: string = auth.pol
       };
     },
     computeStateHash: (state: State) => stateSnapshotHash(state),
-    computePolicyId: () => enginePolicyId,
   };
 }
 
-function makeGuardConfig(
-  auth: AuthorizationV1,
-  overrides?: Partial<OxDeAIGuardConfig>,
-  enginePolicyId?: string
-): OxDeAIGuardConfig {
+function makeGuardConfig(auth: AuthorizationV1, overrides?: Partial<OxDeAIGuardConfig>): OxDeAIGuardConfig {
   let storedState = makeBaseState();
   let storedVersion = 0;
   return {
-    engine: makeFakeEngine(auth, enginePolicyId) as any,
+    engine: makeFakeEngine(auth) as any,
     getState: async () => ({ state: storedState, version: storedVersion }),
     setState: async (s, v) => { if (v !== storedVersion) return false; storedState = s; storedVersion++; return true; },
     trustedKeySets: [TEST_KEYSET],
@@ -238,66 +227,6 @@ test("A-5 missing trustedKeySets: OxDeAIGuardConfigurationError thrown at constr
 // A-6: Valid auth → execute runs, result returned
 // ---------------------------------------------------------------------------
 
-// ---------------------------------------------------------------------------
-// A-7: policy_id is checked against TRUSTED ENGINE CONFIGURATION (#301)
-// ---------------------------------------------------------------------------
-
-test("A-7 policy_id mismatch against engine.computePolicyId(): execute blocked", async () => {
-  // Everything else about this artifact is valid: correctly signed, correct
-  // audience, correct intent and state binding, unexpired. The ONLY defect is
-  // that its policy_id is not the policy this engine is configured for.
-  //
-  // Before #301 the guard passed `expectedPolicyId: authorization.policy_id`,
-  // comparing the artifact with itself, so this case could not fail. It now
-  // compares against `engine.computePolicyId()`, established from trusted
-  // engine configuration before the artifact exists.
-  const ARTIFACT_POLICY = "P2-artifact-policy";
-  const ENGINE_POLICY = "P1-engine-policy";
-  assert.notEqual(ARTIFACT_POLICY, ENGINE_POLICY);
-
-  const auth = signAuth({
-    auth_id: "a7-policy-mismatch",
-    audience: "aud-test",
-    state_hash: stateSnapshotHash(makeBaseState()),
-    intent_hash: FIXED_INTENT_HASH,
-    policy_id: ARTIFACT_POLICY,
-  });
-  const guard = OxDeAIGuard(makeGuardConfig(auth, undefined, ENGINE_POLICY));
-
-  let executed = false;
-  await assert.rejects(
-    () => guard(ACTION, async () => { executed = true; return "ok"; }),
-    (err: unknown) => {
-      assert.ok(err instanceof OxDeAIAuthorizationError, `expected OxDeAIAuthorizationError, got ${String(err)}`);
-      assert.match(
-        String((err as Error).message),
-        /AUTH_POLICY_ID_MISMATCH/,
-        "must fail specifically on the policy-id binding"
-      );
-      return true;
-    }
-  );
-  assert.equal(executed, false, "execute must never run for a foreign policy_id");
-});
-
-test("A-7b matching engine policy id still executes (a real check, not blanket denial)", async () => {
-  const POLICY = "P1-engine-policy";
-  const auth = signAuth({
-    auth_id: "a7b-policy-match",
-    audience: "aud-test",
-    state_hash: stateSnapshotHash(makeBaseState()),
-    intent_hash: FIXED_INTENT_HASH,
-    policy_id: POLICY,
-  });
-  const guard = OxDeAIGuard(makeGuardConfig(auth, undefined, POLICY));
-
-  let executed = false;
-  const result = await guard(ACTION, async () => { executed = true; return "ok"; });
-
-  assert.ok(executed, "an artifact matching the engine's configured policy must execute");
-  assert.equal(result, "ok");
-});
-
 test("A-6 valid auth: execute runs and result is returned", async () => {
   const auth = signAuth({ auth_id: "a6-auth", audience: "aud-test", state_hash: stateSnapshotHash(makeBaseState()), intent_hash: FIXED_INTENT_HASH });
   const guard = OxDeAIGuard(makeGuardConfig(auth));
@@ -307,4 +236,75 @@ test("A-6 valid auth: execute runs and result is returned", async () => {
 
   assert.ok(executed, "execute must be called for a valid authorization");
   assert.equal(result, "ok");
+});
+
+// ---------------------------------------------------------------------------
+// A-8 / A-9: same-producer provenance (#316)
+// ---------------------------------------------------------------------------
+
+test("A-8 same-producer construction: evaluatePure().authorization.policy_id equals engine.computePolicyId()", async () => {
+  // Pins WHY recomputing an expectation from `config.engine` was not an
+  // independent check. A real PolicyEngine derives `authorization.policy_id`
+  // from the same policy configuration that `computePolicyId()` reads, so both
+  // values come from one producer and one derivation.
+  //
+  // Verifying an artifact against a value recomputed from its own producer
+  // restates that producer's derivation; it establishes no constraint that an
+  // independent authority would impose. That is the defect #316 removes, and
+  // it is why the expectation was deleted rather than re-sourced.
+  const { PolicyEngine, RECOMMENDED_TRUSTED_TIME_PROFILE } = await import("@oxdeai/core");
+  const engine = new PolicyEngine({
+    // must match makeBaseState().policy_version, or the engine DENYs on version.
+    policy_version: "policy-auth",
+    engine_secret: "test-secret-must-be-at-least-32-chars!!",
+    authorization_signing_alg: "Ed25519",
+    authorization_signing_kid: "k1",
+    authorization_issuer: TEST_KEYSET.issuer,
+    authorization_audience: "agent-auth",
+    authorization_ttl_seconds: 600,
+    authorization_private_key_pem: TEST_KEYPAIR.privateKey.toString(),
+    ...RECOMMENDED_TRUSTED_TIME_PROFILE,
+  });
+
+  const state = makeBaseState();
+  const intent = defaultNormalizeAction(ACTION);
+  const out = engine.evaluatePure(intent, state, T_NOW);
+
+  assert.equal(out.decision, "ALLOW", `expected ALLOW, got ${out.decision}: ${JSON.stringify(out.reasons)}`);
+  assert.ok(out.authorization, "engine must emit an authorization on ALLOW");
+  assert.equal(
+    out.authorization!.policy_id,
+    engine.computePolicyId(),
+    "the artifact's policy_id and the engine's recomputed policy id are the SAME producer's value; " +
+      "comparing them cannot establish independent policy authority"
+  );
+});
+
+test("A-9 validateConfig requires only what the execution path consumes: an engine without computePolicyId is accepted", () => {
+  // Scoped claim: validateConfig no longer demands a capability solely to
+  // support the removed comparison. It is NOT a compatibility promise that
+  // arbitrary custom or duck-typed engines are a supported public extension
+  // surface — `OxDeAIGuardConfig.engine` remains typed as `PolicyEngine`.
+  const auth = signAuth({
+    auth_id: "a9-auth",
+    audience: "aud-test",
+    state_hash: stateSnapshotHash(makeBaseState()),
+    intent_hash: FIXED_INTENT_HASH,
+  });
+
+  const engineWithoutComputePolicyId = {
+    evaluatePure(_intent: Intent, state: State) {
+      return { decision: "ALLOW" as const, reasons: [], authorization: auth as Authorization, nextState: state };
+    },
+    computeStateHash: (state: State) => stateSnapshotHash(state),
+  };
+  assert.equal(
+    (engineWithoutComputePolicyId as { computePolicyId?: unknown }).computePolicyId,
+    undefined,
+    "fixture must genuinely lack the method for this test to mean anything"
+  );
+
+  assert.doesNotThrow(() =>
+    OxDeAIGuard(makeGuardConfig(auth, { engine: engineWithoutComputePolicyId as never }))
+  );
 });

--- a/packages/guard/src/test/guard.boundary-audit.test.ts
+++ b/packages/guard/src/test/guard.boundary-audit.test.ts
@@ -47,7 +47,7 @@ import {
 } from "@oxdeai/core";
 import type { AuthorizationV1, DelegationScope, DelegationV1, Intent, State } from "@oxdeai/core";
 import { buildState } from "@oxdeai/sdk";
-import { TEST_KEYSET, TEST_KEYPAIR, signAuth, DELEGATION_AUTHORITIES, FIXTURE_POLICY_ID } from "./helpers/fixtures.js";
+import { TEST_KEYSET, TEST_KEYPAIR, signAuth, DELEGATION_AUTHORITIES } from "./helpers/fixtures.js";
 
 import { OxDeAIGuard } from "../guard.js";
 import { createSecureGuard } from "../secureGuard.js";
@@ -138,7 +138,7 @@ function mockEngine(
   evaluatePure: (intent: Intent, state: State, at: number) => unknown,
   computeStateHash: (state: State) => string = () => "0".repeat(64)
 ): PolicyEngine {
-  return { evaluatePure, computeStateHash, computePolicyId: () => FIXTURE_POLICY_ID } as unknown as PolicyEngine;
+  return { evaluatePure, computeStateHash } as unknown as PolicyEngine;
 }
 
 // ── delegation fixtures (mirrors guard.delegation.test.ts) ────────────────────

--- a/packages/guard/src/test/guard.boundary.test.ts
+++ b/packages/guard/src/test/guard.boundary.test.ts
@@ -216,9 +216,6 @@ test("auth_id replay is denied on second use", async () => {
     computeStateHash(state: State) {
       return stateSnapshotHash(state);
     }
-    computePolicyId() {
-      return auth.policy_id;
-    }
     verifyAuthorization() {
       return { valid: true };
     }
@@ -619,9 +616,6 @@ test("missing required auth fields is denied before execution", async () => {
   class FakeEngineBadAuth {
     evaluatePure(_intent: Intent, state: State) {
       return { decision: "ALLOW" as const, reasons: [], authorization: badAuth as Authorization, nextState: state };
-    }
-    computePolicyId() {
-      return badAuth.policy_id;
     }
     verifyAuthorization() {
       return { valid: true };

--- a/packages/guard/src/test/guard.cas.test.ts
+++ b/packages/guard/src/test/guard.cas.test.ts
@@ -82,7 +82,6 @@ function makeFakeEngine(auth: ReturnType<typeof signAuth>) {
       };
     },
     computeStateHash: (s: State) => stateSnapshotHash(s),
-    computePolicyId: () => auth.policy_id,
   };
 }
 
@@ -241,7 +240,6 @@ test("CAS-3 concurrent double-execution: second guard call is denied when versio
       };
     },
     computeStateHash: (s: State) => stateSnapshotHash(s),
-    computePolicyId: () => auth1.policy_id,
   };
 
   const config: OxDeAIGuardConfig = {
@@ -365,7 +363,6 @@ test("CAS-5 CAS failure: engine's nextState not committed, beforeExecute and exe
       };
     },
     computeStateHash: (s: State) => stateSnapshotHash(s),
-    computePolicyId: () => auth.policy_id,
   };
 
   const config: OxDeAIGuardConfig = {

--- a/packages/guard/src/test/guard.intent-binding.test.ts
+++ b/packages/guard/src/test/guard.intent-binding.test.ts
@@ -92,7 +92,6 @@ function makeFakeEngine(auth: AuthorizationV1): PolicyEngine {
       };
     },
     computeStateHash: (s: State) => stateSnapshotHash(s),
-    computePolicyId: () => auth.policy_id,
     verifyAuthorization: () => ({ valid: true }),
   } as unknown as PolicyEngine;
 }

--- a/packages/guard/src/test/guard.pep-conformance.test.ts
+++ b/packages/guard/src/test/guard.pep-conformance.test.ts
@@ -117,7 +117,6 @@ function makeFakeEngine(auth: AuthorizationV1): PolicyEngine {
       };
     },
     computeStateHash: (s: State) => stateSnapshotHash(s),
-    computePolicyId: () => auth.policy_id,
     verifyAuthorization: () => ({ valid: true }),
   } as unknown as PolicyEngine;
 }
@@ -383,7 +382,6 @@ test("GPC-9 missing auth artifact: ALLOW without authorization blocks execute", 
       };
     },
     computeStateHash: (s: State) => stateSnapshotHash(s),
-    computePolicyId: () => "",
     verifyAuthorization: () => ({ valid: true }),
   } as unknown as PolicyEngine;
 

--- a/packages/guard/src/test/guard.property.test.ts
+++ b/packages/guard/src/test/guard.property.test.ts
@@ -175,7 +175,6 @@ const EXPIRED_STUB_AUTH = signAuth({ auth_id: "stub-expired", issued_at: 1_000, 
 function makeDenyEngine(): PolicyEngine {
   return {
     evaluatePure: () => ({ decision: "DENY" as const, reasons: ["KILL_SWITCH_GLOBAL"] }),
-    computePolicyId: () => "p".repeat(64),
     verifyAuthorization: () => ({ valid: true }),
   } as unknown as PolicyEngine;
 }
@@ -196,7 +195,6 @@ function makeAllowEngine(state: State, nextState?: State): PolicyEngine {
       };
     },
     computeStateHash: (s: State) => stateSnapshotHash(s),
-    computePolicyId: () => "p".repeat(64),
     verifyAuthorization: () => ({ valid: true }),
   } as unknown as PolicyEngine;
 }
@@ -209,7 +207,6 @@ function makeAllowEngineNoAuth(nextState: State): PolicyEngine {
       authorization: undefined as unknown as Authorization,
       nextState,
     }),
-    computePolicyId: () => "p".repeat(64),
     verifyAuthorization: () => ({ valid: true }),
   } as unknown as PolicyEngine;
 }
@@ -222,7 +219,6 @@ function makeAuthFailEngine(nextState: State): PolicyEngine {
       authorization: EXPIRED_STUB_AUTH,
       nextState,
     }),
-    computePolicyId: () => EXPIRED_STUB_AUTH.policy_id,
   } as unknown as PolicyEngine;
 }
 
@@ -728,11 +724,11 @@ function genValidReasons(rng: () => number): string[] {
 }
 
 function makeMalformedDenyEngine(reasons: unknown): PolicyEngine {
-  return { evaluatePure: () => ({ decision: "DENY" as const, reasons }), computePolicyId: () => "p".repeat(64) } as unknown as PolicyEngine;
+  return { evaluatePure: () => ({ decision: "DENY" as const, reasons }) } as unknown as PolicyEngine;
 }
 
 function makeReasonsDenyEngine(reasons: string[]): PolicyEngine {
-  return { evaluatePure: () => ({ decision: "DENY" as const, reasons }), computePolicyId: () => "p".repeat(64) } as unknown as PolicyEngine;
+  return { evaluatePure: () => ({ decision: "DENY" as const, reasons }) } as unknown as PolicyEngine;
 }
 
 // ── G8: malformed DENY reasons always fail closed as an engine-contract violation (#247) ──

--- a/packages/guard/src/test/guard.replay-store.redis.test.ts
+++ b/packages/guard/src/test/guard.replay-store.redis.test.ts
@@ -145,7 +145,6 @@ function makeFakeEngine(auth: AuthorizationV1) {
       };
     },
     computeStateHash: (state: State) => stateSnapshotHash(state),
-    computePolicyId: () => auth.policy_id,
   };
 }
 
@@ -323,7 +322,7 @@ test("RS-R7 Redis error in consumeDelegationId: throws OxDeAIAuthorizationError 
   const delegation = makeDelegationWithScope(parentAuth, { tools: ["pay"], max_amount: 1_000_000n });
 
   const guard = OxDeAIGuard({
-    engine: { evaluatePure: () => { throw new Error("should not reach engine"); }, computePolicyId: () => "unused-on-delegation-path" } as any,
+    engine: { evaluatePure: () => { throw new Error("should not reach engine"); } } as any,
     getState: async () => ({ state: makeBaseState(), version: 0 }),
     setState: async () => true,
     trustedKeySets: [TEST_KEYSET],

--- a/packages/guard/src/test/guard.replay-store.test.ts
+++ b/packages/guard/src/test/guard.replay-store.test.ts
@@ -72,7 +72,6 @@ function makeFakeEngine(auth: AuthorizationV1) {
       };
     },
     computeStateHash: (state: State) => stateSnapshotHash(state),
-    computePolicyId: () => auth.policy_id,
   };
 }
 
@@ -127,7 +126,7 @@ test("RS-2 default store: delegation_id replay blocked on second call to same gu
   const delegation = makeDelegationWithScope(parentAuth, { tools: ["pay"], max_amount: 1_000_000n });
 
   const guard = OxDeAIGuard({
-    engine: { evaluatePure: () => { throw new Error("should not reach engine on delegation path"); }, computePolicyId: () => "unused-on-delegation-path" } as any,
+    engine: { evaluatePure: () => { throw new Error("should not reach engine on delegation path"); } } as any,
     getState: async () => ({ state: makeBaseState(), version: 0 }),
     setState: async () => true,
     trustedKeySets: [TEST_KEYSET],
@@ -192,7 +191,7 @@ test("RS-4 shared store: delegation_id replay blocked across two distinct guard 
 
   function makeDelGuard() {
     return OxDeAIGuard({
-      engine: { evaluatePure: () => { throw new Error("should not reach engine"); }, computePolicyId: () => "unused-on-delegation-path" } as any,
+      engine: { evaluatePure: () => { throw new Error("should not reach engine"); } } as any,
       getState: async () => ({ state: makeBaseState(), version: 0 }),
       setState: async () => true,
       trustedKeySets: [TEST_KEYSET],
@@ -269,7 +268,7 @@ test("RS-6 failing consumeDelegationId: execution blocked when store throws on d
   const delegation = makeDelegationWithScope(parentAuth, { tools: ["pay"], max_amount: 1_000_000n });
 
   const guard = OxDeAIGuard({
-    engine: { evaluatePure: () => { throw new Error("should not reach engine"); }, computePolicyId: () => "unused-on-delegation-path" } as any,
+    engine: { evaluatePure: () => { throw new Error("should not reach engine"); } } as any,
     getState: async () => ({ state: makeBaseState(), version: 0 }),
     setState: async () => true,
     trustedKeySets: [TEST_KEYSET],
@@ -313,7 +312,7 @@ test("RS-7 store without consumeDelegationId: delegation executes; parentAuth re
   const delegation = makeDelegationWithScope(parentAuth, { tools: ["pay"], max_amount: 1_000_000n });
 
   const guard = OxDeAIGuard({
-    engine: { evaluatePure: () => { throw new Error("should not reach engine"); }, computePolicyId: () => "unused-on-delegation-path" } as any,
+    engine: { evaluatePure: () => { throw new Error("should not reach engine"); } } as any,
     getState: async () => ({ state: makeBaseState(), version: 0 }),
     setState: async () => true,
     trustedKeySets: [TEST_KEYSET],
@@ -384,7 +383,7 @@ test("RS-9 store unavailable for parentAuth auth_id: execution blocked on delega
   const delegation = makeDelegationWithScope(parentAuth, { tools: ["pay"], max_amount: 1_000_000n });
 
   const guard = OxDeAIGuard({
-    engine: { evaluatePure: () => { throw new Error("should not reach engine"); }, computePolicyId: () => "unused-on-delegation-path" } as any,
+    engine: { evaluatePure: () => { throw new Error("should not reach engine"); } } as any,
     getState: async () => ({ state: makeBaseState(), version: 0 }),
     setState: async () => true,
     trustedKeySets: [TEST_KEYSET],

--- a/packages/guard/src/test/guard.state-binding.test.ts
+++ b/packages/guard/src/test/guard.state-binding.test.ts
@@ -78,7 +78,6 @@ function makeFakeEngine(auth: ReturnType<typeof signAuth>, _state: State) {
       };
     },
     computeStateHash: (s: State) => stateSnapshotHash(s),
-    computePolicyId: () => auth.policy_id,
   };
 }
 
@@ -322,7 +321,6 @@ test("SB-7 null execution state: computeStateHash throws and execution is blocke
       }
       return stateSnapshotHash(s as State);
     },
-    computePolicyId: () => auth.policy_id,
   };
 
   const config: OxDeAIGuardConfig = {

--- a/packages/guard/src/test/guard.test.ts
+++ b/packages/guard/src/test/guard.test.ts
@@ -311,7 +311,6 @@ test("guard: DENY fires onDecision hook with DENY decision", async () => {
 
 function makeMalformedDenyEngine(reasons: unknown): PolicyEngine {
   return {
-    computePolicyId: () => "p".repeat(64),
     evaluatePure: () => ({ decision: "DENY" as const, reasons }),
   } as unknown as PolicyEngine;
 }
@@ -403,7 +402,6 @@ test("guard: ALLOW without authorization artifact throws OxDeAIAuthorizationErro
   let currentVersion = 0;
 
   const mockEngine = {
-    computePolicyId: () => "p".repeat(64),
     evaluatePure: () => ({
       decision: "ALLOW" as const,
       reasons: [] as [],
@@ -441,7 +439,6 @@ test("guard: ALLOW without nextState throws OxDeAIAuthorizationError", async () 
   let currentVersion = 0;
 
   const mockEngine = {
-    computePolicyId: () => "p".repeat(64),
     evaluatePure: () => ({
       decision: "ALLOW" as const,
       reasons: [] as [],
@@ -483,7 +480,6 @@ test("guard: failed verifyAuthorization throws OxDeAIAuthorizationError", async 
   const expiredAuth = signAuth({ auth_id: "stub-expired", issued_at: 1_000, expiry: 2_000 });
 
   const mockEngine = {
-    computePolicyId: () => "p".repeat(64),
     evaluatePure: () => ({
       decision: "ALLOW" as const,
       reasons: [] as [],


### PR DESCRIPTION
## Summary

Remove the same-producer `policy_id` expectation from the local direct guard verification path.

The guard previously passed:

```ts
expectedPolicyId: config.engine.computePolicyId(),
````

immediately after receiving the authorization from the same engine's `evaluatePure()` call.

Because both `authorization.policy_id` and `expectedPolicyId` came from the same producer and the same policy derivation, the comparison did not establish an independent policy-authority constraint.

This PR removes that comparison rather than replacing it with another locally derived value. It also removes the `validateConfig()` requirement that existed only to support that check, cleans up the related test scaffolding, and adds a normative provenance rule for optional `expected*` verification values.

External authorization boundaries introduced by #301 remain unchanged.

## Changes

Removed `expectedPolicyId: config.engine.computePolicyId()` from the locally emitted direct authorization verification path.

Removed the corresponding `validateConfig()` requirement for `computePolicyId()` and the comments that described same-engine recomputation as a trusted policy constraint.

Preserved strict signature verification, trusted key sets, expected audience, intent/state binding, replay handling, and fail-closed behavior.

Preserved #301 issuer-policy authority enforcement for externally supplied authorizations in the PEP gateway and delegation path.

Removed test-only `computePolicyId()` scaffolding that existed solely to satisfy the reverted configuration requirement.

Removed A-7/A-7b tests that documented the now-removed local policy comparison.

Added focused regression coverage for the same-producer derivation and for `validateConfig()` no longer requiring `computePolicyId()` solely for this removed check.

Added a normative provenance rule to `verification-v1.md` requiring configured optional `expected*` values to originate from an independent trusted source.

This is a targeted normative specification change that closes the provenance ambiguity exposed by #316. It does not make any `expected*` value mandatory.

## Security impact

Does this change affect authorization, verification, replay protection, trusted state, provenance, execution boundaries, or CI security gates?

* [ ] No security-relevant behavior changed
* [x] Security-relevant behavior changed and is described below

Details:

This PR removes a verification constraint that did not use an independent trust source.

The local direct path no longer passes any `expectedPolicyId` value from any source.

Signature verification, expected-audience verification, issuer binding through deployer-configured trusted key sets, intent/state binding, replay handling, and fail-closed execution behavior remain in place.

No external authorization boundary is weakened. `trustedAuthorizationAuthorities` in the PEP gateway and `trustedDelegationAuthorities` remain unchanged, including exact atomic `(issuer, policyId)` authority matching and fail-closed configuration behavior.

The specification change clarifies that optional `expected*` values must have independent trusted provenance when configured.

## Validation

```text
pnpm --filter @oxdeai/core test PASS  383 pass / 0 fail
pnpm --filter @oxdeai/guard test PASS  267 pass / 0 fail
pnpm typecheck PASS
pnpm verify:spec-claims PASS  structural verification only
pnpm test:spec-claims PASS  43 pass / 0 fail
git diff --check PASS
```

Focused regression runs also passed:

```text
guard.authorization PASS  8/8
guard.delegation.authority + gateway.authority + authorizationAuthority PASS  29/29
```

`verify:spec-claims` is structural evidence only and is not treated as semantic proof of this fix.

## Regression proof

The defect is reproduced by the normal `PolicyEngine` construction:

```text
evaluatePure()
  -> computePolicyId()
  -> authorization.policy_id
```

while the removed verifier expectation was derived through:

```text
config.engine.computePolicyId()
  -> expectedPolicyId
```

Both values came from the same engine instance and the same policy derivation.

A focused A-8 regression test now pins this relationship using a real `PolicyEngine`:

```ts
engine.evaluatePure(...).authorization.policy_id === engine.computePolicyId()
```

This demonstrates why recomputation from the same producer is not an independent policy-authority constraint.

A-9 verifies that `validateConfig()` no longer requires `computePolicyId()` solely to support the removed comparison. This test is scoped to configuration validation and does not declare arbitrary third-party engines to be a supported public extension surface.

Existing negative coverage for tampered signatures, unknown issuers, wrong audience, and expired authorizations remains green.

A source scan confirms that no active `expectedPolicyId` value remains on the local direct path.

`gateway.ts` is unmodified, and no delegation-path behavior changed.

## Scope

* [x] No unrelated changes
* [x] No required CI check weakened, bypassed, or made advisory
* [x] No production behavior changed unless explicitly described
* [x] Documentation updated where required

No conformance vectors were modified.

No normative specification was changed beyond the provenance clarification required by this issue.

## Related issue

Closes #316