### PR TITLE
docs(replay): clarify conformance and durability boundary

### DIFF
--- a/docs/architecture/replay-store-ttl-alignment.md
+++ b/docs/architecture/replay-store-ttl-alignment.md
@@ -1,7 +1,7 @@
 # OxDeAI Replay-Store TTL Alignment
 
 **Status:** Non-normative (developer documentation)
-**Scope:** Replay-store TTL requirements, durability tiers, timing constraints, and operational guidance for production deployments
+**Scope:** Replay-store TTL requirements, deployment durability assumptions, timing constraints, and operational guidance for production deployments
 
 ---
 
@@ -11,6 +11,16 @@ This document complements:
 - [`docs/architecture/key-custody-and-rotation.md`](./key-custody-and-rotation.md) — key lifecycle (replay retention relates to authorization expiry)
 - [`packages/guard/src/replayStore.ts`](../../packages/guard/src/replayStore.ts) — `ReplayStore` interface and in-memory implementation
 - [`packages/guard/src/replayStore.redis.ts`](../../packages/guard/src/replayStore.redis.ts) — Redis implementation and `computeTtl`
+
+The [normative store contract](../spec/verification/verification-v1.md#43-replay-store-contract-and-deployment-boundary)
+requires atomic consume and retention throughout possible acceptance in the declared
+replay domain. Backend examples below are integration sketches, not deployment
+certifications. Generic conformance and the current corpus do not prove crash/restart
+behavior, arbitrary interleavings, replica visibility, persistence configuration,
+topology correctness, HA/SLA, or recovery. Restart resistance needs deployment evidence.
+
+Consumption spends an entitlement, not proof of a completed effect. A crash after
+consume and before execution may leave it spent without an effect.
 
 **Core invariant:**
 
@@ -27,7 +37,7 @@ An authorization artifact has a **validity window** — the period between `issu
 The alignment rule is:
 
 ```text
-replay store entry retention ≥ authorization validity window
+replay store entry retention ≥ remaining possible acceptance period at consume
 ```
 
 `authorization validity window = expiry − issued_at`
@@ -39,11 +49,13 @@ An entry that is evicted while the authorization is still unexpired creates a **
 - `expiry` / `expires_at` — the guard rejects the authorization after this time (`AUTH_EXPIRED`)
 - Replay TTL — the guard rejects re-use of `auth_id` for this duration
 
-If the replay TTL is too short, the authorization expires naturally before any replay window opens. If the authorization's expiry window is long, the replay TTL must match.
+If replay TTL is too short, eviction can reopen replay while the authorization is still acceptable. Retention must cover the remaining acceptance period across the declared domain, including verifier clock differences.
 
 ---
 
 ## 2. Replay Lifecycle
+
+This example assumes aligned verifier clocks; the eviction shown is too early.
 
 ```text
                                       ┌── replay store entry evicted
@@ -53,18 +65,18 @@ If the replay TTL is too short, the authorization expires naturally before any r
 ────┼────────────────┼───────────────┼────────────┼──────────►  time
     │                │               │            │
     │◄──────────────►│               │            │
-    │  validity      │               │            │
-    │  window        │               │            │
+    │  before first  │               │            │
+    │  consume       │               │            │
     │                │◄─────────────►│            │
     │                │  replay TTL   │            │
-    │                │  (minimum)    │            │
+    │                │  (too short)  │            │
     │
     │ LIFECYCLE STATES:
     │
     │  [ISSUABLE] issued_at → first use
     │      auth_id not yet consumed; authorization is valid
     │
-    │  [CONSUMED] first use → eviction / expiry (whichever is later)
+    │  [CONSUMED] first use → eviction
     │      auth_id consumed; replay attempts denied
     │
     │  [EXPIRED-CONSUMED] expiry reached, entry still in store
@@ -80,7 +92,7 @@ If the replay TTL is too short, the authorization expires naturally before any r
     │      (or store would have returned true — still safe)
 ```
 
-**The only dangerous state is EVICTED-VALID.** Correct TTL alignment eliminates it.
+EVICTED-VALID illustrates early eviction. Lost history after restart or failover can create the same risk even with a correct TTL.
 
 ---
 
@@ -92,13 +104,13 @@ If the replay TTL is too short, the authorization expires naturally before any r
 replay_ttl(auth) ≥ auth.expiry − now_at_consume
 ```
 
-Where `now_at_consume` is the clock time at the moment `consumeAuthId` is called (the first execution). Equivalently, since `consumeAuthId` is called before expiry:
+Under aligned verifier/store clock and expiry assumptions, `now_at_consume` is the clock time when `consumeAuthId` is called, before execution. A conservative bound under those assumptions is:
 
 ```text
 replay_ttl(auth) ≥ auth.expiry − auth.issued_at   (conservative bound)
 ```
 
-Using `auth.expiry − now_at_consume` produces a tighter and correct TTL. Using `auth.expiry − auth.issued_at` is a safe over-estimate — the entry persists slightly longer than strictly necessary but eliminates all replay windows.
+These bounds assume eviction cannot precede the last permissible acceptance anywhere in the replay domain. The full issuance window is not required when only a shorter acceptance period remains.
 
 The Redis implementation uses the tighter bound:
 
@@ -113,39 +125,37 @@ The minimum of 1 second prevents zero-TTL or negative-TTL conditions for already
 
 ### Rule 2 — Clock Skew Buffer
 
-Clock skew between the issuer, guard host, and replay store can cause the guard's `now` to differ from the issuer's clock at signing time. A skew of ±30 seconds is typical for NTP-synchronized hosts.
-
-To account for skew, add a buffer:
-
-```text
-replay_ttl(auth) ≥ (auth.expiry − now_at_consume) + clock_skew_buffer
-```
-
-Recommended buffer: **60 seconds** for standard deployments; **120 seconds** for distributed multi-region deployments.
-
-The Redis implementation does not add a buffer — it relies on the expiry check in `verifyAuthorization` being the primary expiry gate, and uses TTL only for garbage collection. Deployers requiring strict skew tolerance should set a longer authorization expiry window rather than relying on store TTL.
-
-### Rule 3 — Minimum Retention Regardless of Expiry
-
-Even if `expiry − now` evaluates to zero or negative (already-expired artifact), the store entry must be retained for at least 1 second. This prevents edge cases at exact expiry boundaries where a race between eviction and a concurrent replay attempt could permit a brief window.
+Verifier clocks (including injected verification time), the adapter's local wall
+clock, and store expiry behavior must be aligned or bounded. Any retention buffer
+must cover the deployment's actual maximum acceptance difference; a generic number
+or NTP configuration alone does not prove that bound.
 
 ```text
-replay_ttl ≥ max(1, expiry − now_at_consume)
+replay_ttl(auth) ≥ remaining acceptance period across all verifiers in the domain
 ```
 
-This is exactly what `computeTtl` enforces.
+The Redis adapter adds no buffer. If its TTL cannot meet the domain's retention
+requirement, use a store policy that can, or block execution while required history
+is indeterminate. Extending issuer expiry also extends acceptance; it does not fix
+an eviction/verification clock mismatch.
+
+### Rule 3 — Adapter Minimum TTL
+
+`computeTtl` floors TTL at one second to avoid invalid zero/negative TTL values.
+This implementation detail is not a normative retention duration or proof against
+clock mismatch. Expired artifacts are independently rejected by verification.
 
 ### Rule 4 — Delegation ID TTL
 
 `consumeDelegationId` follows the same rules as `consumeAuthId`. The `opts.expiry` passed is the delegation's expiry, not the parent authorization's. The stricter of the two (parent auth expiry or delegation expiry) governs the effective validity window. In practice, delegations must not exceed the parent authorization's expiry (`DELEGATION_EXPIRY_EXCEEDS_PARENT`), so delegation TTL ≤ parent auth TTL.
 
-### Summary Formula
+### Illustrative Buffered Formula
 
 ```text
 replay_ttl_seconds = max(1, auth.expiry − floor(Date.now() / 1000)) + optional_buffer
 ```
 
-For a 5-minute authorization window with 60-second buffer:
+For illustration only, assuming a justified 60-second retention buffer (not added by the built-in adapter):
 
 ```text
 issued_at = T
@@ -171,17 +181,17 @@ const store = createInMemoryReplayStore();
 | TTL / eviction | No — entries persist until process ends (no GC) |
 | Multi-process | No — each process has an independent `Set` |
 | Restart durability | No |
-| Production-ready | Development and single-process testing only |
+| Scope | One store instance lifetime; no deployment durability claim |
 
 **Limitations:**
 - Grows unboundedly — `auth_id` entries are never evicted. For long-lived processes handling high volume, memory pressure accumulates.
 - Does not prevent replay across process restarts or across multiple guard instances.
 - The `opts.expiry` parameter is accepted but ignored.
 
-**When it is safe to use:**
-- Single-process deployments where replay risk is acceptable if the process restarts.
-- Development and test environments.
-- Short-lived processes (e.g., a Lambda function handling a single request).
+**Scope:** Suitable for tests or an explicitly bounded store-instance lifetime.
+If still-valid authorizations can be accepted after restart or by another store
+instance, preserve shared authoritative history or block that acceptance. Short
+artifact lifetime alone does not make lost history safe.
 
 ### 4.2 Redis Store (`createRedisReplayStore`)
 
@@ -192,11 +202,11 @@ const store = createRedisReplayStore({ client: redis });
 | Property | Value |
 |---|---|
 | Atomicity | Yes — `SET NX EX` is a single atomic Redis command |
-| Persistence | Configurable — AOF/RDB persistence survives restarts |
+| Persistence | Depends on configuration and assessed loss/recovery behavior |
 | TTL / eviction | Yes — key expires at `max(1, expiry − now)` seconds |
-| Multi-process | Yes — all instances share one Redis cluster |
-| Restart durability | Yes (with Redis persistence enabled) |
-| Production-ready | Yes |
+| Multi-process | Requires all domain participants to use the authoritative keyspace |
+| Restart durability | Requires deployment evidence; enabling persistence alone is insufficient |
+| Deployment compliance | Requires evidence for the declared domain and failure model |
 
 **Key schema:**
 ```text
@@ -206,14 +216,12 @@ replay:delegation:<delegation_id> → "1" with TTL
 
 **Atomicity mechanism:** `SET key value NX EX ttl` either sets the key and returns `"OK"` (first use) or returns `null` (key exists — replay). No TOCTOU window exists; the check and set are one operation.
 
-**Persistence configuration:**
-- Enable AOF (`appendonly yes`) or RDB snapshots for restart durability.
-- Without persistence, a Redis restart drops all replay state — equivalent to an in-memory store for the post-restart window.
-- For regulated or high-security deployments, enable AOF with `appendfsync always`.
-
-**Cluster behavior:**
-- Redis Cluster: keys are sharded by slot. `auth_id` values are distributed across slots by default. All `SET NX EX` operations remain atomic per-slot; cross-slot TOCTOU is not a concern because each `auth_id` maps to exactly one slot.
-- Redis Sentinel: automatic failover; short window during failover where store may be unavailable → guard throws → DENY (fail-closed).
+**Persistence and topology:** AOF/RDB settings, replicas, Cluster, or Sentinel do
+not by themselves establish the retention contract. Assess acknowledged-write loss,
+failover visibility, eviction policy, and recovery for the declared domain. Atomic
+commands on one authoritative keyspace do not prove atomic consume across independent
+primaries. Unavailable or indeterminate required history must block execution,
+including after recovery; a reachable empty store is not evidence that IDs are unused.
 
 **Client compatibility:**
 - ioredis: native positional argument style — compatible directly.
@@ -242,13 +250,13 @@ const store: ReplayStore = {
 | Property | Value |
 |---|---|
 | Atomicity | Yes — `INSERT ... ON CONFLICT DO NOTHING` is atomic per row |
-| Persistence | Yes — full ACID guarantees |
+| Persistence | Depends on transaction, storage, and recovery configuration |
 | TTL / eviction | Manual — requires a scheduled cleanup job (e.g., `DELETE WHERE expires_at < now()`) |
 | Multi-process | Yes |
-| Restart durability | Yes |
-| Production-ready | Yes, with proper index on `(auth_id)` and periodic eviction |
+| Restart durability | Requires deployment-specific evidence |
+| Deployment compliance | Requires domain-wide uniqueness, retention, and failure evidence |
 
-**TTL note:** Relational databases do not have native per-row TTL. An eviction job must run at interval to remove expired entries. The eviction interval should be short enough that the table does not grow unboundedly, but this is a maintenance concern — entries are rejected by the expiry check before the store lookup regardless.
+**TTL note:** This sketch uses scheduled cleanup; deletion is safe only after all domain verifiers reject the artifact. An eviction job must run at interval to remove expired entries. The eviction interval should be short enough that the table does not grow unboundedly, but this is a maintenance concern — entries are rejected by the expiry check before the store lookup regardless.
 
 ### 4.4 DynamoDB Store
 
@@ -279,13 +287,15 @@ const store: ReplayStore = {
 | Property | Value |
 |---|---|
 | Atomicity | Yes — conditional `PutItem` with `attribute_not_exists` is atomic |
-| Persistence | Yes — DynamoDB is durable by default |
-| TTL / eviction | Yes — native DynamoDB TTL attribute (eventual eviction, up to 48h lag) |
+| Persistence | Backend guarantees must be assessed against the deployment failure model |
+| TTL / eviction | Native TTL attribute; deletion is eventual |
 | Multi-process | Yes |
-| Restart durability | Yes |
-| Production-ready | Yes |
+| Restart durability | Requires deployment-specific evidence |
+| Deployment compliance | Requires evidence for the declared domain and failure model |
 
-**DynamoDB TTL note:** DynamoDB TTL eviction is eventual — items may persist for up to 48 hours after the TTL timestamp. This is safe: items are only evicted after they expire, never before. A consumed `auth_id` will not be evicted while the authorization is still valid; the authorization's expiry check fires first.
+**TTL note:** Delayed eviction is compatible with replay retention. The configured
+TTL timestamp must not precede the last permissible acceptance across the domain;
+backend choice alone does not establish that alignment or cross-region atomicity.
 
 ### 4.5 Shared `Map` (test / multi-instance simulation)
 
@@ -312,22 +322,13 @@ const store: ReplayStore = {
 
 ### 5.1 Clock Skew
 
-Clock skew between the issuer (signing time), the guard host (verification time), and the Redis server (TTL base) can cause subtle misalignments:
+The relevant comparison is the adapter/store eviction time against every verifier's
+last permissible acceptance time, not simply issuer versus guard wall time. A slower
+verifier may still accept an artifact after a faster host's computed TTL elapses.
+Bound these differences and retain accordingly. Extending authorization expiry or
+adding a verification grace period extends the required retention period too.
 
-```text
-Issuer clock: T
-Guard clock:  T + Δ   (Δ = skew, typically ±30s for NTP-synced hosts)
-Redis clock:  T + δ   (δ = skew relative to guard host, typically <1s for co-located Redis)
-```
-
-**Effect on TTL:**
-- If guard clock is ahead of issuer (`Δ > 0`): computed TTL = `expiry − (T + Δ)` is shorter than `expiry − T`. The store entry is evicted slightly earlier than the issuer intended.
-- If guard clock is behind issuer (`Δ < 0`): computed TTL is longer. Entry persists slightly longer — no security impact.
-
-**Mitigation:**
-- Keep guard hosts NTP-synchronized (±1 second typical).
-- Add a clock skew buffer to the authorization expiry window (e.g., issue authorizations with `expiry = now + window + 60s`). This is an issuer-side concern.
-- Do not rely on replay store eviction for security — the expiry check in `verifyAuthorization` is the primary gate.
+The following timing examples assume aligned clocks and unchanged acceptance rules.
 
 ### 5.2 Delayed Delivery
 
@@ -369,11 +370,11 @@ For stores with TTL-based eviction (Redis):
 
 ### 5.5 Distributed Clock Drift
 
-In multi-region deployments, guard instances in different regions may have clocks drifted by up to several seconds even with NTP. The computed TTL at each instance will differ by this drift amount.
-
-**Safe direction:** If one instance computes a shorter TTL and evicts the key while another instance would not have evicted it yet, the expiry check provides the backstop — the authorization's `expiry` field is an absolute timestamp verified independently.
-
-**Unsafe direction:** Clock drift could in theory cause one guard instance to accept an authorization (its clock says `now < expiry`) while another rejects it (`now ≥ expiry`). This is an expiry-consistency concern, not a replay-store concern. Mitigate with NTP synchronization and a short expiry grace period.
+If an entry expires while any verifier in the domain still accepts the artifact,
+replay can succeed. An absolute expiry timestamp does not eliminate clock differences.
+This is a replay-retention concern as well as an expiry-consistency concern. Validate
+the domain's clock bounds and retention policy; do not accept through an indeterminate
+history window.
 
 ---
 
@@ -388,7 +389,7 @@ In multi-region deployments, guard instances in different regions may have clock
 | **Expected verifier behavior** | Replay succeeds; guard executes the action again |
 | **Operational impact** | Authorization reuse within the original expiry window is possible |
 | **Fail-closed outcome** | Not fail-closed — this is the primary misconfiguration risk |
-| **Mitigation** | Enforce Rule 1: TTL ≥ authorization validity window. Add skew buffer. |
+| **Mitigation** | Retain through the last permissible acceptance in the declared domain, including bounded clock differences. |
 
 ### RT-2: Authorization Still Valid After Replay Eviction
 
@@ -398,7 +399,7 @@ In multi-region deployments, guard instances in different regions may have clock
 | **Enforcement point** | Expiry check still rejects if `now ≥ expiry`; but if `now < expiry`, replay succeeds |
 | **Expected verifier behavior** | Second execution allowed |
 | **Fail-closed outcome** | No — depends on TTL alignment correctness |
-| **Mitigation** | Use `computeTtl(expiry) = max(1, expiry − now)` (as the Redis implementation does). Never set TTL shorter than `expiry − issued_at`. |
+| **Mitigation** | Validate retention against every domain verifier; the default adapter formula assumes clock alignment. |
 
 ### RT-3: Process Restart Loses Replay State
 
@@ -409,7 +410,7 @@ In multi-region deployments, guard instances in different regions may have clock
 | **Expected verifier behavior** | Replayed authorizations succeed after restart |
 | **Operational impact** | Any authorization consumed before restart can be replayed until its expiry |
 | **Fail-closed outcome** | Not fail-closed for the restart window |
-| **Mitigation** | Use a durable backend-backed store (Redis with persistence, PostgreSQL, DynamoDB) for production. In-memory store is explicitly development-only. |
+| **Mitigation** | Preserve authoritative history across the declared restart boundary, or block acceptance until required history is known or affected authorizations can no longer be accepted. |
 
 ### RT-4: Distributed Store Inconsistency
 
@@ -446,8 +447,8 @@ In multi-region deployments, guard instances in different regions may have clock
 
 | Field | Detail |
 |---|---|
-| **Description** | Guard host clock is ahead of issuer clock by Δ seconds; computed TTL = `expiry − (T + Δ)` is shorter than intended |
-| **Enforcement point** | Expiry check still fires at `expiry` per guard clock; replay store entry expires at `expiry − Δ` per guard clock |
+| **Description** | Adapter wall clock is ahead of a domain verifier by Δ seconds; computed retention may end while that verifier still accepts |
+| **Enforcement point** | The slower verifier still sees `now < expiry` after the entry is evicted |
 | **Expected verifier behavior** | Window of replay risk = `Δ` seconds before expiry (entry evicted before expiry check fires) |
 | **Fail-closed outcome** | Partially — replay is possible within the skew window |
 | **Mitigation** | Add a skew buffer to TTL: `TTL = max(1, expiry − now + skew_buffer)`. Sync clocks with NTP. |
@@ -479,7 +480,7 @@ In multi-region deployments, guard instances in different regions may have clock
 | **Enforcement point** | Post-restart, lost entries are unknown to the store; replay is possible |
 | **Operational impact** | Window of vulnerability = entries consumed since last persistence sync |
 | **Fail-closed outcome** | Not fully fail-closed for lost entries |
-| **Mitigation** | Use `appendfsync always` for maximum durability (performance trade-off). For most deployments, `appendfsync everysec` is an acceptable balance — at most 1 second of entries may be lost on crash. |
+| **Mitigation** | Assess persistence and recovery against the declared failure model. Losing still-required consumed IDs violates retention; block execution if their history cannot be established. No persistence setting alone certifies compliance. |
 
 ---
 
@@ -493,19 +494,14 @@ Always compute TTL from the authorization's absolute expiry, not from a static c
 TTL = max(1, auth.expiry − floor(now_seconds)) + clock_skew_buffer
 ```
 
-Recommended clock skew buffers by deployment type:
-
-| Deployment | Skew buffer |
-|---|---|
-| Single-host | 0 (NTP-synced clocks) |
-| Multi-host same region | 30 seconds |
-| Multi-host multi-region | 60–120 seconds |
+Derive the buffer from measured/enforced clock and expiry bounds for the declared
+domain. This is deployment guidance, not a new adapter option or a conformance proof.
 
 ### 7.2 Monitoring Signals
 
 | Signal | Threshold | Meaning |
 |---|---|---|
-| `auth_id` consume rate (true) | Baseline | Normal execution flow |
+| `auth_id` consume rate (true) | Baseline | Entitlements spent; not a count of completed effects |
 | `auth_id` consume rate (false) | > 0 | Replay attempts detected |
 | Store error rate | > 0 | Replay store degraded; executions being denied |
 | Store latency (P99) | > 50ms | Store under load; risk of timeout → DENY |
@@ -520,13 +516,12 @@ Recommended clock skew buffers by deployment type:
 Guard: 1 instance
 Replay store: createInMemoryReplayStore()
 Durability: none (process restart resets)
-Risk: replay after restart (acceptable for low-risk, short-lived deployments)
+Scope: one store instance lifetime; no protection across lost history
 ```
 
 **Checklist:**
-- [ ] Authorization expiry window is short (< 5 minutes recommended)
-- [ ] Process restarts are infrequent and audited
-- [ ] Not used for high-value or regulated actions
+- [ ] Domain is explicitly limited to the store instance lifetime
+- [ ] Still-valid artifacts cannot be accepted elsewhere or after history loss
 
 #### HA Deployment (Multi-Instance, Same Region)
 
@@ -534,14 +529,14 @@ Risk: replay after restart (acceptable for low-risk, short-lived deployments)
 Guard: N instances behind a load balancer
 Replay store: createRedisReplayStore({ client: redis })
 Redis: single-primary with replica(s) + Sentinel for failover
-Durability: AOF persistence (appendfsync everysec)
+Durability: assess persistence, acknowledged-write loss, failover, and recovery
 ```
 
 **Checklist:**
-- [ ] Redis persistence enabled (`appendonly yes`)
-- [ ] Sentinel or Cluster for HA
-- [ ] TTL = `max(1, expiry − now)` (default `computeTtl`)
-- [ ] Clock skew buffer: 30 seconds added to authorization expiry window (issuer-side)
+- [ ] Persistence/recovery retains all still-required consumption history
+- [ ] Failover preserves authoritative history or blocks acceptance
+- [ ] Adapter TTL covers all domain acceptance windows
+- [ ] Retention accounts for bounded verifier/store clock differences
 - [ ] Guard handles Redis errors by DENY (no fallback to in-memory)
 - [ ] Monitor: replay rate, store error rate, P99 latency
 
@@ -559,37 +554,36 @@ Offline verification (`createVerifier` / `verifyAuthorization`) does not enforce
 
 ```text
 Guard: instances in region A and region B
-Replay store: Redis Cluster with cross-region replication, or DynamoDB global tables
-Durability: full persistence
-Clock skew buffer: 120 seconds
+Replay store: domain-wide atomic consume with assessed retention and visibility
+Durability: deployment-specific evidence required
+Clock skew buffer: derived from domain acceptance bounds
 ```
 
 **Checklist:**
-- [ ] Cross-region replication lag is accounted for in authorization expiry window
-- [ ] DynamoDB global tables or Redis Enterprise active-active for multi-region atomic SET NX
-- [ ] Clock skew buffer 120 seconds (issuer-side expiry extension)
-- [ ] Replay entries in region A are visible to region B within replication lag window
-- [ ] Accept brief replay window equal to replication lag if using eventually-consistent replication
+- [ ] Same ID/domain cannot be consumed successfully in two regions
+- [ ] Acknowledged consumes remain authoritative during failover and recovery
+- [ ] Retention covers every region's acceptance window
+- [ ] Replica lag cannot permit reuse; unavailable/indeterminate history blocks execution
 
 ### 7.4 Production Checklist
 
 ```
 REPLAY STORE SELECTION
-[ ] Use createRedisReplayStore or equivalent durable backend in production
-[ ] createInMemoryReplayStore is limited to development/test
+[ ] Declare the replay domain and select a store satisfying its contract
+[ ] In-memory scope ends with the store instance; do not accept through lost history
 
 ATOMICITY
 [ ] consumeAuthId uses atomic check-and-set (SET NX EX for Redis; INSERT ON CONFLICT for SQL)
 [ ] No read-then-write patterns
 
 PERSISTENCE
-[ ] Redis: appendonly yes + appendfsync everysec (or always for regulated deployments)
-[ ] All guard instances share the same store
+[ ] Validate persistence, replica visibility, and recovery for the declared failure model
+[ ] All domain participants share authoritative consumption history
 
 TTL
 [ ] TTL derived from auth.expiry, not a static constant
-[ ] TTL = max(1, expiry − now)
-[ ] Optional clock skew buffer added at the issuer (authorization expiry window)
+[ ] Retention covers the last permissible acceptance across the domain
+[ ] Any retention buffer covers bounded clock differences, not an issuer expiry extension
 
 FAIL-CLOSED
 [ ] Store errors propagate as throws — no silent fallback

--- a/docs/spec/artifacts/delegation-v1.md
+++ b/docs/spec/artifacts/delegation-v1.md
@@ -228,7 +228,25 @@ A `DelegationV1` artifact MUST NOT be used as the parent of another `DelegationV
 
 `delegation_id` is the replay nonce. Implementations that track consumed delegation IDs MUST reject a `DelegationV1` whose `delegation_id` has been previously seen in the same policy scope.
 
-Implementations that do not track consumed IDs MUST document this as a deployment assumption. Fail-closed behavior is REQUIRED if replay state is ambiguous.
+The optional `consumed_ids` input describes standalone artifact verification; it
+does not waive replay resistance required by an execution profile. Implementations
+that do not track consumed IDs MUST document that limitation and MUST NOT claim
+replay-resistant execution on that basis. A PEP whose profile requires replay
+resistance MUST enforce the [replay-store contract](../verification/verification-v1.md#43-replay-store-contract-and-deployment-boundary)
+in its declared/configured replay domain. Fail-closed behavior is REQUIRED if
+required replay state is unavailable or ambiguous.
+
+Whether separate `delegation_id` consumption is required is determined by the
+declared artifact/execution profile and replay model. An implementation MUST NOT
+omit replay tracking required by that profile merely because another identifier
+is consumed. Unavailable or indeterminate required replay state MUST block
+protected execution.
+
+As implementation behavior, the current TypeScript Guard always consumes the
+parent `auth_id`, including when its store lacks `consumeDelegationId`. This is
+not a general protocol rule permitting `delegation_id` tracking to be omitted,
+and does not authorize repeated use of a parent for distinct delegations.
+Optional tracking is not a deployment durability claim.
 
 ### 4.6 Fail-Closed Conditions
 
@@ -359,9 +377,13 @@ A PEP that accepts `DelegationV1` as an authorization credential MUST:
 
 1. Resolve the parent `AuthorizationV1` locally (from cache or request context - no live control plane call)
 2. Run the full verification algorithm above
-3. Execute the action only if verification returns `ALLOW`
-4. Record a delegation audit event referencing both `delegation_id` and `parent_auth_hash`
-5. Mark `delegation_id` as consumed if replay tracking is active
+3. After successful verification/authentication, atomically consume the required replay entitlement under §4.5; unavailable or indeterminate required replay state MUST block execution
+4. Execute the action only if verification returns `ALLOW` and required consumption succeeds
+5. Record a delegation audit event referencing both `delegation_id` and `parent_auth_hash`
+
+A consumed entitlement is not a completed action. Failure or crash between steps
+3 and 4 can spend it without execution; restart persistence is a deployment
+property, not proof supplied by this verification algorithm.
 
 A PEP MUST NOT:
 

--- a/docs/spec/conformance/conformance-v1.md
+++ b/docs/spec/conformance/conformance-v1.md
@@ -215,6 +215,35 @@ subsequent prohibited reuse
 
 Replay tests MUST use the replay identifier and replay scope defined by the relevant artifact or profile.
 
+Three boundaries MUST remain distinct:
+
+1. **Implementation conformance:** authenticate/verify before authoritative replay
+   mutation; consume before protected execution; unauthenticated input MUST NOT
+   mutate trusted replay state. Required replay-state unavailability or an
+   indeterminate result MUST prevent protected execution.
+2. **Normative store contract:** atomic consume permits at most one success for
+   the same identifier/domain under concurrency, retains consumed IDs throughout
+   their possible acceptance window, and never treats store failure as success.
+   No backend technology is mandated; see [verification §4.3](../verification/verification-v1.md#43-replay-store-contract-and-deployment-boundary).
+3. **Deployment compliance:** restart persistence, replica sharing/visibility,
+   persistence configuration, topology, HA/SLA and recovery guarantees require
+   deployment-specific evidence. Generic conformance MUST NOT be presented as
+   proof of these properties.
+
+The replay domain MUST be declared/configured; local code cannot infer every
+valid deployment boundary. “Same security history implies the same decision” is
+only meaningful with the same trusted inputs and available, authoritative replay
+state. Loss or unavailability of required history MUST fail closed rather than
+reconstructing a permissive decision from missing state.
+
+Consumed means entitlement spent, not effect completed. A crash after consume
+and before effect can spend an authorization without execution. The current
+corpus does not prove crash/restart behavior, arbitrary concurrent interleavings
+or deployment persistence. Guard tests cover selected shared-instance and error
+paths; the Redis unit tests use an in-memory fake and selected concurrency/TTL
+cases. Neither those tests nor portable replay vectors certify a deployed
+backend's durability. They do not weaken its required store contract.
+
 Replay semantics MUST NOT be generalized across artifacts.
 
 For example, the presence of an optional nonce in an artifact does not establish replay protection unless its specification defines the required replay-state behavior.

--- a/docs/spec/core/trusted-time-v1.md
+++ b/docs/spec/core/trusted-time-v1.md
@@ -312,6 +312,18 @@ the trusted-time gates is preserved.
 
 ### 7.1 Persisted window state and deployment migration
 
+Persisted window state here means retained policy state; its use does not prove
+restart persistence or a replay backend's durability. Deterministic evaluation
+assumes identical trusted inputs and available authoritative state, not merely
+the same past security events. Required state that is unavailable or indeterminate
+MUST NOT be treated as empty history permitting protected execution.
+
+The nonce-retention rules in §2.1/§7 remain mandatory for their declared domain.
+They do not replace the authorization/delegation entitlement store contract in
+[verification §4.3](../verification/verification-v1.md#43-replay-store-contract-and-deployment-boundary),
+or establish replica visibility, topology, persistence configuration, HA/SLA or
+recovery guarantees. Those require deployment evidence.
+
 The state schema is unchanged. Before the trusted-clock migration, existing
 `window_start` values may have been derived from attacker-controlled
 `intent.timestamp`; trusted and legacy values cannot be distinguished

--- a/docs/spec/enforcement/pep-gateway-v1.md
+++ b/docs/spec/enforcement/pep-gateway-v1.md
@@ -290,7 +290,21 @@ The gateway **MUST** enforce replay resistance.
 ### 12.2 Minimum Model
 
 * Unique authorization identifier (`auth_id`)
-* Persistent consumption tracking
+* Atomic consumption tracking in a declared/configured replay domain
+* Retention of consumed IDs while their authorizations could otherwise still be accepted
+
+The gateway MUST authenticate/verify before authoritative replay mutation and
+consume before the protected side effect. Unauthenticated input MUST NOT mutate
+trusted replay state. Required replay-state failure, unavailability or an
+indeterminate consume result MUST block execution; it MUST NOT become permissive
+success. The [store contract](../verification/verification-v1.md#43-replay-store-contract-and-deployment-boundary)
+mandates atomicity and retention, not a backend technology.
+
+“Tracking” does not itself prove restart persistence, replica sharing, backend
+persistence settings, topology correctness, HA/SLA or recovery guarantees. Those
+are deployment properties. A successful consume spends the authorization; it does
+not prove execution completed or even started. A crash between consume and effect
+may leave a spent authorization with no effect.
 
 ---
 

--- a/docs/spec/interoperability/external-provider-profile.md
+++ b/docs/spec/interoperability/external-provider-profile.md
@@ -452,7 +452,17 @@ A provider or adapter claiming OxDeAI interoperability MUST:
 ### 4.7 Replay Safety
 
 - Never issue the same `auth_id` twice
-- Size `auth_id` replay store TTL as: `max(1, expiry − now)` per [replay-store TTL alignment guide](../../architecture/replay-store-ttl-alignment.md)
+- Declare/configure the replay domain and retain consumed IDs while any verifier
+  in that domain could otherwise still accept the authorization.
+- `max(1, expiry − now)` is the current Redis adapter's TTL calculation, not a
+  generic clock-skew or durability guarantee. Validate its alignment with all
+  verifier clocks/acceptance windows; see the non-normative
+  [TTL guide](../../architecture/replay-store-ttl-alignment.md).
+- Profiles A/B/C require atomic, fail-closed consumption before protected
+  execution under [verification §4.3](../verification/verification-v1.md#43-replay-store-contract-and-deployment-boundary).
+  Unavailable/indeterminate required replay state MUST block execution.
+- Consumption spends the entitlement; it does not prove an effect occurred.
+  Restart resistance, replica visibility and recovery require deployment evidence.
 
 ---
 
@@ -511,7 +521,13 @@ Any ambiguity → DENY:
 - `createPepGatewayExecutor` supports Profiles A and B (gateway-level only; no live-state access)
 - `OxDeAIGuard` supports Profiles A, B, and C (with `computeStateHash` for B and C)
 - Profile C requires `OxDeAIGuard`, `getState`, `setState`, and `computeStateHash` correctly configured
-- In-memory replay store is development-only; not production-grade for multi-process or restart-durable deployments
+- An in-memory store can exercise the implementation contract within its instance
+  lifetime. It does not establish replay protection across process restarts or
+  separate store instances.
+- “Production” in this integration matrix describes an available integration
+  surface, not certification of replay-store durability, topology, replica
+  visibility, backend persistence configuration, HA/SLA or recovery. Deployment
+  suitability must be assessed against the declared replay domain.
 
 ---
 
@@ -604,7 +620,9 @@ no partial acceptance, and no advisory-only path.
   as complete `(issuer, policyId)` pairs. A trusted signing key is not policy authority:
   a valid signature only proves that a trusted key for the *claimed* issuer signed the
   artifact (#301). Missing authority configuration **MUST** fail closed.
-- Use any replay store; in-memory for development, durable backend for production
+- Use a replay store satisfying the atomicity, retention and fail-closed contract
+  for the declared replay domain; assess restart and cross-instance guarantees
+  separately for the deployment. No backend technology is mandated.
 - No `computeStateHash` configuration needed
 
 ### Profile B: External provider wire-compatible

--- a/docs/spec/verification/verification-v1.md
+++ b/docs/spec/verification/verification-v1.md
@@ -66,21 +66,56 @@ A durable mutation is any write a verifier or enforcement boundary makes that
 outlives the current request and can affect a later authorization decision —
 replay-store consumption is the canonical example. Authentication here means the
 artifact's signature has been verified against configured trust anchors; a
-structural or presence check is not authentication.
+structural or presence check is not authentication. Here “durable” means surviving
+this request, including a write to an in-memory store; it does not assert restart
+persistence or require a particular persistence technology.
 
 This rule constrains **the ordering of side effects relative to authentication**.
 It does **NOT** make any store operation mandatory, does **NOT** prescribe a store
 implementation, and does **NOT** dictate the ordering of checks *within*
 verification — that is a separate question.
 
-The operative consequence is that a rejected artifact must leave no trace that
-can deny a later legitimate one. Where a boundary both authenticates and consumes
+The operative consequence is that unauthenticated input MUST NOT leave trusted
+replay state that can deny a later legitimate presentation. Where a boundary both authenticates and consumes
 a single-use identifier, the consume **MUST** follow successful authentication and
 **MUST** still precede the protected side effect. Atomicity of the consume is a
 property of the store operation, not of where it is called, so moving it after
 authentication does not weaken replay protection: two concurrent presentations of
-the same identifier still resolve to exactly one consumer, and neither executes
-before consuming.
+the same identifier permit at most one successful consume within the declared
+replay domain, and neither may execute without successful consumption. Store
+unavailability can prevent both from executing.
+
+### 4.3 Replay-Store Contract and Deployment Boundary
+
+Where an artifact or execution profile requires replay resistance:
+
+- The replay identifier and domain MUST be declared/configured. All boundaries
+  accepting the same entitlement within that domain MUST participate in its
+  consumption contract. Local code cannot infer every valid deployment boundary.
+- Consume MUST atomically check and spend the entitlement: at most one consume
+  for the same identifier/domain may succeed under concurrency while that
+  entitlement remains protected. Atomicity is a store contract, not evidence of
+  backend durability. No backend technology is mandated.
+- Consumed identifiers MUST remain unavailable for reuse while the protected
+  authorization could otherwise still be accepted in that domain. Eviction or
+  TTL policy MUST account for the domain's acceptance window and verifier clocks.
+- Store failure, unavailability or an indeterminate required replay result MUST
+  NOT become permissive success. Without a definitive successful consume, the
+  boundary MUST NOT perform the protected side effect.
+
+Consumption means **entitlement spent**, not **effect completed**. A crash after
+consume and before the effect may spend the authorization without the effect
+occurring. A later denial, CAS conflict, hook failure or partial sequence of
+consumes does not imply rollback of a prior successful consume. This contract
+provides no transaction between replay state and the external effect.
+
+Implementation conformance checks ordering and fail-closed behavior against this
+contract. Restart persistence, replica sharing/visibility, backend persistence
+configuration, topology correctness, HA/SLA and recovery guarantees require
+separate deployment evidence. Restart resistance is a deployment property;
+generic conformance does not establish it. This separation does not permit a
+replay-resistant deployment to accept an identifier whose required consumption
+history is unavailable or indeterminate.
 
 
 ## 5. AuthorizationV1 Verification (Required Ordering)

--- a/packages/guard/README.md
+++ b/packages/guard/README.md
@@ -252,23 +252,39 @@ authority, external-resource TOCTOU, post-execution-start failures).
 
 ---
 
-## Replay store: production requirements
+## Replay store: contract and deployment requirements
 
-The guard prevents replay via a pluggable `ReplayStore`. Every `auth_id` and
-`delegation_id` is atomically check-and-consumed before execution.
+The guard verifies/authenticates before authoritative replay mutation and consumes
+required replay entitlements before protected execution. The parent `auth_id` is
+always consumed; `delegation_id` tracking is used when the store provides it.
 
-### Default: in-memory (development only)
+The [normative store contract](../../docs/spec/verification/verification-v1.md#43-replay-store-contract-and-deployment-boundary)
+requires at most one successful consume per identifier in a declared replay domain,
+retention while the authorization could otherwise still be accepted, and no protected
+execution when required replay state is unavailable or indeterminate. No backend
+technology is mandated. Configure the domain through store namespace/routing and
+ensure all accepting boundaries participate; local code cannot infer that topology.
+
+Consumption spends authorization; it does not prove execution completed. A crash
+between consume and effect can spend the authorization without producing the effect.
+Generic conformance does not certify restart persistence, replica visibility, backend
+persistence configuration, topology correctness, HA/SLA, or recovery guarantees.
+
+### Default: in-memory (one store instance lifetime)
 
 ```typescript
 import { OxDeAIGuard } from "@oxdeai/guard";
 // No replayStore config → createInMemoryReplayStore() used automatically.
 ```
 
-**NOT suitable for production.** Replay state is:
+Replay protection is limited to the lifetime and users of this store instance. State is:
 - lost on process restart
 - not shared across instances (horizontal scaling allows cross-instance replay)
 
-### Production: Redis backend
+A deployment accepting still-valid artifacts across restarts or separate store instances
+must preserve authoritative consumption history or block execution when it is missing.
+
+### Redis backend
 
 ```typescript
 import { OxDeAIGuard, createRedisReplayStore } from "@oxdeai/guard";
@@ -286,9 +302,10 @@ const guard = OxDeAIGuard({
 });
 ```
 
-Atomicity is guaranteed by `SET key value NX EX ttl`. Exactly one caller
-wins across any number of instances; all others see `null` and receive
-`OxDeAIAuthorizationError: replay detected`.
+`SET key value NX EX ttl` provides atomic consume in the authoritative Redis
+keyspace: at most one concurrent caller succeeds for a retained key. Existing keys
+return `null` and cause replay denial. This command alone does not establish
+restart durability or safe replica/failover behavior; those require deployment evidence.
 
 **Key schema:**
 
@@ -298,7 +315,9 @@ wins across any number of instances; all others see `null` and receive
 | `DelegationV1` | `replay:delegation:<delegation_id>` |
 
 **TTL:** derived from artifact `expiry`: `max(1, expiry - now)`. Keys
-auto-evict after the artifact expires. No manual cleanup required.
+auto-evict; this is safe only if every verifier in the replay domain can no longer
+accept the artifact at eviction. The adapter uses local wall time with no skew buffer;
+see [TTL alignment](../../docs/architecture/replay-store-ttl-alignment.md).
 
 **Fail-closed:** if Redis is unavailable (network failure, timeout, restart),
 `consumeAuthId` throws. The guard catches this and raises
@@ -329,7 +348,7 @@ const guard = OxDeAIGuard({
 ### Custom backends
 
 Implement `ReplayStore` directly for DynamoDB, Postgres, or any store that
-provides compare-and-set semantics:
+satisfies the atomicity, retention, domain, and failure contract above:
 
 ```typescript
 import type { ReplayStore } from "@oxdeai/guard";

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -415,10 +415,9 @@ export function OxDeAIGuard(config: OxDeAIGuardConfig) {
       // ── Replay consumption: after every verification, before any execution ──
       //
       // Placed here rather than immediately after each id's own verification so
-      // that NO denial on this path leaves a durable write behind — not a
-      // signature failure, not an authority rejection, not a chain or scope
-      // violation. Both ids are consumed only once the request is fully
-      // entitled to execute.
+      // that signature, authority, chain and scope rejection precede replay
+      // mutation. Later store/hook failures can leave an earlier consume spent;
+      // consumption is not a transaction with execution and is not rolled back.
       //
       // Atomicity is unchanged: each consume is still a single atomic
       // check-and-set, and both still strictly precede `execute()` below, so

--- a/packages/guard/src/replayStore.redis.ts
+++ b/packages/guard/src/replayStore.redis.ts
@@ -2,13 +2,14 @@
 /**
  * replayStore.redis.ts
  *
- * Production-grade ReplayStore backed by Redis.
+ * Redis-backed ReplayStore; deployment durability is not certified here.
  *
  * Atomicity guarantee:
  *   SET key value NX EX ttl is a single atomic Redis command.
- *   Across any number of guard instances sharing the same Redis cluster,
- *   exactly one caller will receive "OK" for a given key; all others receive
- *   null. This eliminates the TOCTOU window present in read-then-write patterns.
+ *   Within one authoritative Redis keyspace, at most one concurrent caller can
+ *   receive "OK" for a retained key. Store errors can leave no successful caller.
+ *   This avoids a read-then-write race; it does not prove retention through
+ *   failover, independent replicas, restart, eviction or recovery.
  *
  * Key schema:
  *   replay:auth:<auth_id>           — AuthorizationV1 single-use tokens
@@ -16,7 +17,8 @@
  *
  * TTL policy:
  *   ttl = max(1, expiry - now)
- *   Keys are automatically evicted by Redis once the artifact expires.
+ *   Safe eviction requires alignment with every verifier's acceptance window
+ *   in the declared replay domain; the formula alone does not prove alignment.
  *   A minimum of 1 second is enforced so that already-expired artifacts
  *   never create zero-TTL or infinite-TTL keys.
  *
@@ -35,13 +37,15 @@
  *         nodeRedisClient.set(k, v, { NX: true, EX: ttl }),
  *     };
  *
- * Clock skew:
- *   TTL is derived from artifact expiry (absolute Unix timestamp). If the
- *   guard host clock is skewed relative to the issuer, the TTL may be shorter
- *   or longer than intended. A skew of ±30 seconds is typical and acceptable
- *   given that authorization artifacts already carry explicit expiry checks in
- *   strictVerifyAuthorization. The Redis TTL only governs key eviction, not
- *   authorization validity.
+ * Replay domain and clocks:
+ *   The caller configures the authoritative keyspace through the supplied client;
+ *   fixed key prefixes do not discover deployment boundaries. TTL uses the local
+ *   wall clock, which may differ from injected verifier time or other hosts.
+ *   No generic clock-skew allowance is established here. Deployments must ensure
+ *   a consumed key cannot expire or be lost while any verifier in that domain
+ *   could still accept the authorization. Uncertain required replay state must
+ *   block execution. Backend persistence, replication and recovery need separate
+ *   validation; a consume result is not evidence that the effect occurred.
  */
 
 import type { ReplayStore } from "./replayStore.js";
@@ -102,10 +106,9 @@ function delegationKey(delegationId: string): string {
 /**
  * Compute the TTL (seconds) to assign to a Redis key.
  *
- * Always at least 1 second — zero or negative TTLs would cause Redis to either
- * reject the command or create a key that expires immediately, which could allow
- * replay of already-expired artifacts on a subsequent request within the same
- * second.
+ * Always at least 1 second to avoid invalid/non-positive Redis TTLs.
+ * Authorization expiry is enforced by the verifier independently. This minimum
+ * is not a clock-skew buffer or proof of retention across the replay domain.
  */
 function computeTtl(expiry: number): number {
   const now = Math.floor(Date.now() / 1000);
@@ -117,7 +120,8 @@ function computeTtl(expiry: number): number {
 // ---------------------------------------------------------------------------
 
 /**
- * createRedisReplayStore — production-grade, multi-instance-safe ReplayStore.
+ * createRedisReplayStore — atomic consume within the configured Redis keyspace.
+ * Restart resistance and cross-instance visibility depend on deployment setup.
  *
  * Usage:
  *

--- a/packages/guard/src/replayStore.ts
+++ b/packages/guard/src/replayStore.ts
@@ -3,22 +3,30 @@
 /**
  * ReplayStore — pluggable replay-prevention backend for the OxDeAI guard.
  *
- * The guard calls consumeAuthId (and optionally consumeDelegationId) before
- * every execution. Implementations MUST be fail-closed: if the store is
+ * The guard authenticates/verifies before calling consumeAuthId (and optionally
+ * consumeDelegationId), and consumes before protected execution. Implementations
+ * MUST be fail-closed: if the store is
  * unavailable, throw rather than returning a permissive result. Any thrown
  * error is caught by the guard and re-raised as OxDeAIAuthorizationError,
  * blocking execution.
  *
- * Atomicity:
- *   From the guard's perspective each call is a single check-and-consume
- *   operation. Durable backends should implement this using compare-and-swap
- *   or an equivalent operation so that concurrent callers cannot both observe
- *   a "not yet consumed" result for the same ID.
+ * Normative store contract (verification-v1 §4.3):
+ *   At most one concurrent consume may succeed for an identifier in its declared
+ *   replay domain. Consumed IDs MUST remain unavailable while the protected
+ *   authorization could otherwise still be accepted. An indeterminate result
+ *   MUST NOT be reported as successful consumption. No backend is mandated.
  *
- * Durability tiers:
- *   - In-memory (default)  : single-process only; replay state lost on restart.
- *   - Redis / DynamoDB     : survives restarts and horizontal scaling.
- *   - Relational DB        : full ACID guarantees; suits regulated environments.
+ * Consumption spends the replay entitlement; it does not record a completed
+ * effect. A crash or failure after consume may spend an authorization without
+ * execution. Multiple consume calls are not one transaction with the effect.
+ *
+ * Deployment boundary:
+ *   The caller declares/configures the replay domain through store selection and
+ *   namespace/routing. Local code cannot infer every valid deployment boundary.
+ *   In-memory stores lose state on restart. External backends can support shared
+ *   retention, but restart persistence, replica visibility, topology, backend
+ *   persistence settings and HA/recovery guarantees require deployment evidence.
+ *   Generic implementation conformance does not prove these properties.
  */
 export interface ReplayStore {
   /**
@@ -26,8 +34,9 @@ export interface ReplayStore {
    *
    * @param authId        The auth_id from the AuthorizationV1 artifact.
    * @param opts.expiry   Unix timestamp (seconds) when the auth expires.
-   *                      Durable backends may use this to set a TTL on the
-   *                      record so that expired entries are garbage-collected.
+   *                      Backends may garbage-collect only after the identifier
+   *                      can no longer authorize reuse anywhere in the declared
+   *                      domain, accounting for its verifier clocks/acceptance rules.
    * @returns `true`  if the auth_id was successfully consumed (first use).
    * @returns `false` if the auth_id was already consumed (replay detected).
    * @throws             if the store is unavailable — the guard will DENY.
@@ -41,9 +50,9 @@ export interface ReplayStore {
    * consumeAuthId on the parent authorization: consuming the parentAuth
    * once prevents the same delegation chain from being replayed.
    *
-   * Implement this method when stricter delegation tracking is required
-   * (e.g. when a parent auth may authorise multiple distinct delegations and
-   * per-delegation replay tracking is needed independently of parentAuth).
+   * Implement this method when separate delegation-ID tracking is required by
+   * the declared profile/domain. The current guard always consumes parentAuth
+   * as well; adding this method does not enable multiple uses of that parent.
    *
    * @param delegationId  The delegation_id from the DelegationV1 artifact.
    * @param opts.expiry   Unix timestamp (seconds) when the delegation expires.
@@ -68,8 +77,9 @@ export interface ReplayStore {
  *   - Multi-process / horizontally-scaled deployments
  *   - Scenarios where replay prevention must survive process restarts
  *
- * For production deployments requiring durability, implement ReplayStore
- * backed by Redis, DynamoDB, a relational database, or equivalent.
+ * Where the declared replay domain spans restarts or processes, use a backend
+ * and deployment configuration that preserve the contract across that domain.
+ * A backend's technology name alone does not demonstrate that guarantee.
  */
 export function createInMemoryReplayStore(): ReplayStore {
   const consumedAuthIds = new Set<string>();

--- a/packages/guard/src/test/guard.replay-consume-ordering.test.ts
+++ b/packages/guard/src/test/guard.replay-consume-ordering.test.ts
@@ -12,8 +12,10 @@
  * later legitimate authorization carrying the same id.
  *
  * These tests pin two properties that must hold together:
- *   1. no denial, for ANY reason, leaves a replay write behind; and
+ *   1. the tested pre-consumption verification denials leave no replay write; and
  *   2. replay protection still works for requests that do execute.
+ * Later store/CAS/hook failures may follow a successful consume. These tests
+ * do not prove rollback, completed execution, crash recovery or restart durability.
  */
 import test from "node:test";
 import assert from "node:assert/strict";


### PR DESCRIPTION
## Summary

Clarifies the normative boundary between replay implementation behavior, the replay-store contract, and deployment durability guarantees.

This PR prevents implementation-level replay conformance from being interpreted as proof of restart persistence, replica visibility, backend persistence configuration, topology correctness, HA, or recovery guarantees.

It also clarifies that replay consumption spends an authorization entitlement but does not prove that the protected effect executed.

## Changes

- Define the normative replay-store contract: atomic consume, fail-closed behavior, replay-domain scoping, and retention while an authorization could otherwise still be accepted.
- Separate implementation conformance from deployment-specific durability evidence across the replay, delegation, PEP, trusted-time, interoperability, and conformance documentation.
- Qualify Redis/backend durability language and document that backend technology alone does not establish deployment guarantees.
- Clarify delegation replay tracking: requirements are determined by the declared artifact/execution profile and replay model; current Guard behavior does not establish a general protocol exemption.
- Preserve verify/authenticate → consume → protected effect ordering.
- Clarify that `consumed != executed` and that a crash after consumption may spend an authorization without the effect occurring.
- Document current corpus/test limitations for crash/restart behavior, arbitrary interleavings, persistence, and deployment topology.
- Update implementation comments to match the clarified normative boundary. No executable TypeScript behavior changed.

## Security impact

Does this change affect authorization, verification, replay protection, trusted state, provenance, execution boundaries, or CI security gates?

- [ ] No security-relevant behavior changed
- [x] Security-relevant behavior changed and is described below

Details:

This is a security-relevant specification and documentation clarification around replay protection and trusted replay state.

No runtime execution semantics are changed. Existing fail-closed behavior and verification-before-consumption ordering are preserved.

The PR narrows previously overbroad durability claims and makes explicit that generic implementation conformance does not prove deployment properties such as restart persistence, replica visibility, backend persistence configuration, topology correctness, HA/SLA, or recovery guarantees.

Required replay-state failure, unavailability, or indeterminate consumption remains fail-closed: protected execution must not proceed without definitive successful consumption where replay resistance is required.

## Validation

```text
@oxdeai/guard test suite PASS
spec-claim tests 43 PASS
authorization/delegation/PEP vectors 33 PASS
spec reference validation PASS
corpus authority validation PASS
executable TypeScript syntax comparison PASS no executable TypeScript changes
git diff --check PASS
````

## Regression proof

The issue was reproduced as a specification/evidence-boundary inconsistency rather than a runtime bypass.

Existing documentation and comments could imply that selecting Redis or another external backend automatically established properties such as restart durability, horizontal-scaling safety, or production-grade persistence. Existing conformance evidence does not establish those deployment properties.

The fix makes the evidence boundary explicit:

* implementation conformance proves the exercised replay ordering and fail-closed behavior;
* the normative store contract requires atomic consumption, appropriate retention, and non-permissive failure handling;
* deployment durability properties require separate deployment-specific evidence.

Existing replay tests and vectors continue to pass, and executable TypeScript comparison confirms that the clarification does not alter production runtime behavior.

## Scope

* [x] No unrelated changes
* [x] No required CI check weakened, bypassed, or made advisory
* [x] No production behavior changed unless explicitly described
* [x] Documentation updated where required

## Related issue

Closes #321